### PR TITLE
Added h5ac module to h5py hidden imports

### DIFF
--- a/PyInstaller/hooks/hook-h5py.py
+++ b/PyInstaller/hooks/hook-h5py.py
@@ -13,4 +13,4 @@ Hook for http://pypi.python.org/pypi/h5py/
 """
 
 
-hiddenimports = ['_proxy','utils','defs']
+hiddenimports = ['_proxy', 'utils', 'defs', 'h5ac']


### PR DESCRIPTION
The latest version of h5py adds a module h5ac which PyInstaller does not discover automatically. This PR adds it to the h5py hook.
