### PR TITLE
Fix: Discovery of Django root dir in a subdirectory

### DIFF
--- a/PyInstaller/hooks/hookutils.py
+++ b/PyInstaller/hooks/hookutils.py
@@ -483,7 +483,7 @@ def django_find_root_dir():
         settings_dir = manage_dir
     else:
         for f in files:
-            if os.path.isdir(f):
+            if os.path.isdir(os.path.join(manage_dir, f)):
                 subfiles = os.listdir(os.path.join(manage_dir, f))
                 # Subdirectory contains critical files.
                 if 'settings.py' in subfiles and 'urls.py' in subfiles:


### PR DESCRIPTION
We need to form the full relative path to the subdirectories when doing the isdir check.
