### PR TITLE
Correct linkage information for Windows Side-by-Side Shared Assemblies

### DIFF
--- a/PyInstaller/build.py
+++ b/PyInstaller/build.py
@@ -785,10 +785,9 @@ def checkCache(fnm, strip=False, upx=False, dist_nm=None):
     # with relative install names. Caching on darwin does not work
     # since we need to modify binary headers to use relative paths
     # to dll depencies and starting with '@loader_path'.
-
-    if ((not strip and not upx and not is_darwin and not is_win)
-        or fnm.lower().endswith(".manifest")):
+    if (not strip and not upx and not is_darwin and not is_win):
         return fnm
+
     if strip:
         strip = True
     else:
@@ -831,6 +830,24 @@ def checkCache(fnm, strip=False, upx=False, dist_nm=None):
             if is_darwin:
                 dylib.mac_set_relative_dylib_deps(cachedfile, dist_nm)
             return cachedfile
+
+    # Change manifest and its deps to private assemblies
+    if fnm.lower().endswith(".manifest"):
+        manifest = winmanifest.Manifest()
+        manifest.filename = fnm
+        with file(fnm, "rb") as f:
+            manifest.parse_string(f.read())
+        if manifest.publicKeyToken:
+            logger.info("Changing %s into private assembly", os.path.basename(fnm))
+        manifest.publicKeyToken = None
+        for dep in manifest.dependentAssemblies:
+            # Exclude common-controls which is not bundled
+            if dep.name != "Microsoft.Windows.Common-Controls":
+                dep.publicKeyToken = None
+
+        manifest.writeprettyxml(cachedfile)
+        return cachedfile
+
     if upx:
         if strip:
             fnm = checkCache(fnm, strip=True, upx=False)
@@ -859,9 +876,16 @@ def checkCache(fnm, strip=False, upx=False, dist_nm=None):
     shutil.copy2(fnm, cachedfile)
     os.chmod(cachedfile, 0755)
 
-    if pyasm and fnm.lower().endswith(".pyd"):
-        # If python.exe has dependent assemblies, check for embedded manifest
-        # of cached pyd file because we may need to 'fix it' for pyinstaller
+    if os.path.splitext(fnm.lower())[1] in (".pyd", ".dll"):
+        # When shared assemblies are bundled into the app, they must be
+        # transformed into private assemblies or else the assembly
+        # loader will not search for them in the app folder. To support
+        # this, all manifests in the app must be modified to point to
+        # the private assembly.
+
+        # Also, if python.exe has dependent assemblies, check for
+        # embedded manifest of cached pyd file because we may need to
+        # 'fix it' for pyinstaller
         try:
             res = winmanifest.GetManifestResources(os.path.abspath(cachedfile))
         except winresource.pywintypes.error, e:
@@ -889,12 +913,16 @@ def checkCache(fnm, strip=False, upx=False, dist_nm=None):
                             logger.error(cachedfile)
                             logger.exception(exc)
                         else:
+                            # change manifest to private assembly
+                            if manifest.publicKeyToken:
+                                logger.info("Changing %s into a private assembly", os.path.basename(fnm))
+                            manifest.publicKeyToken = None
+
                             # Fix the embedded manifest (if any):
                             # Extension modules built with Python 2.6.5 have
                             # an empty <dependency> element, we need to add
                             # dependentAssemblies from python.exe for
                             # pyinstaller
-                            olen = len(manifest.dependentAssemblies)
                             _depNames = set([dep.name for dep in
                                              manifest.dependentAssemblies])
                             for pydep in pyasm:
@@ -904,14 +932,19 @@ def checkCache(fnm, strip=False, upx=False, dist_nm=None):
                                                 pydep.name, cachedfile)
                                     manifest.dependentAssemblies.append(pydep)
                                     _depNames.update(pydep.name)
-                            if len(manifest.dependentAssemblies) > olen:
-                                try:
-                                    manifest.update_resources(os.path.abspath(cachedfile),
-                                                              [name],
-                                                              [language])
-                                except Exception, e:
-                                    logger.error(os.path.abspath(cachedfile))
-                                    raise
+
+                            # Change dep to private assembly
+                            for dep in manifest.dependentAssemblies:
+                                # Exclude common-controls which is not bundled
+                                if dep.name != "Microsoft.Windows.Common-Controls":
+                                    dep.publicKeyToken = None
+                            try:
+                                manifest.update_resources(os.path.abspath(cachedfile),
+                                                          [name],
+                                                          [language])
+                            except Exception, e:
+                                logger.error(os.path.abspath(cachedfile))
+                                raise
 
     if cmd:
         try:

