### PR TITLE
Add hook for netCDF4 due to hidden imports

### DIFF
--- a/PyInstaller/hooks/hook-netCDF4.py
+++ b/PyInstaller/hooks/hook-netCDF4.py
@@ -1,0 +1,12 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2015, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+
+# netCDF4 (tested with v.1.1.9) has some hidden imports
+hiddenimports = ['netCDF4.utils', 'netcdftime']


### PR DESCRIPTION
The added hidden imports are also described here: https://github.com/poidl/slidenc
This should help to fix this type of SO issues: http://stackoverflow.com/questions/29067588/problems-building-python-distribion-containing-netcdf4