### PR TITLE
Failed to start compiled exe from non-ascii path on external usb-flash drive #1396

### DIFF
--- a/PyInstaller/loader/pyimod03_importers.py
+++ b/PyInstaller/loader/pyimod03_importers.py
@@ -167,7 +167,7 @@ class FrozenImporter(object):
             imp_lock()
             try:
                 # Unzip zip archive bundled with the executable.
-                self._pyz_archive = ZlibArchiveReader(pyz_filepath)
+                self._pyz_archive = ZlibArchiveReader(unicode(pyz_filepath, "utf-8"))
                 # Verify the integrity of the zip archive with Python modules.
                 # This is already done when creating the ZlibArchiveReader instance.
                 #self._pyz_archive.checkmagic()


### PR DESCRIPTION
Failed to start compiled exe from non-ascii path on external usb-flash drive (FAT32, where short file names is not used) (closed #1396)