### PR TITLE
Fix collect submodules

### DIFF
--- a/PyInstaller/utils/hooks/__init__.py
+++ b/PyInstaller/utils/hooks/__init__.py
@@ -601,6 +601,17 @@ def remove_file_extension(filename):
     # Fallback to ordinary 'splitext'.
     return os.path.splitext(filename)[0]
 
+def _pkgutil_find_loader(fullname):
+    """
+    Temporarily extend sys.path with pathex to invoke pkgutil.find_loader.
+    """
+    old_path = sys.path
+    try:
+        sys.path.extend(CONF['pathex'])
+        return pkgutil.find_loader(fullname)
+    finally:
+        sys.path = old_path
+
 
 def get_module_file_attribute(package):
     """
@@ -624,7 +635,7 @@ def get_module_file_attribute(package):
     # certain modules in pywin32, which replace all module attributes
     # with those of the .dll
     try:
-        loader = pkgutil.find_loader(package)
+        loader = _pkgutil_find_loader(package)
         attr = loader.get_filename(package)
     # Second try to import module in a subprocess. Might raise ImportError.
     except (AttributeError, ImportError):
@@ -789,7 +800,7 @@ def is_package(module_name):
     """
     # This way determines if module is a package without importing the module.
     try:
-        loader = pkgutil.find_loader(module_name)
+        loader = _pkgutil_find_loader(module_name)
     except Exception:
         # When it fails to find a module loader then it points probably to a clas
         # or function and module is not a package. Just return False.

--- a/PyInstaller/utils/hooks/__init__.py
+++ b/PyInstaller/utils/hooks/__init__.py
@@ -50,7 +50,6 @@ def __exec_python_cmd(cmd, env=None):
     anything that was emitted in the standard output as a single
     string.
     """
-    from ...config import CONF
     if env is None:
         env = {}
     # Update environment. Defaults to 'os.environ'
@@ -518,7 +517,6 @@ def django_find_root_dir():
     """
     # Get the directory with manage.py. Manage.py is supplied to PyInstaller as the
     # first main executable script.
-    from PyInstaller.config import CONF
     manage_py = CONF['main_script']
     manage_dir = os.path.dirname(os.path.abspath(manage_py))
 

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -62,6 +62,10 @@ _SPEC_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'specs')
 # ====
 # Fixtures
 # --------
+@pytest.fixture
+def script_dir():
+    return py.path.local(_SCRIPT_DIR)
+
 # A helper function to copy from data/dir to tmpdir/data.
 def _data_dir_copy(
   # The name of the subdirectory located in data/name to copy.

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -329,7 +329,8 @@ class AppBuilder(object):
         default_args = ['--debug', '--noupx',
                 '--specpath', self._specdir,
                 '--distpath', self._distdir,
-                '--workpath', self._builddir]
+                '--workpath', self._builddir,
+                '--path', _MODULES_DIR]
         default_args.extend(['--debug', '--log-level=DEBUG'])
 
         # Choose bundle mode.
@@ -397,10 +398,6 @@ def pyi_modgraph():
 @pytest.fixture(params=['onedir', 'onefile'])
 def pyi_builder(tmpdir, monkeypatch, request, pyi_modgraph):
     tmp = tmpdir.strpath
-    # Append _MMODULES_DIR to sys.path for building exes.
-    # Some tests need additional test modules.
-    # This also ensures that sys.path is reseted to original value for every test.
-    monkeypatch.syspath_prepend(_MODULES_DIR)
     # Save/restore environment variable PATH.
     monkeypatch.setenv('PATH', os.environ['PATH'], )
     # Set current working directory to

--- a/tests/functional/modules/pyi_collect_submodules_mod.py
+++ b/tests/functional/modules/pyi_collect_submodules_mod.py
@@ -1,0 +1,10 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2015, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+# This used by pyi_collect_submodules.py. See the explanation there.

--- a/tests/functional/scripts/pyi_collect_submodules.py
+++ b/tests/functional/scripts/pyi_collect_submodules.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2015, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+# This is designed to test the operation of PyInstaller.utils.hook.collect_submodules. To do so:
+#
+# 1. It imports the dummy module pyi_collect_submodules_mod, which contains nothing.
+import pyi_collect_submodules_mod
+# 2. This causes hook-pyi_collect_submodules_mod.py to be run, which collects some dummy submodules. In this case, it collects from modules/pyi_testmod_relimp.
+# 3. Therefore, we should be able to find hidden imports under pyi_testmod_relimp.
+__import__('pyi_testmod_relimp.B.C')

--- a/tests/functional/scripts/pyi_hooks/hook-pyi_collect_submodules_mod.py
+++ b/tests/functional/scripts/pyi_hooks/hook-pyi_collect_submodules_mod.py
@@ -1,0 +1,13 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013-2015, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_submodules
+
+hiddenimports = collect_submodules('pyi_testmod_relimp')
+

--- a/tests/functional/test_basic.py
+++ b/tests/functional/test_basic.py
@@ -320,3 +320,6 @@ def test_renamed_exe(pyi_builder):
 @skipif_notosx
 def test_osx_override_info_plist(pyi_builder_spec):
     pyi_builder_spec.test_spec('pyi_osx_override_info_plist.spec')
+
+def test_hook_collect_submodules(pyi_builder, script_dir):
+    pyi_builder.test_script('pyi_collect_submodules.py', ['--additional-hooks-dir='+script_dir.join('pyi_hooks').strpath])


### PR DESCRIPTION
I've run into a problem in which `PyInstaller.utils.hooks.collect_submodules` fails, since its call to `is_package` returns False. Apparently, this happens because `sys.path` does not include the path given in the `pathex` .spec-file argument.

The (probably wrong) fix: ignore a False return value from `is_package`.

The tests included pass in py.test without the fix...but fail from the command line, meaning the py.test environment doesn't quite duplicate the actual execution environment. See `pyi_collect_submodules.py` for an explanation of the somewhat convoluted working on the test itself.

Ideas?