### PR TITLE
Add background option.

### DIFF
--- a/PyInstaller/build.py
+++ b/PyInstaller/build.py
@@ -1101,6 +1101,7 @@ class EXE(Target):
 
         # Available options for EXE in .spec files.
         self.exclude_binaries = kwargs.get('exclude_binaries', False)
+        self.background = kwargs.get('background', False)
         self.console = kwargs.get('console', True)
         self.debug = kwargs.get('debug', False)
         self.name = kwargs.get('name', None)
@@ -1207,7 +1208,9 @@ class EXE(Target):
         return False
 
     def _bootloader_file(self, exe):
-        if not self.console:
+        if self.background and is_darwin:
+            exe = exe + 'b'
+        elif not self.console:
             exe = exe + 'w'
         if self.debug:
             exe = exe + '_d'

--- a/PyInstaller/depend/dylib.py
+++ b/PyInstaller/depend/dylib.py
@@ -27,7 +27,7 @@ import PyInstaller.log as logging
 logger = logging.getLogger(__name__)
 
 
-_BOOTLOADER_FNAMES = set(['run', 'run_d', 'runw', 'runw_d'])
+_BOOTLOADER_FNAMES = set(['run', 'run_d', 'runw', 'runw_d', 'runb', 'runb_d'])
 
 
 # Regex excludes

--- a/PyInstaller/hooks/hook-_tkinter.py
+++ b/PyInstaller/hooks/hook-_tkinter.py
@@ -50,11 +50,11 @@ def _handle_activetcl_install(tcl_root, tcltree):
     Workaround ActiveTcl on OS X
 
     PyInstaller does not package all requirements of ActiveTcl
-    (most notable teapot, which is not typically required), which
+    (most notably teapot, which is not typically required). This
     means packages built against ActiveTcl usually won't run on
     non-host systems.
 
-    This method checks if ActiveTcl is being used, and if so reports
+    This method checks if ActiveTcl is being used, and if so logs
     a warning if the problematic code is not commented out.
 
     https://github.com/pyinstaller/pyinstaller/issues/621

--- a/PyInstaller/hooks/hook-_tkinter.py
+++ b/PyInstaller/hooks/hook-_tkinter.py
@@ -45,6 +45,59 @@ def _handle_broken_tk():
                 v['TIX_LIBRARY'] = abs_path
 
 
+def _handle_activetcl_install(tcl_root, tcltree):
+    """
+    Workaround ActiveTcl on OS X
+
+    PyInstaller does not package all requirements of ActiveTcl
+    (most notable teapot, which is not typically required), which
+    means packages built against ActiveTcl usually won't run on
+    non-host systems.
+
+    This method checks if ActiveTcl is being used, and if so reports
+    a warning if the problematic code is not commented out.
+
+    https://github.com/pyinstaller/pyinstaller/issues/621
+    """
+    if not is_darwin:
+        # this is only relevant for ActiveTcl/OS X
+        return
+
+    from PyInstaller.lib.macholib import util
+    if util.in_system_path(tcl_root):
+        # system libraries do not experience this problem
+        return
+
+    # get the path to the 'init.tcl' script
+    try:
+        init_resource = [r[1] for r in tcltree if r[1].endswith('init.tcl')][0]
+    except IndexError:
+        # couldn't find the init script, return
+        return
+
+    mentions_activetcl = False
+    mentions_teapot = False
+    with open(init_resource, 'r') as init_file:
+        for line in init_file.readlines():
+            line = line.strip().lower()
+            if 'activetcl' in line and not line.startswith('#'):
+                mentions_activetcl = True
+            if 'teapot' in line and not line.startswith('#'):
+                mentions_teapot = True
+            if mentions_activetcl and mentions_teapot:
+                break
+
+    if mentions_activetcl and mentions_teapot:
+        logger.warning("""It seems you are using an ActiveTcl build of Tcl/Tk.\
+ This may not package correctly with PyInstaller.
+To fix the problem, please try commenting out all mentions of 'teapot' in:
+
+     %s
+
+See https://github.com/pyinstaller/pyinstaller/issues/621 for more information"""
+                       % init_resource)
+
+
 def _find_tk_darwin_frameworks(binaries):
     """
     Tcl and Tk are installed as Mac OS X Frameworks.
@@ -137,6 +190,10 @@ def _collect_tkfiles(mod):
 
     tcltree = Tree(tcl_root, os.path.join('_MEI', tcldir),
                    excludes=['demos', '*.lib', 'tclConfig.sh'])
+
+    # handle workaround for ActiveTcl on OS X
+    _handle_activetcl_install(tcl_root, tcltree)
+
     tktree = Tree(tk_root, os.path.join('_MEI', tkdir),
                   excludes=['demos', '*.lib', 'tkConfig.sh'])
     return (tcltree + tktree)
@@ -146,7 +203,7 @@ def hook(mod):
     # If not supported platform, skip TCL/TK detection.
     if not (is_win or is_darwin or is_unix):
         logger.info("... skipping TCL/TK detection on this platform (%s)",
-                sys.platform)
+                    sys.platform)
         return mod
 
     # Get the Tcl/Tk data files for bundling with executable.

--- a/PyInstaller/hooks/hook-_tkinter.py
+++ b/PyInstaller/hooks/hook-_tkinter.py
@@ -45,7 +45,7 @@ def _handle_broken_tk():
                 v['TIX_LIBRARY'] = abs_path
 
 
-def _handle_activetcl_install(tcl_root, tcltree):
+def _warn_if_actvivetcl_or_teapot_install(tcl_root, tcltree):
     """
     Workaround ActiveTcl on OS X
 
