### PR TITLE
"hook-matplotlib.backends" Output Improved

### DIFF
--- a/PyInstaller/hooks/hook-matplotlib.backends.py
+++ b/PyInstaller/hooks/hook-matplotlib.backends.py
@@ -8,8 +8,75 @@
 #-----------------------------------------------------------------------------
 
 
-from PyInstaller.utils.hooks.hookutils import matplotlib_backends
+from PyInstaller.compat import is_darwin
+from PyInstaller.utils.hooks.hookutils import (
+    eval_statement, exec_statement, logger)
 
 
-# Include only available matplotlib backends.
-hiddenimports = matplotlib_backends()
+def get_matplotlib_backend_module_names():
+    """
+    List the names of all matplotlib backend modules importable under the
+    current Python installation.
+
+    Returns
+    ----------
+    list
+        List of the fully-qualified names of all such modules.
+    """
+    # Statement safely importing a single backend module.
+    import_statement = """
+import os, sys
+
+# Preserve stdout.
+sys_stdout = sys.stdout
+
+try:
+    # Redirect output printed by this importation to "/dev/null", preventing
+    # such output from being erroneously interpreted as an error.
+    with open(os.devnull, 'w') as dev_null:
+        sys.stdout = dev_null
+        __import__('%s')
+# If this is an ImportError, print this exception's message without a traceback.
+# ImportError messages are human-readable and require no additional context.
+except ImportError as exc:
+    sys.stdout = sys_stdout
+    print(exc)
+# Else, print this exception preceded by a traceback. traceback.print_exc()
+# prints to stderr rather than stdout and must not be called here!
+except Exception:
+    sys.stdout = sys_stdout
+    import traceback
+    print(traceback.format_exc())
+"""
+
+    # List of the human-readable names of all available backends.
+    backend_names = eval_statement(
+        'import matplotlib; print(matplotlib.rcsetup.all_backends)')
+
+    # List of the fully-qualified names of all importable backend modules.
+    module_names = []
+
+    # If the current system is not OS X and the "CocoaAgg" backend is available,
+    # remove this backend from consideration. Attempting to import this backend
+    # on non-OS X systems halts the current subprocess without printing output
+    # or raising exceptions, preventing its reliable detection.
+    if not is_darwin and 'CocoaAgg' in backend_names:
+        backend_names.remove('CocoaAgg')
+
+    # For safety, attempt to import each backend in a unique subprocess.
+    for backend_name in backend_names:
+        module_name = 'matplotlib.backends.backend_%s' % backend_name.lower()
+        stdout = exec_statement(import_statement % module_name)
+
+        # If no output was printed, this backend is importable.
+        if not stdout:
+            module_names.append(module_name)
+            logger.info('  Matplotlib backend "%s": added' % backend_name)
+        else:
+            logger.info('  Matplotlib backend "%s": ignored\n    %s' % (backend_name, stdout))
+
+    return module_names
+
+# Freeze all importable backends, as PyInstaller is unable to determine exactly
+# which backends are required by the current program.
+hiddenimports = get_matplotlib_backend_module_names()

--- a/PyInstaller/utils/hooks/hookutils.py
+++ b/PyInstaller/utils/hooks/hookutils.py
@@ -440,7 +440,7 @@ def qt5_qml_dir():
                         + 'QT_INSTALL_QML" returned nothing')
     elif not os.path.exists(qmldir):
         logger.error("Directory QT_INSTALL_QML: %s doesn't exist" % qmldir)
-    
+
     # 'qmake -query' uses / as the path separator, even on Windows
     qmldir = os.path.normpath(qmldir)
     return qmldir
@@ -523,39 +523,6 @@ def django_find_root_dir():
                     break  # Find the first directory.
 
     return settings_dir
