### PR TITLE
Add binary dependencies in the same relative path

### DIFF
--- a/PyInstaller/bindepend.py
+++ b/PyInstaller/bindepend.py
@@ -163,12 +163,16 @@ def Dependencies(lTOC, xtrapath=None, manifest=None):
         seen[nm.upper()] = 1
         if is_win:
             for ftocnm, fn in selectAssemblies(pth, manifest):
-                lTOC.append((ftocnm, fn, 'BINARY'))
+                # add ftocnm to the TOC in the same relative path as nm
+                relpath_ftocnm = os.path.join(os.path.dirname(nm), ftocnm)
+                lTOC.append((relpath_ftocnm, fn, 'BINARY'))
         for lib, npth in selectImports(pth, xtrapath):
             if seen.get(lib.upper(), 0) or seen.get(npth.upper(), 0):
                 continue
             seen[npth.upper()] = 1
-            lTOC.append((lib, npth, 'BINARY'))
+            # add lib to the TOC in the same relative path as nm
+            relpath_lib = os.path.join(os.path.dirname(nm), lib)
+            lTOC.append((relpath_lib, npth, 'BINARY'))
 
     return lTOC
 


### PR DESCRIPTION
Hello PyInstaller team,

Following up on getting pyinstaller to fully support the cryptography module, and after having contributed the pycparser hook in pull request 131, there still seems to be an issue left to be addressed on the Windows platform.

The envirnoment is:
* Windows XP 32 bit
* Python 2.7.6
* pywin32 219
* cryptography 0.4 and dependencies: cffi 0.8.2, pycparser 2.10, six 1.7.2
* Latest pyinstaller develop (commit c508ad34e6af30f31fb27268e4fce24d4fd742f2)

When running pyinstaller against a simple cryptography based program (sample at the top of https://cryptography.io/en/latest/fernet/) and, of course, having the OpenSSL libraries in the PATH, the resulting directory structure is as follows:

```
.\dist\sample\sample.exe
.\dist\sample\*.pyd, *.dll and *.manifest
.\dist\sample\cryptography\_Cryptography_cffi_*.pyd files placed here by hook-cryptography
.\dist\sample\LIBEAY32.dll
.\dist\sample\SSLEAY32.dll
```

The last two files were identified by pyinstaller as binary dependencies for one of the `_Cryptography_cffi_*.pyd` files and are OpenSSL shared libs. The limitation is as follows: if `sample.exe` is run from the `.\dist\sample` directory all works file, if it is run from some other working directory it fails because Windows can't locate the OpenSSL `*.dll` files that are needed by the `_Cryptography_cffi_*.pyd` one.

However, if the OpenSSL `*.dll` files are moved over to the `.\dist\sample\cryptography` directory, the same one containing the `_Cryptography_cffi*.pyd` file that depends on them, then running `sample.exe` works no matter what the current working directory is.

(of course, this limitation does not show up on Linux/Mac because these systems always seem to have system level available OpenSSL shared libs; and the same would go for Windows, if the shared libs would be present in the system directory)

So, the core question is: being that the OpenSSL `*.dll` files are dependencies for a particular binary which itself is "frozen" in a subdirectory of the distribution root, shouldn't they themselves be placed in that subdirectory? (and, of course, any subsequent dependencies) Should this be the general case or would it only be applicable the cryptography one?

I'm submitting a request that puts binary dependencies in the same relative path as the binary files that depend on them: this way, the dynamic library loader will find them no matter what the current working directory is. It works fine in my envirnoments (Windows, Linux and Mac) and from my understanding, this approach has no negative impacts in any other case.

What are your thoughts on this?
Thanks in advance for your feedback.