### PR TITLE
XCB: exclude only libxcb-dri

### DIFF
--- a/PyInstaller/depend/dylib.py
+++ b/PyInstaller/depend/dylib.py
@@ -89,10 +89,10 @@ _unix_excludes = {
     r'/libutil\.so\..*': 1,
     # libGL can reference some hw specific libraries (like nvidia libs).
     r'/libGL\..*': 1,
-    # libxcb changes ABI frequently (e.g.: between Ubuntu LTS releases) and is
-    # usually installed as dependency of the graphics stack anyway. No need to
-    # bundle it.
-    r'/libxcb.*\.so\..*': 1,
+    # libxcb-dri changes ABI frequently (e.g.: between Ubuntu LTS releases) and is usually installed
+    # as dependency of the graphics stack anyway. No need to bundle it.
+    r'/libxcb\.so\..*': 1,
+    r'/libxcb-dri.*\.so\..*': 1,
 }
 
 _aix_excludes = {


### PR DESCRIPTION
Changed again the exclusion pattern for libxcb. It seems that we need to exclude only libxcb itself and libxcb-dri to not have problems running applications on Ubuntu 14.04 when they are get built on Ubuntu 12.04.
