### PR TITLE
Modify error message on missing Python shared library

### DIFF
--- a/PyInstaller/building/build_main.py
+++ b/PyInstaller/building/build_main.py
@@ -558,12 +558,9 @@ class Analysis(Target):
             binaries.append((os.path.basename(python_lib), python_lib, 'BINARY'))
             logger.info('Using Python library %s', python_lib)
         else:
-            msg = """Python library not found! This usually happens on Debian/Ubuntu
-where you need to install Python library:
+            msg = """Python library not found! This would mean your Python installation isn't build with shared library.
 
-  apt-get install python3-dev
-  apt-get install python-dev
-
+Please rebuild your Python with `--enable-shared` (or, `--enable-framework` on Darwin).
 """
             raise IOError(msg)
 

--- a/PyInstaller/building/build_main.py
+++ b/PyInstaller/building/build_main.py
@@ -558,9 +558,13 @@ class Analysis(Target):
             binaries.append((os.path.basename(python_lib), python_lib, 'BINARY'))
             logger.info('Using Python library %s', python_lib)
         else:
-            msg = """Python library not found! This would mean your Python installation isn't build with shared library.
+            msg = """Python library not found! This would mean your Python installation doesn't come with proper library files.
+This usually happends by missing development package, or unsuitable build parameters of Python installation.
 
-Please rebuild your Python with `--enable-shared` (or, `--enable-framework` on Darwin).
+* On Debian/Ubuntu, you would need to install Python development packages
+  * apt-get install python3-dev
+  * apt-get install python-dev
+* If you're building Python by yourself, please rebuild your Python with `--enable-shared` (or, `--enable-framework` on Darwin)
 """
             raise IOError(msg)
 


### PR DESCRIPTION
Original message was not correct from the following 2 points:

1. Python library may not be found on platforms other than Debian GNU/Linux
2. Debian's `python-dev` package doesn't contain `libpythonN.M.so`
   (`libpythonN.M.so` is a content of `libpythonN.M` package)

This should fix #1505