### PR TITLE
#884, hook-cryptography: "_cffi_*" -> "*_cffi*".

### DIFF
--- a/PyInstaller/hooks/hook-cryptography.py
+++ b/PyInstaller/hooks/hook-cryptography.py
@@ -29,7 +29,7 @@ def hook(mod):
     """
     cryptography_dir = os.path.dirname(get_module_file_attribute('cryptography'))
     for ext in PY_EXTENSION_SUFFIXES:
-        ffimods = glob.glob(os.path.join(cryptography_dir, '_cffi_*%s*' % ext))
+        ffimods = glob.glob(os.path.join(cryptography_dir, '*_cffi_*%s*' % ext))
         for f in ffimods:
             name = os.path.join('cryptography', os.path.basename(f))
             # TODO fix this hook to use attribute 'binaries'.


### PR DESCRIPTION
```
Naming of the files have changed to _Cryptograpy_cffi_*,
instead of _cffi_*. Update search path to *_cffi_*. This is still compatible with previous versions of cryptography module, yet, also forward-compatible. Since the search path of this code is already well within the 'cryptography' module directory, this search pattern is not too aggressive (would not pick up cffi-related files from other modules)

Previously, on Windows, the error ended:

  File "build\x86\obj\bin\prog\out00-PYZ.pyz\cryptography.hazmat.primitives.padding", line 74, in <module>
  File "build\x86\obj\bin\prog\out00-PYZ.pyz\cffi.api", line 341, in verify
  File "build\x86\obj\bin\prog\out00-PYZ.pyz\cffi.verifier", line 73, in load_library
  File "build\x86\obj\bin\prog\out00-PYZ.pyz\cffi.verifier", line 125, in _write_source
IOError: [Errno 2] No such file or directory: 'C:\\Users\\Administrator\\Documents\\GitHub\\proj\\build\\x86\\obj\\bin\\prog\\out00-PYZ.pyz\\__pycache__\\_Cryptography_cffi_8f86901cxc1767c5a.c'
LOADER: RC: -1 from prog

After this patch, it executes fine, a script with the statement:

from cryptography.fernet import Fernet
```

(edit: wrapped message with code block to prevent markup)
