### PR TITLE
Tcl/Tk data file bundling fixed.

### DIFF
--- a/PyInstaller/build.py
+++ b/PyInstaller/build.py
@@ -637,6 +637,9 @@ class Analysis(Target):
                     name = os.path.basename(f)[5:-3]
                     custom_hooks_mod_cache[name] = pth
 
+        # TODO "temp_toc" appears to be unused and have no side effects.
+        # Remove, please.
+
         # Now find regular hooks and execute them. Get a new TOC, in part
         # because graphing a runtime hook might have added some names, but
         # also because regular hooks can apply to extensions and builtins.
@@ -690,7 +693,11 @@ class Analysis(Target):
                     # as with hidden imports, add to graph as called by imported_name
                     self.graph.run_script(item, from_node)
                 for item in mod._added_binaries:
+                    assert(item[2] == 'BINARY')
                     self.binaries.append(item)  # Supposed to be TOC form (n,p,'BINARY')
+                for item in mod.datas:
+                    assert(item[2] == 'DATA')
+                    self.datas.append(item)  # Supposed to be TOC form (n,p,'DATA')
                 for item in mod._deleted_imports:
                     # Remove the graph link between the hooked module and item.
                     # This removes the 'item' node from the graph if no other

--- a/PyInstaller/hooks/hook-_tkinter.py
+++ b/PyInstaller/hooks/hook-_tkinter.py
@@ -11,66 +11,68 @@
 import os
 import sys
 
-import PyInstaller.depend.bindepend
-
 from PyInstaller.compat import is_win, is_darwin, is_unix, is_venv, base_prefix
 from PyInstaller.compat import modname_tkinter
+from PyInstaller.depend.bindepend import selectImports, getImports
 from PyInstaller.build import Tree
 from PyInstaller.utils.hooks.hookutils import exec_statement, logger
 
 
-def _handle_broken_tk():
+def _handle_broken_tcl_tk():
     """
-    Workaround for broken Tcl/Tk detection in virtualenv on Windows.
+    When freezing from a Windows venv, overwrite the values of the standard
+    `${TCL_LIBRARY}`, `${TK_LIBRARY}`, and `${TIX_LIBRARY}` environment
+    variables.
 
-    There is a bug in older versions of virtualenv in setting paths
-    to Tcl/Tk properly. PyInstaller running in virtualenv is then
-    not able to find Tcl/Tk.
+    This is a workaround for broken Tcl/Tk detection in Windows virtual
+    environments. Older versions of `virtualenv` set such variables erroneously,
+    preventing PyInstaller from properly detecting Tcl/Tk. This issue has been
+    noted for `virtualenv` under Python 2.4 and Windows 7.
 
-    This issue has been experienced in virtualenv with Python 2.4 on Win7.
-
+    See Also
+    -------
     https://github.com/pypa/virtualenv/issues/93
     """
     if is_win and is_venv:
         basedir = os.path.join(base_prefix, 'tcl')
         files = os.listdir(basedir)
-        v = os.environ
+
         # Detect Tcl/Tk paths.
         for f in files:
             abs_path = os.path.join(basedir, f)
             if f.startswith('tcl') and os.path.isdir(abs_path):
-                v['TCL_LIBRARY'] = abs_path
-            if f.startswith('tk') and os.path.isdir(abs_path):
-                v['TK_LIBRARY'] = abs_path
-            if f.startswith('tix') and os.path.isdir(abs_path):
-                v['TIX_LIBRARY'] = abs_path
+                os.environ['TCL_LIBRARY'] = abs_path
+            elif f.startswith('tk') and os.path.isdir(abs_path):
+                os.environ['TK_LIBRARY'] = abs_path
+            elif f.startswith('tix') and os.path.isdir(abs_path):
+                os.environ['TIX_LIBRARY'] = abs_path
 
 
-def _warn_if_actvivetcl_or_teapot_install(tcl_root, tcltree):
+def _warn_if_activetcl_or_teapot_installed(tcl_root, tcltree):
     """
-    Workaround ActiveTcl on OS X
+    If the current Tcl installation is a Teapot-distributed version of ActiveTcl
+    *and* the current platform is OS X, log a non-fatal warning that the
+    resulting executable will (probably) fail to run on non-host systems.
 
-    PyInstaller does not package all requirements of ActiveTcl
-    (most notably teapot, which is not typically required). This
-    means packages built against ActiveTcl usually won't run on
-    non-host systems.
+    PyInstaller does *not* freeze all ActiveTcl dependencies -- including
+    Teapot, which is typically ignorable. Since Teapot is *not* ignorable in
+    this case, this function warns of impending failure.
 
-    This method checks if ActiveTcl is being used, and if so logs
-    a warning if the problematic code is not commented out.
-
+    See Also
+    -------
     https://github.com/pyinstaller/pyinstaller/issues/621
     """
