### PR TITLE
fixed No module named management.commands.runserver (issue #1721)

### DIFF
--- a/PyInstaller/loader/rthooks/pyi_rth_django.py
+++ b/PyInstaller/loader/rthooks/pyi_rth_django.py
@@ -37,7 +37,7 @@ def _get_commands():
          'makemigrations': 'django.core',
          'migrate': 'django.core',
          'runfcgi': 'django.core',
-         'runserver': 'django.contrib.staticfiles',
+         'runserver': 'django.core',
          'shell': 'django.core',
          'showmigrations': 'django.core',
          'sql': 'django.core',


### PR DESCRIPTION
that was caused by rewritten django.core.management.get_commands function
runserver command from django.contrib.staticfiles application does not
work for the 'django.exe runserver 0.0.0.0:80' command line