### PR TITLE
Allow user to override buildin hooks

### DIFF
--- a/PyInstaller/depend/imptracker.py
+++ b/PyInstaller/depend/imptracker.py
@@ -57,7 +57,7 @@ class ImportTrackerModulegraph:
         self.modules = dict()
 
         if hookspath:
-            hooks.__path__.extend(hookspath)
+            hooks.__path__ = hookspath + hooks.__path__
         if excludes is None:
             self.excludes = set()
         else:
@@ -133,7 +133,7 @@ class ImportTracker:
             ]
 
         if hookspath:
-            hooks.__path__.extend(hookspath)
+            hooks.__path__ = hookspath + hooks.__path__
         if excludes is None:
             self.excludes = set()
         else:


### PR DESCRIPTION
Change order in which hooks are searched, so user hooks can override pyinstaller hooks.

I do not know how smart idea this is, but looks like it did not break anything. Problem is that I needed custom hook-codecs and hook-encodings to fix some errors with unicode on Linux.
