### PR TITLE
Robust Module Version Comparisons ~ Redux

### DIFF
--- a/PyInstaller/hooks/hook-sphinx.py
+++ b/PyInstaller/hooks/hook-sphinx.py
@@ -10,57 +10,63 @@
 # ********************************************
 # hook-sphinx.py - Pyinstaller hook for Sphinx
 # ********************************************
+from operator import ge
 from PyInstaller.compat import is_py2
 from PyInstaller.utils.hooks.hookutils import \
     collect_submodules, collect_data_files, is_module_version
 
 hiddenimports = (
-# The following analysis applies to Sphinx v. 1.3.1, reported by ``pip show
-# sphinx``.
+# The following analysis applies to Sphinx v. 1.3.1, reported by "pip show
+# sphinx".
 #
-# From sphinx.application line 248::
+# From sphinx.application line 248:
 #
 #    __import__('sphinx.builders.' + mod, None, None, [cls]), cls)
 #
-# Therefore, we need all modules in ``sphinx.builders``.
+# Therefore, we need all modules in "sphinx.builders". Note this includes the
+# "sphinx.builders.changes" module, which imports from the "sphinx.themes"
+# module via import() rather than __import__(), which unconditionally imports
+# the external "alabaster" and "sphinx_rtd_theme" modules again via import()
+# rather than __import__(). While the data files for these themes must be listed
+# below, these themes need *NOT* be listed as hidden imports here.
                   collect_submodules('sphinx.builders') +
 #
-# From sphinx.application line 429::
+# From sphinx.application line 429:
 #
 #    mod = __import__(extension, None, None, ['setup'])
 #
 # Per http://sphinx-doc.org/extensions.html#builtin-sphinx-extensions,
-# Sphinx extensions are all placed in ``sphinx.ext``. Include these.
+# Sphinx extensions are all placed in "sphinx.ext". Include these.
                   collect_submodules('sphinx.ext') +
 #
-# From sphinx.search line 228::
+# From sphinx.search line 228:
 #
 #    lang_class = getattr(__import__(module, None, None, [classname]),
 #                         classname)
 #
-# From sphinx. search line 119::
+# From sphinx. search line 119:
 #
 #    languages = {
 #        'da': 'sphinx.search.da.SearchDanish',
 #        'de': 'sphinx.search.de.SearchGerman',
 #        'en': SearchEnglish,
 #
-# So, we need all the languages in ``sphinx.search``.
+# So, we need all the languages in "sphinx.search".
                   collect_submodules('sphinx.search') +
 #
-# From sphinx.websupport line 100::
+# From sphinx.websupport line 100:
 #
 #    mod = 'sphinx.websupport.search.' + mod
 #    SearchClass = getattr(__import__(mod, None, None, [cls]), cls)
 #
-# So, include modules under ``sphinx.websupport.search``.
+# So, include modules under "sphinx.websupport.search".
                   collect_submodules('sphinx.websupport.search') +
 #
-# From sphinx.util.inspect line 21::
+# From sphinx.util.inspect line 21:
 #
 #    inspect = __import__('inspect')
 #
-# And from sphinx.cmdline line 173::
+# And from sphinx.cmdline line 173:
 #
 #    locale = __import__('locale')  # due to submodule of the same name
 #
@@ -82,9 +88,9 @@ if is_py2:
 # sphinx.locale, etc.
 datas = collect_data_files('sphinx')
 
-# Sphinx 1.3.1 adds additional mandatory dependencies *NOT* detectable by
-# PyInstaller: the external "alabaster" and "sphinx_rtd_theme" themes.
-if is_module_version('sphinx', '>=', '1.3.1'):
-    hiddenimports += ('alabaster', 'sphinx_rtd_theme')
+# Sphinx 1.3.1 adds additional mandatory dependencies unconditionally imported
+# by the "sphinx.themes" module regardless of the current Sphinx configuration:
+# the "alabaster" and "sphinx_rtd_theme" themes, each relying on data files.
+if is_module_version('sphinx', ge, '1.3.1'):
     datas.extend(collect_data_files('alabaster'))
     datas.extend(collect_data_files('sphinx_rtd_theme'))

--- a/PyInstaller/hooks/hook-sqlalchemy.py
+++ b/PyInstaller/hooks/hook-sqlalchemy.py
@@ -8,6 +8,7 @@
 #-----------------------------------------------------------------------------
 
 
+from operator import ge
 from PyInstaller.utils.hooks.hookutils import exec_statement, is_module_version
 
 # include most common database bindings
@@ -16,7 +17,7 @@ from PyInstaller.utils.hooks.hookutils import exec_statement, is_module_version
 hiddenimports = ['pysqlite2', 'MySQLdb', 'psycopg2']
 
 # sqlalchemy.dialects package from 0.6 and newer sqlachemy versions
-if is_module_version('sqlalchemy', '>=', '0.6'):
+if is_module_version('sqlalchemy', ge, '0.6'):
     dialects = exec_statement("import sqlalchemy.dialects;print(sqlalchemy.dialects.__all__)")
     dialects = eval(dialects.strip())
 

--- a/PyInstaller/utils/hooks/hookutils.py
+++ b/PyInstaller/utils/hooks/hookutils.py
@@ -662,26 +662,16 @@ print(module.__file__)
     return exec_statement(statement % module_name)
 
 
-def is_module_version(module_name, comparison_name, module_version):
+def is_module_version(module_name, comparison_func, module_version):
     """
     Check the version of the module with the passed name against the passed
-    version string using the comparison operator with the passed name.
+    version string using the passed comparison function.
 
     This function provides robust version checking based on the same low-level
     algorithm leveraged by both `easy_install` and `pip`, and should _always_ be
     called in lieu of manually comparing version strings. In particular, version
     strings should _never_ be compared lexicographically (e.g., `'00.5' > '0.6'`
     is technically `True`, despite being semantically untrue).
-
-    The passed module name should be a fully-qualified `.`-delimited module name
-    (e.g., `PyInstaller.util`). The passed version string should be a PEP
-    0440-compliant `.`-delimited version specifier (e.g., `3.14-rc5`). The
-    passed comparison name should be one of the following eight strings:
-
-    * '>=' or 'ge', performing a greater-than-or-equal-to comparison.
-    * '<=' or 'le', performing a less-than-or-equal-to comparison.
-    * '>' or 'gt', performing a greater-than comparison.
-    * '<' or 'lt', performing a less-than comparison.
 
     Implementation
     ----------
@@ -691,15 +681,13 @@ def is_module_version(module_name, comparison_name, module_version):
       module's `__version__` attribute.
     . Converts both that value and the passed version string to comparable
       tuples via the `pkg_resources.parse_version()` `setuptools` function.
-    . Returns the boolean returned by dynamically calling the private method of
-      the first such tuple corresponding to the passed comparison operator name
-      (e.g., the `tuple.__lt__()` method if that name is either `<` or `lt`),
-      passed the second such tuple.
+    . Returns the boolean returned by passing the passed comparison function
+      such tuples.
 
     Note that `pkg_resources.parse_version()` is generally considered to be the
-    most robust means of comparing version strings in Python. The
-    alternative `LooseVersion()` and `StrictVersion()` functions provided by the
-    standard `distutils.version` module fail for common edge-cases: e.g.,
+    most robust means of comparing version strings in Python. The alternative
+    `LooseVersion()` and `StrictVersion()` functions provided by the standard
+    `distutils.version` module fail for common edge cases: e.g.,
 
         >>> from distutils.version import LooseVersion
         >>> LooseVersion('1.5') >= LooseVersion('1.5-rc2')
@@ -711,11 +699,16 @@ def is_module_version(module_name, comparison_name, module_version):
     Parameters
     ----------
     module_name : str
-        Fully-qualified `.`-delimited module name.
-    comparison_name : str
-        Either '>=', 'ge', '<=', 'le', '>', 'gt', '<', or 'lt'.
+        Fully-qualified `.`-delimited module name (e.g., `PyInstaller.util`).
+        If this module does _not_ define the `__version__` attribute, an
+        exception is raised.
+    comparison_func : function
+        Function returning the boolean result of comparing two passed tuples.
+        For most purposes, the comparison functions predefined by the standard
+        `operator` module suffice (e.g., `operator.ge`, comparing module
+        versions with the `>=` operator). See the example below.
     module_version : str
-        PEP 0440-compliant `.`-delimited version specifier.
+        PEP 0440-compliant `.`-delimited version specifier (e.g., `3.14-rc5`).
 
     Returns
     ----------
@@ -725,26 +718,11 @@ def is_module_version(module_name, comparison_name, module_version):
     Examples
     ----------
         # Test whether the local version of Sphinx is 1.3.x or newer.
+        >>> from operator import ge
         >>> from PyInstaller.utils.hooks.hookutils import is_module_version
-        >>> is_module_version('sphinx', '>=', '1.3.1')
+        >>> is_module_version('sphinx', ge, '1.3.1')
         True
     """
-    # Dictionary mapping passed comparison names to private tuple method names.
-    comparison_to_method_name = {
-        '>=': '__ge__',
-        'ge': '__ge__',
-        '<=': '__le__',
-        'le': '__le__',
-        '>':  '__gt__',
-        'gt': '__gt__',
-        '<':  '__lt__',
-        'lt': '__lt__',
-    }
-
-    # If the passed comparison name is unrecognized, raise an exception.
-    if comparison_name not in comparison_to_method_name:
-        raise KeyError('Comparison name "%s" unrecognized.' % comparison_name)
-
     # String module version obtained by importing this module in a subprocess.
     statement = """
 import %s as module
@@ -756,12 +734,8 @@ print(module.__version__)
     module_version_real_tuple = pkg_resources.parse_version(module_version_real)
     module_version_fake_tuple = pkg_resources.parse_version(module_version)
 
-    # Private tuple method performing this comparison.
-    module_version_real_tuple_comparator = getattr(
-        module_version_real_tuple, comparison_to_method_name[comparison_name])
-
-    # Finally, compare the two versions.
-    return module_version_real_tuple_comparator(module_version_fake_tuple)
+    # Compare the two tuples in the expected order.
+    return comparison_func(module_version_real_tuple, module_version_fake_tuple)
 
 
 def is_package(module_name):


### PR DESCRIPTION
I'm all out of bubblegum. *Again.*

@htgoebels [astutely noted](https://github.com/pyinstaller/pyinstaller/pull/1368#discussion_r36033479) that the current implementation of `is_module_version()` ignores the existence of the standard `operator` module and is thus bonkers. He's right. He's Hartmut!

This pull request refactors `is_module_version()` to accept a comparison function (e.g., `operator.ge`) rather than a string merely _describing_ a comparison function (e.g., `">="`). Wut wuz I thinking? Only [Gyango](http://ultra.wikia.com/wiki/Gango) knows.

![image](http://vignette4.wikia.nocookie.net/ultra/images/a/a2/Gango.png/revision/latest?cb=20130924111611)

# That All You Got?

**Nope.**

The Sphinx hook unnecessarily added the `alabaster` and `sphinx_rtd_theme` modules to the `hiddenimports` list. Since this hook already adds the `sphinx.builders.changes` module, which imports from the `sphinx.themes` module via `import()` rather than `__import__()`, which unconditionally imports the `alabaster` and `sphinx_rtd_theme` modules again via `import()` rather than `__import__()`, the latter two modules need _not_ be listed as hidden imports.

So, we don't.

I've also cleaned up inline commentary in the Sphinx hook. Just... *because*.

# That Had Better Be It.

It is! You may celebrate by rewatching "Ultraman: Season One," everyone.