### PR TITLE
Remove the duplicate items in cbinaries

### DIFF
--- a/PyInstaller/depend/utils.py
+++ b/PyInstaller/depend/utils.py
@@ -286,6 +286,7 @@ def scan_code_for_ctypes(co, instrs, i):
 def _resolveCtypesImports(cbinaries):
     """Completes ctypes BINARY entries for modules with their full path.
     """
+    cbinaries = list(set(cbinaries))
     from ctypes.util import find_library
 
     if is_unix:


### PR DESCRIPTION
There is a missing duplicate check before trying to resolve the full path inside cbinaries. Below is a sample cbinaries during my windows 7 debuging:

![dump](https://cloud.githubusercontent.com/assets/2742842/8975129/d082c2e8-36ac-11e5-8326-ae9c40553421.png)