### PR TITLE
Bugfix. Invalid syntax spec file generated when `-w --onefile` options gave on OS X.

### DIFF
--- a/PyInstaller/makespec.py
+++ b/PyInstaller/makespec.py
@@ -93,7 +93,7 @@ coll = COLLECT(exe, dll,
 """
 
 bundleexetmplt = """app = BUNDLE(exe,
-             name='%(exename)s.app'))
+             name='%(exename)s.app')
 """
 
 bundletmplt = """app = BUNDLE(coll,


### PR DESCRIPTION
As above.
