### PR TITLE
Fix AIX compile problem when using gcc

### DIFF
--- a/bootloader/common/pyi_utils.c
+++ b/bootloader/common/pyi_utils.c
@@ -23,7 +23,13 @@
     #include <signal.h>  // signal
 #else
     #include <dirent.h>
-    #include <dlfcn.h>
+    #if defined(AIX) && !defined(_ALL_SOURCE)
+    	#define _ALL_SOURCE
+    	#include <dlfcn.h>
+    	#undef  _ALL_SOURCE
+    #else
+    	#include <dlfcn.h>
+    #endif
     #include <limits.h>  // PATH_MAX
     #include <signal.h>  // kill,
     #include <sys/wait.h>


### PR DESCRIPTION
`RTLD_MEMBER` is only visible when `_ALL_SOURCE` flag is defined.

When PyInstaller is built on AIX6.1, there is quite a few issues with xlC compiler.  GCC is much better, but it got stuck on the `RTLD_MEMBER` flag.  Close examination shows that  flag `_ALL_SOURCE` is required.

This is a kludge that will bypass the issue.  A better approach is need to become a fix.