### PR TITLE
trying to work with signature offset

### DIFF
--- a/bootloader/common/pyi_archive.c
+++ b/bootloader/common/pyi_archive.c
@@ -254,6 +254,15 @@ int pyi_arch_open(ARCHIVE_STATUS *status)
 	if (pyi_arch_check_cookie(status, filelen) < 0)
 	{
 		VS("LOADER: %s does not contain an embedded package\n", status->archivename);
+		// Lets try to check signature_offset
+		while (filelen > (int)sizeof(COOKIE)) {
+			filelen -= 1;
+			if (pyi_arch_check_cookie(status, filelen) == 0) {
+				goto succ;
+			}
+		}
+		
+		
 #ifndef WIN32
     return -1;
 #else
@@ -277,6 +286,7 @@ int pyi_arch_open(ARCHIVE_STATUS *status)
 		VS("LOADER: package found skipping digital signature in %s\n", status->archivename);
 #endif
 	}
+	succ:
 
     /* Set the flag that Python library was not loaded yet. */
     status->is_pylib_loaded = false;


### PR DESCRIPTION
Hi everybody.

We decided to use python instead of C++ in some parts of our project to speed up the development (and pyinstaller to build binaries)

Everything worked just great until we decided to add signature to the file.

Signature is applied to the end of the file, and pyinstaller searches for the magic number only at the end of the file.

Fix is very simple: look for the magic number not only at the end of the file, but also at various offsets from the end of the file.

I understand that this solution is not ideal for many reasons:
- time consuming (if magic number is not there it will take a lot of time to run throughout file)
- not error prone - this magic number can be a normal combination of bytes inside file

But still this patch is working - and as for me, it adds quite important feature to the pyinstaller.

So, if you are interested, we can ingrate this solution together