### PR TITLE
Add hook for `speech_recognition`.

### DIFF
--- a/PyInstaller/hooks/hook-speech_recognition.py
+++ b/PyInstaller/hooks/hook-speech_recognition.py
@@ -1,0 +1,15 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+# Hook for speech_recognition: https://pypi.python.org/pypi/SpeechRecognition/
+# Tested on Windows 8.1 x64 with SpeechRecognition 1.5
+
+from PyInstaller.hooks.hookutils import collect_data_files
+
+datas = collect_data_files("speech_recognition")


### PR DESCRIPTION
`speech_recognition` comes bundled with FLAC encoding binaries, which need to be bundled with PyInstaller in order for the library to work properly.