### PR TITLE
Modified IPython hook in order to catch every IPython submodule.

### DIFF
--- a/PyInstaller/hooks/hook-IPython.py
+++ b/PyInstaller/hooks/hook-IPython.py
@@ -8,9 +8,10 @@
 #-----------------------------------------------------------------------------
 
 
-from hookutils import collect_data_files
+from hookutils import (collect_data_files, collect_submodules)
 
 
 # IPython (tested with 0.13) requires the following files:
 #   ./site-packages/IPython/config/profile/README_STARTUP
 datas = collect_data_files('IPython')
+hiddenimports = collect_submodules('IPython')


### PR DESCRIPTION
With IPython 1.1.0 this hook wasn't working because it can't found a
bunch of submodules like html.notebookapp.
