### PR TITLE
Analysis._format_hook_datas() fixed for #1190.

### DIFF
--- a/PyInstaller/build.py
+++ b/PyInstaller/build.py
@@ -399,7 +399,16 @@ class Analysis(Target):
         toc_datas = []
 
         for src_root_path_or_glob, trg_root_dir in getattr(hook, 'datas', []):
-            for src_root_path in glob.glob(src_root_path_or_glob):
+            # List of the absolute paths of all source paths matching the
+            # current glob.
+            src_root_paths = glob.glob(src_root_path_or_glob)
+
+            if not src_root_paths:
+                raise FileNotFoundError(
+                    'Path or glob "%s" not found or matches no files.' % (
+                    src_root_path_or_glob))
+
+            for src_root_path in src_root_paths:
                 if os.path.isfile(src_root_path):
                     toc_datas.append((
                         os.path.join(

--- a/PyInstaller/build.py
+++ b/PyInstaller/build.py
@@ -368,26 +368,61 @@ class Analysis(Target):
 
     def _format_hook_datas(self, hook):
         """
-        hook.datas is a list of globs of files or
-        directories to bundle as datafiles. For each
-        glob, a destination directory is specified.
-        """
-        datas = []
+        Convert the passed `hook.datas` list to a list of `TOC`-style 3-tuples.
 
-        for g, dest_dir in getattr(hook, 'datas', []):
-            if dest_dir:
-                dest_dir += os.sep
-            for fn in glob.glob(g):
-                if os.path.isfile(fn):
-                    datas.append((dest_dir + os.path.basename(fn), fn, 'DATA'))
-                else:
-                    for root, dirs, files in os.walk(fn):
-                        dest_dir = dest_dir + os.path.basename(fn) + os.sep
-                        for file in files:
-                            fn = os.path.join(root, file)
-                            if os.path.isfile(fn):
-                                datas.append((dest_dir + os.path.basename(fn), fn, 'DATA'))
-        return datas
+        `hook.datas` is a list of 2-tuples whose:
+
+        * First item is either:
+          * A glob matching only the absolute paths of source non-Python data
+            files.
+          * The absolute path of a directory containing only such files.
+        * Second item is either:
+          * The relative path of the target directory into which such files will
+            be recursively copied.
+          * The empty string. In such case, if the first item was:
+            * A glob, such files will be recursively copied into the top-level
+              target directory. (This is usually *not* what you want.)
+            * A directory, such files will be recursively copied into a new
+              target subdirectory whose name is such directory's basename.
+              (This is usually what you want.)
+        """
+        toc_datas = []
+
+        for src_root_path_or_glob, trg_root_dir in getattr(hook, 'datas', []):
+            for src_root_path in glob.glob(src_root_path_or_glob):
+                if os.path.isfile(src_root_path):
+                    toc_datas.append((
+                        os.path.join(
+                            trg_root_dir, os.path.basename(src_root_path)),
+                        src_root_path, 'DATA'))
+                elif os.path.isdir(src_root_path):
+                    # If no top-level target directory was passed, default this
+                    # to the basename of the top-level source directory.
+                    if not trg_root_dir:
+                        trg_root_dir = os.path.basename(src_root_path)
+
+                    for src_dir, src_subdir_basenames, src_file_basenames in\
+                        os.walk(src_root_path):
+                        # Ensure the current source directory is a subdirectory
+                        # of the passed top-level source directory. Since
+                        # os.walk() does *NOT* follow symlinks by default, this
+                        # should be the case. (But let's make sure.)
+                        assert src_dir.startswith(src_root_path)
+
+                        # Relative path of the current target directory,
+                        # obtained by removing the top-level source directory
+                        # from the current source directory (e.g., removing
+                        # "/top" from "/top/dir").
+                        trg_dir = trg_root_dir + src_dir[len(src_root_path):]
+
+                        for src_file_basename in src_file_basenames:
+                            src_file = os.path.join(src_dir, src_file_basename)
+                            if os.path.isfile(src_file):
+                                toc_datas.append((
+                                    os.path.join(trg_dir, src_file_basename),
+                                    src_file, 'DATA'))
+
+        return toc_datas
 
     # TODO What are 'check_guts' methods useful for?
     def check_guts(self, last_build):


### PR DESCRIPTION
This method was fundamentally broken when passed a directory rather than glob or file. Specifically, directory walking accumulated invalid directories via the local `dest_dir` variable. This corrects that, thereby also correcting issue #1190 and hence matplotlib integration.

To support these changes, this method has been lightly refactored. Single-and double-letter variable names have been renamed for human-readability, multi-line comments and docstrings have been added, and various subtle errors in the original have been amended.

~~In particular, the original implementation assumed that existing paths which do *not* satisfy `os.path.isfile(pathname)` must be directories. This was an erroneous assumption: since `os.path.isfile(pathname)` returns False for *all* most special files (e.g., device nodes, sockets, and symlinks to such files), such implementation would have erroneously attempted to walk non-directory special files as if they were directories. (**Yeah.** That's not gonna work.)~~ **EDIT:** *Surprisingly, that does appear to work. Well, sort of. When passed a non-directory, `os.walk()` returns the empty list rather than raising an error. Ignore this paragraph. It is bad.*

This changeset has been tested on a reasonably complex Python 3 application importing `matplotlib`, `numpy`, and `scipy`. Happily, everything appears to work as advertised now.