### PR TITLE
Issue #791 on python3 branch: distribute to setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -119,7 +119,7 @@ class my_sdist(sdist):
         return res
 
 setup(
-    install_requires=['distribute'],
+    install_requires=['setuptools'],
 
     name='PyInstaller',
     version=get_version(),


### PR DESCRIPTION
Change the requirement from distribute to setuptools, 
as was fixed for #791 on the develop branch ( 0ea8f92ac63468551135dffa67853cb12563bc6e ),
but not for the python3 branch