### PR TITLE
Update hook-gi.repository.GdkPixbuf.py

### DIFF
--- a/PyInstaller/hooks/hook-gi.repository.GdkPixbuf.py
+++ b/PyInstaller/hooks/hook-gi.repository.GdkPixbuf.py
@@ -52,7 +52,7 @@ if pattern:
     
     cachefile = os.path.join(CONF['workpath'], 'loaders.cache')
     with open(cachefile, 'w') as fp:
-        fp.write(cachedata)
+        fp.write(cachedata.decode('utf-8'))
     
     datas.append((cachefile, 'lib/gdk-pixbuf-2.0/2.10.0'))
 else:


### PR DESCRIPTION
I have an error in python3 with PyInstaller 3.1.1, TypeError: must be 'str' not 'byte' 
fp.write(cachedata)

so, I changed the hook file in my computer byte to str.
I'm OK.