### PR TITLE
Wx pubsub fix

### DIFF
--- a/PyInstaller/hooks/hook-sphinx.py
+++ b/PyInstaller/hooks/hook-sphinx.py
@@ -37,7 +37,7 @@ hiddenimports = (
 #    lang_class = getattr(__import__(module, None, None, [classname]),
 #                         classname)
 #
-# From sphinx. search line 119::
+# From sphinx.search line 119::
 #
 #    languages = {
 #        'da': 'sphinx.search.da.SearchDanish',

--- a/PyInstaller/hooks/hook-wx.lib.pubsub.py
+++ b/PyInstaller/hooks/hook-wx.lib.pubsub.py
@@ -23,6 +23,12 @@ hiddenimports = collect_submodules('wx.lib.pubsub')
 pubsub_datas = collect_data_files('wx.lib.pubsub', include_py_files=True)
 
 def _match(dst):
-    return "pubsub1" in dst or "pubsub2" in dst or "autosetuppubsubv1" in dst
+    # Since ``pubsub1`` and ``pubsub2`` are directories, they shoud up in dst.
+    # However, ``autosetuppubsubv1`` is a ``.py`` file, so it will only appear
+    # in the ``src``. For example::
+    #
+    #     pubsub_datas = [('c:\\python27\\lib\\site-packages\\wx-2.8-msw-unicode\\wx\\lib\\pubsub\\autosetuppubsubv1.py',
+    #       'wx\\lib\\pubsub') ]
+    return "pubsub1" in dst or "pubsub2" in dst or "autosetuppubsubv1" in src
 
 datas = [(src, dst) for src, dst in pubsub_datas if _match(dst)]


### PR DESCRIPTION
Fix: Actually include autosetuppubsubv1.py.

The existing hook docs state that it should be included...but it wasn't. Now it is. This applies to wxPython v 2.8.