### PR TITLE
Adding a scipy.linalg hook for Scipy 0.16+

### DIFF
--- a/PyInstaller/hooks/hook-scipy.linalg.py
+++ b/PyInstaller/hooks/hook-scipy.linalg.py
@@ -1,0 +1,13 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+
+# The hidden import is necessary for SciPy 0.16+.
+hiddenimports = ['scipy.linalg.cython_blas', 'scipy.linalg.cython_lapack']
+


### PR DESCRIPTION
The current development branch fails to works with `scipy.linalg` in  Scipy 0.16 as `scipy.linalg.cython_blas` and   `scipy.linalg.cython_lapack` modules are not included. This was discussed at length in issue #1430 and was supposed to be fixed then, but I still experience this problem with the current development branch.

 This PR adds a hook for `scipy.linalg`  as mentioned by @matysek in issue #1430 .  I checked that this fixes the issue for PY2, PY3 on Linux and PY3 on Windows using conda with scipy-0.16. Also checked that this does not break anything with scipy-0.15 (PY3, conda, Windows)  which does not include those cython modules.  

 This PR is also related to the issue #1465 (although apparently adding this hook did not solve the problem for @Csega ). 

**Edit**: test  `tests/functional/test_basic.py::test_stdout_encoding[onedir]` initially failed for PY2, Linux, but passed when rerun the travis build (closed and re-opened the PR). 