### PR TITLE
Update hook-sysconfig.py

### DIFF
--- a/PyInstaller/hooks/hook-sysconfig.py
+++ b/PyInstaller/hooks/hook-sysconfig.py
@@ -32,8 +32,11 @@ def _find_prefix(filename):
         common = os.path.commonprefix([prefix, filename])
         if common == prefix:
             possible_prefixes.append(prefix)
-    possible_prefixes.sort(key=lambda p: len(p), reverse=True)
-    return possible_prefixes[0]
+    
+    if possible_prefixes:
+        possible_prefixes.sort(key=lambda p: len(p), reverse=True)
+        return possible_prefixes[0]
+    return sys.prefix
 
 def _relpath(filename):
     # Relative path in the dist directory.


### PR DESCRIPTION
fixes a weird issue where there may not be commonality between the prefixes (OSX).

someone may want to check my math on this one; the setup i have is on OSX mav; where Python.h is under /opt/local... (installed via macports, local python variables set by a higher level configure.ac) and the python stuff is contained within a virtual env.

this is just a quick-fix based on the first two lines of the function where we default to sys.prefix anyway.

the original error was:

```
  File "/Users/wes/.virtualenvs/xxx/lib/python2.7/site-packages/PyInstaller-2.1.1dev_12e4047-py2.7.egg/PyInstaller/hooks/hook-sysconfig.py", line 55, in <module>
    datas.append((_CONFIG_H, _relpath(_CONFIG_H)))
  File "/Users/wes/.virtualenvs/xxx/lib/python2.7/site-packages/PyInstaller-2.1.1dev_12e4047-py2.7.egg/PyInstaller/hooks/hook-sysconfig.py", line 40, in _relpath
    prefix = _find_prefix(filename)
  File "/Users/wes/.virtualenvs/xxx/lib/python2.7/site-packages/PyInstaller-2.1.1dev_12e4047-py2.7.egg/PyInstaller/hooks/hook-sysconfig.py", line 36, in _find_prefix
    return possible_prefixes[0]
IndexError: list index out of range
```

and the two inputs to the function where:

```
/Users/wes/.virtualenvs/xxx/bin/..
/opt/local/Library/Frameworks/Python.framework/Versions/2.7
```
