### PR TITLE
Fix zmq not being found in hook-zmq.py

### DIFF
--- a/PyInstaller/hooks/hook-zmq.py
+++ b/PyInstaller/hooks/hook-zmq.py
@@ -14,6 +14,7 @@ http://www.zeromq.org/
 """
 import glob
 import os
+import itertools
 from PyInstaller.hooks.hookutils import collect_submodules
 
 hiddenimports = ['zmq.utils.garbage']
@@ -25,9 +26,8 @@ def hook(mod):
     # For predictable behavior, the libzmq search here must be equivalent
     # to the search in zmq/__init__.py.
     zmq_directory = os.path.dirname(mod.__file__)
-    for libname in ('libzmq', 'libsodium'):
-        bundled = glob.glob(os.path.join(zmq_directory,
-                                         libname + '*.{pyd,so,dll,dylib}*'))
+    for libname, ext in itertools.product(('libzmq', 'libsodium'), ('pyd', 'so', 'dll', 'dylib')):
+        bundled = glob.glob(os.path.join(zmq_directory, libname + '.' + ext))
         if bundled:
             # zmq/__init__.py will look in os.join(sys._MEIPASS, 'zmq'),
             # so libzmq has to land there.


### PR DESCRIPTION
When `hook-zmq.py` was modified to also find libsodium, the wrong syntax was used for `glob.glob` which does not accept the `{foo,bar}` syntax (see [`fnmatch.fnmatch`](https://docs.python.org/2/library/fnmatch.html)). This change allows libzmq.pyd to be found correctly.