### PR TITLE
Add hooks for PySide.{QtCore,QtGui}

### DIFF
--- a/PyInstaller/hooks/hook-PySide.QtCore.py
+++ b/PyInstaller/hooks/hook-PySide.QtCore.py
@@ -1,0 +1,20 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+
+hiddenimports = []
+
+from PyInstaller.hooks.hookutils import qt4_plugins_binaries
+
+ns = "PySide"
+
+def hook(mod):
+    # TODO fix this hook to use attribute 'binaries'.
+    mod.pyinstaller_binaries.extend(qt4_plugins_binaries('codecs', ns=ns))
+    return mod

--- a/PyInstaller/hooks/hook-PySide.QtGui.py
+++ b/PyInstaller/hooks/hook-PySide.QtGui.py
@@ -1,0 +1,24 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+
+hiddenimports = ['PySide.QtCore']
+
+from PyInstaller.hooks.hookutils import qt4_plugins_binaries
+
+ns = "PySide"
+
+def hook(mod):
+    # TODO fix this hook to use attribute 'binaries'.
+    mod.pyinstaller_binaries.extend(qt4_plugins_binaries('accessible', ns=ns))
+    mod.pyinstaller_binaries.extend(qt4_plugins_binaries('iconengines', ns=ns))
+    mod.pyinstaller_binaries.extend(qt4_plugins_binaries('imageformats', ns=ns))
+    mod.pyinstaller_binaries.extend(qt4_plugins_binaries('inputmethods', ns=ns))
+    mod.pyinstaller_binaries.extend(qt4_plugins_binaries('graphicssystems', ns=ns))
+    return mod

--- a/PyInstaller/hooks/hookutils.py
+++ b/PyInstaller/hooks/hookutils.py
@@ -159,18 +159,18 @@ print(list(diff))
     return module_imports
 
 
-def qt4_plugins_dir():
+def qt4_plugins_dir(ns="PyQt4"):
     qt4_plugin_dirs = eval_statement(
-        "from PyQt4.QtCore import QCoreApplication;"
+        "from %s.QtCore import QCoreApplication;"
         "app=QCoreApplication([]);"
-        "print(map(unicode,app.libraryPaths()))")
+        "print(map(unicode,app.libraryPaths()))" % ns)
     if not qt4_plugin_dirs:
-        logger.error("Cannot find PyQt4 plugin directories")
+        logger.error("Cannot find %s plugin directories" % ns)
         return ""
     for d in qt4_plugin_dirs:
         if os.path.isdir(d):
             return str(d)  # must be 8-bit chars for one-file builds
-    logger.error("Cannot find existing PyQt4 plugin directory")
+    logger.error("Cannot find existing %s plugin directory" % ns)
     return ""
 
 
@@ -191,10 +191,10 @@ def qt4_phonon_plugins_dir():
     return ""
 
 
-def qt4_plugins_binaries(plugin_type):
+def qt4_plugins_binaries(plugin_type, ns="PyQt4"):
     """Return list of dynamic libraries formatted for mod.pyinstaller_binaries."""
     binaries = []
-    pdir = qt4_plugins_dir()
+    pdir = qt4_plugins_dir(ns=ns)
     files = misc.dlls_in_dir(os.path.join(pdir, plugin_type))
 
     # Windows:


### PR DESCRIPTION
I'm not sure if this will be useful fo the plans onr #299, but I'm using this patch on osx.

I was having troubles because the application would launch on osx, but would crash shortly after due to the "duplicated Qt libs" error. One of the plugins was the cause of the trouble.

For what it's worth, the only way I've been able to get it not to crash is installing pyside as a --standalone bundle (which needs some hacks on pyside-setup too, by the way).