### PR TITLE
Use findLibrary to search for shared libraries when using ldd

### DIFF
--- a/PyInstaller/bindepend.py
+++ b/PyInstaller/bindepend.py
@@ -476,6 +476,10 @@ def _getImports_ldd(pth):
                 # http://www.trilithium.com/johan/2005/08/linux-gate/
                 continue
 
+            # try to use dlopen way of searching for the library
+            tlib = findLibrary(name)
+            if tlib:
+                lib = tlib
             if os.path.exists(lib):
                 # Add lib if it is not already found.
                 if lib not in rslt:


### PR DESCRIPTION
findLibrary function emulates the dlopen algorithm for searching
for shared libraries which is necessary when non standard locations
were used during compilation.