### PR TITLE
fix PYDYLIB_NAMES for FreeBSD 10.2 64bit, try 2

### DIFF
--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -62,7 +62,9 @@ elif is_aix:
     PYDYLIB_NAMES = set(['libpython%d.%d.a' % _pyver])
 elif is_freebsd:
     PYDYLIB_NAMES = set(['libpython%d.%d.so.1' % _pyver,
-                         'libpython%d.%dm.so.1' % _pyver])
+                         'libpython%d.%dm.so.1' % _pyver,
+                         'libpython%d.%d.so.1.0' % _pyver,
+                         'libpython%d.%dm.so.1.0' % _pyver])
 elif is_unix:
     # Other *nix platforms.
     # Python 2 .so library on Linux is: libpython2.7.so.1.0


### PR DESCRIPTION
I tried to build a binary with python 3.5 and it did not find the
python dynlib again. Seems to have another extension now.