### PR TITLE
Fix: Skip scapy tests if its dependences aren't installed.

### DIFF
--- a/tests/functional/test_libraries.py
+++ b/tests/functional/test_libraries.py
@@ -165,7 +165,10 @@ def test_sqlite3(pyi_builder):
         """)
 
 
-@importorskip('scapy')
+# Note that @importorskip('scapy') isn't sufficient; this doesn't ask scapy to
+# import its backend dependencies (such as pcapy or dnet). scapy.all does import
+# the backends, skipping this test if they aren't installed.
+@importorskip('scapy.all')
 def test_scapy(pyi_builder):
     pyi_builder.test_source(
         """
@@ -184,7 +187,7 @@ def test_scapy(pyi_builder):
         """)
 
 
-@importorskip('scapy')
+@importorskip('scapy.all')
 def test_scapy2(pyi_builder):
     pyi_builder.test_source(
         """
@@ -193,7 +196,7 @@ def test_scapy2(pyi_builder):
         """)
 
 
-@importorskip('scapy')
+@importorskip('scapy.all')
 def test_scapy3(pyi_builder):
     pyi_builder.test_source(
         """


### PR DESCRIPTION
This is an updated, cleaner version of 9f8e9ae16be34ff523a26dd08559c7bff9fcab5a. See also https://github.com/pyinstaller/pyinstaller/pull/1355.