### PR TITLE
Failed to start compiled exe from non-ascii path on external usb-flash drive #1396

### DIFF
--- a/PyInstaller/loader/pyi_importers.py
+++ b/PyInstaller/loader/pyi_importers.py
@@ -133,7 +133,7 @@ class FrozenImporter(object):
         for pyz_filepath in sys.path:
             try:
                 # Unzip zip archive bundled with the executable.
-                self._pyz_archive = ZlibArchive(pyz_filepath)
+                self._pyz_archive = ZlibArchive(unicode(pyz_filepath, "utf-8"))
                 # Verify the integrity of the zip archive with Python modules.
                 self._pyz_archive.checkmagic()
                 # End this method since no Exception was raised we can assume


### PR DESCRIPTION
(FAT32, where short file names is not used) (closed #1396)