### PR TITLE
opengl_arrays_modules() fixed, fixing #1210.

### DIFF
--- a/PyInstaller/utils/hooks/hookutils.py
+++ b/PyInstaller/utils/hooks/hookutils.py
@@ -451,6 +451,7 @@ except ImportError as e:
     return ['backend_' + x.lower() for x in avail_bk]
 
 
+# TODO Move to "hooks/hook-OpenGL.py", the only place where this is called.
 def opengl_arrays_modules():
     """
     Return list of array modules for OpenGL module.
@@ -458,7 +459,7 @@ def opengl_arrays_modules():
     e.g. 'OpenGL.arrays.vbo'
     """
     statement = 'import OpenGL; print(OpenGL.__path__[0])'
-    opengl_mod_path = PyInstaller.hooks.hookutils.exec_statement(statement)
+    opengl_mod_path = exec_statement(statement)
     arrays_mod_path = os.path.join(opengl_mod_path, 'arrays')
     files = glob.glob(arrays_mod_path + '/*.py')
     modules = []


### PR DESCRIPTION
The utility function `opengl_arrays_modules()` called `exec_statement()` in a fundamentally broken manner, thereby breaking the `hook-OpenGL.py` hook. This fixes that, as well as adding a **TODO** comment suggesting that function be moved directly into that hook. (It's not called anywhere else. Time to put down stray dogs, I reckon.)

See #1210 for curmudgeonly details.