### PR TITLE
Debug output squelched, fixing #1196.

### DIFF
--- a/PyInstaller/loader/pyi_importers.py
+++ b/PyInstaller/loader/pyi_importers.py
@@ -469,8 +469,6 @@ class CExtensionImporter(object):
                         # Load module.
                         import _frozen_importlib
                         loader = _frozen_importlib.ExtensionFileLoader(fullname, filename)
-                        print(fullname)
-                        print(filename)
                         module = loader.load_module(fullname)
 
         except Exception:


### PR DESCRIPTION
A few more erroneous `print()` statements are now commented out. Thus dies issue #1196.