### PR TITLE
Fix TOC's minus operator ignoring normalized filenames.

### DIFF
--- a/PyInstaller/build.py
+++ b/PyInstaller/build.py
@@ -1665,12 +1665,18 @@ class TOC(UserList.UserList):
         fd = self.fltr.copy()
         # remove from fd if it's in other
         for tpl in other:
-            if fd.get(tpl[0], 0):
-                del fd[tpl[0]]
+            fn = tpl[0]
+            if tpl[2] == 'BINARY':
+                fn = os.path.normcase(fn)
+            if fd.get(fn, 0):
+                del fd[fn]
         rslt = TOC()
         # return only those things still in fd (preserve order)
         for tpl in self.data:
-            if fd.get(tpl[0], 0):
+            fn = tpl[0]
+            if tpl[2] == 'BINARY':
+                fn = os.path.normcase(fn)
+            if fd.get(fn, 0):
                 rslt.append(tpl)
         return rslt
 


### PR DESCRIPTION
Previously, subtracting a TOC from another one (even an empty one, as in `a.binaries = a.binaries - TOC([])`) would return a TOC that is missing tuples whose filename != its normalized filename. Specifically, this causes the VC90 runtime lib manifests to be dropped on win32.

This fix to `TOC.__sub__` considers that filenames in self.fltr are normalized, but filenames in the tuples are not.
