### PR TITLE
Improve root directory detection of django projects

### DIFF
--- a/PyInstaller/utils/hooks/__init__.py
+++ b/PyInstaller/utils/hooks/__init__.py
@@ -482,13 +482,7 @@ def qt5_qml_plugins_binaries(dir):
     return binaries
 
 
-def django_dottedstring_imports(django_root_dir):
-    """
-    Get all the necessary Django modules specified in settings.py.
-
-    In the settings.py the modules are specified in several variables
-    as strings.
-    """
+def eval_script_with_django(django_root_dir, name, env=None):
     pths = []
     # Extend PYTHONPATH with parent dir of django_root_dir.
     pths.append(misc.get_path_to_toplevel_modules(django_root_dir))
@@ -496,12 +490,26 @@ def django_dottedstring_imports(django_root_dir):
     # Many times Django users do not specify absolute imports in the settings module.
     pths.append(django_root_dir)
 
-    package_name = os.path.basename(django_root_dir) + '.settings'
-    env = {'DJANGO_SETTINGS_MODULE': package_name,
-           'PYTHONPATH': os.pathsep.join(pths)}
-    ret = eval_script('django_import_finder.py', env=env)
+    python_path = os.getenv('PYTHONPATH', '').split(os.pathsep)
+    python_path.extend(pths)
+    python_path = os.pathsep.join(python_path)
 
-    return ret
+    django_settings_module = os.getenv('DJANGO_SETTINGS_MODULE', os.path.basename(django_root_dir) + '.settings')
+    if env is None:
+        env = {}
+    env.setdefault('DJANGO_SETTINGS_MODULE', django_settings_module)
+    env.setdefault('PYTHONPATH', python_path)
+    return eval_script(name, env=env)
+
+
+def django_dottedstring_imports(django_root_dir):
+    """
+    Get all the necessary Django modules specified in settings.py.
+
+    In the settings.py the modules are specified in several variables
+    as strings.
+    """
+    return eval_script_with_django(django_root_dir, 'django_import_finder.py')
 
 
 def django_find_root_dir():
@@ -519,9 +527,13 @@ def django_find_root_dir():
     # first main executable script.
     manage_py = CONF['main_script']
     manage_dir = os.path.dirname(os.path.abspath(manage_py))
+    try:
+        return eval_script_with_django(manage_dir, 'django_find_basedir.py')
+    except Exception:
+        pass
 
-    # Get the Django root directory. The directory that contains settings.py and url.py.
-    # It could be the directory containig manage.py or any of its subdirectories.
+    # Get the Django root directory. The directory that contains settings.py and urls.py.
+    # It could be the directory containing manage.py or any of its subdirectories.
     settings_dir = None
     files = set(os.listdir(manage_dir))
     if 'settings.py' in files and 'urls.py' in files:

--- a/PyInstaller/utils/hooks/subproc/django_find_basedir.py
+++ b/PyInstaller/utils/hooks/subproc/django_find_basedir.py
@@ -1,0 +1,16 @@
+"""
+This module is used to reliably locate root directory of django projects by
+using BASE_DIR or PROJECT_ROOT variables in settings.
+"""
+
+import django
+django.setup()
+
+# This allows to access all django settings even from the settings.py module.
+from django.conf import settings
+
+base_dir = getattr(settings, 'BASE_DIR', None)
+if base_dir is None:
+    base_dir = getattr(settings, 'PROJECT_ROOT', None)
+
+print(repr(base_dir or ''))

--- a/PyInstaller/utils/hooks/subproc/django_import_finder.py
+++ b/PyInstaller/utils/hooks/subproc/django_import_finder.py
@@ -103,9 +103,18 @@ for app in settings.INSTALLED_APPS:
 from django.core.urlresolvers import RegexURLPattern, RegexURLResolver
 
 
-# Construct base module name - without 'settings' suffix.
 base_module_name = '.'.join(os.environ['DJANGO_SETTINGS_MODULE'].split('.')[0:-1])
-base_module = __import__(base_module_name, {}, {}, ["urls"])
+root_urlconf = getattr(settings, 'ROOT_URLCONF', None)
+if root_urlconf is None:
+    # Construct base module name - without 'settings' suffix.
+    base_module = __import__(base_module_name, {}, {}, ["urls"])
+else:
+    names = root_urlconf.split('.')
+    urls_path = '.'.join(names[:-1])
+    urls_module_name = names[-1]
+    if not urls_path:
+        urls_path = base_module_name
+    base_module = __import__(urls_path, {}, {}, [urls_module_name])
 urls = base_module.urls
 
 # Find url imports.

--- a/PyInstaller/utils/misc.py
+++ b/PyInstaller/utils/misc.py
@@ -89,13 +89,17 @@ def get_path_to_toplevel_modules(filename):
     Returned directory might be used to extend the PYTHONPATH.
     """
     curr_dir = os.path.dirname(os.path.abspath(filename))
+    module_name = curr_dir.split(os.path.sep)[-1]
     pattern = '__init__.py'
 
     # Try max. 10 levels up.
     try:
         for i in range(10):
             files = set(os.listdir(curr_dir))
-            # 'curr_dir' is still not top-leve go to parent dir.
+            # 'curr_dir' is still not top-level go to parent dir.
+            if module_name in files:  # prevent wrong imports because of duplicate module names in parent folders
+                return None
+
             if pattern in files:
                 curr_dir = os.path.dirname(curr_dir)
             # Top-level dir found - return it.
@@ -121,7 +125,7 @@ def compile_py_files(toc, workpath):
     Given a TOC or equivalent list of tuples, generates all the required
     pyc/pyo files, writing in a local directory if required, and returns the
     list of tuples with the updated pathnames.
-    
+
     In the old system using ImpTracker, the generated TOC of "pure" modules
     already contains paths to nm.pyc or nm.pyo and it is only necessary
     to check that these files are not older than the source.


### PR DESCRIPTION
Use settings.ROOT_URLCONF to import the proper urls module when collecting hidden imports.