### PR TITLE
Add hook for appy package

### DIFF
--- a/PyInstaller/hooks/hook-appy.pod.py
+++ b/PyInstaller/hooks/hook-appy.pod.py
@@ -9,7 +9,4 @@
 
 from PyInstaller.hooks.hookutils import collect_data_files
 
-files = ['styles.in.content.xml', 
-         'styles.in.styles.xml',]
-
-datas = collect_data_files('appy.pod', files)
+datas = collect_data_files('appy.pod')

--- a/PyInstaller/hooks/hook-appy.py
+++ b/PyInstaller/hooks/hook-appy.py
@@ -1,0 +1,15 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2015, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+from PyInstaller.hooks.hookutils import collect_data_files
+
+files = ['styles.in.content.xml', 
+         'styles.in.styles.xml',]
+
+datas = collect_data_files('appy.pod', files)


### PR DESCRIPTION
The package needs a couple of xml files that aren't added without a hook, this way code seems to execute correctly.

I'm not sure if this would be the correct way to do it, please feel free to adapt it as you wish.

appy: https://pypi.python.org/pypi/appy/0.9.1