### PR TITLE
Detect gst usage in kivy.

### DIFF
--- a/PyInstaller/loader/rthooks.dat
+++ b/PyInstaller/loader/rthooks.dat
@@ -8,6 +8,7 @@
     'gi.repository.Gtk':    ['pyi_rth_gtk.py'],
     'gi.repository.Gst':    ['pyi_rth_gstreamer.py'],
     'gst':        ['pyi_rth_gstreamer.py'],
+    'kivy.lib.gstplayer': ['pyi_rth_gstreamer.py'],
     'matplotlib': ['pyi_rth_mplconfig.py', 'pyi_rth_mpldata.py'],
     'osgeo':      ['pyi_rth_osgeo.py'],
     'pkg_resources':  ['pyi_rth_pkgres.py'],


### PR DESCRIPTION
This is required to make pyinstaller include the gstreamer rthook when kivy uses gstreamer.

Hopefully not too late for 3.1 :)