### PR TITLE
Don't embed full pathname of PYZ in compiled python code.

### DIFF
--- a/PyInstaller/loader/pyi_archive.py
+++ b/PyInstaller/loader/pyi_archive.py
@@ -355,7 +355,7 @@ class ZlibArchive(Archive):
             txt = txt.replace('\r\n', '\n')
             try:
                 import os
-                co = compile(txt, self.os.path.join(self.path, nm), 'exec')
+                co = compile(txt, self.os.path.join(self.os.path.basename(self.path), nm), 'exec')
             except SyntaxError, e:
                 print("Syntax error in " + pth[:-1])
                 print(e.args)


### PR DESCRIPTION
ZlibArchive is responsible for finding files specified in its TOC and compiling the python source to bytecode. If both .py and .py[co] files are present, it prefers to read the .py file and recompile it.

It compiles the source using the `compile()` builtin, which takes as arguments the source text plus a "purported filename" to embed into the source for traceback purposes. This change simply uses the basename of the .pyz file to compute the purported filename, instead of the full path to the .pyz file.

This change has no effect for .py[co] files that have no corresponding .py file present.

#### Sidenote

While researching this fix, I noticed something curious. ZlibArchive prefers to read the .py file even if a .py[co] file is present. In doing this it assumes the filesystem names of the files in its TOC are always .pyc or .pyo, and never .py. This is probably because during the Analysis step, the filenames collected from imptracker are all .pyc or .pyo (I admit I didn't find out exactly where these filenames are coming from.)

What this implies is that during `compile_pycos()`, the .pyc and .pyo files are generated but never used, since ZlibArchive will just ignore them if it finds the .py file. So we end up compiling every .py file twice - once in `compile_pycos()` and once more in `ZlibArchive.add()`. 

The only time this is not the case is when the output directory is not writable (IOError is raised in `compile_pycos()`) which will result in the .pyc and .pyo files being generated in a temporary directory, and the TOC is updated to the new locations of those files. Then, ZlibArchive will find those pycos without any .py nearby and use them without recompiling them. However, in this case we compiled the .py files twice anyway in `compile_pycos()` because of the IOError.

(Actually, the files are compiled *three* times! First by the imptracker, then again by `compile_pycos()`, and then a third time by ZlibArchive. Now I understand that change on the python3 branch we talked about in #1281.)

I'm not sure if you'll want to merge this if you're going to bring the `code_dict` changes (and modulegraph) into this branch. The code relevant to this change is commented-out on the python3 branch. Mainly, this change "works for me" - my built app no longer has the full path to the build directory in its tracebacks.