### PR TITLE
Do not use a child process if not needed on windows.

### DIFF
--- a/source/common/launch.c
+++ b/source/common/launch.c
@@ -1301,6 +1301,25 @@ static int extractDependency(ARCHIVE_STATUS *status_list[], const char *item)
     return 0;
 }
 
+
+/*
+ * check if binaries need to be extracted. If not, this is probably a onedir solution,
+ * and a child process will not be required on windows.
+ */
+int needToExtractBinaries(ARCHIVE_STATUS *status_list[])
+{
+	TOC * ptoc = status_list[SELF]->tocbuff;
+	while (ptoc < status_list[SELF]->tocend) {
+		if (ptoc->typcd == 'b' || ptoc->typcd == 'x' || ptoc->typcd == 'Z')
+            return 1;
+        if (ptoc->typcd == 'd') {
+            return 1;
+        }
+		ptoc = incrementTocPtr(status_list[SELF], ptoc);
+	}
+	return 0;
+}
+
 /*
  * extract all binaries (type 'b') and all data files (type 'x') to the filesystem
  * and checks for dependencies (type 'd'). If dependencies are found, extract them.

--- a/source/common/main.c
+++ b/source/common/main.c
@@ -101,6 +101,14 @@ int main(int argc, char* argv[])
         }
     }
 
+#ifdef WIN32
+    if (!extractionpath && !needToExtractBinaries(status_list)) {
+        VS("No need to extract files to run; setting extractionpath to homepath\n");
+        extractionpath = homepath;
+        strcat(MEIPASS2, homepath);
+        putenv(MEIPASS2); //Bootstrap sets sys._MEIPASS, plugins rely on it
+    }
+#endif
     if (extractionpath) {
         VS("Already in the child - running!\n");
         /*  If binaries were extracted to temppath,


### PR DESCRIPTION
This restores 1.5.2's ability to only launch a subprocess on windows if required.

1.5.2 used to call extractBinaries which would return the new extraction path if required. Because you changed this to a boolean result value, I added a new method which returns true if an extraction is needed.

Your docs are a bit nebulous about what a 'onedir' deployment is, as that is really only defined in the specbuilder and mentioned a bit from various comments.

My view is a "one directory" deployment should be defined as "do binaries need to be extracted from packages before the script is run".