-
-
-def matplotlib_backends():
-    """
-    Return matplotlib backends available in current Python installation.
-
-    All matplotlib backends are hardcoded. We have to try import them
-    and return the list of successfully imported backends.
-    """
-    all_bk = eval_statement('import matplotlib; print(matplotlib.rcsetup.all_backends)')
-    avail_bk = []
-    import_statement = """
-try:
-    __import__('matplotlib.backends.backend_%s')
-except ImportError as e:
-    print(e)
-"""
-
-    # CocoaAgg backend causes subprocess to exit and thus detection
-    # is not reliable. This backend is meaningful only on Mac OS X.
-    if not is_darwin and 'CocoaAgg' in all_bk:
-        all_bk.remove('CocoaAgg')
-
-    # Try to import every backend in a subprocess.
-    for bk in all_bk:
-        stdout = exec_statement(import_statement % bk.lower())
-        # Backend import is successful if there is no text in stdout.
-        if not stdout:
-            avail_bk.append(bk)
-
-    # Convert backend name to module name.
-    # e.g. GTKAgg -> backend_gtkagg
-    return ['backend_' + x.lower() for x in avail_bk]
 
 
 # TODO Move to "hooks/hook-OpenGL.py", the only place where this is called.


### PR DESCRIPTION
This minor pull request:

* Adds metadata logging to the existing `matplotlib.backends` hook, improving both debugging and usability.
* Fixes several significant bugs in this hook.
* Documents and refactors this hook for readability.

## Motivation

The `matplotlib.backends` hook is arguably the slowest hook in the PyInstaller repository. Users importing `matplotlib` can expect to become familiar with the following output:

    ...
    21733 INFO: Processing hook   hook-docutils.py
    25967 INFO: Processing hook   hook-pygments.styles.py
    25974 INFO: Processing hook   hook-pygments.lexers.py
    27290 INFO: Processing hook   hook-IPython.py
    27293 INFO: Processing hook   hook-matplotlib.backends.py

