### PR TITLE
Logging

### DIFF
--- a/PyInstaller/bindepend.py
+++ b/PyInstaller/bindepend.py
@@ -28,7 +28,7 @@ import PyInstaller.compat as compat
 
 
 import PyInstaller.log as logging
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(__name__)
 
 seen = {}
 

--- a/PyInstaller/log.py
+++ b/PyInstaller/log.py
@@ -19,20 +19,8 @@ import logging
 from logging import getLogger, INFO, WARN, DEBUG, ERROR, FATAL
 
 FORMAT = '%(relativeCreated)d %(levelname)s: %(message)s'
-
-try:
-    logging.basicConfig(format=FORMAT, level=logging.INFO)
-except TypeError:
-    # In Python 2.3 basicConfig does not accept arguments
-    # :todo: remove when dropping Python 2.3 compatibility
-    logging.basicConfig()
-    root = logging.getLogger()
-    assert len(root.handlers) == 1
-    root.handlers[0].setFormatter(logging.Formatter(FORMAT))
-    root.setLevel(logging.INFO)
-
+logging.basicConfig(format=FORMAT, level=logging.INFO)
 logger = getLogger('PyInstaller')
-
 
 def __add_options(parser):
     levels = ('DEBUG', 'INFO', 'WARN', 'ERROR', 'CRITICAL')

--- a/PyInstaller/main.py
+++ b/PyInstaller/main.py
@@ -26,8 +26,10 @@ import PyInstaller.log
 # Warn when old command line option is used
 
 from PyInstaller import get_version
-from PyInstaller.log import logger
 from PyInstaller.utils import misc
+import PyInstaller.log as logging
+
+logger = logging.getLogger(__name__)
 
 
 def run_makespec(opts, args):

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -51,6 +51,7 @@ from PyInstaller.lib import unittest2 as unittest
 from PyInstaller.lib import junitxml
 from PyInstaller.utils import misc, winutils
 from PyInstaller.cliutils import archive_viewer
+import PyInstaller.log as logging
 
 # HACK
 PyInstaller.makespec._EXENAME_FORCED_SUFFIX_ = '.exe'
@@ -814,6 +815,20 @@ def main():
     global VERBOSE, REPORT, PYI_CONFIG
     VERBOSE = opts.verbose
     REPORT = opts.junitxml is not None
+    # The function called by configure.get_config uses logging. So, we need to
+    # set a logging level now, in addition to passing it as a "log-level=XXXX"
+    # option in test_building (see the OPTS dict), in order for the logging
+    # level to be consistent. Otherwise, the default logging level of INFO will
+    # produce messages, then be overriden by runtest's default (when the -v /
+    # --verbose option isn't specificed on runtest's command line) of ERROR
+    # (again, see the OPTS dict in test_building).
+    if VERBOSE:
+        # logging's default of INFO is fine.
+        pass
+    else:
+        # Set the logging level to ERROR.
+        logger = logging.getLogger('PyInstaller')
+        logger.setLevel(logging.ERROR)
     PYI_CONFIG = configure.get_config(upx_dir=None)  # Run configure phase only once.
 
 


### PR DESCRIPTION
`runtests.py` emits INFO logging message initially, then stops doing so for no definite reason. This pull request keeps the logging level consistent: `runtests.py` now emits all INFO messages (when run with the `-v / --verbose` flag) or none (without this flag). It also fixes a minor bug which caused "INFO: Adding xxxxxx to dependent assemblies of final executable" log message to be output when INFO logging was disabled, and removes some Python 2.3 compatibility code.