### PR TITLE
Issue #687 - Dotfiles fix for Collect on OSX

### DIFF
--- a/PyInstaller/build.py
+++ b/PyInstaller/build.py
@@ -1246,7 +1246,7 @@ class COLLECT(Target):
                                  and config['hasUPX'], dist_nm=inm)
             if typ != 'DEPENDENCY':
                 if os.path.basename(fnm).startswith("."):
-                    logger.debug(fnm + " starts with a period. Skipping.")
+                    logger.debug("%s starts with a period. Skipping." % fnm)
                 else:
                     shutil.copy2(fnm, tofnm)
             if typ in ('EXTENSION', 'BINARY'):


### PR DESCRIPTION
I am filing the ticket for this now and I believe the number will be #687. This fixes an issue when copying files that start with a period on OSX.
