### PR TITLE
Add runtime hook to make requests find SSL certificates

### DIFF
--- a/PyInstaller/loader/rthooks.dat
+++ b/PyInstaller/loader/rthooks.dat
@@ -17,6 +17,7 @@
     'PyQt5.QtQuick':  ['pyi_rth_qml.py'],
     'PyQt5.QtWebEngineWidgets': ['pyi_rth_qt5webengine.py'],
     'PySide':      ['pyi_rth_qt4plugins.py'],
+    'requests':    ['pyi_rth_requests.py'],
     '_tkinter':    ['pyi_rth__tkinter.py'],
     'twisted.internet.reactor':        ['pyi_rth_twisted.py'],
     'usb':        ['pyi_rth_usb.py'],

--- a/PyInstaller/loader/rthooks/pyi_rth_requests.py
+++ b/PyInstaller/loader/rthooks/pyi_rth_requests.py
@@ -1,0 +1,14 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2016, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+import os
+import sys
+
+os.environ['REQUESTS_CA_BUNDLE'] = os.path.join(
+    sys._MEIPASS, 'requests', 'cacert.pem')


### PR DESCRIPTION
Without this, the `requests` library fails to validate SSL certificates as it cannot find its `cacert.pem` file. (At least on my Windows machine, with a binary built on Linux using Wine)
