### PR TITLE
Fix: Provide correct encoding for Windows based on querying chcp.

### DIFF
--- a/tests/basic/expected_stdxxx_encoding.py
+++ b/tests/basic/expected_stdxxx_encoding.py
@@ -1,0 +1,28 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2015, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+import sys
+import subprocess
+
+# For various OSes the encoding is different.
+if sys.platform.startswith('win'):
+    # The default Windows encoding is based on the active console code page,
+    # which varies from PC to PC and may be changed by the user. For more info,
+    # See https://technet.microsoft.com/en-us/library/bb490874.aspx.
+    # Therefore, ask for the current encoding using chcp (see link above
+    # for details). The expected output: 'Active code page: nnn\r\n'.
+    # We want only the nnn (a number which specifies the code page).
+    chcp_out = subprocess.check_output(['chcp'], shell=True)
+    # The encoding consists of the string `cpnnn`, where the nnn is replaced
+    # by the active code page.
+    encoding = 'cp' + chcp_out.split()[-1]
+else:
+    # On Linux, MAC OS X, and other Unixes it should be mostly 'UTF-8'.
+    encoding = 'UTF-8'
+

--- a/tests/basic/test_stderr_encoding.py
+++ b/tests/basic/test_stderr_encoding.py
@@ -7,28 +7,11 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-
 import sys
-import subprocess
-
+# Get the expected stdout/stderr encoding for this platform.
+from expected_stdxxx_encoding import encoding
 
 frozen_encoding = str(sys.stderr.encoding)
-
-# For various OSes the encoding is different.
-if sys.platform.startswith('win'):
-    # The default Windows encoding is based on the active console code page,
-    # which varies from PC to PC and may be changed by the user. For more info,
-    # See https://technet.microsoft.com/en-us/library/bb490874.aspx.
-    # Therefore, ask for the current encoding using chcp (see link above
-    # for details). The expected output: 'Active code page: nnn\r\n'.
-    # We want only the nnn (a number which specifies the code page).
-    chcp_out = subprocess.check_output(['chcp'], shell=True)
-    # The encoding consists of the string `cpnnn`, where the nnn is replaced
-    # by the active code page.
-    encoding = 'cp' + chcp_out.split()[-1]
-else:
-    # On Linux, MAC OS X, and other Unixes it should be mostly 'UTF-8'.
-    encoding = 'UTF-8'
 
 print('Encoding expected: ' + encoding)
 print('Encoding current: ' + frozen_encoding)

--- a/tests/basic/test_stderr_encoding.py
+++ b/tests/basic/test_stderr_encoding.py
@@ -9,21 +9,31 @@
 
 
 import sys
+import subprocess
 
 
 frozen_encoding = str(sys.stderr.encoding)
 
-
-# For various OS encoding is different.
-# On Windows it should be still cp850.  ## FIXME: Is this correct???  I don't have Windows!
-# On Linux, MAC OS X, and other unixes it should be mostly 'UTF-8'.
-encoding = 'cp850' if sys.platform.startswith('win') else 'UTF-8'
-
+# For various OSes the encoding is different.
+if sys.platform.startswith('win'):
+    # The default Windows encoding is based on the active console code page,
+    # which varies from PC to PC and may be changed by the user. For more info,
+    # See https://technet.microsoft.com/en-us/library/bb490874.aspx.
+    # Therefore, ask for the current encoding using chcp (see link above
+    # for details). The expected output: 'Active code page: nnn\r\n'.
+    # We want only the nnn (a number which specifies the code page).
+    chcp_out = subprocess.check_output(['chcp'], shell=True)
+    # The encoding consists of the string `cpnnn`, where the nnn is replaced
+    # by the active code page.
+    encoding = 'cp' + chcp_out.split()[-1]
+else:
+    # On Linux, MAC OS X, and other Unixes it should be mostly 'UTF-8'.
+    encoding = 'UTF-8'
 
 print('Encoding expected: ' + encoding)
 print('Encoding current: ' + frozen_encoding)
 
-
 if not frozen_encoding == encoding:
     raise SystemExit('Frozen encoding %s is not the same as unfrozen %s.' %
                      (frozen_encoding, encoding))
+

--- a/tests/basic/test_stdout_encoding.py
+++ b/tests/basic/test_stdout_encoding.py
@@ -9,21 +9,31 @@
 
 
 import sys
+import subprocess
 
 
 frozen_encoding = str(sys.stdout.encoding)
 
-
-# For various OS encoding is different.
-# On Windows it should be still cp850.  ## FIXME: Is this correct???  I don't have Windows!
-# On Linux, MAC OS X, and other unixes it should be mostly 'UTF-8'.
-encoding = 'cp850' if sys.platform.startswith('win') else 'UTF-8'
-
+# For various OSes the encoding is different.
+if sys.platform.startswith('win'):
+    # The default Windows encoding is based on the active console code page,
+    # which varies from PC to PC and may be changed by the user. For more info,
+    # see https://technet.microsoft.com/en-us/library/bb490874.aspx.
+    # Therefore, ask for the current encoding using chcp (see link above
+    # for details). The expected output: 'Active code page: nnn\r\n'.
+    # We want only the nnn (a number which specifies the code page).
+    chcp_out = subprocess.check_output(['chcp'], shell=True)
+    # The encoding consists of the string `cpnnn`, where the nnn is replaced
+    # by the active code page.
+    encoding = 'cp' + chcp_out.split()[-1]
+else:
+    # On Linux, MAC OS X, and other Unixes it should be mostly 'UTF-8'.
+    encoding = 'UTF-8'
 
 print('Encoding expected: ' + encoding)
 print('Encoding current: ' + frozen_encoding)
 
-
 if not frozen_encoding == encoding:
     raise SystemExit('Frozen encoding %s is not the same as unfrozen %s.' %
                      (frozen_encoding, encoding))
+

--- a/tests/basic/test_stdout_encoding.py
+++ b/tests/basic/test_stdout_encoding.py
@@ -7,28 +7,11 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-
 import sys
-import subprocess
-
+# Get the expected stdout/stderr encoding for this platform.
+from expected_stdxxx_encoding import encoding
 
 frozen_encoding = str(sys.stdout.encoding)
-
-# For various OSes the encoding is different.
-if sys.platform.startswith('win'):
-    # The default Windows encoding is based on the active console code page,
-    # which varies from PC to PC and may be changed by the user. For more info,
-    # see https://technet.microsoft.com/en-us/library/bb490874.aspx.
-    # Therefore, ask for the current encoding using chcp (see link above
-    # for details). The expected output: 'Active code page: nnn\r\n'.
-    # We want only the nnn (a number which specifies the code page).
-    chcp_out = subprocess.check_output(['chcp'], shell=True)
-    # The encoding consists of the string `cpnnn`, where the nnn is replaced
-    # by the active code page.
-    encoding = 'cp' + chcp_out.split()[-1]
-else:
-    # On Linux, MAC OS X, and other Unixes it should be mostly 'UTF-8'.
-    encoding = 'UTF-8'
 
 print('Encoding expected: ' + encoding)
 print('Encoding current: ' + frozen_encoding)


### PR DESCRIPTION
This updates https://github.com/pyinstaller/pyinstaller/pull/1243#issuecomment-116799566, in which the Windows encoding was left as a fixme.

The underlying problem -- the bootloader doesn't select the correct stdout/stderr encoding on Windows -- isn't resolved, but at least this pull requests makes the test correct.