### PR TITLE
Fix iteration bug with user-defined hook directories

### DIFF
--- a/PyInstaller/depend/analysis.py
+++ b/PyInstaller/depend/analysis.py
@@ -127,7 +127,7 @@ class PyiModuleGraph(ModuleGraph):
             # If this directory exists, cache all hooks in this directory.
             if os.path.isdir(user_hook_type_dir):
                 # logger.debug("Caching user %s hook dir %r" % (hook_type, hooks_user_dir))
-                hooks_cache.add_custom_paths(user_hook_type_dir)
+                hooks_cache.add_custom_paths([user_hook_type_dir])
 
         return hooks_cache
 


### PR DESCRIPTION
When ``Analysis`` has ``hookspath=["path/to/hooks"]``, and ``path/to/hooks`` has a ``pre_find_module_path`` folder (or a ``pre_safe_import_module`` folder), during analysis, there are a bunch of errors like this:
```
1158 ERROR: Hook directory '<os.getcwd()>/p' not found
1158 ERROR: Hook directory '<os.getcwd()>/a' not found
1158 ERROR: Hook directory '<os.getcwd()>/t' not found
1158 ERROR: Hook directory '<os.getcwd()>/h' not found
1159 ERROR: Hook directory '<os.getcwd()>/t' not found
1159 ERROR: Hook directory '<os.getcwd()>/o' not found
1159 ERROR: Hook directory '<os.getcwd()>/h' not found
1159 ERROR: Hook directory '<os.getcwd()>/o' not found
1159 ERROR: Hook directory '<os.getcwd()>/o' not found
1159 ERROR: Hook directory '<os.getcwd()>/k' not found
1159 ERROR: Hook directory '<os.getcwd()>/s' not found
1159 ERROR: Hook directory '<os.getcwd()>/p' not found
1159 ERROR: Hook directory '<os.getcwd()>/r' not found
1159 ERROR: Hook directory '<os.getcwd()>/e' not found
1160 ERROR: Hook directory '<os.getcwd()>/_' not found
1160 ERROR: Hook directory '<os.getcwd()>/f' not found
1160 ERROR: Hook directory '<os.getcwd()>/i' not found
1160 ERROR: Hook directory '<os.getcwd()>/n' not found
1160 ERROR: Hook directory '<os.getcwd()>/d' not found
1160 ERROR: Hook directory '<os.getcwd()>/_' not found
1160 ERROR: Hook directory '<os.getcwd()>/m' not found
1160 ERROR: Hook directory '<os.getcwd()>/o' not found
1160 ERROR: Hook directory '<os.getcwd()>/d' not found
1160 ERROR: Hook directory '<os.getcwd()>/u' not found
1160 ERROR: Hook directory '<os.getcwd()>/l' not found
1160 ERROR: Hook directory '<os.getcwd()>/e' not found
1160 ERROR: Hook directory '<os.getcwd()>/_' not found
1160 ERROR: Hook directory '<os.getcwd()>/p' not found
1160 ERROR: Hook directory '<os.getcwd()>/a' not found
1161 ERROR: Hook directory '<os.getcwd()>/t' not found
1161 ERROR: Hook directory '<os.getcwd()>/h' not found
```
(nb, it's not literally ``os.getcwd()`` but is whatever your current working directory is).

Applying the attached patch solves the issue. Regular hooks seem to be unaffected (they work fine before and after this patch)