### PR TITLE
fix NameError: name 'CONF' is not defined

### DIFF
--- a/PyInstaller/build.py
+++ b/PyInstaller/build.py
@@ -931,6 +931,7 @@ def checkCache(fnm, strip=False, upx=False, dist_nm=None):
                to determine level of paths for @loader_path like
                '@loader_path/../../' for qt4 plugins.
     """
+    from .config import CONF
     # On darwin a cache is required anyway to keep the libaries
     # with relative install names. Caching on darwin does not work
     # since we need to modify binary headers to use relative paths


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "C:\Python34\lib\runpy.py", line 170, in _run_module_as_main
    "__main__", mod_spec)
  File "C:\Python34\lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "C:\Python34\Scripts\pyinstaller.exe\__main__.py", line 9, in <module>
  File "C:\Python34\lib\site-packages\PyInstaller\main.py", line 96, in run
    run_build(opts, spec_file, pyi_config)
  File "C:\Python34\lib\site-packages\PyInstaller\main.py", line 49, in run_build
    PyInstaller.build.main(pyi_config, spec_file, **opts.__dict__)
  File "C:\Python34\lib\site-packages\PyInstaller\build.py", line 2168, in main
    build(specfile, kw.get('distpath'), kw.get('workpath'), kw.get('clean_build'))
  File "C:\Python34\lib\site-packages\PyInstaller\build.py", line 2114, in build
    exec(text, spec_namespace)
  File "<string>", line 29, in <module>
  File "C:\Python34\lib\site-packages\PyInstaller\build.py", line 1626, in __init__
    self.__postinit__()
  File "C:\Python34\lib\site-packages\PyInstaller\build.py", line 240, in __postinit__
    self.assemble()
  File "C:\Python34\lib\site-packages\PyInstaller\build.py", line 1659, in assemble
    dist_nm=inm)
  File "C:\Python34\lib\site-packages\PyInstaller\build.py", line 1085, in checkCache
    for pydep in CONF['pylib_assemblies']:
NameError: name 'CONF' is not defined
```