At which point, PyInstaller silently hangs for ten to twenty seconds before silently proceeding onward. As [user experience (UX)](https://en.wikipedia.org/wiki/User_experience_design) goes, it's not the best. But there's an even *more* pressing issue: **debuggability**.

As of matplotlib 1.4.2, the hook internally attempts to import 27 backends – most internally attempting to import some combination of external shared libraries and C extensions. When something invariably goes wrong, the responsible exception is squelched (i.e., neither printed nor logged). That's bad, but the hook *also* fails to inform the user of which backends will be frozen with (and hence importable by) the executable. This is vital information, especially for backends available to non-frozen applications but unavailable to frozen executables.

Yes, PyInstaller is currently unable to freeze a few otherwise available backends – most due to issue #1212, as fixed by pull request #1213.

## Solution

For each possible backend, the user is now informed of whether that backend will be frozen with the executable or not and, if not, why not. Output resembles:

    ...
    21733 INFO: Processing hook   hook-docutils.py
    25967 INFO: Processing hook   hook-pygments.styles.py
    25974 INFO: Processing hook   hook-pygments.lexers.py
    27290 INFO: Processing hook   hook-IPython.py
    27293 INFO: Processing hook   hook-matplotlib.backends.py
    28489 INFO:   Matplotlib backend "GTK": ignored
        Gtk* backend requires pygtk to be installed.
    30170 INFO:   Matplotlib backend "GTKAgg": ignored
        Gtk* backend requires pygtk to be installed.
    30787 INFO:   Matplotlib backend "GTKCairo": ignored
        No module named 'gtk'
    32443 INFO:   Matplotlib backend "MacOSX": ignored
        cannot import name _macosx
    34195 INFO:   Matplotlib backend "Qt4Agg": added
    35951 INFO:   Matplotlib backend "Qt5Agg": added
    37657 INFO:   Matplotlib backend "TkAgg": added
    38266 INFO:   Matplotlib backend "WX": ignored
        Matplotlib backend_wx and backend_wxagg require wxversion, which was not found.
    39927 INFO:   Matplotlib backend "WXAgg": ignored
        Matplotlib backend_wx and backend_wxagg require wxversion, which was not found.
    41780 INFO:   Matplotlib backend "GTK3Cairo": added
    43600 INFO:   Matplotlib backend "GTK3Agg": added
    /usr/lib64/python3.3/site-packages/matplotlib/backends/backend_gtk3agg.py:18: UserWarning: The Gtk3Agg backend is known to not work on Python 3.x with pycairo. Try installing cairocffi.
      "The Gtk3Agg backend is known to not work on Python 3.x with pycairo. "
    45514 INFO:   Matplotlib backend "WebAgg": added
    46299 INFO:   Matplotlib backend "nbAgg": added
    47959 INFO:   Matplotlib backend "agg": added
    49622 INFO:   Matplotlib backend "cairo": added
    50227 INFO:   Matplotlib backend "emf": ignored
        No module named 'matplotlib.backends.backend_emf'
    50833 INFO:   Matplotlib backend "gdk": ignored
        No module named 'gobject'
    52511 INFO:   Matplotlib backend "pdf": added
    54234 INFO:   Matplotlib backend "pgf": added
    55900 INFO:   Matplotlib backend "ps": added
    57566 INFO:   Matplotlib backend "svg": added
    59226 INFO:   Matplotlib backend "template": added

That's mildly nice.

## Bugs Ahoy!

The hook has several subtle (but significant) issues, all pertaining to the following block:

    try:
        __import__('matplotlib.backends.backend_%s')
    except ImportError as e:
        print(str(e))

This code attempts to import each backend and, on failure, prints to stdout. Subsequent logic then tests whether any output was printed to stdout or not and, if so, ignores that backend. There are a few gotchas with the above implementation, however:

* If the current backend prints to standard output on importation, that backend will be ignored – even if its importation succeeds. (This isn't terribly likely, but it *could* happen. **Which means it will.**)
* If that importation raises an exception other than `ImportError`, that backend will *not* be ignored – even though it should be.

The latter gotcha is pretty likely. In fact, it happened to us. Both the `WebAgg` and `nbAgg` backends fail with the following non-`ImportError` exception and are thus currently added when they should be ignored:

    Traceback (most recent call last):
      File "<string>", line 12, in <module>
      File "/usr/lib64/python3.3/site-packages/matplotlib/backends/backend_webagg.py", line 42, in <module>
        from .backend_nbagg import TimerTornado
      File "/usr/lib64/python3.3/site-packages/matplotlib/backends/backend_nbagg.py", line 16, in <module>
        from IPython.display import display, Javascript, HTML
      File "/usr/lib64/python3.3/site-packages/IPython/__init__.py", line 48, in <module>
        from .core.application import Application
      File "/usr/lib64/python3.3/site-packages/IPython/core/application.py", line 40, in <module>
        from IPython.core import release, crashhandler
      File "/usr/lib64/python3.3/site-packages/IPython/core/crashhandler.py", line 30, in <module>
        from IPython.utils.sysinfo import sys_info
      File "/usr/lib64/python3.3/site-packages/IPython/utils/sysinfo.py", line 101, in <module>
        @py3compat.doctest_refactor_print
      File "/usr/lib64/python3.3/site-packages/IPython/utils/py3compat.py", line 45, in wrapper
        doc = str_change_func(doc)
      File "/usr/lib64/python3.3/site-packages/IPython/utils/py3compat.py", line 125, in doctest_refactor_print
        return _print_statement_re.sub(_print_statement_sub, doc)
    TypeError: expected string or buffer

This pull request fixes both of these gotchas in the expected way.

## Other Changes

For maintainability, the `matplotlib_backends()` function has been moved from the `utils.hooks.hookutils` module to this hook. (This hook is the only module calling this function, and `utils.hooks.hookutils` is already quite cluttered.)

This function's docstring has been revised to be Sphinx-compatible. Likewise, this function's local variables have been given human-readable names (e.g., from `bk` to `module_name`). For safety, this function now returns a list of absolute rather than relative module names (e.g., `matplotlib.backends.backend_tkagg` rather than `backend_tkagg`).

> And [leycec](https://github.com/leycec) saw the code, and it was mostly good.