### PR TITLE
Lib2to3 hook

### DIFF
--- a/PyInstaller/hooks/hook-lib2to3.py
+++ b/PyInstaller/hooks/hook-lib2to3.py
@@ -7,8 +7,7 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-# This is needed to bundle draft3.json and draft4.json files that come
-# with jsonschema module
+# This is needed to bundle lib2to3 Grammars files
 
 from PyInstaller.utils.hooks import collect_data_files
 

--- a/PyInstaller/hooks/hook-lib2to3.py
+++ b/PyInstaller/hooks/hook-lib2to3.py
@@ -1,0 +1,15 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2016, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+# This is needed to bundle draft3.json and draft4.json files that come
+# with jsonschema module
+
+from PyInstaller.utils.hooks import collect_data_files
+
+datas = collect_data_files('lib2to3')


### PR DESCRIPTION
A hook for lib2to3, used by networkx library for their GML language ( https://github.com/networkx/networkx/blob/master/networkx/readwrite/gml.py )