### PR TITLE
Wx python fail

### DIFF
--- a/tests/functional/modules/pyi_testmod_path/__init__.py
+++ b/tests/functional/modules/pyi_testmod_path/__init__.py
@@ -1,0 +1,13 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2015, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+import os.path
+# Insert a/ at the beginning of __path__.
+__path__.insert(0, os.path.join(__path__[0], 'a'))
+# Import b, which should now find a/b.py, no ./b.py.
+import b

--- a/tests/functional/modules/pyi_testmod_path/a/b.py
+++ b/tests/functional/modules/pyi_testmod_path/a/b.py
@@ -1,0 +1,9 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2015, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+

--- a/tests/functional/modules/pyi_testmod_path/b.py
+++ b/tests/functional/modules/pyi_testmod_path/b.py
@@ -1,0 +1,9 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2015, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+raise ImportError

--- a/tests/functional/scripts/pyi_hooks/hook-pyi_testmod_path.py
+++ b/tests/functional/scripts/pyi_hooks/hook-pyi_testmod_path.py
@@ -1,0 +1,13 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013-2015, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+from PyInstaller.utils.hooks import collect_data_files
+
+# Since pyi_testmod_path/b lacks an __init__, it's not a module and won't be
+# found by modulegraph. So, include its contents in the filesystem.
+datas = collect_data_files('pyi_testmod_path', True, 'a')

--- a/tests/functional/test_hooks/test_wx_lib_pubsub.py
+++ b/tests/functional/test_hooks/test_wx_lib_pubsub.py
@@ -39,7 +39,11 @@ def test_wx_lib_pubsub_protocol_default(pyi_builder):
     pyi_builder.test_script('pyi_hooks/wx_lib_pubsub.py')
 
 @xfail_py3
-@xfail(wxPython_fail, reason='Unsupported wxPython version')
+# This test will pass when test_import.test_import_respects_path passes, since
+# that test provides a simple example of what causes this wxPython version to
+# fail.
+@xfail(wxPython_fail,
+       reason='PyInstaller does not support this wxPython version')
 @importorskip('wx.lib.pubsub.core')
 def test_wx_lib_pubsub_protocol_kwargs(pyi_builder):
     """

--- a/tests/functional/test_hooks/test_wx_lib_pubsub.py
+++ b/tests/functional/test_hooks/test_wx_lib_pubsub.py
@@ -14,10 +14,17 @@ Since wxPython is currently only stably supported under Python 2, these tests
 are implicitly skipped under Python 3.
 """
 
-from PyInstaller.utils.tests import importorskip, xfail_py3
+import pkg_resources
+from PyInstaller.utils.tests import importorskip, xfail_py3, xfail
 
+# These tests fail under wxPython versions which support multiple pubsub APIs.
+# See https://github.com/pyinstaller/pyinstaller/issues/1704.
+wxPython_fail = ( pkg_resources.parse_version('2.8.10') <=
+                  pkg_resources.get_distribution('wxPython').parsed_version <
+                  pkg_resources.parse_version('2.9') )
 
 @xfail_py3
+@xfail(wxPython_fail, reason='Unsupported wxPython version')
 @importorskip('wx.lib.pubsub')
 def test_wx_lib_pubsub_protocol_default(pyi_builder):
     """
@@ -26,6 +33,7 @@ def test_wx_lib_pubsub_protocol_default(pyi_builder):
     pyi_builder.test_script('pyi_hooks/wx_lib_pubsub.py')
 
 @xfail_py3
+@xfail(wxPython_fail, reason='Unsupported wxPython version')
 @importorskip('wx.lib.pubsub.core')
 def test_wx_lib_pubsub_protocol_kwargs(pyi_builder):
     """
@@ -36,6 +44,7 @@ def test_wx_lib_pubsub_protocol_kwargs(pyi_builder):
     pyi_builder.test_script('pyi_hooks/wx_lib_pubsub_setupkwargs.py')
 
 @xfail_py3
+@xfail(wxPython_fail, reason='Unsupported wxPython version')
 @importorskip('wx.lib.pubsub.core')
 def test_wx_lib_pubsub_protocol_arg1(pyi_builder):
     """

--- a/tests/functional/test_hooks/test_wx_lib_pubsub.py
+++ b/tests/functional/test_hooks/test_wx_lib_pubsub.py
@@ -17,11 +17,17 @@ are implicitly skipped under Python 3.
 import pkg_resources
 from PyInstaller.utils.tests import importorskip, xfail_py3, xfail
 
-# These tests fail under wxPython versions which support multiple pubsub APIs.
-# See https://github.com/pyinstaller/pyinstaller/issues/1704.
-wxPython_fail = ( pkg_resources.parse_version('2.8.10') <=
-                  pkg_resources.get_distribution('wxPython').parsed_version <
-                  pkg_resources.parse_version('2.9') )
+
+try:
+    # These tests fail under wxPython versions which support multiple pubsub
+    # APIs. See https://github.com/pyinstaller/pyinstaller/issues/1704.
+    wxPython_fail = ( pkg_resources.parse_version('2.8.10') <=
+                      pkg_resources.get_distribution('wxPython').parsed_version <
+                      pkg_resources.parse_version('2.9') )
+except pkg_resources.DistributionNotFound:
+    # Linux wxPython installations don't provide distribution metadata, but pass
+    # all the tests below.
+    wxPython_fail = False
 
 @xfail_py3
 @xfail(wxPython_fail, reason='Unsupported wxPython version')

--- a/tests/functional/test_import.py
+++ b/tests/functional/test_import.py
@@ -13,7 +13,8 @@ import pytest
 import ctypes, ctypes.util
 
 from PyInstaller.compat import is_win
-from PyInstaller.utils.tests import skipif, importorskip, xfail_py2, skipif_notwin
+from PyInstaller.utils.tests import skipif, importorskip, xfail_py2, \
+  skipif_notwin, xfail
 
 
 # :todo: find a way to get this from `conftest` or such
@@ -64,7 +65,7 @@ def test_relative_import3(pyi_builder):
 #   * a/ -- contains no __init__.py.
 #
 #     * b.py - Empty. Should be imported.
-#
+@xfail(reason='__path__ not respected for filesystem modules.')
 def test_import_respects_path(pyi_builder, script_dir):
     pyi_builder.test_source('import pyi_testmod_path',
       ['--additional-hooks-dir='+script_dir.join('pyi_hooks').strpath])

--- a/tests/functional/test_import.py
+++ b/tests/functional/test_import.py
@@ -54,6 +54,21 @@ def test_relative_import3(pyi_builder):
         """
     )
 
+# Verify that __path__ is respected for imports from the filesystem:
+#
+# * pyi_testmod_path/
+#
+#   * __init__.py -- inserts a/ into __path__, then imports b, which now refers
+#     to a/b.py, not ./b.py.
+#   * b.py - raises an exception. **Should not be imported.**
+#   * a/ -- contains no __init__.py.
+#
+#     * b.py - Empty. Should be imported.
+#
+def test_import_respects_path(pyi_builder, script_dir):
+    pyi_builder.test_source('import pyi_testmod_path',
+      ['--additional-hooks-dir='+script_dir.join('pyi_hooks').strpath])
+
 
 def test_import_pyqt5_uic_port(pyi_builder):
     extra_path = os.path.join(_MODULES_DIR, 'pyi_import_pyqt.uic.port')


### PR DESCRIPTION
This shows a corner case not (yet) correctly handled by PyInstaller: `__path__` is not respected when imports come from the filesystem. For this reason, some of the wxPython tests are also marked as xfail. See #1704.