### PR TITLE
Fixes bug

### DIFF
--- a/PyInstaller/loader/pyi_carchive.py
+++ b/PyInstaller/loader/pyi_carchive.py
@@ -364,7 +364,7 @@ class CArchive(pyi_archive.Archive):
         # Before saving cookie we need to convert it to corresponding
         # C representation.
         cookie = struct.pack(self._cookie_format, self.MAGIC, totallen,
-                tocpos, self.toclen, pyvers, self._pylib_name)
+                tocpos, self.toclen, pyvers, self._pylib_name.encode('utf8'))
         self.lib.write(cookie)
 
     def openEmbedded(self, name):


### PR DESCRIPTION
Otherwise, this happens (checked and in develop this still appears):
    /Library/Enthought/Canopy_64bit/User/lib/python2.7/site-packages/PyInstaller/loader/pyi_carchive.py", line 367, in save_cookie
        tocpos, self.toclen, pyvers, self._pylib_name)
    struct.error: argument for 's' must be a string