--- a/PyInstaller/build.py
+++ b/PyInstaller/build.py
@@ -789,7 +789,8 @@ def checkCache(fnm, strip=False, upx=False, dist_nm=None):
         return fnm
 
     if dist_nm is not None and ":" in dist_nm:
-        # A file embedded in another pyinstaller build via multipackage - no actual file exists to process
+        # A file embedded in another pyinstaller build via multipackage
+        # No actual file exists to process
         return fnm
 
     if strip:
@@ -919,7 +920,8 @@ def checkCache(fnm, strip=False, upx=False, dist_nm=None):
                         else:
                             # change manifest to private assembly
                             if manifest.publicKeyToken:
-                                logger.info("Changing %s into a private assembly", os.path.basename(fnm))
+                                logger.info("Changing %s into a private assembly",
+                                            os.path.basename(fnm))
                             manifest.publicKeyToken = None
 
                             # Fix the embedded manifest (if any):
@@ -1154,7 +1156,7 @@ class EXE(Target):
         self.uac_admin = kwargs.get('uac_admin', False)
         self.uac_uiaccess = kwargs.get('uac_uiaccess', False)
 
-        if config['hasUPX']: 
+        if config['hasUPX']:
            self.upx = kwargs.get('upx', False)
         else:
            self.upx = False
@@ -1163,7 +1165,7 @@ class EXE(Target):
         # app. New format includes only exename.
         #
         # Ignore fullpath in the 'name' and prepend DISTPATH or WORKPATH.
-        # DISTPATH - onefile 
+        # DISTPATH - onefile
         # WORKPATH - onedir
         if self.exclude_binaries:
             # onedir mode - create executable in WORKPATH.
@@ -1171,7 +1173,7 @@ class EXE(Target):
         else:
             # onefile mode - create executable in DISTPATH.
             self.name = os.path.join(DISTPATH, os.path.basename(self.name))
-        
+
         # Base name of the EXE file without .exe suffix.
         base_name = os.path.basename(self.name)
         if is_win or is_cygwin:
@@ -1270,10 +1272,13 @@ class EXE(Target):
             shutil.copy2(exe, tmpnm)
             os.chmod(tmpnm, 0755)
 
-            # In onefile mode, dependencies in the onefile manifest refer to files that are about to be unpacked when
-            # the exe is run. The Windows DLL loader doesn't know that and refuses to run the exe at all. Since the
-            # .exe does not in fact depend on those, and the actual manifest will be used later when an activation
-            # context is created, all dependencies are removed from the embedded manifest.
+            # In onefile mode, dependencies in the onefile manifest
+            # refer to files that are about to be unpacked when the exe
+            # is run. The Windows DLL loader doesn't know that and
+            # refuses to run the exe at all. Since the .exe does not in
+            # fact depend on those, and the actual manifest will be used
+            # later when an activation context is created, all
+            # dependencies are removed from the embedded manifest. 
             self.manifest.dependentAssemblies = []
             self.manifest.update_resources(tmpnm, [1]) # 1 for executable
             trash.append(tmpnm)
@@ -1406,7 +1411,7 @@ class COLLECT(Target):
         Target.__init__(self)
         self.strip_binaries = kws.get('strip', False)
 
-        if config['hasUPX']: 
+        if config['hasUPX']:
            self.upx_binaries = kws.get('upx', False)
         else:
            self.upx_binaries = False
@@ -1467,7 +1472,7 @@ class COLLECT(Target):
                 os.makedirs(todir)
             if typ in ('EXTENSION', 'BINARY'):
                 fnm = checkCache(fnm, strip=self.strip_binaries,
-                                 upx=(self.upx_binaries and (is_win or is_cygwin)), 
+                                 upx=(self.upx_binaries and (is_win or is_cygwin)),
                                  dist_nm=inm)
             if typ != 'DEPENDENCY':
                 shutil.copy(fnm, tofnm)
@@ -1499,7 +1504,7 @@ class BUNDLE(Target):
         self.icon = os.path.abspath(self.icon)
 
         Target.__init__(self)
- 
+
         # .app bundle is created in DISTPATH.
         self.name = kws.get('name', None)
         base_name = os.path.basename(self.name)
@@ -1522,9 +1527,9 @@ class BUNDLE(Target):
         for arg in args:
             if isinstance(arg, EXE):
                 self.toc.append((os.path.basename(arg.name), arg.name, arg.typ))
-                self.toc.extend(arg.dependencies) 
+                self.toc.extend(arg.dependencies)
                 self.strip = arg.strip
-                self.upx = arg.upx 
+                self.upx = arg.upx
             elif isinstance(arg, TOC):
                 self.toc.extend(arg)
                 # TOC doesn't have a strip or upx attribute, so there is no way for us to
