### PR TITLE
Flush special flags with os.chflags() on cache files

### DIFF
--- a/PyInstaller/building/utils.py
+++ b/PyInstaller/building/utils.py
@@ -240,6 +240,11 @@ def checkCache(fnm, strip=False, upx=False, dist_nm=None):
     if not os.path.exists(os.path.dirname(cachedfile)):
         os.makedirs(os.path.dirname(cachedfile))
     shutil.copy2(fnm, cachedfile)
+    if hasattr(os, 'chflags'):
+        # Some libraries on FreeBSD have immunable flag (libthr.so.3, for example)
+        # If flags still remains, os.chmod will failed with:
+        # OSError: [Errno 1] Operation not permitted.
+        os.chflags(cachedfile, 0)
     os.chmod(cachedfile, 0o755)
 
     if os.path.splitext(fnm.lower())[1] in (".pyd", ".dll"):


### PR DESCRIPTION
Some libraries on FreeBSD have immunable flag (libthr.so.3, for example)
If flags still remains, os.chmod will failed with:
OSError: [Errno 1] Operation not permitted.add comment