### PR TITLE
Fix for Menu not displayed with app bundle on OSX

### DIFF
--- a/PyInstaller/build.py
+++ b/PyInstaller/build.py
@@ -1562,7 +1562,7 @@ class BUNDLE(Target):
                            # side effect, the main application doesn't get one
                            # as well, but at startup time the loader will take
                            # care of transforming the process type.
-                           "LSBackgroundOnly": "1",
+                           "LSBackgroundOnly": "0",
 
                            }
 

--- a/bootloader/common/main.c
+++ b/bootloader/common/main.c
@@ -145,6 +145,9 @@ int main(int argc, char* argv[])
         if (pyi_utils_set_environment(archive_status) == -1)
             return -1;
 
+	/* Transform parent to background process on OSX only. */
+	pyi_parent_to_background();
+
         /* Run user's code in a subprocess and pass command line arguments to it. */
         rc = pyi_utils_create_child(executable, argc, argv);
 

--- a/bootloader/common/pyi_launch.c
+++ b/bootloader/common/pyi_launch.c
@@ -486,4 +486,14 @@ void pyi_launch_finalize(ARCHIVE_STATUS *status)
 }
 
 
-
+/*
+ * On OS X this ensures that the parent process goes to background.
+ * Call TransformProcessType() in the parent process.
+ */
+void pyi_parent_to_background()
+{
+    #if defined(__APPLE__) && defined(WINDOWED)
+    ProcessSerialNumber psn = { 0, kCurrentProcess };
+    OSStatus returnCode = TransformProcessType(&psn, kProcessTransformToBackgroundApplication);
+    #endif
+}

--- a/bootloader/common/pyi_launch.h
+++ b/bootloader/common/pyi_launch.h
@@ -65,6 +65,12 @@ int pyi_launch_execute(ARCHIVE_STATUS *status, int argc, char *argv[]);
 
 
 /*
+ * Transform parent process to background (OSX only).
+ */
+void pyi_parent_to_background();
+
+
+/*
  * Call a simple "int func(void)" entry point.  Assumes such a function
  * exists in the main namespace.
  * Return non zero on failure, with -2 if the specific error is


### PR DESCRIPTION
As discussed in issue #1078 , this pull requests fixes the problem with the missing menu at startup on OSX. I tested the code OSX Mountain Lion, Maverick and Yosemite.
For discussion please see issue #1078 !

More information about this issue is here:
http://dvitonis.net/blog/2015/01/07/menu-bar-not-visible-when-building-pyqt-app-bundle-pyinstaller-mac-osx-mavericks-yosemite/