### PR TITLE
Skip duplicate binaries using the internal name, not the filesystem name

### DIFF
--- a/PyInstaller/build.py
+++ b/PyInstaller/build.py
@@ -1027,15 +1027,16 @@ class PKG(Target):
                 if self.exclude_binaries and typ != 'DEPENDENCY':
                     self.dependencies.append((inm, fnm, typ))
                 else:
-                    fnm = checkCache(fnm, strip=self.strip_binaries,
-                                     upx=(self.upx_binaries and (is_win or is_cygwin)),
-                                     dist_nm=inm)
                     # Avoid importing the same binary extension twice. This might
                     # happen if they come from different sources (eg. once from
                     # binary dependence, and once from direct import).
-                    if typ == 'BINARY' and fnm in seen:
+                    if typ == 'BINARY' and inm in seen:
                         continue
-                    seen[fnm] = 1
+                    seen[inm] = 1
+
+                    fnm = checkCache(fnm, strip=self.strip_binaries,
+                                     upx=(self.upx_binaries and (is_win or is_cygwin)),
+                                     dist_nm=inm)
 
                     mytoc.append((inm, fnm, self.cdict.get(typ, 0),
                                   self.xformdict.get(typ, 'b')))


### PR DESCRIPTION
For various reasons, a single file can get included multiple times in the built app. When duplicate files are excluded using the filesystem name, the file will not appear in all of the locations requested by the spec file and/or hooks. 

This was causing a certain lib (`libzmq.pyd`, I think) to be randomly (depending on dict ordering or something) included in the "wrong" location. Some module is looking for that lib in one of the requested locations, and when the lib appears in a different internal location, a vague sounding ImportError results. Seemingly unrelated changes that would result in differing TOC lists, such as adding extra imports, would change the location the lib ends up being in and would apparently fix the problem, but the real issue is that `PKG.assemble()` is only including the lib in one of the requested locations.

The *real*, real issue is that some combination of module-finding and hooks is requesting one file to be in multiple locations in the built app, but this issue just exacerbates the problem.

