### PR TITLE
For development version, install from develop branch

### DIFF
--- a/doc/source/Manual.rst
+++ b/doc/source/Manual.rst
@@ -1855,11 +1855,10 @@ This version might have fixes or features that are not yet at `PyPI`_.
 You can download the latest stable version and the latest development
 version from the `PyInstaller Downloads`_ page.
 
-If you have Git_ installed on your development system,
-you can use it together with pip
-to install the latest version of |PyInstaller| directly::
+You can also install the latest version of |PyInstaller| directly
+using pip_::
 
-    pip install -e git://github.com/pyinstaller/pyinstaller.git#egg=PyInstaller
+    pip install -e https://github.com/pyinstaller/pyinstaller/archive/develop.zip
 
 Asking for Help
 ~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Using this

```
pip install -e git://github.com/pyinstaller/pyinstaller.git#egg=PyInstaller
```

installs PyInstaller from master, which is confusing since the latest development happens on the develop branch.

(For some reason, GitHub introduced some superfluous changes to the diff. I'll try to get rid of those.)