### PR TITLE
Allow customising CONFIGDIR

### DIFF
--- a/PyInstaller/__init__.py
+++ b/PyInstaller/__init__.py
@@ -78,7 +78,9 @@ if is_win:
             pass
 
 
-if is_win:
+if os.environ.get('PYINSTALLERCONFIGDIR'):
+    CONFIGDIR = os.environ['PYINSTALLERCONFIGDIR']
+elif is_win:
     CONFIGDIR = compat.getenv('APPDATA')
     if not CONFIGDIR:
         CONFIGDIR = os.path.expanduser('~\\Application Data')

--- a/PyInstaller/__init__.py
+++ b/PyInstaller/__init__.py
@@ -78,8 +78,8 @@ if is_win:
             pass
 
 
-if os.environ.get('PYINSTALLERCONFIGDIR'):
-    CONFIGDIR = os.environ['PYINSTALLERCONFIGDIR']
+if os.environ.get('PYINSTALLER_CONFIG_DIR'):
+    CONFIGDIR = os.environ['PYINSTALLER_CONFIG_DIR']
 elif is_win:
     CONFIGDIR = compat.getenv('APPDATA')
     if not CONFIGDIR:

--- a/doc/source/Manual.rst
+++ b/doc/source/Manual.rst
@@ -892,7 +892,7 @@ for example both Windows and Mac OS X, you must install |PyInstaller|
 on each platform and bundle your app separately on each.
 
 Should you share the same home directory on multiple platforms, for
-example Linux and OS X, you will need to set the PYINSTALLERCONFIGDIR
+example Linux and OS X, you will need to set the PYINSTALLER_CONFIG_DIR
 environment variable to different values on each platform otherwise
 PyInstaller may cache files for one platform and use them on the other
 platform, as by default it uses a subdirectory of your home directory

--- a/doc/source/Manual.rst
+++ b/doc/source/Manual.rst
@@ -891,6 +891,13 @@ If you need to distribute your application for more than one OS,
 for example both Windows and Mac OS X, you must install |PyInstaller|
 on each platform and bundle your app separately on each.
 
+Should you share the same home directory on multiple platforms, for
+example Linux and OS X, you will need to set the PYINSTALLERCONFIGDIR
+environment variable to different values on each platform otherwise
+PyInstaller may cache files for one platform and use them on the other
+platform, as by default it uses a subdirectory of your home directory
+as its cache location.
+
 You can do this from a single machine using virtualization.
 The free virtualBox_ or the paid VMWare_ and Parallels_
 allow you to run another complete operating system as a "guest".

--- a/doc/source/pyi-build.rst
+++ b/doc/source/pyi-build.rst
@@ -61,6 +61,13 @@ OPTIONS
                       (default: INFO, choose one of DEBUG, INFO, WARN,
                       ERROR, CRITICAL)
 
+ENVIRONMENT VARIABLES
+=====================
+
+PYINSTALLERCONFIGDIR  This changes the directory where PyInstaller caches
+                      some files. The default location for this is operating
+                      system dependent, but is typically a subdirectory of
+                      the home directory.
 
 SEE ALSO
 =============

--- a/doc/source/pyi-build.rst
+++ b/doc/source/pyi-build.rst
@@ -64,12 +64,12 @@ OPTIONS
 ENVIRONMENT VARIABLES
 =====================
 
-==================== ========================================================
-PYINSTALLERCONFIGDIR This changes the directory where PyInstaller caches some
-                     files. The default location for this is operating system
-                     dependent, but is typically a subdirectory of the home
-                     directory.
-==================== ========================================================
+====================== ========================================================
+PYINSTALLER_CONFIG_DIR This changes the directory where PyInstaller caches some
+                       files. The default location for this is operating system
+                       dependent, but is typically a subdirectory of the home
+                       directory.
+====================== ========================================================
 
 SEE ALSO
 =============

--- a/doc/source/pyi-build.rst
+++ b/doc/source/pyi-build.rst
@@ -64,10 +64,12 @@ OPTIONS
 ENVIRONMENT VARIABLES
 =====================
 
-PYINSTALLERCONFIGDIR  This changes the directory where PyInstaller caches
-                      some files. The default location for this is operating
-                      system dependent, but is typically a subdirectory of
-                      the home directory.
+==================== ========================================================
+PYINSTALLERCONFIGDIR This changes the directory where PyInstaller caches some
+                     files. The default location for this is operating system
+                     dependent, but is typically a subdirectory of the home
+                     directory.
+==================== ========================================================
 
 SEE ALSO
 =============

--- a/doc/source/pyi-make_comserver.rst
+++ b/doc/source/pyi-make_comserver.rst
@@ -51,12 +51,12 @@ OPTIONS
 ENVIRONMENT VARIABLES
 =====================
 
-==================== ========================================================
-PYINSTALLERCONFIGDIR This changes the directory where PyInstaller caches some
-                     files. The default location for this is operating system
-                     dependent, but is typically a subdirectory of the home
-                     directory.
-==================== ========================================================
+====================== ========================================================
+PYINSTALLER_CONFIG_DIR This changes the directory where PyInstaller caches some
+                       files. The default location for this is operating system
+                       dependent, but is typically a subdirectory of the home
+                       directory.
+====================== ========================================================
 
 SEE ALSO
 =============

--- a/doc/source/pyi-make_comserver.rst
+++ b/doc/source/pyi-make_comserver.rst
@@ -48,6 +48,15 @@ OPTIONS
 --out <dir>
     Generate the driver script and spec file in dir.
 
+ENVIRONMENT VARIABLES
+=====================
+
+==================== ========================================================
+PYINSTALLERCONFIGDIR This changes the directory where PyInstaller caches some
+                     files. The default location for this is operating system
+                     dependent, but is typically a subdirectory of the home
+                     directory.
+==================== ========================================================
 
 SEE ALSO
 =============

--- a/doc/source/pyi-makespec.rst
+++ b/doc/source/pyi-makespec.rst
@@ -156,12 +156,12 @@ Mac OS X specific options
 ENVIRONMENT VARIABLES
 =====================
 
-==================== ========================================================
-PYINSTALLERCONFIGDIR This changes the directory where PyInstaller caches some
-                     files. The default location for this is operating system
-                     dependent, but is typically a subdirectory of the home
-                     directory.
-==================== ========================================================
+====================== ========================================================
+PYINSTALLER_CONFIG_DIR This changes the directory where PyInstaller caches some
+                       files. The default location for this is operating system
+                       dependent, but is typically a subdirectory of the home
+                       directory.
+====================== ========================================================
 
 SEE ALSO
 =============

--- a/doc/source/pyi-makespec.rst
+++ b/doc/source/pyi-makespec.rst
@@ -153,6 +153,15 @@ Mac OS X specific options
                     com.mycompany.department.appname (default: first
                     script's basename)
 
+ENVIRONMENT VARIABLES
+=====================
+
+==================== ========================================================
+PYINSTALLERCONFIGDIR This changes the directory where PyInstaller caches some
+                     files. The default location for this is operating system
+                     dependent, but is typically a subdirectory of the home
+                     directory.
+==================== ========================================================
 
 SEE ALSO
 =============


### PR DESCRIPTION
When building multiple branches of my project simultaneously, PyInstaller simultaneously tries to modify the same files. By specifying different config directories, I can avoid this problem.