### PR TITLE
Make pyinstaller-gui look more native

### DIFF
--- a/pyinstaller-gui.py
+++ b/pyinstaller-gui.py
@@ -18,9 +18,11 @@ import subprocess
 # In Python 3 module name is 'tkinter'
 try:
     from tkinter import *
+    from tkinter.ttk import *
     import tkinter.filedialog as filedialog
 except ImportError:
     from Tkinter import *
+    from ttk import *
     import tkFileDialog as filedialog
 
 


### PR DESCRIPTION
import ttk (overwrites widgets from tkinter) to make the application look more native on windows and osx (nothing really changes on linux)

Without ttk
![without ttk](https://cloud.githubusercontent.com/assets/10107858/9280086/3dd5b9fc-42bc-11e5-8573-723ba957530f.png)
With ttk
![with ttk](https://cloud.githubusercontent.com/assets/10107858/9280090/43067eca-42bc-11e5-8175-283ab7510525.png)