-
     from PyInstaller.lib.macholib import util
+
+    # System libraries do not experience this problem.
     if util.in_system_path(tcl_root):
-        # system libraries do not experience this problem
         return
 
-    # get the path to the 'init.tcl' script
+    # Absolute path of the "init.tcl" script.
     try:
         init_resource = [r[1] for r in tcltree if r[1].endswith('init.tcl')][0]
+    # If such script could not be found, silently return.
     except IndexError:
-        # couldn't find the init script, return
         return
 
     mentions_activetcl = False
@@ -88,58 +90,73 @@ def _warn_if_actvivetcl_or_teapot_install(tcl_root, tcltree):
                 break
 
     if mentions_activetcl and mentions_teapot:
-        logger.warning("""It seems you are using an ActiveTcl build of Tcl/Tk.\
- This may not package correctly with PyInstaller.
-To fix the problem, please try commenting out all mentions of 'teapot' in:
+        logger.warning(
+            """
+You appear to be using an ActiveTcl build of Tcl/Tk, which PyInstaller has
+difficulty freezing. To fix this, comment out all references to "teapot" in:
 
      %s
 
-See https://github.com/pyinstaller/pyinstaller/issues/621 for more information"""
-                       % init_resource)
+See https://github.com/pyinstaller/pyinstaller/issues/621 for more information.
+            """ % init_resource)
 
 
-def _find_tk_darwin_frameworks(binaries):
+def _find_tcl_tk_darwin_frameworks(binaries):
     """
-    Tcl and Tk are installed as Mac OS X Frameworks.
+    Get an OS X-specific 2-tuple of the absolute paths of the top-level
+    external data directories for both Tcl and Tk, respectively.
+
+    Under OS X, Tcl and Tk are installed as Frameworks requiring special care.
+
+    Returns
+    -------
+    list
+        2-tuple whose first element is the value of `${TCL_LIBRARY}` and whose
+        second element is the value of `${TK_LIBRARY}`.
     """
     tcl_root = tk_root = None
     for nm, fnm in binaries:
         if nm == 'Tcl':
             tcl_root = os.path.join(os.path.dirname(fnm), 'Resources/Scripts')
-        if nm == 'Tk':
-            tk_root = os.path.join(os.path.dirname(fnm), 'Resources/Scripts')
+        elif nm == 'Tk':
+            tk_root =  os.path.join(os.path.dirname(fnm), 'Resources/Scripts')
     return tcl_root, tk_root
 
 
-def _find_tk_tclshell():
+def _find_tcl_tk_dir():
     """
-    Get paths to Tcl/Tk from the Tcl shell command 'info library'.
+    Get a platform-agnostic 2-tuple of the absolute paths of the top-level
+    external data directories for both Tcl and Tk, respectively.
 
-    This command will return path to TCL_LIBRARY.
-    On most systems are Tcl and Tk libraries installed
-    in the same prefix.
+    Returns
+    -------
+    list
+        2-tuple whose first element is the value of `${TCL_LIBRARY}` and whose
+        second element is the value of `${TK_LIBRARY}`.
     """
-    tcl_root = tk_root = None
-
     # Python code to get path to TCL_LIBRARY.
-    code = 'from %s import Tcl; t = Tcl(); print(t.eval("info library"))' % modname_tkinter
+    tcl_root = exec_statement(
+        'from %s import Tcl; print(Tcl().eval("info library"))' % modname_tkinter)
+    tk_version = exec_statement(
+        'from _tkinter import TK_VERSION; print(TK_VERSION)')
 
-    tcl_root = exec_statement(code)
-    tk_version = exec_statement('from _tkinter import TK_VERSION as v; print(v)')
     # TK_LIBRARY is in the same prefix as Tcl.
     tk_root = os.path.join(os.path.dirname(tcl_root), 'tk%s' % tk_version)
     return tcl_root, tk_root
 
 
-def _find_tk(mod):
+def _find_tcl_tk(mod):
     """
-    Find paths with Tcl and Tk data files to be bundled by PyInstaller.
+    Get a platform-specific 2-tuple of the absolute paths of the top-level
+    external data directories for both Tcl and Tk, respectively.
 