@@ -59,9 +59,6 @@ def _handle_activetcl_install(tcl_root, tcltree):
 
     https://github.com/pyinstaller/pyinstaller/issues/621
     """
-    if not is_darwin:
-        # this is only relevant for ActiveTcl/OS X
-        return
 
     from PyInstaller.lib.macholib import util
     if util.in_system_path(tcl_root):
@@ -80,9 +77,11 @@ def _handle_activetcl_install(tcl_root, tcltree):
     with open(init_resource, 'r') as init_file:
         for line in init_file.readlines():
             line = line.strip().lower()
-            if 'activetcl' in line and not line.startswith('#'):
+            if line.startswith('#'):
+                continue
+            if 'activetcl' in line:
                 mentions_activetcl = True
-            if 'teapot' in line and not line.startswith('#'):
+            if 'teapot' in line:
                 mentions_teapot = True
             if mentions_activetcl and mentions_teapot:
                 break
@@ -191,8 +190,9 @@ def _collect_tkfiles(mod):
     tcltree = Tree(tcl_root, os.path.join('_MEI', tcldir),
                    excludes=['demos', '*.lib', 'tclConfig.sh'])
 
-    # handle workaround for ActiveTcl on OS X
-    _handle_activetcl_install(tcl_root, tcltree)
+    if is_darwin:
+        # handle workaround for ActiveTcl on OS X
+        _warn_if_actvivetcl_or_teapot_install(tcl_root, tcltree)
 
     tktree = Tree(tk_root, os.path.join('_MEI', tkdir),
                   excludes=['demos', '*.lib', 'tkConfig.sh'])

--- a/PyInstaller/makespec.py
+++ b/PyInstaller/makespec.py
@@ -45,6 +45,7 @@ exe = EXE(pyz,
           debug=%(debug)s,
           strip=%(strip)s,
           upx=%(upx)s,
+          background=%(background)s,
           console=%(console)s %(exe_options)s)
 """
 
