### PR TITLE
Fix: Provide missing hidden imports for astroid v. 1.4.1.

### DIFF
--- a/PyInstaller/hooks/hook-astroid.py
+++ b/PyInstaller/hooks/hook-astroid.py
@@ -28,9 +28,16 @@
 # since this is run-time discovered and loaded. Therefore, these
 # files are all data files.
 
-from PyInstaller.utils.hooks import collect_data_files
+from PyInstaller.utils.hooks import collect_data_files, collect_submodules
 
 # Note that brain/ isn't a module (it lacks an __init__.py, so it can't be
 # referred to as astroid.brain; instead, locate it as package astriod,
 # subdirectory brain/.
 datas = collect_data_files('astroid', True, 'brain')
+
+# Update: in astroid v 1.4.1, the brain/ module import parts of astroid. Since
+# everything in brain/ is dynamically imported, these are hidden imports. For
+# simplicity, include everything in astroid. Exclude all the tests/ subpackage
+# contents and the test_util module.
+hiddenimports = [x for x in collect_submodules('astroid')
+                 if not x.startswith('astroid.test')]

--- a/PyInstaller/hooks/hook-logilab.py
+++ b/PyInstaller/hooks/hook-logilab.py
@@ -10,21 +10,14 @@
 # ***************************************************
 # hook-logilab.py - PyInstaller hook file for logilab
 # ***************************************************
-from PyInstaller.compat import is_py2
+# The following was written about logilab, version 1.1.0, based on executing
+# ``pip show logilab-common``.
 #
-# The following was written about logilab, version 0.32.2, based on the contents
-# of logilab.common.__pkginfo__.
+# In logilab.common, line 33::
 #
-# In logilab.common.configuration, line 126::
+#    __version__ = pkg_resources.get_distribution('logilab-common').version
 #
-#    from six.moves import range, configparser as cp, input
-#
-# Therefore, the modules must be listed as hidden imports, due to the six
-# module's lazy import structure. The range module is a builtin, so we
-# don't need to list that. The configparser imports as ConfigParser in
-# Python 2.
-#
-# Pyinstaller for Python 3 can auto-detect six imports, so omit it.
-if is_py2:
-    hiddenimports = ['ConfigParser']
+# Therefore, we need metadata for logilab.
+from PyInstaller.utils.hooks import copy_metadata
 
+datas = copy_metadata('logilab-common')

--- a/PyInstaller/utils/hooks/__init__.py
+++ b/PyInstaller/utils/hooks/__init__.py
@@ -1221,3 +1221,61 @@ def collect_glib_translations(prog):
 
     return [(src, dst) for src, dst in _glib_translations if src[-namelen:] in names]
 
