### PR TITLE
OS X: Fixed `Info.plist` override merge

### DIFF
--- a/PyInstaller/building/osx.py
+++ b/PyInstaller/building/osx.py
@@ -148,7 +148,7 @@ class BUNDLE(Target):
 
         # Merge info_plist settings from spec file
         if isinstance(self.info_plist, dict) and self.info_plist:
-            info_plist_dict = dict(info_plist_dict.items() + self.info_plist.items())
+            info_plist_dict = dict(info_plist_dict, **self.info_plist)
 
         info_plist = """<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">


### PR DESCRIPTION
I got the following exception when providing overrides for the `Info.plist` file in my `app.spec`. This fixes it.

    9346 INFO: Building BUNDLE out00-BUNDLE.toc
    9346 WARNING: icon not found /Users/rainer/work/pyinstaller/PyInstaller/building/bootloader/images/icon-windowed.icns
    Traceback (most recent call last):
      File "/usr/local/bin/pyinstaller", line 9, in <module>
        load_entry_point('PyInstaller===3.0dev-9080d3b', 'console_scripts', 'pyinstaller')()
      File "/Users/rainer/work/pyinstaller/PyInstaller/main.py", line 107, in run
        run_build(opts, spec_file, pyi_config)
      File "/Users/rainer/work/pyinstaller/PyInstaller/main.py", line 50, in run_build
        PyInstaller.building.build_main.main(pyi_config, spec_file, **opts.__dict__)
      File "/Users/rainer/work/pyinstaller/PyInstaller/building/build_main.py", line 820, in main
        build(specfile, kw.get('distpath'), kw.get('workpath'), kw.get('clean_build'))
      File "/Users/rainer/work/pyinstaller/PyInstaller/building/build_main.py", line 767, in build
        exec(text, spec_namespace)
      File "<string>", line 36, in <module>
      File "/Users/rainer/work/pyinstaller/PyInstaller/building/osx.py", line 85, in __init__
        self.__postinit__()
      File "/Users/rainer/work/pyinstaller/PyInstaller/building/datastruct.py", line 146, in __postinit__
        self.assemble()
      File "/Users/rainer/work/pyinstaller/PyInstaller/building/osx.py", line 151, in assemble
        info_plist_dict = dict(info_plist_dict.items() + self.info_plist.items())
    TypeError: unsupported operand type(s) for +: 'dict_items' and 'dict_items'