@@ -67,6 +68,7 @@ exe = EXE(pyz,
           debug=%(debug)s,
           strip=%(strip)s,
           upx=%(upx)s,
+          background=%(background)s,
           console=%(console)s %(exe_options)s)
 coll = COLLECT(exe,
                a.binaries,
@@ -96,6 +98,7 @@ exe = EXE(pyz,
           debug=%(debug)s,
           strip=%(strip)s,
           upx=%(upx)s,
+          background=%(background)s,
           console=%(console)s %(exe_options)s)
 dll = DLL(pyz,
           a.scripts,
@@ -284,6 +287,12 @@ def __add_options(parser):
                       'name for code signing purposes. The usual form is a hierarchical name '
                       'in reverse DNS notation. For example: com.mycompany.department.appname '
                       "(default: first script's basename)")
+    g.add_option("-b", "--background", dest="background",
+                 action="store_true",
+                 help="Mac OS X: run this app entirely in the background "
+                      "not showing up in the dock or in CMD-Tab."
+                      "This option is ignored on non OS X systems."
+                      "This option enables windowed mode by default.")
 
 
 def main(scripts, name=None, onefile=False,
@@ -291,7 +300,8 @@ def main(scripts, name=None, onefile=False,
          pathex=[], version_file=None, specpath=DEFAULT_SPECPATH,
          icon_file=None, manifest=None, resources=[], bundle_identifier=None,
          hiddenimports=None, hookspath=None, key=None, runtime_hooks=[],
-         excludes=[], uac_admin=False, uac_uiaccess=False, **kwargs):
+         excludes=[], uac_admin=False, uac_uiaccess=False, background=False,
+         **kwargs):
     # If appname is not specified - use the basename of the main script as name.
     if name is None:
         name = os.path.splitext(os.path.basename(scripts[0]))[0]
@@ -352,6 +362,9 @@ def main(scripts, name=None, onefile=False,
     hiddenimports = hiddenimports or []
     scripts = map(Path, scripts)
 
+    if background:
+        console = False
+
     if key:
         # Tries to import PyCrypto since we need it for bytecode obfuscation. Also make sure its
         # version is >= 2.4.
@@ -393,6 +406,8 @@ def main(scripts, name=None, onefile=False,
         'excludes': excludes,
         # only Windows and Mac OS X distinguish windowed and console apps
         'console': console,
+        # Mac OS X apps show up in the dock bar unless background is set.
+        'background': background,
         # Icon filename. Only OSX uses this item.
         'icon': icon_file,
         # .app bundle identifier. Only OSX uses this item.

--- a/bootloader/common/pyi_launch.c
+++ b/bootloader/common/pyi_launch.c
@@ -408,7 +408,7 @@ done:
 
 void pyi_launch_initialize(const char *executable, const char *extractionpath)
 {
-    #if defined(__APPLE__) && defined(WINDOWED)
+    #if defined(__APPLE__) && defined(WINDOWED) && !defined(BACKGROUND)
     /*
      * On OS X this ensures that the application is handled as GUI app.
      * Call TransformProcessType() in the child process.

--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -372,6 +372,14 @@ def configure(conf):
         # conf.env.append_value('LINKFLAGS', '-framework')
         # conf.env.append_value('LINKFLAGS', 'ApplicationServices')
 
+    dbgb = conf.env.copy() # BACKGROUND DEBUG environment
+    dbgb.set_variant('debugb') # separate subfolder for building
+    dbgb.detach()
+
+    ## setup background DEBUG environment
+    conf.set_env_name('debugb', dbgb)
+    conf.setenv('debugb')
+    conf.env.append_value('CCDEFINES', 'BACKGROUND')
 
     ## setup RELEASE environment
     conf.set_env_name('release', rel)
@@ -399,6 +407,14 @@ def configure(conf):
         # conf.env.append_value('LINKFLAGS', '-framework')
         # conf.env.append_value('LINKFLAGS', 'ApplicationServices')
 
+    relb = conf.env.copy() # BACKGROUND RELEASE environment
+    relb.set_variant('releaseb') # separate subfolder for building
+    relb.detach()
+
+    ## setup background RELEASE environment
+    conf.set_env_name('releaseb', relb)
+    conf.setenv('releaseb')
+    conf.env.append_value('CCDEFINES', 'BACKGROUND')
 
 # TODO Use 'strip' command to decrease the size of compiled bootloaders.
 def build(bld):
@@ -414,7 +430,8 @@ def build(bld):
     install_path = '../../PyInstaller/bootloader/' + platform.system() + "-" + bld.env.MYARCH
     if bld.env.MYMACHINE:
         install_path += '-' + bld.env.MYMACHINE
-    targets = dict(release='run', debug='run_d', releasew='runw', debugw='runw_d')
+    targets = dict(release='run', debug='run_d', releasew='runw', debugw='runw_d',
+                   releaseb='run_b', debugb='runb_d')
 
     if myplatform.startswith('win'):
 
@@ -445,7 +462,7 @@ def build(bld):
 
         # windowed
 
-        for key in ('releasew', 'debugw'):
+        for key in ('releasew', 'debugw', 'releaseb', 'debugb'):
             bld(
                 features = 'cc cprogram',
                 source = bld.path.ant_glob('windows/utils.c windows/runw.rc common/*.c'), # uses different RC file (icon)
@@ -481,7 +498,8 @@ def build(bld):
 
         ## inprocsrvr windowed
 
-        for key, value in dict(releasew='inprocsrvrw', debugw='inprocsrvrw_d').items():
+        for key, value in dict(releasew='inprocsrvrw', debugw='inprocsrvrw_d',
+                               releaseb='inprocsrvrw', debugb='inprocsrvrw_d').items():
             bld(
                 features = 'cc cshlib',
                 source = bld.path.ant_glob('common/pyi_*.c windows/*.c'),


### PR DESCRIPTION
The background option enables OSX apps to avoid displaying an icon in the dock when it doesn't make since to do so. Setting background to True in EXE uses a new background loader that doesn't have the window loader's icon properties but is otherwise identical.