### PR TITLE
Add: Skip USB tests if no backend is available.

### DIFF
--- a/tests/functional/test_libraries.py
+++ b/tests/functional/test_libraries.py
@@ -332,6 +332,15 @@ def test_pyexcelerate(pyi_builder):
 
 @importorskip('usb')
 def test_usb(pyi_builder):
+    # See if the usb package is supported on this platform.
+    try:
+        import usb
+        # This will verify that the backend is present; if not, it will
+        # skip this test.
+        usb.core.find(find_all = True)
+    except (ImportError, ValueError):
+        pytest.skip('USB backnd not found.')
+
     pyi_builder.test_source(
         """
         import usb.core


### PR DESCRIPTION
This updates #1356 for the python3 branch. It skips the USB test if no backend is present.