### PR TITLE
Robust Module Version Comparisons

### DIFF
--- a/PyInstaller/depend/bindepend.py
+++ b/PyInstaller/depend/bindepend.py
@@ -175,7 +175,7 @@ def Dependencies(lTOC, xtrapath=None, manifest=None):
     return lTOC
 
 
-def pkg_resouces_get_default_cache():
+def pkg_resources_get_default_cache():
     """
     Determine the default cache location
 
@@ -251,7 +251,7 @@ def check_extract_from_egg(pth, todir=None):
                     # if the specific egg was accessed before (not necessarily
                     # by pyinstaller), the extracted contents already exist
                     # (pkg_resources puts them there) and can be used.
-                    todir = os.path.join(pkg_resouces_get_default_cache(),
+                    todir = os.path.join(pkg_resources_get_default_cache(),
                                          name + "-tmp")
                 if components[i + 1:]:
                     members = ["/".join(components[i + 1:])]

--- a/PyInstaller/hooks/hook-sqlalchemy.py
+++ b/PyInstaller/hooks/hook-sqlalchemy.py
@@ -8,7 +8,7 @@
 #-----------------------------------------------------------------------------
 
 
-from PyInstaller.utils.hooks.hookutils import exec_statement
+from PyInstaller.utils.hooks.hookutils import exec_statement, is_module_version
 
 # include most common database bindings
 # some database bindings are detected and include some
@@ -16,10 +16,7 @@ from PyInstaller.utils.hooks.hookutils import exec_statement
 hiddenimports = ['pysqlite2', 'MySQLdb', 'psycopg2']
 
 # sqlalchemy.dialects package from 0.6 and newer sqlachemy versions
-version = exec_statement('import sqlalchemy; print(sqlalchemy.__version__)')
-is_alch06 = version >= '0.6'
-
-if is_alch06:
+if is_module_version('sqlalchemy', '>=', '0.6'):
     dialects = exec_statement("import sqlalchemy.dialects;print(sqlalchemy.dialects.__all__)")
     dialects = eval(dialects.strip())
 


### PR DESCRIPTION
This pull request adds a utility function for safely comparing module versions and then refactors import hooks requiring such comparisons to call this function.

## Swell. Why?

The SQLAlchemy hook checks whether the currently installed module is version 0.6 or newer like so:

```
version = exec_statement('import sqlalchemy; print(sqlalchemy.__version__)')
is_alch06 = version >= '0.6'
```

This is me doing my disgusted face. :disappointed: 

**Version specifiers are _not_ reliably comparable as strings.** Since string comparison is lexicographic rather than numeric, comparing version specifiers as strings results in erroneous results in common edge cases: e.g.,

```
>>> '0.7' >= '0.6'
True
>>> ' 0.7' >= '0.6'
False
>>> '0.5' >= '0.6'
False
>>> '00.5' >= '0.6'
True
```

Version specifiers should _always_ be compared as tuples whose elements are the in-order integer components of those specifiers. By definition, this approach is resilient to lexicographic ordering: e.g.,

```
# The tuple "(0, 5)" corresponds to the version specifier "0.5".
>>> (0, 5) >= (0, 6)
False
>>> (-0, 5) >= (0, 6)
False
>>> (00, 5) >= (0, 6)
False
```

## Nice. Fix This Yourself, Did You?

Sort of. Being slobbish, greasy, and lazy (*the holy couch-potato trifecta*), I "borrowed" existing Python functionality rather than implement my own version comparator. It turns out that implementing your own is nail-bitingly hard and therefore a bad idea, thanks to bizarre outliers like release candidates. (Yes, version `1.0_rc1` is older than version `1.0`. Good luck handling that.)

Interestingly, core Python already provides little-known version comparators. These include:

* The `distutils.StrictVersion()` function, a zealous non-[PEP 0440](https://www.python.org/dev/peps/pep-0440)-compliant version comparator. Sadly, it's broken by design and hence useless for most purposes (e.g., the versions `3` and `3.1.4.1` both raise exceptions when passed to this function).
* The `distutils.LooseVersion()` function, a permissive non-[PEP 0440](https://www.python.org/dev/peps/pep-0440)-compliant version comparator. Sadly, it's broken for popular edge cases and hence mostly useless for most purposes (e.g., `LooseVersion("1.0_rc1") > LooseVersion("1.0") == True`).
* The `pkg_resources.parse_version()` function bundled with `setuptools`, a permissive [PEP 0440](https://www.python.org/dev/peps/pep-0440)-compliant version comparator. It actually works (e.g., `parse_version("1.0_rc1") > parse_version("1.0") == False`), probably due to being PEP 0440-compliant. Praise be to the `setuptools` for it is not quite so awful.

Which do we use? Three stuffed platypuses to the best guess!

## Nice. Get to the Point.

Safely and reliably comparing module versions is non-trivial even _with_ the `pkg_resources.parse_version()` function. You have to query the module for its version string in a subprocess, convert version strings to comparable tuples, and blah-blah-blah. The new `PyInstaller.utils.hook.hookutils.is_module_version()` function abstracts away that complexity for import hooks in a general-purpose manner.

*Great...* What's that mean? Specifically, that this function compares the version of the passed module against the passed version using the passed operator – which, in hot action, looks like this:

```
from PyInstaller.utils.hooks.hookutils import is_module_version
if is_module_version('sqlalchemy', '>=', '0.6'):
    print('Houston, we are a go for SQLAlchemy 0.6 or newer.')
if is_module_version('sphinx', '<', '1.3.1'):
    print('Houston, we just lost Sphinx 1.3.x. Is that good? Over.')
```

Thus is the fragile balance between good and evil preserved.

## Nice. Are You Done Yet?

Nope.

Sphinx 1.3.x added [two new mandatory dependencies](https://github.com/sphinx-doc/sphinx/issues/1346#issuecomment-75538604) _not_ detectable by PyInstaller and hence requiring the usual `hiddenimports` support: the external [`alabaster`](https://github.com/bitprophet/alabaster) and [`sphinx_rtd_theme`](https://github.com/snide/sphinx_rtd_theme) modules. Sphinx versions older than 1.3.x do _not_ require these modules.

@htgoebel [smartly fixed that](https://github.com/pyinstaller/pyinstaller/commit/2c3ac86c1ea0ac81dcf98810d942e01d0db8e06f) by conditionally freezing `alabaster` and `sphinx_rtd_theme` only if those modules exist. That's problematic, however: **those modules are mandatory for basic Sphinx operation.** Sphinx's [`setup.py`](https://github.com/sphinx-doc/sphinx/blob/master/setup.py) even lists both as hard installation-time requirements. If either module does _not_ exist when freezing Sphinx 1.3.x, that's a fatal error – and PyInstaller should fail during freezing. That's what used to happen. Arguably, that's what should still happen.

This pull request sort-of maybe reverts htgoebel's fix <sup>(*Sorry, man. You're still cool.*)</sup> by conditionally freezing `alabaster` and `sphinx_rtd_theme` only when Sphinx is newer than 1.3.x. Order is restored.

## Jebus Crust. You'd Better Be Done.

*Uhrm...*

I may have also fixed a minor typo in module `depend.bindepend`, renaming
`pkg_resouces_get_default_cache()` to `pkg_resources_get_default_cache()`. But that's it. I swear it on the [Virgin Gomira](http://ultra.wikia.com/wiki/Gomira).

![Gomira the Terrible](http://vignette1.wikia.nocookie.net/ultra/images/3/33/Gomira_Full_Body.jpg/revision/latest/scale-to-width-down/250?cb=20130908002913)