### PR TITLE
Link zlib witb bootloader statically on Solaris

### DIFF
--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -215,6 +215,12 @@ def configure(conf):
     if myplatform.startswith('sun'):
         conf.env.append_value('CCDEFINES', 'SUNOS')
 
+        if conf.env.CC_NAME == 'gcc':
+            # On Solaris using gcc the linker options for shared and static libraries
+            # are slightly different from other platforms.
+            conf.env['SHLIB_MARKER'] = '-Wl,-Bdynamic'
+            conf.env['STLIB_MARKER'] = '-Wl,-Bstatic'
+
     if myplatform.startswith('aix'):
         conf.env.append_value('CCDEFINES', 'AIX')
 
@@ -494,6 +500,9 @@ def build(bld):
             if sysconfig.get_config_vars('HAVE_PTHREAD_H').pop():
                 libs.append('thr')
         elif sys.platform.startswith('aix'):
+            libs = ['dl', 'm']
+            staticlibs = ['z']
+        elif sys.platform.startswith('sun'):
             libs = ['dl', 'm']
             staticlibs = ['z']
 


### PR DESCRIPTION
Similarly to AIX, link zlib with the bootloader statically on Solaris, so it does not depend if zlib will be detected on the target machine.
