### PR TITLE
Add hook for `mpl_toolkits.basemap` auxiliary data

### DIFF
--- a/PyInstaller/hooks/hook-mpl_toolkits.basemap.py
+++ b/PyInstaller/hooks/hook-mpl_toolkits.basemap.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2015, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+
+from PyInstaller.utils.hooks import (collect_data_files)
+
+
+# mpl_toolkits.basemap (tested with v.1.0.7) is shipped with auxiliary data,
+# usually stored in mpl_toolkits\basemap\data and used to plot maps
+datas = collect_data_files('mpl_toolkits.basemap')


### PR DESCRIPTION
This hook avoid to use a solution similar to what is described here: http://stackoverflow.com/questions/17749296/get-pyinstaller-to-import-basemap