### PR TITLE
add hook file for u1db

### DIFF
--- a/PyInstaller/hooks/hook-u1db.py
+++ b/PyInstaller/hooks/hook-u1db.py
@@ -1,0 +1,15 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2015, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+#
+# ********************************************
+# hook-u1db.py - Pyinstaller hook for u1db 
+# ********************************************
+from PyInstaller.hooks.hookutils import collect_data_files
+
+datas = collect_data_files('u1db')


### PR DESCRIPTION
this adds the missing dbschema.sql

Tested with the following configuration, inside a virtualenv.

Dependency
----------
Name: u1db
Version: 13.09

Python 2.7.10 (default, Jul  1 2015, 10:54:53)
[GCC 4.9.2] on linux2

System info
-----------

Distributor ID: Debian
Description:    Debian GNU/Linux unstable (sid)
Release:        unstable
Codename:       sid

Test script used
----------------

import u1db
db = u1db.open("mydb1.u1db", create=True)
doc = db.create_doc({"key": "value"}, doc_id="testdoc")
print doc.content
print doc.doc_id