### PR TITLE
Fix: ctypes: ignore the libc on unix

### DIFF
--- a/PyInstaller/depend/utils.py
+++ b/PyInstaller/depend/utils.py
@@ -321,6 +321,9 @@ def _resolveCtypesImports(cbinaries):
         # 'W: library coredll.dll required via ctypes not found'
         if cbin in ['coredll.dll', 'kernel32.dll']:
             continue
+        # On unix ignore the libc
+        if is_unix and cbin in ['libc.so', 'libc.so.6']:
+            continue
         ext = os.path.splitext(cbin)[1]
         # On Windows, only .dll files can be loaded.
         if os.name == "nt" and ext.lower() in [".so", ".dylib"]:


### PR DESCRIPTION
Loading a different version of the libc cause a segfault at runtime.

A simple test case is:

````python
import ctypes
ctypes.CDLL("libc.so.6")
````

building this on debian wheezy (glibc 2.13) and running it on debian jessie (glibc 2.19) was causing a segfault.

If found the issue with the "watchdog" package which use inotify on linux and have this piece of code.

As a workaround we can use this sample code in the spec file:

````python
a = Analysis(...)

for e in a.binaries[:]:
    if e[0] in ("libc.so", "libc.so.6"):
        a.binaries.remove(e)

[...]
````