### PR TITLE
fix empty basedir problem in Windows

### DIFF
--- a/doc/source/Manual.rst
+++ b/doc/source/Manual.rst
@@ -1603,7 +1603,7 @@ you get the path to the file with the following code::
         basedir = sys._MEIPASS
     else:
         # we are running in a normal Python environment
-        basedir = os.path.dirname(__file__)
+        basedir = os.path.dirname(os.path.abspath(__file__))
 
 This code sets ``basedir`` to the path to the folder containing
 your script and any other files or folders bundled with it.


### PR DESCRIPTION
in the manual, basedir in `basedir = os.path.dirname(__file__)` will return an empty string in Windows.

it should use a cross-platform method: `os.path.dirname(os.path.abspath(__file__))`

see http://stackoverflow.com/a/7783326

i tested it on windows xp with python 2.7