@@ -1532,7 +1537,7 @@ class BUNDLE(Target):
             elif isinstance(arg, COLLECT):
                 self.toc.extend(arg.toc)
                 self.strip = arg.strip_binaries
-                self.upx = arg.upx_binaries 
+                self.upx = arg.upx_binaries
             else:
                 logger.info("unsupported entry %s", arg.__class__.__name__)
         # Now, find values for app filepath (name), app name (appname), and name
@@ -1977,7 +1982,7 @@ def build(spec, distpath, workpath, clean_build):
     for pth in (DISTPATH, WORKPATH):
         if not os.path.exists(WORKPATH):
             os.makedirs(WORKPATH)
- 
+
     # Executing the specfile. The executed .spec file will use DISTPATH and
     # WORKPATH values.
     execfile(spec)

--- a/PyInstaller/build.py
+++ b/PyInstaller/build.py
@@ -785,7 +785,11 @@ def checkCache(fnm, strip=False, upx=False, dist_nm=None):
     # with relative install names. Caching on darwin does not work
     # since we need to modify binary headers to use relative paths
     # to dll depencies and starting with '@loader_path'.
-    if (not strip and not upx and not is_darwin and not is_win):
+    if not strip and not upx and not is_darwin and not is_win:
+        return fnm
+
+    if dist_nm is not None and ":" in dist_nm:
+        # A file embedded in another pyinstaller build via multipackage - no actual file exists to process
         return fnm
 
     if strip:

--- a/PyInstaller/build.py
+++ b/PyInstaller/build.py
@@ -1265,6 +1265,12 @@ class EXE(Target):
             tmpnm = tempfile.mktemp()
             shutil.copy2(exe, tmpnm)
             os.chmod(tmpnm, 0755)
+
+            # In onefile mode, dependencies in the onefile manifest refer to files that are about to be unpacked when
+            # the exe is run. The Windows DLL loader doesn't know that and refuses to run the exe at all. Since the
+            # .exe does not in fact depend on those, and the actual manifest will be used later when an activation
+            # context is created, all dependencies are removed from the embedded manifest.
+            self.manifest.dependentAssemblies = []
             self.manifest.update_resources(tmpnm, [1]) # 1 for executable
             trash.append(tmpnm)
             exe = tmpnm


### PR DESCRIPTION
### Summary

Some shared libraries on Windows are packaged as **Assemblies**, which can either be **Shared** or **Private**. Shared assemblies can only be loaded from system-wide locations under the Windows folder. In order to package a shared assembly into a PyInstaller app, the assembly must be transformed into a private assembly. Since the shared/private status of an assembly *forms part of its identity*, all files which depend on this assembly must also be altered.

This patch applies the needed changes to the packaged assemblies and all of their dependents as part of the build process. This patch also fixes a bug where a `onefile` app cannot launch because it depends on the very files it is going to extract.

### Background

