### PR TITLE
Change file() to open() in updating manifests

### DIFF
--- a/PyInstaller/build.py
+++ b/PyInstaller/build.py
@@ -988,7 +988,7 @@ def checkCache(fnm, strip=False, upx=False, dist_nm=None):
     if fnm.lower().endswith(".manifest"):
         manifest = winmanifest.Manifest()
         manifest.filename = fnm
-        with file(fnm, "rb") as f:
+        with open(fnm, "rb") as f:
             manifest.parse_string(f.read())
         if manifest.publicKeyToken:
             logger.info("Changing %s into private assembly", os.path.basename(fnm))


### PR DESCRIPTION
I made the patch on python2 not knowing that file() was removed in python3. Now I know to use open() everywhere from now on.