### PR TITLE
"Fix" signal handling on linux by not forking a process

### DIFF
--- a/bootloader/src/pyi_utils.c
+++ b/bootloader/src/pyi_utils.c
@@ -670,44 +670,8 @@ int pyi_utils_create_child(const char *thisfile, const int argc, char *const arg
     process_apple_events_new();
 #endif
 
-
-    pid = fork();
-
-    /* Child code. */
-    if (pid == 0)
-        /* Replace process by starting a new application. */
-        execvp(thisfile, argv_pyi);
-    /* Parent code. */
-    else
-    {
-        child_pid = pid;
-
-        /* Redirect termination signals received by parent to child process. */
-        signal(SIGINT, &_signal_handler);
-        signal(SIGKILL, &_signal_handler);
-        signal(SIGTERM, &_signal_handler);
-    }
-
-    wait(&rc);
-
-    /* Parent code. */
-    if(child_pid != 0 )
-    {
-        /* When child process exited, reset signal handlers to default values. */
-        signal(SIGINT, SIG_DFL);
-        signal(SIGKILL, SIG_DFL);
-        signal(SIGTERM, SIG_DFL);
-
-        for (i = 0; i < argc_pyi; i++) free(argv_pyi[i]);
-        free(argv_pyi);
-    }
-    if (WIFEXITED(rc))
-        return WEXITSTATUS(rc);
-    /* Process ended abnormally */
-    if (WIFSIGNALED(rc))
-        /* Mimick the signal the child received */
-        raise(WTERMSIG(rc));
-    return 1;
+    /* Replace process by starting a new application. */
+    execvp(thisfile, argv_pyi);
 }
 
 


### PR DESCRIPTION
Possibly fixes #208

I built the bootloader and re-built `docker-compose` using this patch and it seems to have fixed all the signal handling issues we've been having.

Is this `fork()` really necessary? The only thing that seems to be done to cleanup is a `free()` for the args, but if the process exits immediately afterward, is that really necessary? 

The exit status is already correct without doing any meddling.