### PR TITLE
Add background option.

### DIFF
--- a/PyInstaller/build.py
+++ b/PyInstaller/build.py
@@ -1101,6 +1101,7 @@ class EXE(Target):
 
         # Available options for EXE in .spec files.
         self.exclude_binaries = kwargs.get('exclude_binaries', False)
+        self.background = kwargs.get('background', False)
         self.console = kwargs.get('console', True)
         self.debug = kwargs.get('debug', False)
         self.name = kwargs.get('name', None)
@@ -1207,7 +1208,9 @@ class EXE(Target):
         return False
 
     def _bootloader_file(self, exe):
-        if not self.console:
+        if self.background and is_darwin:
+            exe = exe + 'b'
+        elif not self.console:
             exe = exe + 'w'
         if self.debug:
             exe = exe + '_d'

--- a/PyInstaller/depend/dylib.py
+++ b/PyInstaller/depend/dylib.py
@@ -27,7 +27,7 @@ import PyInstaller.log as logging
 logger = logging.getLogger(__name__)
 
 
-_BOOTLOADER_FNAMES = set(['run', 'run_d', 'runw', 'runw_d'])
+_BOOTLOADER_FNAMES = set(['run', 'run_d', 'runw', 'runw_d', 'runb', 'runb_d'])
 
 
 # Regex excludes

