### PR TITLE
Suppress Windows Error Reporting dialogs while calling Py_Initialize

### DIFF
--- a/bootloader/src/pyi_pythonlib.c
+++ b/bootloader/src/pyi_pythonlib.c
@@ -281,9 +281,24 @@ int pyi_pylib_start_python(ARCHIVE_STATUS *status)
 
    pyi_pylib_set_runtime_opts(status);
 
+	/*
+	 * Py_Initialize() may rudely call abort(), and on Windows this triggers the error
+	 * reporting service, which results in a dialog box that says "Close program", "Check
+	 * for a solution", and also "Debug" if Visual Studio is installed. The dialog box
+	 * makes it frustrating to run the test suite.
+	 *
+	 * For debug builds of the bootloader, disable the error reporting before calling
+	 * Py_Initialize and enable it afterward.
+	 */
+
+#if defined(_WIN32) && defined(LAUNCH_DEBUG)
+	SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX);
+#endif
 	VS("LOADER: Initializing python\n");
 	PI_Py_Initialize();
-
+#if defined(_WIN32) && defined(LAUNCH_DEBUG)
+	SetErrorMode(0);
+#endif
 	/*
 	 * Set sys.path list. In Python 2 this is the only way to set sys.path.
 	 * Without


### PR DESCRIPTION
Out of sheer curiosity (as I don't develop for Python 3), I checked out the `python3` branch to try the new py.test suite on Windows. I found that several tests fail in a way that displays the Windows Error Reporting dialog, which stalls the test suite until it is dismissed.

(Incidentally, the test failures may be related to running the suite from within a virtualenv, which gets some-path-or-another wrong causing `create_py3_base_library` to fail, saying `py.test.exe\\__main__.py not found`...but that's a separate issue.)

The dialog is caused by Py_Initialize. Py_Initialize when failing calls `abort()` to terminate the entire application. (This is very rude, especially for embedded pythons.) `abort()` on Windows triggers the Windows Error Reporting Dialog, which will pause the test suite until it is dismissed. This patch disables the dialog during the call to Py_Initialize for debug builds of the bootloader.

I decided only disabling them for debug builds would be best, as release builds will still want to tell the user that something, at least, has gone wrong. It might be prudent to disable them for the entire execution instead of just the Py_Initialize call, but I figure nothing else is rude enough to call `abort()` out of nowhere.