### PR TITLE
Fixes attribute error

### DIFF
--- a/PyInstaller/utils/hooks/hookutils.py
+++ b/PyInstaller/utils/hooks/hookutils.py
@@ -458,7 +458,7 @@ def opengl_arrays_modules():
     e.g. 'OpenGL.arrays.vbo'
     """
     statement = 'import OpenGL; print(OpenGL.__path__[0])'
-    opengl_mod_path = PyInstaller.hooks.hookutils.exec_statement(statement)
+    opengl_mod_path = exec_statement(statement)
     arrays_mod_path = os.path.join(opengl_mod_path, 'arrays')
     files = glob.glob(arrays_mod_path + '/*.py')
     modules = []


### PR DESCRIPTION
Under Python3.3.5 pyinstaller crashes with the following error:
  File "C:\storage\software\WinPython-32bit-3.3.5.0\python-3.3.5\lib\site-packages\PyInstaller\utils\hooks\hookutils.py", line 461, in opengl_arrays_modules
    opengl_mod_path = PyInstaller.hooks.hookutils.exec_statement(statement)
AttributeError: 'module' object has no attribute 'hooks'

exec_statement is a local function so this change fixes the issue