### PR TITLE
Changed Analysis to not write `self.pure['code']` to out00-Analysis.toc

### DIFF
--- a/PyInstaller/build.py
+++ b/PyInstaller/build.py
@@ -796,7 +796,15 @@ class Analysis(Target):
             oldstuff = None
 
         # Collect the work-product of this run
-        newstuff = tuple([getattr(self, g[0]) for g in self.GUTS])
+        # Discard self.pure['code'] and only save self.pure['toc']
+        newstuff = []
+        for g in self.GUTS:
+            gutstoc = getattr(self, g[0])
+            if g[0] == 'pure':
+                gutstoc = gutstoc['toc']
+            newstuff.append(gutstoc)
+        newstuff = tuple(newstuff)
+
         # If there was no previous, or if it is different, save the new
         if oldstuff != newstuff:
             # Save all the new stuff to avoid regenerating it later, maybe


### PR DESCRIPTION
Analysis is currently writing `self.pure['code']` to out00-Analysis.toc, which is unparseable because it contains things like `<code object <module> at 0x00000000047D85D0, file "C:\Python34\lib\encodings\euc_jp.py", line 7>`

This was causing the tocfile to never be readable and the Analysis step always reports `INFO: Building because out00-Analysis.toc missing or bad`. This change makes the tocfile readable again and the Analysis step can be skipped as usual if nothing else changed.

In `Analysis.check_guts()`, the `pure` from the tocfile is correctly placed in `self.pure['toc']` already, and `self.pure['code']` is populated in `Analysis.assemble()` using the stored toc, so this change is all that is needed.

This patch is not relevant for the `develop` branch, which does not cache the code objects in `self.pure`