### PR TITLE
Deal with unicode filenames

### DIFF
--- a/PyInstaller/loader/pyi_carchive.py
+++ b/PyInstaller/loader/pyi_carchive.py
@@ -68,6 +68,8 @@ class CTOC(object):
         entrylen = struct.calcsize(self.ENTRYSTRUCT)
         rslt = []
         for (dpos, dlen, ulen, flag, typcd, nm) in self.data:
+            if isinstance(nm, unicode):
+                nm = nm.encode('utf-8')
             nmlen = len(nm) + 1       # add 1 for a '\0'
             # FIXME Why are here two versions? Is it safe to remove version 4?
             # version 4


### PR DESCRIPTION
A collaborator (Toni Petrovič) of my [mikroe-uhb](https://github.com/thotypous/mikroe-uhb) project was having issues generating an executable using pyinstaller's onefile mode in the following environment:
- Python(x,y)-2.7.6.1
- PyInstaller-2.1
- cython-hidapi-master

Apparently it is the same issue as [Trac#828](http://www.pyinstaller.org/ticket/828) and [this stackoverflow report](http://stackoverflow.com/questions/18181073/struct-error-reported-in-pyinstaller).

He got the following output / stacktrace:

```
PS D:\mikroe-uhb-0.2> pyinstaller -F mikroe-uhb
33 INFO: wrote D:\mikroe-uhb-0.2\mikroe-uhb.spec
53 INFO: Testing for ability to set icons, version resources...
64 INFO: ... resource update available
66 INFO: UPX is not available.
92 INFO: Processing hook hook-os
220 INFO: Processing hook hook-time
224 INFO: Processing hook hook-cPickle
303 INFO: Processing hook hook-_sre
438 INFO: Processing hook hook-cStringIO
546 INFO: Processing hook hook-encodings
563 INFO: Processing hook hook-codecs
1042 INFO: Processing hook hook-httplib
1049 INFO: Processing hook hook-email
1176 INFO: Processing hook hook-email.message
1428 WARNING: library python%s%s required via ctypes not found
1536 INFO: Processing hook hook-xml
1623 INFO: Processing hook hook-xml.sax
1658 INFO: Processing hook hook-pyexpat
1740 INFO: Extending PYTHONPATH with D:\mikroe-uhb-0.2
1741 INFO: checking Analysis
1800 INFO: checking PYZ
1830 INFO: checking PKG
1831 INFO: building because name changed
1831 INFO: building PKG (CArchive) out00-PKG.pkg
Traceback (most recent call last):
  File "C:\Python27\Scripts\pyinstaller-script.py", line 9, in <module>
    load_entry_point('PyInstaller==2.1', 'console_scripts', 'pyinstaller')()
  File "C:\Python27\lib\site-packages\PyInstaller\main.py", line 88, in run
    run_build(opts, spec_file, pyi_config)
  File "C:\Python27\lib\site-packages\PyInstaller\main.py", line 46, in run_build
    PyInstaller.build.main(pyi_config, spec_file, **opts.__dict__)
  File "C:\Python27\lib\site-packages\PyInstaller\build.py", line 1924, in main
    build(specfile, kw.get('distpath'), kw.get('workpath'), kw.get('clean_build'))
  File "C:\Python27\lib\site-packages\PyInstaller\build.py", line 1873, in build
    execfile(spec)
  File "D:\mikroe-uhb-0.2\mikroe-uhb.spec", line 17, in <module>
    console=True )
  File "C:\Python27\lib\site-packages\PyInstaller\build.py", line 1170, in __init__
    strip_binaries=self.strip, upx_binaries=self.upx,
  File "C:\Python27\lib\site-packages\PyInstaller\build.py", line 1008, in __init__
    self.__postinit__()
  File "C:\Python27\lib\site-packages\PyInstaller\build.py", line 309, in __postinit__
    self.assemble()
  File "C:\Python27\lib\site-packages\PyInstaller\build.py", line 1069, in assemble
    archive.build(self.name, mytoc)
  File "C:\Python27\lib\site-packages\PyInstaller\loader\pyi_archive.py", line 217, in build
    self._finalize()
  File "C:\Python27\lib\site-packages\PyInstaller\loader\pyi_carchive.py", line 190, in _finalize
    self.save_toc(toc_pos)
  File "C:\Python27\lib\site-packages\PyInstaller\loader\pyi_carchive.py", line 351, in save_toc
    tocstr = self.toc.tobinary()
  File "C:\Python27\lib\site-packages\PyInstaller\loader\pyi_carchive.py", line 85, in tobinary
    nmlen + entrylen, dpos, dlen, ulen, flag, typcd, nm + pad))
struct.error: argument for 's' must be a string
```

The modification contained in this pull request solved the issue for him.
