### PR TITLE
Create test_stderr_encoding.py

### DIFF
--- a/tests/basic/test_stderr_encoding.py
+++ b/tests/basic/test_stderr_encoding.py
@@ -1,0 +1,28 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+
+import sys
+
+
+frozen_encoding = str(sys.stderr.encoding)
+
+
+# For various OS encoding is different.
+# On Windows it should be still cp850.  ## FIXME: Is this correct???  I don't have Windows!
+# On Linux, MAC OS X, and other unixes it should be mostly 'UTF-8'.
+encoding = 'cp850' if sys.platform.startswith('win') else 'UTF-8'
+
+
+print('Encoding expected: ' + encoding)
+print('Encoding current: ' + frozen_encoding)
+
+
+if not frozen_encoding == encoding:
+    raise SystemExit('Frozen encoding is not the same as unfrozen.')


### PR DESCRIPTION
Catches the error described in issue https://github.com/pyinstaller/pyinstaller/issues/1240

An alternative approach would be that this test fails only `if not sys.stderr.encoding`.

On Mac OS X, this test passed on:
* `python test_stderr_encoding.py`
* `python3 test_stderr_encoding.py`
* `pypy test_stderr_encoding.py`
* `pypy3 test_stderr_encoding.py`
* `jython test_stderr_encoding.py`

but failed on:
* `pyinstaller --onefile test_stderr_encoding.py ; open dist/test_stderr_encoding`

I do not have a Windows machine but my buddy tells me that he got `cp850` when he did `python -c "import sys ; print(sys.stderr.encoding)"` on his Windows machine.