### PR TITLE
Remove redundant compile() calls

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -119,4 +119,4 @@ build: none
 
 test_script:
   # Split tests into several subprocesses.
-  - "%CMD_IN_ENV% py.test -n 3  --timeout 180 --maxfail 5 --durations=10"
+  - "%CMD_IN_ENV% py.test -n 3 --maxfail 5 --durations=10"


### PR DESCRIPTION
This adds a modest optimization, removing an extra `compile()` call from `ModuleGraph._scan_code()` and its callers. This also removes the timeout from the pytest invocation, allowing tests to run to completion. This should show us that all tests pass if allowed to run to completion.

Previous changes added a list of the 10 longest-running tests to the output, the longest of which is usually `test_pandas_extension[onefile]` at 300+ seconds. A more generous timeout may be added later if desired.

The longest-running tests are generally `matplotlib`, `django`, `pandas`, `sqlalchemy`, `sphinx`, and `ipython` (which optionally imports matplotlib and could probably exclude it.). Initial profiling on `matplotlib` showed that most of the time is spent creating the modulegraph (~55%) and running the COLLECT build step (~25%), but local tests ran in less than half of the time they took on appveyor, so some way of getting profiling data from appveyor would be useful.

