### PR TITLE
Simplify MANIFEST.in commands

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,46 +1,22 @@
-recursive-include bootloader/src *
-recursive-include bootloader/tools *
-recursive-include bootloader/windows *
-recursive-include bootloader/zlib *
-include bootloader/README.txt
-include bootloader/waf
-include bootloader/wscript
-
-
-recursive-include doc/images *
-recursive-include doc/stylesheets *
-recursive-include doc *.1 *.html *.pdf *.rst *.txt
-
-recursive-include PyInstaller *
-
-recursive-include tests/functional *
-recursive-include tests/unit *
-recursive-include tests/old_suite *
-recursive-include tests *.txt
-
-recursive-include utils *.py
+graft bootloader
+graft doc
+graft PyInstaller
+graft tests
 
 include *.rst
 include *.txt
 include pyinstaller.py
 include pyinstaller-gui.py
 
-recursive-exclude bootloader/build *
-recursive-exclude bootloader/.waf* *
-recursive-exclude bootloader/waf3-* *
+prune bootloader/build
+prune bootloader/.waf*
+prune bootloader/waf3-*
 exclude bootloader/.lock-waf*
 
-recursive-exclude doc/source *
-exclude doc/source
-
-recursive-exclude old *
-exclude old
-
-recursive-exclude scripts *
-exclude scripts
-
-recursive-exclude tests/scripts *
-exclude tests/scripts
+prune doc/source
+prune old
+prune scripts
+prune tests/scripts
 
 exclude .* *.yml
-global-exclude *.pyc *.pyo
+global-exclude *.py[co]


### PR DESCRIPTION
The full MANIFEST.in syntax is [here](https://docs.python.org/3/distutils/commandref.html#creating-a-source-distribution-the-sdist-command).