### PR TITLE
Correct syntax errors in setup_windows.py for testing.

### DIFF
--- a/tests/setupenv_windows.py
+++ b/tests/setupenv_windows.py
@@ -33,7 +33,7 @@ if not hasattr(sys, 'real_prefix'):
     sys.path.insert(0, pyi_home)
 
 
-from PyInstaller.compat import is_py25, is_py26
+from PyInstaller.compat import is_py25, is_py26, is_py27
 
 
 PYVER = '.'.join([str(x) for x in sys.version_info[0:2]])

--- a/tests/setupenv_windows.py
+++ b/tests/setupenv_windows.py
@@ -20,6 +20,7 @@ import optparse
 import os
 import platform
 import sys
+import tempfile
 
 # easy_install command used in a Python script.
 from setuptools.command import easy_install
@@ -105,7 +106,8 @@ _PY_VERSION = {
 def main():
     parser = optparse.OptionParser()
     parser.add_option('-d', '--download-dir',
-        help='Directory with maually downloaded python modules.'
+        help='Directory with maually downloaded python modules.',
+        default=tempfile.gettempdir()
     )
     opts, _ = parser.parse_args()
 


### PR DESCRIPTION
Fix: Missing ispy27.
     Provide a default tempdir, so that the --download_dir isn't required.

Before these fixes:
```
C:\Users\bjones\Documents\pyinstaller-git\tests>python setupenv_windows.py
Traceback (most recent call last):
  File "setupenv_windows.py", line 99, in <module>
    'twisted': is_py27,  # wheels are avalable for 2.7 only
NameError: name 'is_py27' is not defined
```

and

```
C:\Users\bjones\Documents\pyinstaller-git\tests>python setupenv_windows.py
Already installed... markdown
Installing module... pyusb
  pyusb
Searching for pyusb
Reading https://pypi.python.org/simple/pyusb/
Best match: pyusb 1.0.0b2
Downloading https://pypi.python.org/packages/source/p/pyusb/pyusb-1.0.0b2.tar.gz#md5=bc12e83ff3ef104
5d4306d13a9955fc1
Processing pyusb-1.0.0b2.tar.gz
Writing c:\users\bjones\appdata\local\temp\easy_install-4qkx9s\pyusb-1.0.0b2\setup.cfg
Running pyusb-1.0.0b2\setup.py -q bdist_egg --dist-dir c:\users\bjones\appdata\local\temp\easy_insta
ll-4qkx9s\pyusb-1.0.0b2\egg-dist-tmp-viorg6
warning: no files found matching 'ChangeLog'
zip_safe flag not set; analyzing archive contents...
Adding pyusb 1.0.0b2 to easy-install.pth file

Installed c:\python27\lib\site-packages\pyusb-1.0.0b2-py2.7.egg
Already installed... pycparser
Traceback (most recent call last):
  File "setupenv_windows.py", line 152, in <module>
    main()
  File "setupenv_windows.py", line 129, in main
    pattern = os.path.join(opts.download_dir, pattern)
  File "C:\Python27\lib\ntpath.py", line 96, in join
    assert len(path) > 0
TypeError: object of type 'NoneType' has no len()
```