### PR TITLE
Adding an rthook for ctypes so the app can find the usb dynamic libs at runtime.

### DIFF
--- a/support/rthooks.dat
+++ b/support/rthooks.dat
@@ -9,4 +9,5 @@
     'Tkinter':    ['support/rthooks/pyi_rth_Tkinter.py'],
     'encodings':  ['support/rthooks/pyi_rth_encodings.py'],
     'usb':        ['support/rthooks/pyi_rth_usb.py'],
+    'ctypes':	  ['support/rthooks/pyi_rth_ctypes.py'],
 }

--- a/support/rthooks/pyi_rth_ctypes.py
+++ b/support/rthooks/pyi_rth_ctypes.py
@@ -1,0 +1,13 @@
+import ctypes.util
+import os
+
+def find_library_decorator(func):
+    def wrapper(name):
+        lib = func(name)
+        if lib == None:
+            lib_path = os.path.join(sys._MEIPASS, name)
+            lib - func(lib_path)
+        return lib
+    return wrapper
+
+ctypes.util.find_library = find_library_decorator(ctypes.util.find_library)


### PR DESCRIPTION
I needed this rthook to get my program working on the Mac. Pyinstaller bundles the libusb dylibs correctly, but ctypes can't find them at runtime. This rthook fixes that and allows my application to find the dylibs. 
