### PR TITLE
More PyGObject fixes

### DIFF
--- a/PyInstaller/depend/bindepend.py
+++ b/PyInstaller/depend/bindepend.py
@@ -16,6 +16,7 @@ import os
 import sys
 import re
 import platform
+import ctypes.util
 from glob import glob
 
 # Required for extracting eggs.
@@ -888,4 +889,5 @@ def findSystemLibrary(name):
     elif is_win:
         return getfullnameof(name)
     else:
-        raise ValueError("findSystemLibrary not implemented for this platform")
+        # This seems to work, and is similar to what we have above..
+        return ctypes.util.find_library(name)

--- a/PyInstaller/hooks/hook-gi.repository.GLib.py
+++ b/PyInstaller/hooks/hook-gi.repository.GLib.py
@@ -20,3 +20,4 @@ from PyInstaller.utils.hooks import collect_glib_translations, collect_glib_shar
 binaries, datas, hiddenimports = get_gi_typelibs('GLib', '2.0')
 datas += collect_glib_translations('glib20')
 datas += collect_glib_share_files('glib-2.0', 'schemas')
+

--- a/PyInstaller/hooks/hook-gi.repository.GLib.py
+++ b/PyInstaller/hooks/hook-gi.repository.GLib.py
@@ -15,7 +15,8 @@ Tested with GLib 2.44.1, PyGObject 3.16.2, and GObject Introspection 1.44.0 on M
 GLib 2.42.2, PyGObject 3.14.0, and GObject Introspection 1.42 on Windows 7
 """
 
-from PyInstaller.utils.hooks import collect_glib_translations, get_gi_typelibs
+from PyInstaller.utils.hooks import collect_glib_translations, collect_glib_share_files, get_gi_typelibs
 
 binaries, datas, hiddenimports = get_gi_typelibs('GLib', '2.0')
 datas += collect_glib_translations('glib20')
+datas += collect_glib_share_files('glib-2.0', 'schemas')

--- a/PyInstaller/hooks/hook-gi.repository.Gio.py
+++ b/PyInstaller/hooks/hook-gi.repository.Gio.py
@@ -20,7 +20,7 @@ import os
 import sys
 
 import PyInstaller.log as logging
-from PyInstaller.compat import is_darwin, is_win, is_linux
+from PyInstaller.compat import is_darwin, is_win, is_linux, base_prefix
 from PyInstaller.utils.hooks import get_gi_typelibs, get_gi_libdir, exec_statement
 
 logger = logging.getLogger(__name__)
@@ -33,7 +33,12 @@ path = None
 if is_win:
     pattern = os.path.join(libdir, 'gio', 'modules', '*.dll')
 elif is_darwin or is_linux:
-    pattern = os.path.join(libdir, 'gio', 'modules', '*.so')
+    gio_libdir = os.path.join(libdir, 'gio', 'modules')
+    if not os.path.exists(gio_libdir):
+        # homebrew installs the files elsewhere..
+        gio_libdir = os.path.join(os.path.commonprefix([base_prefix, gio_libdir]), 'lib', 'gio', 'modules')
+
+    pattern = os.path.join(gio_libdir, '*.so')
 
 if pattern:
     for f in glob.glob(pattern):

--- a/PyInstaller/hooks/hook-gi.repository.Gst.py
+++ b/PyInstaller/hooks/hook-gi.repository.Gst.py
@@ -28,6 +28,8 @@ binaries, datas, hiddenimports = get_gi_typelibs('Gst', '1.0')
 
 datas += collect_glib_share_files('gstreamer-1.0')
 
+hiddenimports += ["gi.repository.Gio"]
+
 for prog in ['gst-plugins-bad-1.0',
              'gst-plugins-base-1.0',
              'gst-plugins-good-1.0',

--- a/PyInstaller/hooks/hook-gi.repository.Gtk.py
+++ b/PyInstaller/hooks/hook-gi.repository.Gtk.py
@@ -15,7 +15,7 @@ import os.path
 import glob
 
 from PyInstaller.compat import is_win
-from PyInstaller.utils.hooks import collect_glib_share_files, collect_glib_translations, exec_statement, get_gi_typelibs
+from PyInstaller.utils.hooks import collect_glib_share_files, collect_glib_etc_files, collect_glib_translations, exec_statement, get_gi_typelibs
 
 binaries, datas, hiddenimports = get_gi_typelibs('Gtk', '3.0')
 
@@ -24,3 +24,8 @@ datas += collect_glib_share_files('icons')
 datas += collect_glib_share_files('themes')
 datas += collect_glib_translations('gtk30')
 
+# these only seem to be required on Windows
+if is_win:
+    datas += collect_glib_etc_files('fonts')
+    datas += collect_glib_etc_files('pango')
+    datas += collect_glib_share_files('fonts')

--- a/PyInstaller/hooks/hook-gi.repository.PangoCairo.py
+++ b/PyInstaller/hooks/hook-gi.repository.PangoCairo.py
@@ -9,7 +9,7 @@
 """
 Import hook for PyGObject https://wiki.gnome.org/PyGObject
 """
+
 from PyInstaller.utils.hooks import get_gi_typelibs
 
-binaries, datas, hiddenimports = get_gi_typelibs('Gdk', '3.0')
-hiddenimports += ['gi._gi_cairo', 'gi.repository.cairo']
+binaries, datas, hiddenimports = get_gi_typelibs('PangoCairo', '1.0')

--- a/PyInstaller/hooks/hook-gi.repository.cairo.py
+++ b/PyInstaller/hooks/hook-gi.repository.cairo.py
@@ -9,7 +9,7 @@
 """
 Import hook for PyGObject https://wiki.gnome.org/PyGObject
 """
+
 from PyInstaller.utils.hooks import get_gi_typelibs
 
-binaries, datas, hiddenimports = get_gi_typelibs('Gdk', '3.0')
-hiddenimports += ['gi._gi_cairo', 'gi.repository.cairo']
+binaries, datas, hiddenimports = get_gi_typelibs('cairo', '1.0')

--- a/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.PangoCairo.py
+++ b/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.PangoCairo.py
@@ -6,10 +6,10 @@
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
-"""
-Import hook for PyGObject https://wiki.gnome.org/PyGObject
-"""
-from PyInstaller.utils.hooks import get_gi_typelibs
 
-binaries, datas, hiddenimports = get_gi_typelibs('Gdk', '3.0')
-hiddenimports += ['gi._gi_cairo', 'gi.repository.cairo']
+
+def pre_safe_import_module(api):
+    # PyGObject modules loaded through the gi repository are marked as
+    # MissingModules by modulegraph so we convert them to
+    # RuntimeModules so their hooks are loaded and run.
+    api.add_runtime_module(api.module_name)

--- a/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.cairo.py
+++ b/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.cairo.py
@@ -6,10 +6,10 @@
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
-"""
-Import hook for PyGObject https://wiki.gnome.org/PyGObject
-"""
-from PyInstaller.utils.hooks import get_gi_typelibs
 
-binaries, datas, hiddenimports = get_gi_typelibs('Gdk', '3.0')
-hiddenimports += ['gi._gi_cairo', 'gi.repository.cairo']
+
+def pre_safe_import_module(api):
+    # PyGObject modules loaded through the gi repository are marked as
+    # MissingModules by modulegraph so we convert them to
+    # RuntimeModules so their hooks are loaded and run.
+    api.add_runtime_module(api.module_name)

--- a/PyInstaller/utils/hooks/__init__.py
+++ b/PyInstaller/utils/hooks/__init__.py
@@ -1197,11 +1197,16 @@ print(GLib.get_system_data_dirs())
 
 def collect_glib_share_files(path):
     glib_data_dirs = get_glib_system_data_dirs()
-    if glib_data_dirs == None or len(glib_data_dirs) == 0:
+    if glib_data_dirs == None:
         return []
 
-    path = os.path.join(glib_data_dirs[0], path)
-    return collect_system_data_files(path, destdir='share', include_py_files=False)
+    # TODO: will this return too much?
+    collected = []
+    for data_dir in glib_data_dirs:
+        p = os.path.join(data_dir, path)
+        collected += collect_system_data_files(p, destdir='share', include_py_files=False)
+
+    return collected
 
 _glib_translations = None
 

--- a/PyInstaller/utils/hooks/__init__.py
+++ b/PyInstaller/utils/hooks/__init__.py
@@ -1219,31 +1219,35 @@ print(GLib.get_system_config_dirs())
         # :todo: should we raise a SystemError here?
     return data_dirs
 
-def collect_glib_share_files(path):
+def collect_glib_share_files(*path):
     '''path is relative to the system data directory (eg, /usr/share)'''
     glib_data_dirs = get_glib_system_data_dirs()
     if glib_data_dirs == None:
         return []
 
+    destdir = os.path.join('share', *path[:-1])
+
     # TODO: will this return too much?
     collected = []
     for data_dir in glib_data_dirs:
-        p = os.path.join(data_dir, path)
-        collected += collect_system_data_files(p, destdir='share', include_py_files=False)
+        p = os.path.join(data_dir, *path)
+        collected += collect_system_data_files(p, destdir=destdir, include_py_files=False)
 
     return collected
 
-def collect_glib_etc_files(path):
+def collect_glib_etc_files(*path):
     '''path is relative to the system config directory (eg, /etc)'''
     glib_config_dirs = get_glib_sysconf_dirs()
     if glib_config_dirs == None:
         return []
 
+    destdir = os.path.join('etc', *path[:-1])
+
     # TODO: will this return too much?
     collected = []
     for config_dir in glib_config_dirs:
-        p = os.path.join(config_dir, path)
-        collected += collect_system_data_files(p, destdir='etc', include_py_files=False)
+        p = os.path.join(config_dir, *path)
+        collected += collect_system_data_files(p, destdir=destdir, include_py_files=False)
 
     return collected
 

--- a/PyInstaller/utils/hooks/__init__.py
+++ b/PyInstaller/utils/hooks/__init__.py
@@ -1138,7 +1138,7 @@ def gir_library_path_fix(path):
     from ...config import CONF
 
     path = os.path.abspath(path)
-    common_path = os.path.commonprefix([sys.prefix, path])
+    common_path = os.path.commonprefix([compat.base_prefix, path])
     gir_path = os.path.join(common_path, 'share', 'gir-1.0')
 
     typelib_name = os.path.basename(path)


### PR DESCRIPTION
- Older PyGObject Gdk doesn't declare cairo as a dependency
- Add cairo/pangocairo repositories
- Include all system data directories when collecting glib data files