### PR TITLE
Use relative symlinks when moving data files out of `MacOS` folder.

### DIFF
--- a/PyInstaller/build.py
+++ b/PyInstaller/build.py
@@ -1619,7 +1619,7 @@ class BUNDLE(Target):
             res_d = os.path.join(res_dir, d)
             if os.path.isdir(abs_d) and d not in ignore_dirs:
                 shutil.move(abs_d, res_d)
-                os.symlink(res_d, abs_d)
+                os.symlink(os.path.relpath(res_d, os.path.dirname(abs_d)), abs_d)
 
         return 1
 


### PR DESCRIPTION
Absolute paths won't work on anyone else's system.