### PR TITLE
Add hook file for skimage.transform module

### DIFF
--- a/PyInstaller/hooks/hook-skimage.transform.py
+++ b/PyInstaller/hooks/hook-skimage.transform.py
@@ -8,6 +8,8 @@
 #-----------------------------------------------------------------------------
 
 
+# Hook tested with scikit-image (skimage) 0.9.3 on Mac OS 10.9 and Windows 7
+# 64-bit
 hiddenimports = ['skimage.draw.draw',
                  'skimage._shared.geometry',
                  'skimage._shared.interpolation',


### PR DESCRIPTION
I had to create the following hook file to get skimage 0.9.3 working on Windows 7 64-bit.

This fixes import errors I was getting by trying the following import:

from skimage.transform import hough_line
