### PR TITLE
fix PYDYLIB_NAMES for FreeBSD 10.2 64bit

### DIFF
--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -61,7 +61,8 @@ elif is_aix:
     # Shared libs on AIX are archives with shared object members, thus the ".a" suffix.
     PYDYLIB_NAMES = set(['libpython%d.%d.a' % _pyver])
 elif is_freebsd:
-    PYDYLIB_NAMES = set(['libpython%d.%d.so.1' % _pyver])
+    PYDYLIB_NAMES = set(['libpython%d.%d.so.1' % _pyver,
+                         'libpython%d.%dm.so.1' % _pyver])
 elif is_unix:
     # Other *nix platforms.
     # Python 2 .so library on Linux is: libpython2.7.so.1.0


### PR DESCRIPTION
it did not find the libpython because it searched for the wrong filename.