### PR TITLE
Fix: exception on Windows when calculating common prefix

### DIFF
--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -720,7 +720,8 @@ class MERGE(object):
             self._id_to_path[os.path.normcase(i)] = p
 
         # Get the longest common path
-        self._common_prefix = os.path.dirname(os.path.commonprefix([os.path.abspath(a.scripts[-1][1]) for a, _, _ in args]))
+        common_prefix = os.path.commonprefix([os.path.normcase(os.path.abspath(a.scripts[-1][1])) for a, _, _ in args])
+        self._common_prefix = os.path.dirname(common_prefix)
         if self._common_prefix[-1] != os.sep:
             self._common_prefix += os.sep
         logger.info("Common prefix: %s", self._common_prefix)


### PR DESCRIPTION
I've got an exception on Windows 7 on both `master` and `develop` branches when building Enki with [this spec](https://github.com/hlamer/enki/blob/master/win/enki-all.spec) and [this script](https://github.com/hlamer/enki/blob/master/win/build_exe.bat).

The exception
```
68640 INFO: Found binding redirects:
[BindingRedirect(name=u'Microsoft.VC90.MFC', language=None, arch=u'x86', oldVers
ion=(9, 0, 21022, 8), newVersion=(9, 0, 30729, 6161), publicKeyToken=u'1fc8b3b9a
1e18e3b'), BindingRedirect(name=u'Microsoft.VC90.CRT', language=None, arch=u'x86
', oldVersion=(9, 0, 21022, 8), newVersion=(9, 0, 30729, 6161), publicKeyToken=u
'1fc8b3b9a1e18e3b')]
68640 INFO: Warnings written to C:\github\enki\build\enki-all\warnenki-all.txt
Traceback (most recent call last):
  File "C:\Python27\Scripts\pyinstaller-script.py", line 9, in <module>
    load_entry_point('PyInstaller==3.0+2f52ee1', 'console_scripts', 'pyinstaller')()
  File "c:\Python27\lib\site-packages\pyinstaller-3.0+2f52ee1-py2.7.egg\PyInstaller\__main__.py", line 99, in run
    run_build(opts, spec_file, pyi_config)
  File "c:\Python27\lib\site-packages\pyinstaller-3.0+2f52ee1-py2.7.egg\PyInstaller\__main__.py", line 47, in run_build
    PyInstaller.building.build_main.main(pyi_config, spec_file, **opts.__dict__)

  File "c:\Python27\lib\site-packages\pyinstaller-3.0+2f52ee1-py2.7.egg\PyInstaller\building\build_main.py", line 737, in main
    build(specfile, kw.get('distpath'), kw.get('workpath'), kw.get('clean_build'))
  File "c:\Python27\lib\site-packages\pyinstaller-3.0+2f52ee1-py2.7.egg\PyInstaller\building\build_main.py", line 680, in build
    exec(text, spec_namespace)
  File "<string>", line 56, in <module>
  File "c:\Python27\lib\site-packages\pyinstaller-3.0+2f52ee1-py2.7.egg\PyInstaller\building\api.py", line 724, in __init__
    if self._common_prefix[-1] != os.sep:
IndexError: string index out of range
```

happens because my files start on `C:\...` and `c:\..`, and common prefix is an empty string.
 `os.path.normcase` fixes the problem.