### PR TITLE
__wrap_python() docstrings preserved, fixing #1212.

### DIFF
--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -79,10 +79,6 @@ _OLD_OPTIONS = [
     ]
 
 
-# Options for python interpreter when invoked in a subprocess.
-_PYOPTS = __debug__ and '-O' or ''
-
-
 # In a virtual environment created by virtualenv (github.com/pypa/virtualenv)
 # there exists sys.real_prefix with the path to the base Python
 # installation from which the virtual environment was created. This is true regardless of
@@ -273,9 +269,6 @@ def __wrap_python(args, kwargs):
         mapping = {'32bit': '-i386', '64bit': '-x86_64'}
         py_prefix = ['arch', mapping[architecture()]]
         cmdargs = py_prefix + cmdargs
-
-    if _PYOPTS:
-        cmdargs.append(_PYOPTS)
 
     cmdargs.extend(args)
     return cmdargs, kwargs


### PR DESCRIPTION
Previously, `compat.__wrap_python()` conditionally passed option `-O` to the Python interpreter run by subprocesses (e.g., hook utility functions). This stripped docstrings from *all* objects, including methods decorated by decorators raising exceptions on docstring absence. This includes IPython's `@py3compat.doctest_refactor_print` decorator, thus raising exceptions on IPython importation and hence our IPython hook, which indirectly imports IPython via the `hookutils.collect_data_files()` utility function.

This commit fixes that by preventing `__wrap_python()` from passing `-O` **at all**. This option is inherently unsafe and hence *always* the wrong thing to do. Oddly, `__wrap_python()` passed this option via the private global `_PYOPTS`, which has no other use in the codebase. (This is trivial to verify.)

In the interests of [KISS](https://people.apache.org/~fhanik/kiss.html) (the principle, not the horrible band), this global has been killed. It will not be missed.

See #1212 for gratuitous details.