### PR TITLE
Exclude test subdir from sqlite3 submodules

### DIFF
--- a/PyInstaller/hooks/hook-sqlite3.py
+++ b/PyInstaller/hooks/hook-sqlite3.py
@@ -11,3 +11,5 @@
 from PyInstaller.hooks.hookutils import collect_submodules
 
 hiddenimports = collect_submodules('sqlite3')
+# Exclude the test submodule as this causes Tkinter to be included
+hiddenimports = [x for x in hiddenimports if 'test.' not in x]


### PR DESCRIPTION
Importing sqlite causes several test submodules to be searched with the result that tcl, tk and Tkinter get included in the packaged executable. This patch excludes the test submodules from sqlite3.