### PR TITLE
Fix import of cookies and htmlparser on Python 2.x used by Django.

### DIFF
--- a/PyInstaller/hooks/hook-django.py
+++ b/PyInstaller/hooks/hook-django.py
@@ -11,6 +11,7 @@
 # Tested with django 1.8.
 
 
+import sys
 import glob
 import os
 from PyInstaller import log as logging
@@ -53,11 +54,19 @@ if root_dir:
             'django.contrib.messages.storage.fallback',
     ]
     # Django hiddenimports from the standard Python library.
-    # TODO there is some import magic in the 'six' module.
-    hiddenimports += [
-            'http.cookies',
-            'html.parser',
-    ]
+    # Python 3.x
+    if sys.version_info.major == 3:
+      
+        hiddenimports += [
+                'http.cookies',
+                'html.parser',
+        ]
+    # Python 2.x
+    else:
+        hiddenimports += [
+                'Cookie',
+                'HTMLParser',
+        ]
 
     # Include django data files - localizations, etc.
     datas = collect_data_files('django')

--- a/PyInstaller/hooks/hook-django.py
+++ b/PyInstaller/hooks/hook-django.py
@@ -54,15 +54,14 @@ if root_dir:
             'django.contrib.messages.storage.fallback',
     ]
     # Django hiddenimports from the standard Python library.
-    # Python 3.x
     if sys.version_info.major == 3:
-      
+        # Python 3.x
         hiddenimports += [
                 'http.cookies',
                 'html.parser',
         ]
-    # Python 2.x
     else:
+        # Python 2.x
         hiddenimports += [
                 'Cookie',
                 'HTMLParser',


### PR DESCRIPTION
Try to fix import issue for "HTMLParser" and "Cookie" when using Django, due to differences between Python 2 and 3.

It is an explicit solution: in the future could be replaced by a better management of six library (#1231?)