### PR TITLE
A few fixes to get py.test working on Windows

### DIFF
--- a/PyInstaller/depend/utils.py
+++ b/PyInstaller/depend/utils.py
@@ -101,6 +101,7 @@ def create_py3_base_library(libzip_filename):
 
     except Exception as e:
         logger.error('base_library.zip could not be created!')
+        raise
 
 
 ### TODO Minimize this code to only resolving ctypes imports.

--- a/PyInstaller/lib/modulegraph/modulegraph.py
+++ b/PyInstaller/lib/modulegraph/modulegraph.py
@@ -594,6 +594,8 @@ def _ast_names(names):
             result.append(nm.name)
         else:
             result.append(nm)
+
+    result = [r for r in result if r != '__main__']
     return result
 
 

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -126,8 +126,13 @@ class AppBuilder(object):
 
         # Run executable in the directory where it is.
         prog_cwd = os.path.dirname(prog)
-        # The executable will be called as relative not absolute path.
-        prog = os.path.join(os.curdir, os.path.basename(prog))
+
+        # On Windows, `subprocess.call` does not search in its `cwd` for the
+        # executable named as the first argument, so it must be passed as an
+        # absolute path. This is documented for the Windows API `CreateProcess`
+        if not is_win:
+            # The executable will be called as relative not absolute path.
+            prog = os.path.join(os.curdir, os.path.basename(prog))
 
         # Run executable. stderr is redirected to stdout.
         print('RUNNING: ' + prog)


### PR DESCRIPTION
Preface: I've only tested these on 32-bit Python 3.4 for Windows.

These three changes (well, two of them at least) allow the py.test suite to run on Windows.

The original error reads: `Fatal Python error: Py_Initialize: unable to load the file system codec` when running the .exe created by any test. Reading the output log reveals `ERROR: base_library.zip could not be created!`, so the first change makes this error fatal so we can see why it fails.

This reveals the error in `create_py3_base_library`:

```
>                       st = os.stat(mod.filename)
FileNotFoundError: [WinError 3] The system cannot find the path specified: '(...)\\pyinst1328\\env34\\Scripts\\py.test.exe\\__main__.py'
```

This is caused by modulegraph trying to analyze the `__main__` module, so the second change is a tweak to modulegraph's AST analyzer to exclude `__main__` from import analysis.

The problem is related to the way `setuptools` installs Scripts on Windows as exe files. When the script is run, the `__main__` module has a `__file__` that doesn't refer to an actual file. In the case of `py.test.exe`, the `__main__` module is purported to be at `scripts\py.test.exe\__main__.py`, which does not exist.

One way `__main__` is being picked up by modulegraph is because the `warnings` module has this import chain: `['warnings', 'linecache', 'tokenize', 'collections', 'heapq', 'doctest', 'pdb', '__main__']`. Looking at the reason `heapq` imports `doctest`, I decided that import chains leading back to `__main__` were hard to avoid using any special cases, so I simply excluded `__main__` from the modules found by modulegraph during its AST analysis.

For our purposes, analyzing `__main__` is certainly wrong, since it's either going to be PyInstaller's own `main.py` or `py.test`'s main script. (*Is* there a special case for excluding PyInstaller's `main.py`? This problem doesn't happen with `Scripts\pyinstaller.exe`)

The third change addresses a known issue [python#20927](https://bugs.python.org/issue20927) with the behavior of `Popen` and `subprocess` differing between Windows and non-Windows. On Windows, the `cwd` parameter does not affect the search path for the executable given. So, `AppBuilder._runExecutable` is changed to give the executable's absolute path on Windows.

(This behavior is inherited from [`CreateProcess`](https://msdn.microsoft.com/en-us/library/windows/desktop/ms682425(v=vs.85).aspx), which only searches the cwd of the *calling* process and *not* the cwd passed for the `lpCurrentDirectory` argument)