### PR TITLE
Issue #371: Fix Python library search for OS X framework virtualenvs.

### DIFF
--- a/PyInstaller/build.py
+++ b/PyInstaller/build.py
@@ -662,7 +662,7 @@ class Analysis(Target):
 
         for (nm, fnm, typ) in binaries:
             for name in names:
-                if typ == 'BINARY' and fnm.endswith(name):
+                if typ == 'BINARY' and os.path.basename(fnm) == name:
                     # Python library found.
                     # FIXME Find a different way how to pass python libname to CArchive.
                     os.environ['PYI_PYTHON_LIBRARY_NAME'] = name


### PR DESCRIPTION
In a virtualenv created by a framework build of Python on OS X, the
Python library is named ".Python", but Analysis._check_python_library()
thinks it's "Python" (because ".Python".endswith("Python") evaluates to
True).  Using os.path.basename() in lieu of str.endswith() fixes the
problem.
