### PR TITLE
pefile.py optimization

### DIFF
--- a/PyInstaller/depend/bindepend.py
+++ b/PyInstaller/depend/bindepend.py
@@ -104,7 +104,8 @@ def _getImports_pe(pth):
     pe.parse_data_directories(directories=[
         pefile.DIRECTORY_ENTRY['IMAGE_DIRECTORY_ENTRY_IMPORT'],
         pefile.DIRECTORY_ENTRY['IMAGE_DIRECTORY_ENTRY_EXPORT'],
-        ])
+        ], forwarded_exports_only=True,
+        import_dllnames_only=True)
 
     # Some libraries have no other binary dependencies. Use empty list
     # in that case. Otherwise pefile would return None.

--- a/PyInstaller/lib/README.rst
+++ b/PyInstaller/lib/README.rst
@@ -43,6 +43,10 @@ the running Python version.
 - For status of official support for Python3 see
   https://github.com/erocarrera/pefile/issues/36
 
+Our copies of pefile.py are modified with two optimizations to speed up our specific
+use-case of finding DLL names: When scanning the import table, only DLL names are
+loaded and the imported symbols are not parsed; and when scanning the export table,
+only "forwarded" symbols that implicitly import a DLL are returned.
 
 macholib
 --------

--- a/PyInstaller/lib/pefile_py2.py
+++ b/PyInstaller/lib/pefile_py2.py
@@ -3225,21 +3225,8 @@ class PE:
         max_failed_entries_before_giving_up = 10
 
         for i in xrange( min( export_dir.NumberOfNames, length_until_eof(export_dir.AddressOfNames)/4) ):
-
-            symbol_name_address = self.get_dword_from_data(address_of_names, i)
-
-            symbol_name = self.get_string_at_rva( symbol_name_address )
-            try:
-                symbol_name_offset = self.get_offset_from_rva( symbol_name_address )
-            except PEFormatError:
-                max_failed_entries_before_giving_up -= 1
-                if max_failed_entries_before_giving_up <= 0:
-                    break
-                continue
-
             symbol_ordinal = self.get_word_from_data(
                 address_of_name_ordinals, i)
