### PR TITLE
Don't exit if chflags fails

### DIFF
--- a/PyInstaller/building/utils.py
+++ b/PyInstaller/building/utils.py
@@ -249,7 +249,10 @@ def checkCache(fnm, strip=False, upx=False, dist_nm=None):
         # Some libraries on FreeBSD have immunable flag (libthr.so.3, for example)
         # If flags still remains, os.chmod will failed with:
         # OSError: [Errno 1] Operation not permitted.
-        os.chflags(cachedfile, 0)
+        try:
+            os.chflags(cachedfile, 0)
+        except OSError:
+            pass
     os.chmod(cachedfile, 0o755)
 
     if os.path.splitext(fnm.lower())[1] in (".pyd", ".dll"):


### PR DESCRIPTION
On OS X, if the binary cache is in NFS, the chflags call fails (presumably because NFS doesn't support that operation)

See https://github.com/pyinstaller/pyinstaller/pull/1573#issuecomment-158563618