--- a/PyInstaller/makespec.py
+++ b/PyInstaller/makespec.py
@@ -45,6 +45,7 @@ exe = EXE(pyz,
           debug=%(debug)s,
           strip=%(strip)s,
           upx=%(upx)s,
+          background=%(background)s,
           console=%(console)s %(exe_options)s)
 """
 
@@ -67,6 +68,7 @@ exe = EXE(pyz,
           debug=%(debug)s,
           strip=%(strip)s,
           upx=%(upx)s,
+          background=%(background)s,
           console=%(console)s %(exe_options)s)
 coll = COLLECT(exe,
                a.binaries,
@@ -96,6 +98,7 @@ exe = EXE(pyz,
           debug=%(debug)s,
           strip=%(strip)s,
           upx=%(upx)s,
+          background=%(background)s,
           console=%(console)s %(exe_options)s)
 dll = DLL(pyz,
           a.scripts,
@@ -284,6 +287,12 @@ def __add_options(parser):
                       'name for code signing purposes. The usual form is a hierarchical name '
                       'in reverse DNS notation. For example: com.mycompany.department.appname '
                       "(default: first script's basename)")
+    g.add_option("-b", "--background", dest="background",
+                 action="store_true",
+                 help="Mac OS X: run this app entirely in the background "
+                      "not showing up in the dock or in CMD-Tab."
+                      "This option is ignored on non OS X systems."
+                      "This option enables windowed mode by default.")
 
 
 def main(scripts, name=None, onefile=False,
@@ -291,7 +300,8 @@ def main(scripts, name=None, onefile=False,
          pathex=[], version_file=None, specpath=DEFAULT_SPECPATH,
          icon_file=None, manifest=None, resources=[], bundle_identifier=None,
          hiddenimports=None, hookspath=None, key=None, runtime_hooks=[],
-         excludes=[], uac_admin=False, uac_uiaccess=False, **kwargs):
+         excludes=[], uac_admin=False, uac_uiaccess=False, background=False,
+         **kwargs):
     # If appname is not specified - use the basename of the main script as name.
     if name is None:
         name = os.path.splitext(os.path.basename(scripts[0]))[0]
@@ -376,6 +386,9 @@ def main(scripts, name=None, onefile=False,
     else:
         cipher_init = cipher_absent_template
 
+    if background:
+        console = False
+
     d = {'scripts': scripts,
         'pathex': pathex,
         'hiddenimports': hiddenimports,
@@ -393,6 +406,8 @@ def main(scripts, name=None, onefile=False,
         'excludes': excludes,
         # only Windows and Mac OS X distinguish windowed and console apps
         'console': console,
+        # Mac OS X apps show up in the dock bar unless background is set.
+        'background': background,
         # Icon filename. Only OSX uses this item.
         'icon': icon_file,
         # .app bundle identifier. Only OSX uses this item.

--- a/bootloader/common/pyi_launch.c
+++ b/bootloader/common/pyi_launch.c
@@ -408,7 +408,7 @@ done:
 
 void pyi_launch_initialize(const char *executable, const char *extractionpath)
 {
-    #if defined(__APPLE__) && defined(WINDOWED)
+    #if defined(__APPLE__) && defined(WINDOWED) && !defined(BACKGROUND)
     /*
      * On OS X this ensures that the application is handled as GUI app.
      * Call TransformProcessType() in the child process.

--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -372,6 +372,14 @@ def configure(conf):
         # conf.env.append_value('LINKFLAGS', '-framework')
         # conf.env.append_value('LINKFLAGS', 'ApplicationServices')
 
+    dbgb = conf.env.copy() # BACKGROUND DEBUG environment
+    dbgb.set_variant('debugb') # separate subfolder for building
+    dbgb.detach()
+
+    ## setup background DEBUG environment
+    conf.set_env_name('debugb', dbgb)
+    conf.setenv('debugb')
+    conf.env.append_value('CCDEFINES', 'BACKGROUND')
 
     ## setup RELEASE environment
     conf.set_env_name('release', rel)
@@ -399,6 +407,14 @@ def configure(conf):
         # conf.env.append_value('LINKFLAGS', '-framework')
         # conf.env.append_value('LINKFLAGS', 'ApplicationServices')
 
+    relb = conf.env.copy() # BACKGROUND RELEASE environment
+    relb.set_variant('releaseb') # separate subfolder for building
+    relb.detach()
+
+    ## setup background RELEASE environment
+    conf.set_env_name('releaseb', relb)
+    conf.setenv('releaseb')
+    conf.env.append_value('CCDEFINES', 'BACKGROUND')
 
 # TODO Use 'strip' command to decrease the size of compiled bootloaders.
 def build(bld):
@@ -414,7 +430,8 @@ def build(bld):
     install_path = '../../PyInstaller/bootloader/' + platform.system() + "-" + bld.env.MYARCH
     if bld.env.MYMACHINE:
         install_path += '-' + bld.env.MYMACHINE
-    targets = dict(release='run', debug='run_d', releasew='runw', debugw='runw_d')
+    targets = dict(release='run', debug='run_d', releasew='runw', debugw='runw_d',
+                   releaseb='runb', debugb='runb_d')
 
     if myplatform.startswith('win'):
 
@@ -445,7 +462,7 @@ def build(bld):
 
         # windowed
 
-        for key in ('releasew', 'debugw'):
+        for key in ('releasew', 'debugw', 'releaseb', 'debugb'):
             bld(
                 features = 'cc cprogram',
                 source = bld.path.ant_glob('windows/utils.c windows/runw.rc common/*.c'), # uses different RC file (icon)
@@ -481,7 +498,8 @@ def build(bld):
 
         ## inprocsrvr windowed
 
-        for key, value in dict(releasew='inprocsrvrw', debugw='inprocsrvrw_d').items():
+        for key, value in dict(releasew='inprocsrvrw', debugw='inprocsrvrw_d',
+                               releaseb='inprocsrvrw', debugb='inprocsrvrw_d').items():
             bld(
                 features = 'cc cshlib',
                 source = bld.path.ant_glob('common/pyi_*.c windows/*.c'),


### PR DESCRIPTION
The background option enables OSX apps to avoid displaying an icon in the dock when it doesn't make since to do so. Setting background to True in EXE uses a new background loader that doesn't have the window bootloader's icon properties but is otherwise identical. The specfile generator also has a background option that is set to False by default. The background option should only be used with console=False.

(I had some rebasing issues with the last one and Github isn't letting me reopen the old PR)
