### PR TITLE
Fixes multiples pyconfig.h warns with --onefile option

### DIFF
--- a/PyInstaller/build.py
+++ b/PyInstaller/build.py
@@ -1655,7 +1655,7 @@ class TOC(UserList.UserList):
             raise TypeError("Expected tuple, not %s." % type(entry).__name__)
         name, path, typecode = entry
         if typecode in ["BINARY", "DATA"]:
-            # Normalize the case for binary files only (to avoid duplicates
+            # Normalize the case for binary files and data files only (to avoid duplicates
             # for different cases under Windows). We can't do that for
             # Python files because the import semantic (even at runtime)
             # depends on the case.

--- a/PyInstaller/build.py
+++ b/PyInstaller/build.py
@@ -1654,7 +1654,7 @@ class TOC(UserList.UserList):
             logger.info("TOC found a %s, not a tuple", entry)
             raise TypeError("Expected tuple, not %s." % type(entry).__name__)
         name, path, typecode = entry
-        if typecode == "BINARY":
+        if typecode in ["BINARY", "DATA"]:
             # Normalize the case for binary files only (to avoid duplicates
             # for different cases under Windows). We can't do that for
             # Python files because the import semantic (even at runtime)


### PR DESCRIPTION
in class TOC, make append method to normalize path when object typecode is "BINARY" or "DATA" instead of just "BINARY"