### PR TITLE
Improve babel support on windows

### DIFF
--- a/PyInstaller/hooks/hook-babel.py
+++ b/PyInstaller/hooks/hook-babel.py
@@ -8,13 +8,7 @@
 #-----------------------------------------------------------------------------
 
 
-from PyInstaller.hooks.hookutils import exec_statement
+from PyInstaller.hooks.hookutils import collect_data_files
 
 hiddenimports = ["babel.dates"]
-
-babel_localedata_dir = exec_statement(
-    "import babel.localedata; print babel.localedata._dirname")
-
-datas = [
-    (babel_localedata_dir, ""),
-]
+datas = collect_data_files('babel')

--- a/PyInstaller/loader/rthooks/pyi_rth_babel.py
+++ b/PyInstaller/loader/rthooks/pyi_rth_babel.py
@@ -11,8 +11,15 @@
 import os
 import sys
 
-d = "localedata"
-d = os.path.join(sys._MEIPASS, d)
+babel_root = os.path.join(sys._MEIPASS, "babel")
 
 import babel.localedata
-babel.localedata._dirname = d
+import babel.core
+babel.localedata._dirname = os.path.join(babel_root, "localedata")
+
+filename = os.path.join(babel_root, 'global.dat')
+fileobj = open(filename, 'rb')
+try:
+    babel.core._global_data = babel.core.pickle.load(fileobj)
+finally:
+    fileobj.close()


### PR DESCRIPTION
babel.localtime does not work correctly on windows when used with pyinstaller
### Example program:

```
import babel.localtime

print "Hello world"
```
### Expected:

```
Hello world
```
### Got:

```
C:\Documents and Settings\az\My Documents\py-babel> .\dist.fail\test\test.exe
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "C:\pyinstaller\PyInstaller\loader\pyi_importers.py", line 270, in load_module
    exec(bytecode, module.__dict__)
  File "C:\Documents and Settings\az\My Documents\py-babel\build\test\out00-PYZ.pyz\babel.localtime", line 21, in <modul
e>
  File "C:\pyinstaller\PyInstaller\loader\pyi_importers.py", line 270, in load_module
    exec(bytecode, module.__dict__)
  File "C:\Documents and Settings\az\My Documents\py-babel\build\test\out00-PYZ.pyz\babel.localtime._win32", line 13, in
 <module>
  File "C:\Documents and Settings\az\My Documents\py-babel\build\test\out00-PYZ.pyz\babel.core", line 53, in get_global
  File "C:\Documents and Settings\az\My Documents\py-babel\build\test\out00-PYZ.pyz\babel.core", line 25, in _raise_no_d
ata_error
RuntimeError: The babel data files are not available. This usually happens because you are using a source checkout from
Babel and you did not build the data files.  Just make sure to run "python setup.py import_cldr" before installing the l
ibrary.
```
### Problem:

`get_global` function in `babel.core` uses `__file__` to determine location, which results in wrong path in frozen executable.

I fixed `hook-babel.py` to collect all data files belonging to babel package and `pyi_rth_babel.py` to configure correct paths for `localedata` and `global.dat`
