### PR TITLE
Fix: Prevent zipped eggs potentially being skipped for extraction.

### DIFF
--- a/PyInstaller/bindepend.py
+++ b/PyInstaller/bindepend.py
@@ -117,20 +117,19 @@ def _extract_from_egg(toc):
     Ensure all binary modules in zipped eggs get extracted and
     included with the frozen executable.
 
-    The supplied toc is directly modified to make changes effective.
-
     return  modified table of content
     """
+    new_toc = []
     for item in toc:
         # Item is a tupple
         #  (mod_name, path, type)
         modname, pth, typ = item
         if not os.path.isfile(pth):
             pth = check_extract_from_egg(pth)[0][0]
-            # Replace value in original data structure.
-            toc.remove(item)
-            toc.append((modname, pth, typ))
-    return toc
+        
+        # Add value to new data structure.
+        new_toc.append((modname, pth, typ))
+    return new_toc
 
 
 def Dependencies(lTOC, xtrapath=None, manifest=None):


### PR DESCRIPTION
I was bitten by this problem recently. Mutating the TOC during iteration in this function causes items to be skipped over. That means if two zipped eggs are listed in succession, the first will be correctly handled but the second will be skipped, meaning it doesn't end up in the packaged app.

The fix is to create a new TOC instead of mutating the old one. The only existing call to _extract_from_egg doesn't rely on the mutating behaviour, so it should be safe to remove. It fixed my problem, and I tested it and it doesn't break any tests (OS X 10.8 and Windows 7).
