### PR TITLE
Hook fixes

### DIFF
--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -21,6 +21,9 @@ import site
 import subprocess
 import sys
 
+# Distinguish code for different major Python version.
+is_py2 = sys.version_info[0] == 2
+is_py3 = sys.version_info[0] == 3
 
 is_py25 = sys.version_info >= (2, 5)
 is_py26 = sys.version_info >= (2, 6)

--- a/PyInstaller/hooks/hook-logilab.py
+++ b/PyInstaller/hooks/hook-logilab.py
@@ -1,0 +1,26 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2014, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+#
+# ***************************************************
+# hook-logilab.py - PyInstaller hook file for logilab
+# ***************************************************
+#
+# The following was written about logilab, version 0.32.2, based on the contents
+# of logilab.common.__pkginfo__.
+#
+# In logilab.common.configuration, line 126::
+#
+#    from six.moves import range, configparser as cp, input
+#
+# Therefore, the modules must be listed as hidden imports, due to the six
+# module's lazy import structure. The range module is a builtin, so we
+# don't need to list that. The configparser imports as ConfigParser in
+# Python 2.
+hiddenimports = ['ConfigParser']
+

--- a/PyInstaller/hooks/hook-logilab.py
+++ b/PyInstaller/hooks/hook-logilab.py
@@ -10,6 +10,7 @@
 # ***************************************************
 # hook-logilab.py - PyInstaller hook file for logilab
 # ***************************************************
+from PyInstaller.compat import is_py2
 #
 # The following was written about logilab, version 0.32.2, based on the contents
 # of logilab.common.__pkginfo__.
@@ -22,5 +23,8 @@
 # module's lazy import structure. The range module is a builtin, so we
 # don't need to list that. The configparser imports as ConfigParser in
 # Python 2.
-hiddenimports = ['ConfigParser']
+#
+# Pyinstaller for Python 3 can auto-detect six imports, so omit it.
+if is_py2:
+    hiddenimports = ['ConfigParser']
 

--- a/PyInstaller/hooks/hook-pygments.formatters.py
+++ b/PyInstaller/hooks/hook-pygments.formatters.py
@@ -6,8 +6,20 @@
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
-
+#
+# *****************************************************
+# hook-pygments.py - PyInstaller hook file for pygments
+# *****************************************************
+# The following applies to pygments version 2.0.2, as reported by ``pip show
+# pygments``.
+#
+# From pygments.formatters, line 37::
+#
+#    def _load_formatters(module_name):
+#        """Load a formatter (and all others in the module too)."""
+#        mod = __import__(module_name, None, None, ['__all__'])
+#
+# Therefore, we need all the modules in ``pygments.formatters``.
 from PyInstaller.hooks.hookutils import collect_submodules
-
-# Pygments uses a dynamic import for its formatters, so gather them all here.
 hiddenimports = collect_submodules('pygments.formatters')
+

--- a/PyInstaller/hooks/hook-pylint.py
+++ b/PyInstaller/hooks/hook-pylint.py
@@ -10,22 +10,22 @@
 # *************************************************
 # hook-pylint.py - PyInstaller hook file for pylint
 # *************************************************
-# The pylint package, in __pkginfo__.py, is version 1.2.1. Looking at its
+# The pylint package, in __pkginfo__.py, is version 1.4.3. Looking at its
 # source:
 #
-# From checkers/__init__.py, starting at line 141::
+# From checkers/__init__.py, starting at line 122::
 #
 #    def initialize(linter):
 #        """initialize linter with checkers in this package """
 #        register_plugins(linter, __path__[0])
 #
-# From reporters/__init__.py, starting at line 136::
+# From reporters/__init__.py, starting at line 131::
 #
 #    def initialize(linter):
 #        """initialize linter with reporters in this package """
 #        utils.register_plugins(linter, __path__[0])
 #
-# From utils.py, starting at line 722::
+# From utils.py, starting at line 881::
 #
 #    def register_plugins(linter, directory):
 #        """load all module and package in the given directory, looking for a
@@ -43,7 +43,7 @@
 #
 #
 # So, we need all the Python source in the ``checkers/`` and ``reporters/``
-# subdirectories, since thiese are run-time discovered and loaded. Therefore,
+# subdirectories, since these are run-time discovered and loaded. Therefore,
 # these files are all data files. In addition, since this is a module, the
 # pylint/__init__.py file must be included, since submodules must be children of
 # a module.

--- a/tests/libraries/test_pygments.py
+++ b/tests/libraries/test_pygments.py
@@ -7,13 +7,14 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-
-# Test import hooks for the following modules.
-
-# This line must be included for Pyinstaller to work; Python doesn't require it.
+# Pyinstaller executables fail without these imports; Python doesn't need them.
 import pygments.formatters
-from pygments.formatters import HtmlFormatter
-# This line must be included for Pyinstaller to work; Python doesn't require it.
 import pygments.lexers
+
+# This sample code is taken from http://pygments.org/docs/quickstart/.
+from pygments import highlight
 from pygments.lexers import PythonLexer
-formatter = HtmlFormatter(style='vim')
+from pygments.formatters import HtmlFormatter
+
+code = 'print "Hello World"'
+print highlight(code, PythonLexer(), HtmlFormatter())

--- a/tests/libraries/test_pygments.py
+++ b/tests/libraries/test_pygments.py
@@ -9,6 +9,9 @@
 
 
 # Test import hooks for the following modules.
+
+# This line must be included for Pyinstaller to work; Python doesn't require it.
+import pygments.formatters
 from pygments.formatters import HtmlFormatter
 # This line must be included for Pyinstaller to work; Python doesn't require it.
 import pygments.lexers

--- a/tests/libraries/test_pygments.py
+++ b/tests/libraries/test_pygments.py
@@ -18,3 +18,4 @@ from pygments.formatters import HtmlFormatter
 
 code = 'print "Hello World"'
 print highlight(code, PythonLexer(), HtmlFormatter())
+


### PR DESCRIPTION
These commit fix two failing tests (libraries/test_pylint and libraries/test_pygments). Details:

* Add a logilab hook to add the hidden configparser import (dynamically imported by six)
* Add an extra import in test_pygments to make the test pass.