### PR TITLE
Issue 688: Allow VSVersionInfo instances as well as file names.

### DIFF
--- a/PyInstaller/utils/versioninfo.py
+++ b/PyInstaller/utils/versioninfo.py
@@ -512,8 +512,11 @@ class VarStruct:
 
 
 def SetVersion(exenm, versionfile):
-    txt = open(versionfile, 'rU').read()
-    vs = eval(txt)
+    if isinstance(versionfile, VSVersionInfo):
+        vs = versionfile
+    else:
+        txt = open(versionfile, 'rU').read()
+        vs = eval(txt)
     hdst = win32api.BeginUpdateResource(exenm, 0)
     win32api.UpdateResource(hdst, RT_VERSION, 1, vs.toRaw())
     win32api.EndUpdateResource (hdst, 0)


### PR DESCRIPTION
Sometimes its necessary to fill in version resources based on more complicated Python code than a simple expression possible from the current version kwarg approach.

This change lets you pass a VSVersionInfo instance directly as well as a filename.