+def copy_metadata(package_name):
+    """
+    This function returns a list to be assigned to the ``datas`` global
+    variable. This list instructs PyInstaller to copy the metadata for the given
+    package to PyInstaller's data directory.
+
+    Parameters
+    ----------
+    package_name : str
+        Specifies the name of the package for which metadata should be copied.
+
+    Returns
+    ----------
+    list
+        This should be assigned to ``datas``.
+
+    Examples
+    ----------
+        >>> from PyInstaller.utils.hooks import copy_metadata
+        >>> copy_metadata('sphinx')
+        [('c:\\python27\\lib\\site-packages\\Sphinx-1.3.2.dist-info',
+          'Sphinx-1.3.2.dist-info')]
+    """
+
+    # Some notes: to look at the metadata locations for all installed packages::
+    #
+    #     for key, value in pkg_resources.working_set.by_key.iteritems():
+    #         print('{}: {}'.format(key, value.egg_info))
+    #
+    # Looking at this output, I see three general types of packages:
+    #
+    # 1. ``pypubsub: c:\python27\lib\site-packages\pypubsub-3.3.0-py2.7.egg\EGG-INFO``
+    # 2. ``codechat: c:\users\bjones\documents\documentation\CodeChat.egg-info``
+    # 3. ``zest.releaser: c:\python27\lib\site-packages\zest.releaser-6.2.dist-info``
+    # 4. ``pyserial: None``
+    #
+    # The first item shows that some metadata will be nested inside an egg. I
+    # assume we'll have to deal with zipped eggs, but I don't have any examples
+    # handy. The second and third items show different naming conventions for
+    # the metadata-containing directory. The fourth item shows a package with no
+    # metadata.
+    #
+    # So, in cases 1-3, copy the metadata directory. In case 4, emit an error --
+    # there's no metadata to copy. See https://pythonhosted.org/setuptools/pkg_resources.html#getting-or-creating-distributions.
+    # Unfortunately, there's no documentation on the ``egg_info`` attribute; it
+    # was found through trial and error.
+    dist = pkg_resources.get_distribution(package_name)
+    metadata_dir = dist.egg_info
+    assert metadata_dir
+
+    # We want to copy from the ``metadata_dir`` to PyInstaller, leaving off its
+    # prefix in ``sys.path``. The ``location`` attribute provides this prefix,
+    # per https://pythonhosted.org/setuptools/pkg_resources.html#distribution-attributes.
+    # For example, if ``package_name`` is ``regex``, then ``location = c:\python27\lib\site-packages``
+    # and ``metadata_dir = c:\python27\lib\site-packages\regex-2015.11.09.dist-info``.
+    # We should therefore return ``[ ('c:\python27\lib\site-packages\regex-2015.11.09.dist-info',
+    # 'regex-2015.11.09.dist-info') ]``.
+    return [ (metadata_dir, metadata_dir[len(dist.location) + len(os.sep):]) ]

--- a/PyInstaller/utils/hooks/__init__.py
+++ b/PyInstaller/utils/hooks/__init__.py
@@ -1069,7 +1069,7 @@ print(repo.get_shared_library(module))
     for lib in libs:
         path = findSystemLibrary(lib.strip())
         return os.path.dirname(path)
-    
+
     raise ValueError("Could not find libdir for %s-%s" % (module, version))
 
 def get_gi_typelibs(module, version):
@@ -1128,7 +1128,7 @@ print({'sharedlib': repo.get_shared_library(module),
         for dep in typelibs_data['deps']:
             m, _ = dep.rsplit('-', 1)
             hiddenimports += ['gi.repository.%s' % m]
-    
+
     return binaries, datas, hiddenimports
 
 
@@ -1199,7 +1199,7 @@ def collect_glib_share_files(path):
     glib_data_dirs = get_glib_system_data_dirs()
     if glib_data_dirs == None or len(glib_data_dirs) == 0:
         return []
-    
+
     path = os.path.join(glib_data_dirs[0], path)
     return collect_system_data_files(path, destdir='share', include_py_files=False)
 
@@ -1210,14 +1210,14 @@ def collect_glib_translations(prog):
     Returns a list of translations in the system locale directory whose
     names equal prog.mo
     """
-    
+
     global _glib_translations
     if _glib_translations is None:
         _glib_translations = collect_glib_share_files('locale')
-    
+
     names = [os.sep + prog + '.mo',
              os.sep + prog + '.po']
     namelen = len(names[0])
-    
+
     return [(src, dst) for src, dst in _glib_translations if src[-namelen:] in names]
 

--- a/tests/functional/test_libraries.py
+++ b/tests/functional/test_libraries.py
@@ -102,7 +102,6 @@ def test_sphinx(tmpdir, pyi_builder, data_dir):
     # Note that including the data_dir fixture copies files needed by this test.
     pyi_builder.test_script('pyi_lib_sphinx.py')
 
-@pytest.mark.xfail(reason='pkg_resources is not supported yet.')
 @importorskip('pylint')
 def test_pylint(pyi_builder):
     pyi_builder.test_script('pyi_lib_pylint.py')


### PR DESCRIPTION
This fix makes pylint (and its tests) work.