### PR TITLE
hook-sysconfig _relpath based on hook-distutils

### DIFF
--- a/PyInstaller/hooks/hook-sysconfig.py
+++ b/PyInstaller/hooks/hook-sysconfig.py
@@ -20,10 +20,25 @@ except AttributeError:
     # In Python 2.7, get_makefile_filename was private
     get_makefile_filename = sysconfig._get_makefile_filename
 
+# In virtualenv, _CONFIG_H and _MAKEFILE may have same or different
+# prefixes, depending on the version of virtualenv.
+# Try to find the correct one, which is assumed to be the longest one.
+def _find_prefix(filename):
+    if not compat.is_virtualenv:
+        return sys.prefix
+    prefixes = [sys.prefix, compat.venv_real_prefix]
+    possible_prefixes = []
+    for prefix in prefixes:
+        common = os.path.commonprefix([prefix, filename])
+        if common == prefix:
+            possible_prefixes.append(prefix)
+    possible_prefixes.sort(key=lambda p: len(p), reverse=True)
+    return possible_prefixes[0]
 
 def _relpath(filename):
     # Relative path in the dist directory.
-    return compat.relpath(os.path.dirname(filename), sys.prefix)
+    prefix = _find_prefix(filename)
+    return compat.relpath(os.path.dirname(filename), prefix)
 
 # The 'sysconfig' module requires Makefile and pyconfig.h files from
 # Python installation. 'sysconfig' parses these files to get some


### PR DESCRIPTION
Prevents Makefile being added to datas twicely.

http://www.pyinstaller.org/ticket/783#comment:7
