### PR TITLE
Reread from sys.modules before returning module

### DIFF
--- a/PyInstaller/loader/pyi_importers.py
+++ b/PyInstaller/loader/pyi_importers.py
@@ -269,6 +269,8 @@ class FrozenImporter(object):
 
                 # Run the module code.
                 exec(bytecode, module.__dict__)
+                # Reread the module from sys.modules in case it's changed itself
+                module = sys.modules[fullname]
 
         except Exception:
             # Remove 'fullname' from sys.modules if it was appended there.


### PR DESCRIPTION
When frozen, a module that dynamically recreates itself at runtime (by replacing itself in sys.modules) doesn't seem to interact well with the loader.

The main symptom of this problem is something like this:
```python
>>> sys.modules[<dynamic_module>] is __import__(<dynamic_module>)
False
```

The fix seems just to be to make sure to re-read the module from sys.modules before returning it from load_module