Executable files that use shared libraries ("DLLs") must have a way of identifying which libraries they are linked to. The Windows executable file format, **Windows PE**, only identifies its DLLs by a bare filename, such as `KERNEL32.DLL`. In older versions of Windows, the program loader would simply search the `PATH` environ for a file matching that filename and load it. This created many problems with version and architecture mismatches, so the system of Assemblies and Program Manifests called [**Windows Side-by-Side**](http://www.davidlenihan.com/2007/07/winsxs.html) was introduced.

An assembly is a group of DLLs and other files, collected together into one folder and given a name, a version number, a platform or architecture identifier, and an optional token that when present, identifies the assembly as a Shared Assembly. This metadata is stored in the Assembly Manifest.

A Program Manifest contains among other things a list of dependent assemblies, each identified by the assembly's name, version number, platform identifier, and token. The manifest may be stored within the program file as a Resource, or stored alongside the program file as a .manifest file with the same base filename as the program. Both DLLs and EXEs may have a program manifest.

When the program loader finds a program manifest containing a dependent assembly, the older method of searching `PATH` is suspended and the loader searches for an assembly that matches the one in the program manifest in order to locate a DLL. (There are also "application configuration" files that allow a newer version of an assembly to be loaded, but these are limited to changing only the version number - the name, architecture, and token must still match.)

If an assembly has a `publicKeyToken`, that identifies it as a **Shared Assembly**. A shared assembly may only be loaded from the global `WinSxS` folder in `C:\Windows\WinSxS`. The folder containing the program file will not be searched for a shared assembly.

Without a `publicKeyToken`, the assembly is a **Private Assembly**. The global `WinSxS` folder will be searched first, and if it is not found, the folder that contains the program file [will then be searched](https://msdn.microsoft.com/en-us/library/ff951640(v=vs.85).aspx). The importance of the `publicKeyToken` *is stated nowhere in the MSDN documentation* and can only be learned by using `sxstrace.exe`

### Problem

A PyInstaller app is built in 'onedir' mode for a simple "Hello World" program. Upon running the program on a system that does not have *Microsoft Visual C++ Runtime 2008* installed, a dialog box displays the error `The application could not be started because its side-by-side configuration is incorrect` and suggests to use `sxstrace.exe` to diagnose the problem.

### Diagnosis

Properly investigating this problem turned up a number of facts that explain why this problem has gone unfixed for so long. First, the Python installer for Windows silently installs the above runtime as part of the installation procedure. Thus, any Windows dev machine will have this runtime installed.

Second, the runtime can be located in the Add/Remove Programs and uninstalled. *This does not actually remove the runtime files!* The assembly `Microsoft.VC90.CRT` is still present in the `WinSxS` folder and remains there for some time. I couldn't figure out what triggers it to finally be deleted, but this MSDN blog indicates it is [garbage-collected by the Installer service](http://blogs.msdn.com/b/jonwis/archive/2007/01/02/deleting-from-the-winsxs-directory.aspx).

`sxstrace.exe` reveals that the built app is indeed loading these .DLLs from the `WinSxS` folder. I had to manually remove the VC90.CRT assembly from WinSxS (in a virtual machine, as this would prevent me from even running PyInstaller for builds if done on my dev machine...) before I was able to reproduce the "configuration is incorrect" error. With that done, I can finally start investigating the problem for real.

### Actual Diagnosis

`The application could not be started because its side-by-side configuration is incorrect. Please see the application event log or use the command-line sxstrace.exe tool for more detail.`

Using the trace tool reveals something curious. The program loader is unable to find the Microsoft.VC90.CRT assembly, and yet that assembly *is present in the built PyInstaller app's folder!* So why isn't it being found? The answer is the `publicKeyToken` mentioned earlier. Because the manifest embedded in the PyInstaller app (and all of its .dll, .exe, and .pyd files, it turned out) refers to the VC90.CRT assembly with a `publicKeyToken` as part of its identity, the application folder is never searched for this assembly - the program loader searches in WinSxS and then quits.

Simply removing the `publicKeyToken` from the app manifest does nothing to solve the problem. This changes the identity of the assembly it is searching for: It now checks the app's folder for `Microsoft.VC90.CRT.manifest`, but fails to find it because the manifest it finds in the app folder has the `publicKeyToken` identifying it as a different assembly from the one it is looking for.

Removing the token from the VC90 manifest and running the app under `sxstrace.exe` again reveals the full extent of the problem: `python27.dll`, along with *every single .pyd in the app folder*, has an embedded manifest that points to the original VC90.CRT using the key token!

The solution is apparent. If we want to bundle VC90.CRT (or any other shared assembly) in the app folder, we will have to alter that assembly's manifest by removing the key token, *and* alter the manifest for every single assembly, EXE, DLL, and PYD to point to the newly privatized assembly.

(I mean, the obvious solution is to bundle the Visual C Runtime installer and run it from the bootloader, but, you know, admin rights and all that... Plus, doing it this way works for ANY shared assembly and not just VC90.CRT)

Luckily, there is ample support for doing such a thing in PyInstaller. In fact, `checkCache()` already goes and touches the embedded manifests of some executable files in order to add the dependencies of python.exe to every .pyd. I'm not sure this is necessary, but that's mostly because it mentions python2.6 which I didn't bother trying, but if you've read this far then you know how to get a "clean" environment and find out using `sxstrace.exe` whether the .DLLs packaged with the app are actually the ones being loaded.

### Changes

This patch adds code to `checkCache()` to alter the embedded manifests of any .pyd and .dll, removing any publicKeyTokens from references to assemblies in order to point them at the assembly packaged with the app. It also adds code to modify any manifests, embedded or not, of any assemblies that are packaged with the app, removing the publicKeyTokens so that any packaged .pyd or .dll can find them.

The last change is more of a side-note at this point. When the app is built in `onefile` mode instead of `onedir`, the onefile exe has an embedded manifest that refers to assemblies that are about to be unpacked by the exe itself - since they don't exist yet, there's no way the program loader can ever find them. This is the issue described in #1182. The fix is as simple as removing all assembly references from the manifest that is embedded in the onefile exe. As part of the onefile's startup, it unpacks another manifest into the _MEI folder and explicitly loads that as an Activation Context (a mechanism used for dynamically specifying a program manifest in preparation for dynamic DLL loads using LoadLibrary, which is exactly what it is used for here). This secondary manifest is untouched - only the manifest embedded in the onefile exe is stripped. (in `onedir` mode, this manifest is also loaded as an Activation Context - no manifest is embedded in `onedir` mode.)
