### PR TITLE
PyWin32 Anaconda Support

### DIFF
--- a/PyInstaller/__init__.py
+++ b/PyInstaller/__init__.py
@@ -41,7 +41,8 @@ from PyInstaller.utils import git
 # Fail hard if Python on Windows does not have pywin32 installed.
 if is_win:
     try:
-        import pywintypes  # One module from pywin32.
+        from PyInstaller.utils.win32 import winutils
+        pywintypes = winutils.import_pywin32_module('pywintypes')
     except ImportError:
         raise SystemExit('PyInstaller cannot check for assembly dependencies.\n'
                          'Please install PyWin32.\n'

--- a/PyInstaller/depend/analysis.py
+++ b/PyInstaller/depend/analysis.py
@@ -92,6 +92,11 @@ class PyiModuleGraph(ModuleGraph):
         code_dict = {}
         mod_types = set(['Module', 'SourceModule', 'CompiledModule', 'Package'])
         for node in self.flatten():
+            # TODO This is terrible. To allow subclassing, types should never be
+            # directly compared. Use isinstance() instead, which is safer,
+            # simpler, and accepts sets. Most other calls to type() in the
+            # codebase should also be refactored to call isinstance() instead.
+
             # get node type e.g. Script
             mg_type = type(node).__name__
             if mg_type in mod_types:
@@ -113,6 +118,11 @@ class PyiModuleGraph(ModuleGraph):
         """
         result = existing_TOC or TOC()
         for node in self.flatten():
+            # TODO This is terrible. Everything in Python has a type. It's
+            # nonsensical to even speak of "nodes [that] are not typed." How
+            # would that even occur? After all, even "None" has a type! (It's
+            # "NoneType", for the curious.) Remove this, please.
+
             # get node type e.g. Script
             mg_type = type(node).__name__
             if mg_type is None:

--- a/PyInstaller/hooks/hook-pythoncom.py
+++ b/PyInstaller/hooks/hook-pythoncom.py
@@ -16,17 +16,9 @@ attribute.
 """
 
 import os.path
-from PyInstaller.utils.hooks.hookutils import get_module_file_attribute
+from PyInstaller.utils.hooks import hookutils
 
-_pth = get_module_file_attribute('pythoncom')
-
-# Binaries that should be included with the module 'pythoncom'.
-# List mod.pyinstaller_binaries gets extended.
-binaries = [
-    (
-        # Relative path in the ./dist/app_name/ directory.
-        os.path.basename(_pth),
-        # Absolute path on hard disk.
-        _pth,
-    )
-]
+# Absolute path of the corresponding DLL. On importation, this module
+# dynamically imports and replaces itself in memory with this DLL.
+_dll_file = hookutils.get_pywin32_module_file_attribute('pythoncom')
+binaries = [(os.path.basename(_dll_file), _dll_file)]

--- a/PyInstaller/hooks/hook-pywintypes.py
+++ b/PyInstaller/hooks/hook-pywintypes.py
@@ -16,7 +16,9 @@ attribute.
 """
 
 import os.path
-from PyInstaller.utils.hooks.hookutils import get_module_file_attribute
+from PyInstaller.utils.hooks import hookutils
 
-_pth = get_module_file_attribute('pywintypes')
-binaries = [(os.path.basename(_pth), _pth)]
+# Absolute path of the corresponding DLL. On importation, this module
+# dynamically imports and replaces itself in memory with this DLL.
+_dll_file = hookutils.get_pywin32_module_file_attribute('pywintypes')
+binaries = [(os.path.basename(_dll_file), _dll_file)]

--- a/PyInstaller/utils/hooks/hookutils.py
+++ b/PyInstaller/utils/hooks/hookutils.py
@@ -440,7 +440,7 @@ def qt5_qml_dir():
                         + 'QT_INSTALL_QML" returned nothing')
     elif not os.path.exists(qmldir):
         logger.error("Directory QT_INSTALL_QML: %s doesn't exist" % qmldir)
-    
+
     # 'qmake -query' uses / as the path separator, even on Windows
     qmldir = os.path.normpath(qmldir)
     return qmldir
@@ -616,9 +616,21 @@ def remove_file_extension(filename):
 
 def get_module_file_attribute(package):
     """
-    Given a package name, return the value of __file__ attribute.
+    Get the absolute path of the module with the passed name.
 
-    In PyInstaller process we cannot import directly analyzed modules.
+    Since modules *cannot* be directly imported during analysis, this function
+    spawns a subprocess importing this module and returning the value of this
+    module's `__file__` attribute.
+
+    Parameters
+    ----------
+    module_name : str
+        Fully-qualified name of this module.
+
+    Returns
+    ----------
+    str
+        Absolute path of this module.
     """
     # Statement to return __file__ attribute of a package.
     __file__statement = """

--- a/PyInstaller/utils/hooks/hookutils.py
+++ b/PyInstaller/utils/hooks/hookutils.py
@@ -13,7 +13,7 @@ import os
 import sys
 import PyInstaller
 import PyInstaller.compat as compat
-from PyInstaller.compat import is_darwin, is_venv
+from PyInstaller.compat import is_darwin, is_win
 from PyInstaller.utils import misc
 
 import PyInstaller.log as logging
@@ -656,90 +656,15 @@ def get_pywin32_module_file_attribute(module_name):
 
     See Also
     ----------
-    `import_pywin32_module()`
+    `PyInstaller.utils.win32.winutils.import_pywin32_module()`
         For further details.
     """
     statement = """
-from PyInstaller.utils.hooks import hookutils
-module = hookutils.import_pywin32_module('%s')
+from PyInstaller.utils.win32 import winutils
+module = winutils.import_pywin32_module('%s')
 print(module.__file__)
     """
     return exec_statement(statement % module_name)
-
-
-def import_pywin32_module(module_name):
-    """
-    Import and return the PyWin32 module with the passed name.
-
-    When imported, the `pywintypes` and `pythoncom` modules both internally
-    import dynamic libraries (e.g., `pywintypes.py` imports `pywintypes34.dll`
-    under Python 3.4). The Anaconda Python distribution for Windows installs
-    these libraries to non-standard directories, resulting in
-    `ImportError: No system module 'pywintypes' (pywintypes34.dll)` exceptions.
-    This function detects these exceptions, searches for these libraries, adds
-    their parent directories to `sys.path`, and retries.
-
-    Parameters
-    ----------
-    module_name : str
-        Fully-qualified name of this module.
-
-    Returns
-    ----------
-    types.ModuleType
-        This module.
-    """
-    module = None
-
-    try:
-        module = __import__(
-            name=module_name, globals={}, locals={}, fromlist=[''])
-    except ImportError as exc:
-        if str(exc).startswith('No system module'):
-            # True if "sys.frozen" is currently set.
-            is_sys_frozen = hasattr(sys, 'frozen')
-
-            # Current value of "sys.frozen" if any.
-            sys_frozen = getattr(sys, 'frozen', None)
-
-            # Force PyWin32 to search "sys.path" for DLLs. By default, PyWin32
-            # only searches "site-packages\win32\lib/", "sys.prefix", and
-            # Windows system directories (e.g., "C:\Windows\System32"). This is
-            # an ugly hack, but there is no other way.
-            sys.frozen = '|_|GLYH@CK'
-
-            # If isolated to a venv, the preferred site.getsitepackages()
-            # function is unreliable. Fallback to searching "sys.path" instead.
-            if is_venv:
-                sys_paths = sys.path
-            else:
-                import site
-                sys_paths = site.getsitepackages()
-
-            for sys_path in sys_paths:
-                # Absolute path of the directory containing PyWin32 DLLs.
-                pywin32_dll_dir = os.path.join(sys_path, 'pywin32_system32')
-                if os.path.isdir(pywin32_dll_dir):
-                    sys.path.append(pywin32_dll_dir)
-                    try:
-                        module = __import__(
-                            name=module_name, globals={}, locals={}, fromlist=[''])
-                        break
-                    except ImportError:
-                        pass
-
-            # If "sys.frozen" was previously set, restore its prior value.
-            if is_sys_frozen:
-                sys.frozen = sys_frozen
-            # Else, undo this hack entirely.
-            else:
-                del sys.frozen
-
-        # If this module remains unimportable, PyWin32 is not installed. Fail.
-        if module is None:
-            raise
-
-    return module
 
 
 def get_package_paths(package):

--- a/PyInstaller/utils/win32/winutils.py
+++ b/PyInstaller/utils/win32/winutils.py
@@ -16,6 +16,7 @@ Utils for Windows platform.
 __all__ = ['get_windows_dir']
 
 import os
+import sys
 
 from PyInstaller import compat
 
@@ -68,3 +69,78 @@ def extend_system_path(paths):
     paths.append(old_PATH)
     new_PATH = os.pathsep.join(paths)
     compat.setenv('PATH', new_PATH)
+
+
+def import_pywin32_module(module_name):
+    """
+    Import and return the PyWin32 module with the passed name.
+
+    When imported, the `pywintypes` and `pythoncom` modules both internally
+    import dynamic libraries (e.g., `pywintypes.py` imports `pywintypes34.dll`
+    under Python 3.4). The Anaconda Python distribution for Windows installs
+    these libraries to non-standard directories, resulting in
+    `"ImportError: No system module 'pywintypes' (pywintypes34.dll)"`
+    exceptions. This function catches these exceptions, searches for these
+    libraries, adds their directories to `sys.path`, and retries.
+
+    Parameters
+    ----------
+    module_name : str
+        Fully-qualified name of this module.
+
+    Returns
+    ----------
+    types.ModuleType
+        The desired module.
+    """
+    module = None
+
+    try:
+        module = __import__(
+            name=module_name, globals={}, locals={}, fromlist=[''])
+    except ImportError as exc:
+        if str(exc).startswith('No system module'):
+            # True if "sys.frozen" is currently set.
+            is_sys_frozen = hasattr(sys, 'frozen')
+
+            # Current value of "sys.frozen" if any.
+            sys_frozen = getattr(sys, 'frozen', None)
+
+            # Force PyWin32 to search "sys.path" for DLLs. By default, PyWin32
+            # only searches "site-packages\win32\lib/", "sys.prefix", and
+            # Windows system directories (e.g., "C:\Windows\System32"). This is
+            # an ugly hack, but there is no other way.
+            sys.frozen = '|_|GLYH@CK'
+
+            # If isolated to a venv, the preferred site.getsitepackages()
+            # function is unreliable. Fallback to searching "sys.path" instead.
+            if compat.is_venv:
+                sys_paths = sys.path
+            else:
+                import site
+                sys_paths = site.getsitepackages()
+
+            for sys_path in sys_paths:
+                # Absolute path of the directory containing PyWin32 DLLs.
+                pywin32_dll_dir = os.path.join(sys_path, 'pywin32_system32')
+                if os.path.isdir(pywin32_dll_dir):
+                    sys.path.append(pywin32_dll_dir)
+                    try:
+                        module = __import__(
+                            name=module_name, globals={}, locals={}, fromlist=[''])
+                        break
+                    except ImportError:
+                        pass
+
+            # If "sys.frozen" was previously set, restore its prior value.
+            if is_sys_frozen:
+                sys.frozen = sys_frozen
+            # Else, undo this hack entirely.
+            else:
+                del sys.frozen
+
+        # If this module remains unimportable, PyWin32 is not installed. Fail.
+        if module is None:
+            raise
+
+    return module


### PR DESCRIPTION
This pull request substantially improves PyInstaller integration with [Anaconda](http://continuum.io/downloads) under Windows, fixing #1247. The solution is fairly simple. We define two new utility functions:

* `import_pywin32_module()`, importing the passed PyWin32 module (e.g, `pywintypes`, `pythoncom`) in an Anaconda-aware manner. Attempting to import this module directly results in an exception resembling `"ImportError: No system module 'pywintypes' (pywintypes34.dll)"`. Why? Because Anaconda installs the referenced DLL into the `site-packages\pywin32_system32\` and `site-packages\win32\` directories, which PyWin32 does *not* search when attempting to find the DLL. (**Insanity.** We know.) This function instructs PyWin32 to search the first directory with a dollop of [vile black magic](b11d2024f).
* `get_pywin32_module_file_attribute()`, getting the `__file__` attribute of the passed PyWin32 module in the same way.

PyInstaller startup now detects PyWin32 in an Anaconda-aware manner by calling `import_pywin32_module()`. Likewise, the `pywintypes` and `pythoncom` hooks now register PyWin32 DLLs as hidden imports in an Anaconda-aware manner by calling `get_pywin32_module_file_attribute()`.

Thus fell another fey dragon.