### PR TITLE
Add a hook for weasyprint

### DIFF
--- a/PyInstaller/hooks/hook-weasyprint.py
+++ b/PyInstaller/hooks/hook-weasyprint.py
@@ -1,0 +1,7 @@
+import os
+from distutils.sysconfig import get_python_lib
+
+datas = [
+    (os.path.join(get_python_lib(), 'weasyprint', 'css', 'html5_ua.css'),
+     os.path.join('weasyprint', 'css'))
+]

--- a/PyInstaller/hooks/hook-weasyprint.py
+++ b/PyInstaller/hooks/hook-weasyprint.py
@@ -1,7 +1,15 @@
-import os
-from distutils.sysconfig import get_python_lib
+#-----------------------------------------------------------------------------
+# Copyright (c) 2015, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
 
-datas = [
-    (os.path.join(get_python_lib(), 'weasyprint', 'css', 'html5_ua.css'),
-     os.path.join('weasyprint', 'css'))
-]
+# Hook for weasyprint: https://pypi.python.org/pypi/WeasyPrint
+# Tested on version weasyprint 0.24 using Windows 7 and python 2.7
+
+from PyInstaller.hooks.hookutils import collect_data_files
+
+datas = collect_data_files('weasyprint')


### PR DESCRIPTION
Add the needed html5_ua.css datafile.

Note I don't know the weasyprint package very well, but at least this file is required for generating a pdf in the simple use case.