### PR TITLE
Pass static-allocated memory to Py_SetProgramName (backported)

### DIFF
--- a/bootloader/common/pyi_pythonlib.c
+++ b/bootloader/common/pyi_pythonlib.c
@@ -174,7 +174,8 @@ static int pyi_pylib_set_runtime_opts(ARCHIVE_STATUS *status)
 	return 0;
 }
 
-
+/* Required for Py_SetProgramName */
+char _program_name[PATH_MAX+1];
 /*
  * Start python - return 0 on success
  */
@@ -213,7 +214,8 @@ int pyi_pylib_start_python(ARCHIVE_STATUS *status, int argc, char *argv[])
 	*PI_Py_NoSiteFlag = 1;	/* maybe changed to 0 by pyi_pylib_set_runtime_opts() */
     *PI_Py_FrozenFlag = 1;
     pyi_pylib_set_runtime_opts(status);
-	PI_Py_SetProgramName(status->archivename); /*XXX*/
+    strcpy(_program_name, status->archivename);
+	PI_Py_SetProgramName(_program_name); /*XXX*/
 	PI_Py_Initialize();
 
     // TODO set sys.path by function from Python C API (Python 2.6+)


### PR DESCRIPTION
This is the same change as #1217, backported to the develop branch.

[Py_SetProgramName](https://docs.python.org/2.7/c-api/init.html#c.Py_SetProgramName) requires that its argument be a pointer to "a string in static storage". Moving the string buffer to a statically allocated global fulfills this requirement. SetProgramName simply stores the pointer it is given and does not copy the string contents, nor does it ever attempt to free the memory pointed to.

This fixes problems with modules using the result of Py_GetProgramName for various things, [such as _tkinter described here.](https://github.com/pyinstaller/pyinstaller/issues/1164#issuecomment-82262657)