### PR TITLE
Changed pyi_rth_usb.py to support the new libusb module names in pyusb.

### DIFF
--- a/support/rthooks/pyi_rth_usb.py
+++ b/support/rthooks/pyi_rth_usb.py
@@ -20,8 +20,15 @@ import ctypes
 import glob
 import os
 import sys
-import usb.backend.libusb10 as libusb10
-import usb.backend.libusb01 as libusb01
+# Pyusb changed these libusb module names in commit 2082e7.
+try:
+    import usb.backend.libusb10 as libusb10
+except:
+    import usb.backend.libusb1 as libusb10
+try:
+    import usb.backend.libusb01 as libusb01
+except:
+    import usb.backend.libusb0 as libusb01 
 import usb.backend.openusb as openusb
 
 


### PR DESCRIPTION
Pyusb changed the name of the libusb backends around [commit c6a9](https://github.com/walac/pyusb/commit/c6a9a8ea9284b7b460feb78bed77d8a11c92187a). I changed the names of these modules in the pyi_rth_usb.py rthook so applications using the latest version of pyusb are built successfully using pyinstaller.
