### PR TITLE
Fix for http://www.pyinstaller.org/ticket/489

### DIFF
--- a/source/linux/utils.c
+++ b/source/linux/utils.c
@@ -217,6 +217,11 @@ int spawn(const char *thisfile, char *const argv[])
         signal(SIGKILL, SIG_DFL);
         signal(SIGTERM, SIG_DFL);
     }
-
-    return WEXITSTATUS(rc);
+    if (WIFEXITED(rc))
+        return WEXITSTATUS(rc);
+    /* Process ended abnormally */
+    if (WIFSIGNALED(rc))
+        /* Mimick the signal the child received */
+        raise(WTERMSIG(rc));
+    return 1;
 }


### PR DESCRIPTION
All tests passed except for 'import/test_zipimport2', which failed without this patch too.  This patch doesn't include the updated binaries which will need to be made by someone with a full build setup.

Signed-off-by: Brandyn A. White bwhite@dappervision.com
