### PR TITLE
Normalize TOC "DATA" paths to prevent multiple inclusion on Windows

### DIFF
--- a/PyInstaller/build.py
+++ b/PyInstaller/build.py
@@ -1599,8 +1599,8 @@ class TOC(UserList.UserList):
     def append(self, tpl):
         try:
             fn = tpl[0]
-            if tpl[2] == "BINARY":
-                # Normalize the case for binary files only (to avoid duplicates
+            if tpl[2] in ["BINARY", "DATA"]:
+                # Normalize the case for binary and data files only (to avoid duplicates
                 # for different cases under Windows). We can't do that for
                 # Python files because the import semantic (even at runtime)
                 # depends on the case.


### PR DESCRIPTION
This is implements the patch suggested on
http://www.pyinstaller.org/ticket/783

This should also fix a similar problem on OS X when
case-insensitive HFS+ is used.

We are internally using a version of PyInstaller with this
patch since November 2013 on a couple of production
projects targeting both Windows and OS X. We are not
aware of any ill effects yet.
