### PR TITLE
Fix: Add missing hidden import to docutils hook.

### DIFF
--- a/PyInstaller/hooks/hook-docutils.py
+++ b/PyInstaller/hooks/hook-docutils.py
@@ -22,6 +22,7 @@ def hook(mod):
     global hiddenimports, datas
     hiddenimports = (collect_submodules('docutils.languages') +
                      collect_submodules('docutils.writers') +
+                     collect_submodules('docutils.parsers.rst.languages') +
                      collect_submodules('docutils.parsers.rst.directives'))
     datas = collect_data_files('docutils')
     return mod


### PR DESCRIPTION
In using Sphinx/docutils, I discovered an additional hidden import. (Did we discuss this earlier, perhaps with Giovanno Bajo? Or am I completely confused?)
