### PR TITLE
Python3 - PyQt5, winutils, winresource

### DIFF
--- a/PyInstaller/hooks/hook-PyQt5.py
+++ b/PyInstaller/hooks/hook-PyQt5.py
@@ -10,7 +10,7 @@
 
 import os
 
-from PyInstaller.utils.win32.winutils import qt5_menu_nib_dir
+from PyInstaller.utils.hooks.hookutils import qt5_menu_nib_dir
 from PyInstaller.compat import getsitepackages, is_darwin, is_win
 
 
@@ -18,7 +18,7 @@ from PyInstaller.compat import getsitepackages, is_darwin, is_win
 # The PySide directory contains Qt dlls. We need to avoid including different
 # version of Qt libraries when there is installed another application (e.g. QtCreator)
 if is_win:
-    from PyInstaller.utils.winutils import extend_system_path
+    from PyInstaller.utils.win32.winutils import extend_system_path
     extend_system_path([os.path.join(x, 'PyQt4') for x in getsitepackages()])
 
 

--- a/PyInstaller/hooks/hook-PyQt5.py
+++ b/PyInstaller/hooks/hook-PyQt5.py
@@ -10,7 +10,7 @@
 
 import os
 
-from PyInstaller.utils.hooks.hookutils import qt5_menu_nib_dir
+from PyInstaller.utils.win32.winutils import qt5_menu_nib_dir
 from PyInstaller.compat import getsitepackages, is_darwin, is_win
 
 
@@ -23,7 +23,7 @@ if is_win:
 
 
 # In the new consolidated mode any PyQt depends on _qt
-hiddenimports = ['sip']
+hiddenimports = ['sip', 'PyQt5.Qt']
 
 
 # For Qt to work on Mac OS X it is necessary to include directory qt_menu.nib.

--- a/PyInstaller/utils/win32/winresource.py
+++ b/PyInstaller/utils/win32/winresource.py
@@ -202,7 +202,7 @@ def UpdateResources(dstpath, data, type_, names=None, languages=None):
             for language in res[type_][name]:
                 logger.info("Updating resource type %s name %s language %s",
                             type_, name, language)
-                win32api.UpdateResource(hdst, type_, name, data, language)
+                win32api.UpdateResource(hdst, type_, name, bytes(data, 'UTF-8'), language)
     win32api.EndUpdateResource(hdst, 0)
 
 


### PR DESCRIPTION
Fixes:
ImportError: No module named 'PyInstaller.utils.winutils'
TypeError: 'str' does not support the buffer interface
During building of EXE

Fixes:
ImportError: No module named 'PyQt5.Qt'
During startup of newly built EXE with Qt where Pyinstaller missed to include PyQt5.Qt