### PR TITLE
Make PyQt5.sip available as sip at runtime

### DIFF
--- a/PyInstaller/loader/rthooks/pyi_rth_qt5plugins.py
+++ b/PyInstaller/loader/rthooks/pyi_rth_qt5plugins.py
@@ -29,6 +29,16 @@ if 'QT_PLUGIN_PATH' in os.environ:
     os.environ['QT_PLUGIN_PATH'] = ''
     del os.environ['QT_PLUGIN_PATH']
 
+try:
+    import sip
+except ImportError:
+    # The packaging system may name sip PyQt5.sip, so make it available as "sip"
+    try:
+        import PyQt5.sip as sip
+        sys.modules['sip'] = sip
+    except ImportError:
+        pass  # if this didn't work, there will be a NameError later
+
 
 # We cannot use QT_PLUGIN_PATH here, because it would not work when
 # PyQt5 is compiled with a different CRT from Python (eg: it happens


### PR DESCRIPTION
This fixes an issue where, at least on Windows, trying to use a PyQt5 module results in an ImportError at runtime.

Without this patch, a module using python-qt5 exits with the following error:
```
Traceback (most recent call last):
  File "<string>", line 36, in <module>
  File "C:\Python27\Lib\site-packages\PyInstaller\loader\pyi_importers.py", line
 420, in load_module
    fp = open(filename, 'rb')
ImportError: No module named sip
LOADER: RC: -1 from pyi_rth_qt5plugins
```
When I looked at the built binary, it looks like the module is just getting named `PyQt5.sip`. The python-qt5 package expects the name `sip`. This small patch is sufficient to fix the problem, but if you would prefer a different approach, please let me know.