### PR TITLE
support python3 on windows

### DIFF
--- a/pyinstaller-gui.py
+++ b/pyinstaller-gui.py
@@ -76,7 +76,11 @@ class PyInstallerGUI:
         sys.exit(0)
 
     def makePackage(self, event):
-        commands = ['python3', 'pyinstaller.py']
+        if sys.platform.startswith('win'):
+            pythoncmd = ['py', '-3']
+        else:
+            pythoncmd = ['python3']
+        commands = pythoncmd + ['pyinstaller.py']
         if self.filetype.get():
             commands.append('--onefile')
         if self.ascii.get():


### PR DESCRIPTION
First  commit only tested on Linux, sorry.
(https://github.com/Yegers/pyinstaller/commit/26e379a7e1c3759b5d56bb1d1833c23e94efc230)

Support for Windows if python3 is in path (python 3.3+):
(https://docs.python.org/3/using/windows.html)