### PR TITLE
Add SciPy < 0.14.0 dynamic libraries for #1198.

### DIFF
--- a/PyInstaller/build.py
+++ b/PyInstaller/build.py
@@ -399,7 +399,16 @@ class Analysis(Target):
         toc_datas = []
 
         for src_root_path_or_glob, trg_root_dir in getattr(hook, 'datas', []):
-            for src_root_path in glob.glob(src_root_path_or_glob):
+            # List of the absolute paths of all source paths matching the
+            # current glob.
+            src_root_paths = glob.glob(src_root_path_or_glob)
+
+            if not src_root_paths:
+                raise FileNotFoundError(
+                    'Path or glob "%s" not found or matches no files.' % (
+                    src_root_path_or_glob))
+
+            for src_root_path in src_root_paths:
                 if os.path.isfile(src_root_path):
                     toc_datas.append((
                         os.path.join(

--- a/PyInstaller/build.py
+++ b/PyInstaller/build.py
@@ -368,26 +368,61 @@ class Analysis(Target):
 
     def _format_hook_datas(self, hook):
         """
-        hook.datas is a list of globs of files or
-        directories to bundle as datafiles. For each
-        glob, a destination directory is specified.
-        """
-        datas = []
+        Convert the passed `hook.datas` list to a list of `TOC`-style 3-tuples.
 
-        for g, dest_dir in getattr(hook, 'datas', []):
-            if dest_dir:
-                dest_dir += os.sep
-            for fn in glob.glob(g):
-                if os.path.isfile(fn):
-                    datas.append((dest_dir + os.path.basename(fn), fn, 'DATA'))
-                else:
-                    for root, dirs, files in os.walk(fn):
-                        dest_dir = dest_dir + os.path.basename(fn) + os.sep
-                        for file in files:
-                            fn = os.path.join(root, file)
-                            if os.path.isfile(fn):
-                                datas.append((dest_dir + os.path.basename(fn), fn, 'DATA'))
-        return datas
+        `hook.datas` is a list of 2-tuples whose:
+
+        * First item is either:
+          * A glob matching only the absolute paths of source non-Python data
+            files.
+          * The absolute path of a directory containing only such files.
+        * Second item is either:
+          * The relative path of the target directory into which such files will
+            be recursively copied.
+          * The empty string. In such case, if the first item was:
+            * A glob, such files will be recursively copied into the top-level
+              target directory. (This is usually *not* what you want.)
+            * A directory, such files will be recursively copied into a new
+              target subdirectory whose name is such directory's basename.
+              (This is usually what you want.)
+        """
+        toc_datas = []
+
+        for src_root_path_or_glob, trg_root_dir in getattr(hook, 'datas', []):
+            for src_root_path in glob.glob(src_root_path_or_glob):
+                if os.path.isfile(src_root_path):
+                    toc_datas.append((
+                        os.path.join(
+                            trg_root_dir, os.path.basename(src_root_path)),
+                        src_root_path, 'DATA'))
+                elif os.path.isdir(src_root_path):
+                    # If no top-level target directory was passed, default this
+                    # to the basename of the top-level source directory.
+                    if not trg_root_dir:
+                        trg_root_dir = os.path.basename(src_root_path)
+
+                    for src_dir, src_subdir_basenames, src_file_basenames in\
+                        os.walk(src_root_path):
+                        # Ensure the current source directory is a subdirectory
+                        # of the passed top-level source directory. Since
+                        # os.walk() does *NOT* follow symlinks by default, this
+                        # should be the case. (But let's make sure.)
+                        assert src_dir.startswith(src_root_path)
+
+                        # Relative path of the current target directory,
+                        # obtained by removing the top-level source directory
+                        # from the current source directory (e.g., removing
+                        # "/top" from "/top/dir").
+                        trg_dir = trg_root_dir + src_dir[len(src_root_path):]
+
+                        for src_file_basename in src_file_basenames:
+                            src_file = os.path.join(src_dir, src_file_basename)
+                            if os.path.isfile(src_file):
+                                toc_datas.append((
+                                    os.path.join(trg_dir, src_file_basename),
+                                    src_file, 'DATA'))
+
+        return toc_datas
 
     # TODO What are 'check_guts' methods useful for?
     def check_guts(self, last_build):

--- a/PyInstaller/hooks/hook-scipy.py
+++ b/PyInstaller/hooks/hook-scipy.py
@@ -1,0 +1,24 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+
+
+from distutils.version import LooseVersion
+from PyInstaller.utils.hooks import hookutils
+
+def hook(mod):
+    # Current SciPy version string (e.g., "0.12.1").
+    scipy_version = hookutils.exec_statement(
+        'from scipy import version; print(version.short_version)')
+
+    # SciPy < 0.14.0 uses SWIG to import dynamic libraries, which PyInstaller
+    # has difficulty detecting. If the current SciPy is < 0.14.0,
+    # unconditionally add all such libraries.
+    if LooseVersion(scipy_version) < LooseVersion('0.14.0'):
+        mod.add_binary(hookutils.collect_package_binaries('scipy'))
+
+    return mod

--- a/PyInstaller/loader/pyi_importers.py
+++ b/PyInstaller/loader/pyi_importers.py
@@ -469,8 +469,6 @@ class CExtensionImporter(object):
                         # Load module.
                         import _frozen_importlib
                         loader = _frozen_importlib.ExtensionFileLoader(fullname, filename)
-                        print(fullname)
-                        print(filename)
                         module = loader.load_module(fullname)
 
         except Exception:

--- a/PyInstaller/utils/hooks/hookutils.py
+++ b/PyInstaller/utils/hooks/hookutils.py
@@ -453,6 +453,7 @@ except ImportError as e:
     return ['backend_' + x.lower() for x in avail_bk]
 
 
+# TODO Move to "hooks/hook-OpenGL.py", the only place where this is called.
 def opengl_arrays_modules():
     """
     Return list of array modules for OpenGL module.
@@ -460,7 +461,7 @@ def opengl_arrays_modules():
     e.g. 'OpenGL.arrays.vbo'
     """
     statement = 'import OpenGL; print(OpenGL.__path__[0])'
-    opengl_mod_path = PyInstaller.hooks.hookutils.exec_statement(statement)
+    opengl_mod_path = exec_statement(statement)
     arrays_mod_path = os.path.join(opengl_mod_path, 'arrays')
     files = glob.glob(arrays_mod_path + '/*.py')
     modules = []


### PR DESCRIPTION
Due to use of SWIG in SciPy < 0.14.0, PyInstaller fails to detect and add dynamic libraries provided by older versions of SciPy. For voluminous (and *very* boring) details on why this happens, see commentary at issue #1198.

This request corrects that with a new module hook `hook-scipy.py` detecting the current version of SciPy and, if sufficiently old, manually adding all such libraries. Since doing so *really* increases the size of the resulting executable (~11MB in my case), the hook explicitly avoids doing so for newer SciPy versions.

To assist us, two new well-documented helper functions have been added to `hookutils.py`:

* `collect_package_binaries()`, a high-level helper returning a `mod.binaries`-formatted list of all dynamic libraries recursively provided by the passed Python package (e.g., `collect_package_binaries('scipy')` in our case).
* `collect_binaries()`, a low-level helper returning a `mod.binaries`-formatted list of all dynamic libraries recursively found in the passed source directory. This helper is suspiciously similar to the existing `qt5_qml_plugins_binaries()` function. For that reason, a TODO comment has been added to the latter recommending it be rewritten into the following one-liner:

    def qt5_qml_plugins_binaries(): return collect_binaries(qt5_qml_dir(), 'qml')

For safety, **no existing functionality has been modified.** One new module hook and two new hook helpers have been added. And that's it.

Cheers, guys.