### PR TITLE
Fix missing _MEIPASS attribute.

### DIFF
--- a/PyInstaller/loader/_pyi_egg_install.py
+++ b/PyInstaller/loader/_pyi_egg_install.py
@@ -31,8 +31,8 @@
 import os
 import sys
 
-d = "eggs"
-d = os.path.join(sys._MEIPASS, d)
+meipass_dir = getattr(sys, '_MEIPASS', os.path.dirname(sys.executable))
+d = os.path.join(meipass_dir, "eggs")
 
 for fn in os.listdir(d):
     sys.path.append(os.path.join(d, fn))

--- a/PyInstaller/loader/rthooks/pyi_rth_Tkinter.py
+++ b/PyInstaller/loader/rthooks/pyi_rth_Tkinter.py
@@ -12,7 +12,7 @@ import os
 import sys
 
 
-basedir = sys._MEIPASS
+basedir = getattr(sys, '_MEIPASS', os.path.dirname(sys.executable))
 
 
 tcldir = os.path.join(basedir, '_MEI', 'tcl')

--- a/PyInstaller/loader/rthooks/pyi_rth_babel.py
+++ b/PyInstaller/loader/rthooks/pyi_rth_babel.py
@@ -11,7 +11,8 @@
 import os
 import sys
 
-babel_root = os.path.join(sys._MEIPASS, "babel")
+meipass_dir = getattr(sys, '_MEIPASS', os.path.dirname(sys.executable))
+babel_root = os.path.join(meipass_dir, "babel")
 
 import babel.localedata
 import babel.core

--- a/PyInstaller/loader/rthooks/pyi_rth_django.py
+++ b/PyInstaller/loader/rthooks/pyi_rth_django.py
@@ -11,7 +11,7 @@
 import os
 import sys
 
-d = sys._MEIPASS
+d = getattr(sys, '_MEIPASS', os.path.dirname(sys.executable))
 
 import django.core.management
 import django.utils.autoreload

--- a/PyInstaller/loader/rthooks/pyi_rth_gstreamer.py
+++ b/PyInstaller/loader/rthooks/pyi_rth_gstreamer.py
@@ -18,4 +18,5 @@ os.environ['GST_REGISTRY_FORK'] = 'no'
 
 
 # Tested on OSX only.
-os.environ['GST_PLUGIN_PATH'] = os.path.join(sys._MEIPASS, 'gst_plugins')
+meipass_dir = getattr(sys, '_MEIPASS', os.path.dirname(sys.executable))
+os.environ['GST_PLUGIN_PATH'] = os.path.join(meipass_dir, 'gst_plugins')

--- a/PyInstaller/loader/rthooks/pyi_rth_mpldata.py
+++ b/PyInstaller/loader/rthooks/pyi_rth_mpldata.py
@@ -11,4 +11,5 @@
 import os
 import sys
 
-os.environ["MATPLOTLIBDATA"] = os.path.join(sys._MEIPASS, "mpl-data")
+meipass_dir = getattr(sys, '_MEIPASS', os.path.dirname(sys.executable))
+os.environ["MATPLOTLIBDATA"] = os.path.join(meipass_dir, "mpl-data")

--- a/PyInstaller/loader/rthooks/pyi_rth_qml.py
+++ b/PyInstaller/loader/rthooks/pyi_rth_qml.py
@@ -18,7 +18,8 @@
 import os
 import sys
 
-d = os.path.abspath(os.path.join(sys._MEIPASS, "qml"))
+meipass_dir = getattr(sys, '_MEIPASS', os.path.dirname(sys.executable))
+d = os.path.abspath(os.path.join(meipass_dir, "qml"))
 
 print d
 

--- a/PyInstaller/loader/rthooks/pyi_rth_qt4plugins.py
+++ b/PyInstaller/loader/rthooks/pyi_rth_qt4plugins.py
@@ -15,11 +15,11 @@
 import os
 import sys
 
-d = "qt4_plugins"
-d = os.path.join(sys._MEIPASS, d)
+meipass_dir = getattr(sys, '_MEIPASS', os.path.dirname(sys.executable))
+d = os.path.join(meipass_dir, "qt4_plugins")
 
 
-# We remove QT_PLUGIN_PATH variable, beasuse we want Qt4 to load
+# We remove QT_PLUGIN_PATH variable, because we want Qt4 to load
 # plugins only from one path.
 if 'QT_PLUGIN_PATH' in os.environ:
     # On some platforms (e.g. AIX) 'os.unsetenv()' is not available and then

--- a/PyInstaller/loader/rthooks/pyi_rth_qt5plugins.py
+++ b/PyInstaller/loader/rthooks/pyi_rth_qt5plugins.py
@@ -15,8 +15,8 @@
 import os
 import sys
 
-d = "qt5_plugins"
-d = os.path.join(sys._MEIPASS, d)
+meipass_dir = getattr(sys, '_MEIPASS', os.path.dirname(sys.executable))
+d = os.path.join(meipass_dir, "qt5_plugins")
 
 
 # We remove QT_PLUGIN_PATH variable, because we want Qt5 to load

--- a/PyInstaller/loader/rthooks/pyi_rth_usb.py
+++ b/PyInstaller/loader/rthooks/pyi_rth_usb.py
@@ -26,7 +26,7 @@ import usb.backend.openusb as openusb
 
 def get_load_func(type, candidates):
     def _load_library(find_library=None):
-        exec_path = sys._MEIPASS
+        exec_path = getattr(sys, '_MEIPASS', os.path.dirname(sys.executable))
 
         l = None
         for candidate in candidates:


### PR DESCRIPTION
This is a fix for the following error:
```
Traceback (most recent call last):
  File "<string>", line 35, in <module>
  AttributeError: 'module' object has no attribute '_MEIPASS'
```
as discussed previously in #801 (originally from http://www.pyinstaller.org/ticket/801)

In this patch we fall back on `os.path.dirname(sys.executable)` when `sys._MEIPASS` isn't present.