-
 
             if symbol_ordinal*4 < len(address_of_functions):
                 symbol_address = self.get_dword_from_data(
@@ -3268,6 +3255,17 @@ class PE:
                 forwarder_str = None
                 forwarder_offset = None
 
+            symbol_name_address = self.get_dword_from_data(address_of_names, i)
+
+            symbol_name = self.get_string_at_rva( symbol_name_address )
+            try:
+                symbol_name_offset = self.get_offset_from_rva( symbol_name_address )
+            except PEFormatError:
+                max_failed_entries_before_giving_up -= 1
+                if max_failed_entries_before_giving_up <= 0:
+                    break
+                continue
+                
             exports.append(
                 ExportData(
                     pe = self,

--- a/PyInstaller/lib/pefile_py2.py
+++ b/PyInstaller/lib/pefile_py2.py
@@ -2259,7 +2259,9 @@ class PE:
 
 
 
-    def parse_data_directories(self, directories=None):
+    def parse_data_directories(self, directories=None,
+                               forwarded_exports_only=False,
+                               import_dllnames_only=False):
         """Parse and process the PE file's data directories.
 
         If the optional argument 'directories' is given, only
@@ -2279,6 +2281,13 @@ class PE:
 
         If 'directories' is a list, the ones that are processed will be removed,
         leaving only the ones that are not present in the image.
+
+        If `forwarded_exports_only` is True, the IMAGE_DIRECTORY_ENTRY_EXPORT
+        attribute will only contain exports that are forwarded to another DLL.
+
+        If `import_dllnames_only` is True, symbols will not be parsed from
+        the import table and the entries in the IMAGE_DIRECTORY_ENTRY_IMPORT
+        attribute will not have a `symbols` attribute.
         """
 
         directory_parsing = (
@@ -2311,7 +2320,13 @@ class PE:
             if directories is None or directory_index in directories:
 
                 if dir_entry.VirtualAddress:
-                    value = entry[1](dir_entry.VirtualAddress, dir_entry.Size)
+                    if forwarded_exports_only and entry[0] == 'IMAGE_DIRECTORY_ENTRY_EXPORT':
+                        value = entry[1](dir_entry.VirtualAddress, dir_entry.Size, forwarded_only=True)
+                    elif import_dllnames_only and entry[0] == 'IMAGE_DIRECTORY_ENTRY_IMPORT':
+                        value = entry[1](dir_entry.VirtualAddress, dir_entry.Size, dllnames_only=True)
+
+                    else:
+                        value = entry[1](dir_entry.VirtualAddress, dir_entry.Size)
                     if value:
                         setattr(self, entry[0][6:], value)
 
@@ -3154,8 +3169,7 @@ class PE:
                 break
 
 
-
-    def parse_export_directory(self, rva, size):
+    def parse_export_directory(self, rva, size, forwarded_only=False):
         """Parse the export directory.
 
         Given the RVA of the export directory, it will process all
@@ -3249,6 +3263,8 @@ class PE:
                 except PEFormatError:
                     continue
             else:
+                if forwarded_only:
+                    continue
                 forwarder_str = None
                 forwarder_offset = None
 
@@ -3364,7 +3380,7 @@ class PE:
 
 
 
-    def parse_import_directory(self, rva, size):
+    def parse_import_directory(self, rva, size, dllnames_only=False):
         """Walk and parse the import directory."""
 
         import_descs =  []
@@ -3388,20 +3404,23 @@ class PE:
 
             rva += import_desc.sizeof()
 
-            try:
-                import_data =  self.parse_imports(
-                    import_desc.OriginalFirstThunk,
-                    import_desc.FirstThunk,
-                    import_desc.ForwarderChain)
-            except PEFormatError, excp:
-                self.__warnings.append(
-                    'Error parsing the import directory. ' +
-                    'Invalid Import data at RVA: 0x%x (%s)' % ( rva, str(excp) ) )
-                break
-                #raise excp
+            if not dllnames_only:
+                try:
+                    import_data =  self.parse_imports(
+                        import_desc.OriginalFirstThunk,
+                        import_desc.FirstThunk,
+                        import_desc.ForwarderChain)
+                except PEFormatError, excp:
+                    self.__warnings.append(
+                        'Error parsing the import directory. ' +
+                        'Invalid Import data at RVA: 0x%x (%s)' % ( rva, str(excp) ) )
+                    break
+                    #raise excp
 
-            if not import_data:
-                continue
+                if not import_data:
+                    continue
+            else:
+                import_data = None
 
             dll = self.get_string_at_rva(import_desc.Name)
             if not is_valid_dos_filename(dll):
@@ -3414,21 +3433,20 @@ class PE:
                         imports = import_data,
                         dll = dll))
 
-        suspicious_imports = set([ 'LoadLibrary', 'GetProcAddress' ])
-        suspicious_imports_count = 0
-        total_symbols = 0
-        for imp_dll in import_descs:
-            for symbol in imp_dll.imports:
-                for suspicious_symbol in suspicious_imports:
-                    if symbol and symbol.name and symbol.name.startswith( suspicious_symbol ):
-                        suspicious_imports_count += 1
-                        break
-                total_symbols += 1
-        if suspicious_imports_count == len(suspicious_imports) and total_symbols < 20:
-            self.__warnings.append(
-                'Imported symbols contain entries typical of packed executables.' )
-
-
+        if not dllnames_only:
+            suspicious_imports = set([ 'LoadLibrary', 'GetProcAddress' ])
+            suspicious_imports_count = 0
+            total_symbols = 0
+            for imp_dll in import_descs:
+                for symbol in imp_dll.imports:
+                    for suspicious_symbol in suspicious_imports:
+                        if symbol and symbol.name and symbol.name.startswith( suspicious_symbol ):
+                            suspicious_imports_count += 1
+                            break
+                    total_symbols += 1
+            if suspicious_imports_count == len(suspicious_imports) and total_symbols < 20:
+                self.__warnings.append(
+                    'Imported symbols contain entries typical of packed executables.' )
 
         return import_descs
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -119,4 +119,4 @@ build: none
 
 test_script:
   # Split tests into several subprocesses.
-  - "%CMD_IN_ENV% py.test -n 3  --timeout 180 --maxfail 5"
+  - "%CMD_IN_ENV% py.test -n 3  --timeout 180 --maxfail 5 --durations=10"

--- a/tests/speed/speed_pefile.py
+++ b/tests/speed/speed_pefile.py
@@ -1,0 +1,51 @@
+"""
+    speed_pefile
+"""
+import os
+import shutil
+from PyInstaller import log
+from PyInstaller.building.build_main import Analysis
+from PyInstaller.config import CONF
+
+import time
+
+from os.path import join
+from tempfile import mkdtemp
+logger = log.getLogger(__name__)
+
+
+def speed_pefile():
+    log.logging.basicConfig(level=log.DEBUG)
+
+    tempdir = mkdtemp("speed_pefile")
+    workdir = join(tempdir, "build")
+    distdir = join(tempdir, "dist")
+    script = join(tempdir, 'speed_pefile_script.py')
+    warnfile = join(workdir, 'warn.txt')
+    os.makedirs(workdir)
+    os.makedirs(distdir)
+
+    with open(script, 'w') as f:
+        f.write('''
+from PySide import QtCore
+from PySide import QtGui
+''')
+
+    CONF['workpath'] = workdir
+    CONF['distpath'] = distdir
+    CONF['warnfile'] = warnfile
+    CONF['hiddenimports'] = []
+    CONF['spec'] = join(tempdir, 'speed_pefile_script.spec')
+
+    CONF['specpath'] = tempdir
+    CONF['specnm'] = 'speed_pefile_script'
+
+    start = time.time()
+    a = Analysis([script])
+    duration = time.time() - start
+
+    logger.warn("Analysis duration: %s", duration)
+    shutil.rmtree(tempdir, ignore_errors=True)
+
+if __name__ == '__main__':
+    speed_pefile()


### PR DESCRIPTION
Addresses issue #1484

With these changes, pefile.py will skip parsing those parts of the imports and exports tables that we don't care about. This cuts about 10 minutes off of the test suite run times for each Python version, and has a larger impact for builds that include a lot of compiled extensions (e.g. PySide).