### PR TITLE
Try to fix namespace packages are not handled correctly issue

### DIFF
--- a/PyInstaller/depend/modules.py
+++ b/PyInstaller/depend/modules.py
@@ -111,6 +111,12 @@ class PkgModule(PyModule):
         self._ispkg = 1
         pth = os.path.dirname(pth)
         self.__path__ = [pth]
+        
+        # this is possible to be a namespace package, 
+        # let the pkgutil find possible path for us
+        from pkgutil import extend_path
+        self.__path__ = extend_path(self.__path__, nm)
+
         self._update_director(force=True)
 
     def _update_director(self, force=False):


### PR DESCRIPTION
It appears that PyInstaller can't handle namespace packages correctly. For example
- foo.pkg1
- foo.pkg2

When the foo is a namespace package, module or packages in pkg1 or pkg2 can't be find correctly. 

To solve that problem, I add few lines in depend/modules.py. It uses 

```
pkgutil.extend_path
```

function for extending other package paths.  Not sure is there side effect by doing this, but at least, this solution works for me.
