### PR TITLE
Add hook for auxiliary data required by lxml.isoschematron

### DIFF
--- a/PyInstaller/hooks/hook-lxml.isoschematron.py
+++ b/PyInstaller/hooks/hook-lxml.isoschematron.py
@@ -1,0 +1,14 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2015, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_data_files
+import os
+
+# Auxiliary data for isoschematron
+datas = collect_data_files('lxml', subdir=os.path.join('isoschematron', 'resources'))


### PR DESCRIPTION
This should solve this issue: https://github.com/pyinstaller/pyinstaller/issues/1613