-    Return:
-        tcl_root  path to Tcl data files.
-        tk_root   path to Tk data files.
+    Returns
+    -------
+    list
+        2-tuple whose first element is the value of `${TCL_LIBRARY}` and whose
+        second element is the value of `${TK_LIBRARY}`.
     """
-    bins = PyInstaller.depend.bindepend.selectImports(mod.__file__)
+    bins = selectImports(mod.__file__)
 
     if is_darwin:
         # _tkinter depends on system Tcl/Tk frameworks.
@@ -148,7 +165,7 @@ def _find_tk(mod):
             # 'mod.binaries' can't be used because on Mac OS X _tkinter.so
             # might depend on system Tcl/Tk frameworks and these are not
             # included in 'mod.binaries'.
-            bins = PyInstaller.depend.bindepend.getImports(mod.__file__)
+            bins = getImports(mod.__file__)
             # Reformat data structure from
             #     set(['lib1', 'lib2', 'lib3'])
             # to
@@ -164,55 +181,64 @@ def _find_tk(mod):
         # _tkinter depends on Tcl/Tk compiled as frameworks.
         path_to_tcl = bins[0][1]
         if 'Library/Frameworks' in path_to_tcl:
-            tcl_tk = _find_tk_darwin_frameworks(bins)
+            tcl_tk = _find_tcl_tk_darwin_frameworks(bins)
         # Tcl/Tk compiled as on Linux other Unixes.
         # For example this is the case of Tcl/Tk from macports.
         else:
-            tcl_tk = _find_tk_tclshell()
+            tcl_tk = _find_tcl_tk_dir()
 
     else:
-        tcl_tk = _find_tk_tclshell()
+        tcl_tk = _find_tcl_tk_dir()
 
     return tcl_tk
 
 
-def _collect_tkfiles(mod):
+def _collect_tcl_tk_files(mod):
+    """
+    Get a list of TOC-style 3-tuples describing all external Tcl/Tk data files.
+
+    Returns
+    -------
+    Tree
+        Such list.
+    """
     # Workaround for broken Tcl/Tk detection in virtualenv on Windows.
-    _handle_broken_tk()
+    _handle_broken_tcl_tk()
 
-    tcl_root, tk_root = _find_tk(mod)
+    tcl_root, tk_root = _find_tcl_tk(mod)
 
+    # TODO Shouldn't these be fatal exceptions?
     if not tcl_root:
-        logger.error("TCL/TK seams to be not properly installed on this system")
+        logger.error('Tcl/Tk improperly installed on this system.')
+        return []
+    if not os.path.isdir(tcl_root):
+        logger.error('Tcl data directory "%s" not found.', tcl_root)
+        return []
+    if not os.path.isdir(tk_root):
+        logger.error('Tk data directory "%s" not found.', tk_root)
         return []
 
-    tcldir = "tcl"
-    tkdir = "tk"
+    tcltree = Tree(
+        tcl_root, prefix='tcl', excludes=['demos', '*.lib', 'tclConfig.sh'])
+    tktree = Tree(
+        tk_root, prefix='tk', excludes=['demos', '*.lib', 'tkConfig.sh'])
 
-    tcltree = Tree(tcl_root, os.path.join('_MEI', tcldir),
-                   excludes=['demos', '*.lib', 'tclConfig.sh'])
-
+    # If the current Tcl installation is a Teapot-distributed version of
+    # ActiveTcl and the current platform is OS X, warn that this is bad.
     if is_darwin:
-        # handle workaround for ActiveTcl on OS X
-        _warn_if_actvivetcl_or_teapot_install(tcl_root, tcltree)
+        _warn_if_activetcl_or_teapot_installed(tcl_root, tcltree)
 
-    tktree = Tree(tk_root, os.path.join('_MEI', tkdir),
-                  excludes=['demos', '*.lib', 'tkConfig.sh'])
     return (tcltree + tktree)
 
 
 def hook(mod):
-    # If not supported platform, skip TCL/TK detection.
-    if not (is_win or is_darwin or is_unix):
-        logger.info("... skipping TCL/TK detection on this platform (%s)",
-                    sys.platform)
-        return mod
-
-    # Get the Tcl/Tk data files for bundling with executable.
-    #try:
-    tk_files = _collect_tkfiles(mod)
-    mod.datas.extend(tk_files)
-    #except:
-    #logger.error("could not find TCL/TK")
+    """
+    Freeze all external Tcl/Tk data files if this is a supported platform *or*
+    log a non-fatal error otherwise.
+    """
+    if is_win or is_darwin or is_unix:
+        mod.add_data(_collect_tcl_tk_files(mod))
+    else:
+        logger.error("... skipping Tcl/Tk handling on unsupported platform %s", sys.platform)
 
     return mod

--- a/PyInstaller/loader/rthooks/pyi_rth__tkinter.py
+++ b/PyInstaller/loader/rthooks/pyi_rth__tkinter.py
@@ -12,13 +12,14 @@ import os
 import sys
 
 
-basedir = sys._MEIPASS
+tcldir = os.path.join(sys._MEIPASS, 'tcl')
+tkdir = os.path.join(sys._MEIPASS, 'tk')
 
+if not os.path.isdir(tcldir):
+    raise FileNotFoundError('Tcl data directory "%s" not found.' % (tcldir))
+if not os.path.isdir(tkdir):
+    raise FileNotFoundError('Tk data directory "%s" not found.' % (tkdir))
 
-tcldir = os.path.join(basedir, '_MEI', 'tcl')
-tkdir = os.path.join(basedir, '_MEI', 'tk')
-
-
-# Directories with .tcl files.
+# Notify "tkinter" of such directories.
 os.environ["TCL_LIBRARY"] = tcldir
 os.environ["TK_LIBRARY"] = tkdir


### PR DESCRIPTION
## Synopsis

This pull request properly bundles Tcl/Tk data files with frozen executables importing `tkinter`, completing [prior work](https://github.com/pyinstaller/pyinstaller/pull/1174) by [matysek](https://github.com/matysek) and others. It does *not* fix  #1164. It merely ensures that when we *do* fix #1164, everything will work as expected. Which seems nice.

~~This pull request now fixes  #1164. Don't ask how, as you *really* don't want to know. (See the conversation at #1164 for details. Take it from me, though: it's bad. **Real bad.**)~~

**EDIT:** The fanatically awesome [codewarrior0](https://github.com/codewarrior0) appears to have [independently solved #1164](https://github.com/codewarrior0/pyinstaller/commit/a52e1a7ab006c0628b86bca615a68f693d8ca0a4). This pull request together with that commit *should* correct all outstanding `tkinter` issues.

## Details

The `_tkinter` module hook `hooks/hook-_tkinter.py` *and* runtime hook `loader/rthooks/pyi_rth__tkinter.py` are both noops. They don't actually *do* anything – despite taking several hundred lines of code to do it.

The crux of the issue is `_tkinter`'s `hook()` function:

    def hook(mod):
        # If not supported platform, skip TCL/TK detection.
        if is_win or is_darwin or is_unix:
            # Get the Tcl/Tk data files for bundling with executable.
            tk_files = _collect_tkfiles(mod)
            mod.datas.extend(tk_files)
        else:
            logger.info("... skipping TCL/TK detection on this platform (%s)", sys.platform)
        return mod

Looks great, right? **Wrong.** The PyInstaller codebase currently ignores *all* modification of `mod.datas`, as documented by the `FakeModule` class docstring:

> The new `mod` provides these members **for examination only** but has methods for modification:

Of course, the documentation lies. There is *no* `FakeModule` method for modifying `mod.datas` and hence no means of safely modifying such list. Even if there were, the `Analysis.assemble()` method ignores `mod.datas` and hence would simply ignore such modifications.

Fixing this requires changing a few files. Specifically:

* Adding a new `FakeModule.add_data()` method, permitting hooks to modify `mod.datas` safely.
* In the `hook()` function defined by `hook-_tkinter.py`, calling  this method.
* In the `Analysis.assemble()` method, appending the contents of `mod.datas` to the global list of data files.

For safety, the `pyi_rth__tkinter.py` runtime hook has also been improved to raise exceptions if either the Tcl or Tk data directories are *not* found in the frozen executable. (This should prevent this sort of mishap from happening again.)

For safety, several assertions have also been added to the `Analysis.assemble()` method. (This should prevent subtle issues elsewhere, in the future.)

For readability, the internal documentation for both the `FakeModule` class and `_tkinter` hook has been improved. For Sphinx compliance, docstrings have been converted to conventional reStructuredText (reST) syntax.

Since the `_tkinter` hook is fundamentally broken *anyway*, I've taken the liberty of cleaning up the code a bit. This means:

* **Freezing Tcl and Tk data directories directly into the frozen executable.** The current hook freezes these directories into a subdirectory `_MEI` of the frozen executable... which is just *wierd*. No other hooks do this, and there appears to be no demonstrable reason to do this here. So we stop doing that.
* **Renaming private hook functions.** Some function names contained the string `_tk_tcl` (e.g., `_find_tk_tclshell()`); others, merely `_tk` (e.g., `_find_tk()`). Since all of these functions apply to both Tcl and Tk *and* since most of these functions return a 2-tuple describing Tcl and Tk (in that order), I found the existing names to be highly confusing and arguably misleading.
* **Using `elif` rather than `if` for alternate branches of `if` conditionals.**
* **Cleaning up module imports and `exec_statement()` calls.**