### PR TITLE
Fix django imports

### DIFF
--- a/PyInstaller/hooks/hook-django.py
+++ b/PyInstaller/hooks/hook-django.py
@@ -11,6 +11,7 @@
 # Tested with django 1.8.
 
 
+import sys
 import glob
 import os
 from PyInstaller import log as logging
@@ -53,11 +54,19 @@ if root_dir:
             'django.contrib.messages.storage.fallback',
     ]
     # Django hiddenimports from the standard Python library.
-    # TODO there is some import magic in the 'six' module.
-    hiddenimports += [
-            'http.cookies',
-            'html.parser',
-    ]
+    # Python 3.x
+    if sys.version_info.major == 3:
+      
+        hiddenimports += [
+                'http.cookies',
+                'html.parser',
+        ]
+    # Python 2.x
+    else:
+        hiddenimports += [
+                'Cookie',
+                'HTMLParser',
+        ]
 
     # Include django data files - localizations, etc.
     datas = collect_data_files('django')

--- a/PyInstaller/hooks/hook-django.py
+++ b/PyInstaller/hooks/hook-django.py
@@ -54,15 +54,14 @@ if root_dir:
             'django.contrib.messages.storage.fallback',
     ]
     # Django hiddenimports from the standard Python library.
-    # Python 3.x
     if sys.version_info.major == 3:
-      
+        # Python 3.x
         hiddenimports += [
                 'http.cookies',
                 'html.parser',
         ]
-    # Python 2.x
     else:
+        # Python 2.x
         hiddenimports += [
                 'Cookie',
                 'HTMLParser',

--- a/PyInstaller/hooks/hook-django.py
+++ b/PyInstaller/hooks/hook-django.py
@@ -31,6 +31,7 @@ if root_dir:
     settings_py_imports = django_dottedstring_imports(root_dir)
     # Include all submodules of all imports detected in mysite.settings.py.
     for submod in settings_py_imports:
+        hiddenimports.append(submod)
         hiddenimports += collect_submodules(submod)
     # Include main django modules - settings.py, urls.py, wsgi.py.
     # Without them the django server won't run.
@@ -47,8 +48,10 @@ if root_dir:
             'django.template.defaultfilters',
             'django.template.defaulttags',
             'django.template.loader_tags',
+            'django.template.context_processors',
     ]
     hiddenimports += collect_submodules('django.middleware')
+    hiddenimports += collect_submodules('django.templatetags')
     # Other hidden imports to get Django example startproject working.
     hiddenimports += [
             'django.contrib.messages.storage.fallback',

--- a/PyInstaller/hooks/hook-django.template.loaders.py
+++ b/PyInstaller/hooks/hook-django.template.loaders.py
@@ -1,0 +1,12 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2015, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+
+from PyInstaller.utils.hooks import collect_submodules
+hiddenimports = collect_submodules('django.template.loaders')

--- a/PyInstaller/utils/hooks/subproc/django_import_finder.py
+++ b/PyInstaller/utils/hooks/subproc/django_import_finder.py
@@ -29,6 +29,8 @@ django.setup()
 # This allows to access all django settings even from the settings.py module.
 from django.conf import settings
 
+from PyInstaller.utils.hooks import collect_submodules
+
 
 hiddenimports = list(settings.INSTALLED_APPS) + \
                  list(settings.TEMPLATE_CONTEXT_PROCESSORS) + \
@@ -40,7 +42,7 @@ def _remove_class(class_name):
     return '.'.join(class_name.split('.')[0:-1])
 
 
-### Changes in Djang 1.7.
+### Changes in Django 1.7.
 
 # Remove class names and keep just modules.
 if hasattr(settings, 'AUTHENTICATION_BACKENDS'):
@@ -87,6 +89,15 @@ def find_url_callbacks(urls_module):
         elif isinstance(pattern, RegexURLResolver):
             hid_list += find_url_callbacks(pattern.urlconf_module)
     return hid_list
+
+
+# Add templatetags and context processors for each installed app.
+for app in settings.INSTALLED_APPS:
+    app_templatetag_module = app + '.templatetags'
+    app_ctx_proc_module = app + '.context_processors'
+    hiddenimports.append(app_templatetag_module)
+    hiddenimports += collect_submodules(app_templatetag_module)
+    hiddenimports.append(app_ctx_proc_module)
 
 
 from django.core.urlresolvers import RegexURLPattern, RegexURLResolver


### PR DESCRIPTION
In Django-based projects all relevant modules of installed apps should now be collected by PyInstaller.