### PR TITLE
NameError: name 'sys' is not defined

### DIFF
--- a/PyInstaller/building/build_main.py
+++ b/PyInstaller/building/build_main.py
@@ -687,6 +687,7 @@ def build(spec, distpath, workpath, clean_build):
         'TkTree': TkTree,
         # Python modules available for .spec.
         'os': os,
+        'sys': sys,
         'pyi_crypto': pyz_crypto,
     }
 


### PR DESCRIPTION
Fixes this error:
```
File "C:\Python27\lib\site-packages\pyinstaller-3.1.dev0+9826a1c-py2.7.egg\PyInstaller\building\build_main.py", line 701, in build
    exec(text, spec_namespace)
  File "<string>", line 12, in <module>
NameError: name 'sys' is not defined
```
This occurs when running --onefile