### PR TITLE
Issue 687: Ensure pywintypes and pythoncom dlls don't get included twice by adding ...

### DIFF
--- a/PyInstaller/hooks/hook-pythoncom.py
+++ b/PyInstaller/hooks/hook-pythoncom.py
@@ -15,8 +15,11 @@ as a data file. The path to this dll is contained in __file__
 attribute.
 """
 
-
+import os.path
 from PyInstaller.hooks.hookutils import get_module_file_attribute
 
-
-datas = [(get_module_file_attribute('pythoncom'), '.')]
+def hook(mod):
+    pth = get_module_file_attribute('pythoncom')
+    name = os.path.basename(pth)
+    mod.binaries.extend([(name, pth, 'BINARY')])
+    return mod

--- a/PyInstaller/hooks/hook-pywintypes.py
+++ b/PyInstaller/hooks/hook-pywintypes.py
@@ -15,8 +15,11 @@ as a data file. The path to this dll is contained in __file__
 attribute.
 """
 
-
+import os.path
 from PyInstaller.hooks.hookutils import get_module_file_attribute
 
-
-datas = [(get_module_file_attribute('pywintypes'), '.')]
+def hook(mod):
+    pth = get_module_file_attribute('pythoncom')
+    name = os.path.basename(pth)
+    mod.binaries.extend([(name, pth, 'BINARY')])
+    return mod


### PR DESCRIPTION
...the dll as a BINARY instead of as a data.

PyInstaller currently can include the dlls more than once if you import a Python Extension (win32evtlog) that has a binary dependency on pywintypes (or pythoncom).
