### PR TITLE
PY3: sysconfig hook: support pep405 style venv

### DIFF
--- a/PyInstaller/hooks/hook-distutils.py
+++ b/PyInstaller/hooks/hook-distutils.py
@@ -24,7 +24,7 @@ _MAKEFILE = sysconfig.get_makefile_filename()
 
 def _relpath(filename):
     # Relative path in the dist directory.
-    return os.path.relpath(os.path.dirname(filename), sys.prefix)
+    return os.path.relpath(os.path.dirname(filename), sys.base_prefix)
 
 # Data files in PyInstaller hook format.
 datas = [(_CONFIG_H, _relpath(_CONFIG_H))]

--- a/PyInstaller/hooks/hook-sysconfig.py
+++ b/PyInstaller/hooks/hook-sysconfig.py
@@ -23,8 +23,8 @@ _MAKEFILE = sysconfig.get_makefile_filename()
 
 def _relpath(filename):
     # Relative path in the dist directory.
-    #prefix = _find_prefix(filename)
-    return os.path.relpath(os.path.dirname(filename), sys.prefix)
+    # base_prefix exists since python3.2 to deal with venv
+    return os.path.relpath(os.path.dirname(filename), sys.base_prefix)
 
 
 datas = [(_CONFIG_H, _relpath(_CONFIG_H))]


### PR DESCRIPTION
When running PyInstaller from within a pep405 venv,
the sysconfig hook calculates the wrong relative path
(causing a SecurityAlert). The point is that in these
new venvs, the `include` dir is not copied or symlinked,
and the `pyconfig.h` path is relative to `sys.base_prefix`
(new since Python3.2). Outside a venv nothing changes.
https://www.python.org/dev/peps/pep-0405/