### PR TITLE
setting the correct PyQt API version

### DIFF
--- a/buildtests/interactive/pyi_rth_user_config.py
+++ b/buildtests/interactive/pyi_rth_user_config.py
@@ -1,0 +1,2 @@
+# set desired version for PyQt API
+PYQT_API_VERSION = 2

--- a/buildtests/interactive/test_pyqt4_api_v2.py
+++ b/buildtests/interactive/test_pyqt4_api_v2.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import sys
+
+from PyQt4 import Qt
+from PyQt4 import QtCore
+from PyQt4 import QtGui
+
+
+def main():
+    app = Qt.QApplication(sys.argv)
+    print(u'Qt4 plugin paths: ' + u', '.join(app.libraryPaths()))
+    read_formats = u', '.join(
+        [str(img_format).decode('utf-8').lower() for img_format in
+         QtGui.QImageReader.supportedImageFormats()])
+    print(u'Qt4 image read support: ' + read_formats)
+    print(u'Qt4 Libraries path: ' + QtCore.QLibraryInfo.location(
+        QtCore.QLibraryInfo.LibrariesPath))
+    label = Qt.QLabel(u'Hello World from PyQt4', None)
+    label.setWindowTitle(u'Hello World from PyQt4')
+    label.resize(300, 300)
+    label.show()
+    app.exec_()
+
+
+if __name__ == '__main__':
+    main()

--- a/buildtests/interactive/test_pyqt4_api_v2.spec
+++ b/buildtests/interactive/test_pyqt4_api_v2.spec
@@ -1,0 +1,28 @@
+# -*- mode: python -*-
+
+__testname__ = 'test_pyqt4_api_v2'
+
+a = Analysis(['pyi_rth_user_config.py', __testname__ + '.py'])
+pyz = PYZ(a.pure)
+exe = EXE(pyz,
+          a.scripts,
+          exclude_binaries=1,
+          name=os.path.join('build', 'pyi.'+sys.platform, __testname__,
+                            __testname__ + '.exe'),
+          debug=False,
+          strip=False,
+          upx=False,
+          console=True )
+coll = COLLECT(exe,
+               a.binaries,
+               a.zipfiles,
+               a.datas,
+               strip=False,
+               upx=False,
+               name=os.path.join('dist', __testname__))
+
+import sys
+if sys.platform.startswith("darwin"):
+    app = BUNDLE(coll,
+        name=os.path.join('dist', __testname__ + '.app'),
+        version='0.0.1')

--- a/doc/source/Manual.rst
+++ b/doc/source/Manual.rst
@@ -1260,6 +1260,12 @@ free to do almost anything. One provided hook sets things up so that win32com
 can generate modules at runtime (to disk), and the generated modules can be
 found in the win32com package.
 
+It is possible to configure some aspects of the behavior of the runtime hooks
+by adding a ``pyi_rth_user_config`` module to your application::
+
+       anal = Analysis(['path/to/pyi_rth_user_config.py', 'main.py'], ...
+
+
 Adapting to being "frozen"
 --------------------------
 

--- a/support/rthooks/pyi_rth_qt4plugins.py
+++ b/support/rthooks/pyi_rth_qt4plugins.py
@@ -9,7 +9,7 @@ d = "qt4_plugins"
 d = os.path.join(sys._MEIPASS, d)
 
 
-# We remove QT_PLUGIN_PATH variable, beasuse we want Qt4 to load
+# We remove QT_PLUGIN_PATH variable, because we want Qt4 to load
 # plugins only from one path.
 if 'QT_PLUGIN_PATH' in os.environ:
     del os.environ['QT_PLUGIN_PATH']

--- a/support/rthooks/pyi_rth_qt4plugins.py
+++ b/support/rthooks/pyi_rth_qt4plugins.py
@@ -14,6 +14,20 @@ d = os.path.join(sys._MEIPASS, d)
 if 'QT_PLUGIN_PATH' in os.environ:
     del os.environ['QT_PLUGIN_PATH']
 
+# Check if the user has a 'pyi_rth_user_config' module with a valid
+# 'PYQT_API_VERSION' constant defined to override the default PyQt API version.
+try:
+    from pyi_rth_user_config import PYQT_API_VERSION
+    if PYQT_API_VERSION in [1, 2]:
+        import sip
+        for class_name in [
+            'QDate', 'QDateTime', 'QString', 'QTextStream', 'QTime', 'QUrl',
+            'QVariant',
+        ]:
+            sip.setapi(class_name, PYQT_API_VERSION)
+except ImportError:
+    # 'pyi_rth_user_config.PYQT_API_VERSION' doesn't exist: default behaviour
+    pass
 
 # We cannot use QT_PLUGIN_PATH here, because it would not work when
 # PyQt4 is compiled with a different CRT from Python (eg: it happens


### PR DESCRIPTION
Issue #159: Enable configuration of the `pyi_rth_qt4plugins` run-time hook, more specifically setting the correct *PyQt* API version, by a user provided `pyi_rth_user_config` module.

This approach seemed like the less intrusive and should be extendable in a generic way to all run-time hooks.

This is obviously just a proposal, but as mentioned, it solves the problem of the user being able to configure the behaviour of run-time hooks in a simple manner by setting the convention of the  user provided `pyi_rth_user_config` module where constants can be defined to parametrize the behaviour of the run-time hooks.

Any comments an suggestions regarding fixes / enhancements are welcome.