### PR TITLE
`six.moves` Hook Fixed for the Good of (Wo)Mankind

### DIFF
--- a/PyInstaller/hooks/hook-sphinx.py
+++ b/PyInstaller/hooks/hook-sphinx.py
@@ -10,7 +10,6 @@
 # ********************************************
 # hook-sphinx.py - Pyinstaller hook for Sphinx
 # ********************************************
-from PyInstaller.compat import is_py2
 from PyInstaller.utils.hooks import \
     collect_submodules, collect_data_files, is_module_version
 
@@ -66,16 +65,6 @@ hiddenimports = (
 #
 # Add these two modules.
                   ['inspect', 'locale'] )
-
-# TODO: In theory, we shouldn't need this anymore. PyInstaller now detects "six"
-# imports for both Python 2 and 3. Verify this and remove if true.
-
-# Finally, there are a HUGE number of imports from six that must be manually
-# listed. These will be auto-detected in Python 3, so omit them.
-if is_py2:
-    hiddenimports += ('StringIO', 'cStringIO', 'cPickle', 'itertools',
-                      'UserString', 'urllib', 'urllib2', 'HTMLParser',
-                      'ConfigParser')
 
 # Sphinx also relies on a number of data files in its directory hierarchy: for
 # example, *.html and *.conf files in sphinx.themes, translation files in


### PR DESCRIPTION
This pull request fixes a **critical defect** in the `six.moves` module, and should probably be merged in time for the **PyInstaller 3.0** milestone.

Previously, our `six.moves` pre-safe import module hook mapped "moved modules" (i.e., modules marked as moved by `six.moves`) but _not_ "moved attributes" (i.e., module attributes marked as moved by `six.moves`). Any attempt to import a moved attribute therefore currently fails.

This is unspeakably bad.

## So What Did You Do About It?

Commit 0df9267 fixes this by mapping both moved modules _and_ attributes. Thankfully, it was trivial. (No applause, please.)

Commit 37270f6 demonstrates this defect by removing all `six.moves`-specific hidden imports from the Sphinx hook. Previously, all `six.moves` imports required by Sphinx were previously listed as hidden – but only under Python 2.7 (for some obscure reason). Since our `six.moves` pre-safe import module hook now automatically detects all `six.moves` imports, they don't need to be listed as hidden anymore. Since several of these imports were moved attributes (e.g., `UserString`), however, attempting to remove these hidden imports _without_ commit 0df9267 results in the Sphinx test failing at runtime with:

```
LOADER: Running pyi_lib_sphinx.py
Error: The UserString module cannot be found. Did you install Sphinx and its dependencies correctly?
```

See also [this Travis report](https://travis-ci.org/pyinstaller/pyinstaller/jobs/83063350).

## Not Bad, Buddy

Thanks. My name's not Buddy, though. _Why does everyone call me that!?_