### PR TITLE
Use objcopy to create a vaild ELF file

### DIFF
--- a/PyInstaller/__init__.py
+++ b/PyInstaller/__init__.py
@@ -14,7 +14,7 @@ import os
 import sys
 
 from . import compat
-from .compat import is_darwin, is_win, is_py2
+from .compat import is_darwin, is_win, is_py2, is_linux
 from .utils.git import get_repo_revision
 
 

--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -658,7 +658,6 @@ class EXE(Target):
             outf.close()
             logger.info("Copying archive to %s", self.pkgname)
             shutil.copy(self.pkg.name, self.pkgname)
-            
 
         if is_darwin:
             # Fix Mach-O header for codesigning on OS X.

--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -20,14 +20,13 @@ import tempfile
 import pkgutil
 import pprint
 import sys
-import subprocess
 from operator import itemgetter
 
-from PyInstaller import is_win, is_darwin, HOMEPATH, PLATFORM
+from PyInstaller import is_win, is_darwin, is_linux, HOMEPATH, PLATFORM
 from PyInstaller.archive.writers import ZlibArchiveWriter, CArchiveWriter
 from PyInstaller.building.utils import _check_guts_toc_mtime, _check_guts_toc, add_suffix_to_extensions, \
     checkCache, _check_path_overlap, _rmtree
-from PyInstaller.compat import is_cygwin
+from PyInstaller.compat import is_cygwin, exec_command_all
 from PyInstaller.config import CONF
 from PyInstaller.depend import bindepend
 from PyInstaller.depend.analysis import get_bootstrap_modules
@@ -637,21 +636,29 @@ class EXE(Target):
             exe = tmpnm
         exe = checkCache(exe, strip=self.strip, upx=self.upx)
         self.copy(exe, outf)
-        if subprocess.check_call(['objcopy','--help']) != 0:
-            if self.append_pkg:
+        if self.append_pkg:
+            if is_linux:
+                outf.close()
+                logger.info("Appending archive to ELF section in EXE %s", self.name)
+                retcode, stdout, stderr = exec_command_all(*['objcopy',
+                                                             '--add-section',
+                                                             'pydata=%s' % self.pkg.name, 
+                                                             self.name])
+                logger.debug("objcopy:%i", retcode)
+                logger.debug(stdout)
+                logger.debug(stderr)
+                if retcode != 0:
+                    raise SystemError("objcopy Failure")
+            else:
+                # Fall back to just append on end of file
                 logger.info("Appending archive to EXE %s", self.name)
                 self.copy(self.pkg.name, outf)
-            else:
-                logger.info("Copying archive to %s", self.pkgname)
-                shutil.copy(self.pkg.name, self.pkgname)
-            outf.close()
+                outf.close()
         else:
             outf.close()
-            if subprocess.check_call(['objcopy',
-                                      '--add-section',
-                                      'pydata=%s' % self.pkg.name, 
-                                      self.name]) != 0:
-                raise SystemError("objcopy Failure")
+            logger.info("Copying archive to %s", self.pkgname)
+            shutil.copy(self.pkg.name, self.pkgname)
+            
 
         if is_darwin:
             # Fix Mach-O header for codesigning on OS X.

--- a/bootloader/src/pyi_archive.c
+++ b/bootloader/src/pyi_archive.c
@@ -330,9 +330,6 @@ int pyi_arch_open(ARCHIVE_STATUS *status)
 #if defined(WIN32)
     int i;
     int alignment = 8;
-#elif defined(__APPLE__)
-    int i;
-    int alignment = 4096;
 #else
     int i;
     int alignment = 4096;
@@ -356,8 +353,8 @@ int pyi_arch_open(ARCHIVE_STATUS *status)
 		filelen = findDigitalSignature(status);
 		if (filelen < 1)
 			return -1;
-#else
-		VS("LOADER: Search fopr cookie");
+#endif
+		VS("LOADER: Search for cookie");
 		/* The digital signature has been aligned to a boundary.
 		   We need to look for our cookie taking into account some
 		   padding. */
@@ -374,7 +371,6 @@ int pyi_arch_open(ARCHIVE_STATUS *status)
 		}
 		VS("LOADER: package found skipping digital signature in %s\n", status->archivename);
 
-#endif
 	}
 
     /* Set the flag that Python library was not loaded yet. */

--- a/bootloader/src/pyi_archive.c
+++ b/bootloader/src/pyi_archive.c
@@ -333,6 +333,9 @@ int pyi_arch_open(ARCHIVE_STATUS *status)
 #elif defined(__APPLE__)
     int i;
     int alignment = 4096;
+#else
+    int i;
+    int alignment = 4096;
 #endif
 	int filelen;
     VS("LOADER: archivename is %s\n", status->archivename);
@@ -353,6 +356,8 @@ int pyi_arch_open(ARCHIVE_STATUS *status)
 		filelen = findDigitalSignature(status);
 		if (filelen < 1)
 			return -1;
+#else
+		VS("LOADER: Search fopr cookie");
 		/* The digital signature has been aligned to a boundary.
 		   We need to look for our cookie taking into account some
 		   padding. */
@@ -368,8 +373,7 @@ int pyi_arch_open(ARCHIVE_STATUS *status)
 			return -1;
 		}
 		VS("LOADER: package found skipping digital signature in %s\n", status->archivename);
-#else
-        return -1;
+
 #endif
 	}
 

--- a/tests/functional/test_basic.py
+++ b/tests/functional/test_basic.py
@@ -177,7 +177,6 @@ def test_getfilesystemencoding(pyi_builder):
 def test_helloworld(pyi_builder):
     pyi_builder.test_source("print('Hello Python!')")
 
-
 def test_module__file__attribute(pyi_builder):
     pyi_builder.test_script('pyi_module__file__attribute.py')
 

--- a/tests/functional/test_basic.py
+++ b/tests/functional/test_basic.py
@@ -177,6 +177,7 @@ def test_getfilesystemencoding(pyi_builder):
 def test_helloworld(pyi_builder):
     pyi_builder.test_source("print('Hello Python!')")
 
+
 def test_module__file__attribute(pyi_builder):
     pyi_builder.test_script('pyi_module__file__attribute.py')
 


### PR DESCRIPTION
Use objcopy to create a valid ELF file. This stops prelink stripping off the archive. 

https://github.com/pyinstaller/pyinstaller/issues/1812