### PR TITLE
Rename PyInstaller.utils.hooks.hookutils into PyInstaller.utils.hooks.

### DIFF
--- a/PyInstaller/hooks/hook-weasyprint.py
+++ b/PyInstaller/hooks/hook-weasyprint.py
@@ -10,6 +10,6 @@
 # Hook for weasyprint: https://pypi.python.org/pypi/WeasyPrint
 # Tested on version weasyprint 0.24 using Windows 7 and python 2.7
 
-from PyInstaller.hooks.hookutils import collect_data_files
+from PyInstaller.utils.hooks import collect_data_files
 
 datas = collect_data_files('weasyprint')


### PR DESCRIPTION
Forgotten part of commit 2a853f6eeadcc8ffbe95468bfc9b7223d3e32cd0