### PR TITLE
add boto as a test requirement

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -27,6 +27,7 @@ Django==1.8.3
 # Latest babel 1.3.1 fails with Python 3.3/3.4 on Windows:
 # https://github.com/mitsuhiko/babel/issues/174
 babel==1.3  # Required by sphinx. This version works on Windows.
+boto
 boto3
 botocore
 gevent


### PR DESCRIPTION
when the boto hook was added, boto not added to
test/requirements.txt, causing the boto tests to be skipped by CI