### PR TITLE
fix IndexError when len(VERSION) < 5

### DIFF
--- a/PyInstaller/__init__.py
+++ b/PyInstaller/__init__.py
@@ -120,6 +120,6 @@ def get_version():
     if len(VERSION) >= 4 and VERSION[3]:
         version = '%s%s' % (version, VERSION[3])
         # include git revision in version string
-        if VERSION[3] == 'dev' and VERSION[4] > 0:
+        if VERSION[3] == 'dev' and len(VERSION) == 5 and VERSION[4] > 0:
             version = '%s-%s' % (version, VERSION[4])
     return version


### PR DESCRIPTION
I just tried "pip install https://github.com/pyinstaller/pyinstaller/tarball/develop" and got an IndexError:

```
ubuntu@ubuntu-VirtualBox ~> 
sudo pip install https://github.com/pyinstaller/pyinstaller/tarball/develop
[sudo] password for ubuntu: 
Downloading/unpacking https://github.com/pyinstaller/pyinstaller/tarball/develop
  Downloading develop (unknown size): 4.9MB downloaded
  Running setup.py (path:/tmp/pip-8UoCj0-build/setup.py) egg_info for package from https://github.com/pyinstaller/pyinstaller/tarball/develop
    Traceback (most recent call last):
      File "<string>", line 17, in <module>
      File "/tmp/pip-8UoCj0-build/setup.py", line 125, in <module>
        version=get_version(),
      File "PyInstaller/__init__.py", line 123, in get_version
        if VERSION[3] == 'dev' and VERSION[4] > 0:
    IndexError: tuple index out of range
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):

  File "<string>", line 17, in <module>

  File "/tmp/pip-8UoCj0-build/setup.py", line 125, in <module>

    version=get_version(),

  File "PyInstaller/__init__.py", line 123, in get_version

    if VERSION[3] == 'dev' and VERSION[4] > 0:

IndexError: tuple index out of range

----------------------------------------
Cleaning up...
Command python setup.py egg_info failed with error code 1 in /tmp/pip-8UoCj0-build
Storing debug log for failure in /home/ubuntu/.pip/pip.log
```

Line 123 currently assumes VERSION has length 5, but in fact it currently has length 4 (from lines 42-44):

``` python
# Uncomment this line for development of version 3.0.
#VERSION = (3, 0, 0, 'dev', git.get_repo_revision())
VERSION = (2, 1, 1, 'dev')
```

This patch adds a check that VERSION has length 5 before trying to access VERSION[4].
