### PR TITLE
Lazy Hook I: A Not Really New Hope

### DIFF
--- a/PyInstaller/building/imphook.py
+++ b/PyInstaller/building/imphook.py
@@ -12,18 +12,550 @@
 Code related to processing of import hooks.
 """
 
-import glob
+import glob, sys, weakref
 import os.path
 
 from .. import log as logging
-from .utils import format_binaries_and_datas
-from ..compat import expand_path
-from ..compat import importlib_load_source
+from ..compat import (
+    expand_path, importlib_load_source, FileNotFoundError, UserDict,)
 from .imphookapi import PostGraphAPI
+from .utils import format_binaries_and_datas
 
 logger = logging.getLogger(__name__)
 
 
+# Note that the "UserDict" superclass is old-style under Python 2.7! Avoid
+# calling the super() method for this subclass.
+class ModuleHookCache(UserDict):
+    """
+    Cache of lazily loadable hook script objects.
+
+    This cache is implemented as a `dict` subclass mapping from the
+    fully-qualified names of all modules with at least one hook script to lists
+    of `ModuleHook` instances encapsulating these scripts. As a `dict` subclass,
+    all cached module names and hook scripts are accessible via standard
+    dictionary operations.
+
+    Attributes
+    ----------
+    module_graph : ModuleGraph
+        Current module graph.
+    _hook_module_name_prefix : str
+        String prefixing the names of all in-memory modules lazily loaded from
+        cached hook scripts. See also the `hook_module_name_prefix` parameter
+        passed to the `ModuleHook.__init__()` method.
+    """
+
+    _cache_id_next = 0
+    """
+    0-based identifier unique to the next `ModuleHookCache` to be instantiated.
+
+    This identifier is incremented on each instantiation of a new
+    `ModuleHookCache` to isolate in-memory modules of lazily loaded hook scripts
+    in that cache to the same cache-specific namespace, preventing edge-case
+    collisions with existing in-memory modules in other caches.
+    """
+
+    def __init__(self, module_graph, hook_dirs):
+        """
+        Cache all hook scripts in the passed directories.
+
+        **Order of caching is significant** with respect to hooks for the same
+        module, as the values of this dictionary are lists. Hooks for the same
+        module will be run in the order in which they are cached. Previously
+        cached hooks are always preserved rather than overidden.
+
+        By default, official hooks are cached _before_ user-defined hooks. For
+        modules with both official and user-defined hooks, this implies that the
+        former take priority over and hence will be loaded _before_ the latter.
+
+        Parameters
+        ----------
+        module_graph : ModuleGraph
+            Current module graph.
+        hook_dirs : list
+            List of the absolute or relative paths of all directories containing
+            **hook scripts** (i.e., Python scripts with filenames matching
+            `hook-{module_name}.py`, where `{module_name}` is the module hooked
+            by that script) to be cached.
+        """
+
+        UserDict.__init__(self)
+
+        # To avoid circular references and hence increased memory consumption,
+        # a weak rather than strong reference is stored to the passed graph.
+        # Since this graph is guaranteed to live longer than this cache, this is
+        # guaranteed to be safe.
+        self.module_graph = weakref.proxy(module_graph)
+
+        # String unique to this cache prefixing the names of all in-memory
+        # modules lazily loaded from cached hook scripts, privatized for safety.
+        self._hook_module_name_prefix = '__PyInstaller_hooks_{}_'.format(
+            ModuleHookCache._cache_id_next)
+        ModuleHookCache._cache_id_next += 1
+
+        # Cache all hook scripts in the passed directories.
+        self._cache_hook_dirs(hook_dirs)
+
+
+    def _cache_hook_dirs(self, hook_dirs):
+        """
+        Cache all hook scripts in the passed directories.
+
+        Parameters
+        ----------
+        hook_dirs : list
+            List of the absolute or relative paths of all directories containing
+            hook scripts to be cached.
+        """
+
+        for hook_dir in hook_dirs:
+            # Canonicalize this directory's path and validate its existence.
+            hook_dir = os.path.abspath(expand_path(hook_dir))
+            if not os.path.isdir(hook_dir):
+                raise FileNotFoundError(
+                    'Hook directory "{}" not found.'.format(hook_dir))
+
+            # For each hook script in this directory...
+            hook_filenames = glob.glob(os.path.join(hook_dir, 'hook-*.py'))
+            for hook_filename in hook_filenames:
+                # Fully-qualified name of this hook's corresponding module,
+                # constructed by removing the "hook-" prefix and ".py" suffix.
+                module_name = os.path.basename(hook_filename)[5:-3]
+
+                # Lazily loadable hook object.
+                module_hook = ModuleHook(
+                    module_graph=self.module_graph,
+                    module_name=module_name,
+                    hook_filename=hook_filename,
+                    hook_module_name_prefix=self._hook_module_name_prefix,
+                )
+
+                # Add this hook to this module's list of hooks.
+                module_hooks = self.setdefault(module_name, [])
+                module_hooks.append(module_hook)
+
+
+    def remove_modules(self, *module_names):
+        """
+        Remove the passed modules and all hook scripts cached for these modules
+        from this cache.
+
+        Parameters
+        ----------
+        module_names : list
+            List of all fully-qualified module names to be removed.
+        """
+
+        for module_name in module_names:
+            # Unload this module's hook script modules from memory. Since these
+            # are top-level pure-Python modules cached only in the "sys.modules"
+            # dictionary, popping these modules from this dictionary suffices
+            # to garbage collect these modules.
+            module_hooks = self.get(module_name, [])
+            for module_hook in module_hooks:
+                sys.modules.pop(module_hook.hook_module_name, None)
+
+            # Remove this module and its hook script objects from this cache.
+            self.pop(module_name, None)
+
+# Dictionary mapping the names of magic attributes required by the "ModuleHook"
+# class to 2-tuples "(default_type, sanitizer_func)", where:
+#
+# * "default_type" is the type to which that attribute will be initialized when
+#   that hook is lazily loaded.
+# * "sanitizer_func" is the callable sanitizing the original value of that
+#   attribute defined by that hook into a safer value consumable by "ModuleHook"
+#   callers if any or "None" if the original value requires no sanitization.
+#
+# To avoid subtleties in the ModuleHook.__getattr__() method, this dictionary is
+# declared as a module rather than a class attribute. If declared as a class
+# attribute and then undefined (...for whatever reason), attempting to access
+# this attribute from that method would produce infinite recursion.
+_MAGIC_MODULE_HOOK_ATTRS = {
+    # Collections in which order is insignificant. This includes:
+    #
+    # * "datas", sanitized from hook-style 2-tuple lists defined by hooks into
+    #   TOC-style 2-tuple sets consumable by "ModuleHook" callers.
+    # * "binaries", sanitized in the same way.
+    'datas':    (set, format_binaries_and_datas),
+    'binaries': (set, format_binaries_and_datas),
+    'excludedimports': (set, None),
+
+    # Collections in which order is significant. This includes:
+    #
+    # * "hiddenimports", as order of importation is significant. On module
+    #   importation, hook scripts are loaded and hook functions declared by
+    #   these scripts are called. As these scripts and functions can have side
+    #   effects dependent on module importation order, module importation itself
+    #   can have side effects dependent on this order!
+    'hiddenimports': (list, None),
+}
+
+class ModuleHook(object):
+    """
+    Cached object encapsulating a lazy loadable hook script.
+
+    This object exposes public attributes (e.g., `datas`) of the underlying hook
+    script as attributes of the same name of this object. On the first access of
+    any such attribute, this hook script is lazily loaded into an in-memory
+    private module reused on subsequent accesses. These dynamic attributes are
+    referred to as "magic." All other static attributes of this object (e.g.,
+    `hook_module_name`) are referred to as "non-magic."
+
+    Attributes (Magic)
+    ----------
+    datas : set
+        Set of `TOC`-style 2-tuples `(target_file, source_file)` for all
+        external non-executable files required by the module being hooked,
+        converted from the `datas` list of hook-style 2-tuples
+        `(source_dir_or_glob, target_dir)` defined by this hook script.
+    binaries : set
+        Set of `TOC`-style 2-tuples `(target_file, source_file)` for all
+        external executable files required by the module being hooked, converted
+        from the `binaries` list of hook-style 2-tuples
+        `(source_dir_or_glob, target_dir)` defined by this hook script.
+    excludedimports : set
+        Set of the fully-qualified names of all modules imported by the module
+        being hooked to be ignored rather than imported from that module,
+        converted from the `excludedimports` list defined by this hook script.
+        These modules will only be "locally" rather than "globally" ignored.
+        These modules will remain importable from all modules other than the
+        module being hooked.
+    hiddenimports : set
+        Set of the fully-qualified names of all modules imported by the module
+        being hooked that are _not_ automatically detectable by PyInstaller
+        (usually due to being dynamically imported in that module), converted
+        from the `hiddenimports` list defined by this hook script.
+
+    Attributes (Non-magic)
+    ----------
+    module_graph : ModuleGraph
+        Current module graph.
+    module_name : str
+        Name of the module hooked by this hook script.
+    hook_filename : str
+        Absolute or relative path of this hook script.
+    hook_module_name : str
+        Name of the in-memory module of this hook script's interpreted contents.
+    _hook_module : module
+        In-memory module of this hook script's interpreted contents, lazily
+        loaded on the first call to the `_load_hook_module()` method _or_ `None`
+        if this method has yet to be accessed.
+    """
+
+    ## Magic
+
+    def __init__(self, module_graph, module_name, hook_filename,
+                 hook_module_name_prefix):
+        """
+        Initialize this metadata.
+
+        Parameters
+        ----------
+        module_graph : ModuleGraph
+            Current module graph.
+        module_name : str
+            Name of the module hooked by this hook script.
+        hook_filename : str
+            Absolute or relative path of this hook script.
+        hook_module_name_prefix : str
+            String prefixing the name of the in-memory module for this hook
+            script. To avoid namespace clashes with similar modules created by
+            other `ModuleHook` objects in other `ModuleHookCache` containers,
+            this string _must_ be unique to the `ModuleHookCache` container
+            containing this `ModuleHook` object. If this string is non-unique,
+            an existing in-memory module will be erroneously reused when lazily
+            loading this hook script, thus erroneously resanitizing previously
+            sanitized hook script attributes (e.g., `datas`) with the
+            `format_binaries_and_datas()` helper.
+        """
+
+        # Note that the passed module graph is already a weak reference,
+        # avoiding circular reference issues. See ModuleHookCache.__init__().
+        assert isinstance(module_graph, weakref.ProxyTypes)
+        self.module_graph = module_graph
+        self.module_name = module_name
+        self.hook_filename = hook_filename
+
+        # Name of the in-memory module fabricated to refer to this hook script.
+        self.hook_module_name = (
+            hook_module_name_prefix + self.module_name.replace('.', '_'))
+
+        # Attributes subsequently defined by the _load_hook_module() method.
+        self._hook_module = None
+
+
+    def __getattr__(self, attr_name):
+        '''
+        Get the magic attribute with the passed name (e.g., `datas`) from this
+        lazily loaded hook script if any _or_ raise `AttributeError` otherwise.
+
+        This special method is called only for attributes _not_ already defined
+        by this object. This includes undefined attributes and the first attempt
+        to access magic attributes.
+
+        This special method is _not_ called for subsequent attempts to access
+        magic attributes. The first attempt to access magic attributes defines
+        corresponding instance variables accessible via the `self.__dict__`
+        instance dictionary (e.g., as `self.datas`) without calling this method.
+        This approach also allows magic attributes to be deleted from this
+        object _without_ defining the `__delattr__()` special method.
+
+        See Also
+        ----------
+        Class docstring for supported magic attributes.
+        '''
+
+        # If this is a magic attribute, initialize this attribute by lazy
+        # loading this hook script and then return this attribute. To avoid
+        # recursion, the superclass method rather than getattr() is called.
+        if attr_name in _MAGIC_MODULE_HOOK_ATTRS:
+            self._load_hook_module()
+            return super(ModuleHook, self).__getattr__(attr_name)
+        # Else, this is an undefined attribute. Raise an exception.
+        else:
+            raise AttributeError(attr_name)
+
+
+    def __setattr__(self, attr_name, attr_value):
+        '''
+        Set the attribute with the passed name to the passed value.
+
+        If this is a magic attribute, this hook script will be lazily loaded
+        before setting this attribute. Unlike `__getattr__()`, this special
+        method is called to set _any_ attribute -- including magic, non-magic,
+        and undefined attributes.
+
+        See Also
+        ----------
+        Class docstring for supported magic attributes.
+        '''
+
+        # If this is a magic attribute, initialize this attribute by lazy
+        # loading this hook script before overwriting this attribute.
+        if attr_name in _MAGIC_MODULE_HOOK_ATTRS:
+            self._load_hook_module()
+
+        # Set this attribute to the passed value. To avoid recursion, the
+        # superclass method rather than setattr() is called.
+        return super(ModuleHook, self).__setattr__(attr_name, attr_value)
+
+
+    ## Loading
+
+    def _load_hook_module(self):
+        """
+        Lazily load this hook script into an in-memory private module.
+
+        This method (and, indeed, this class) preserves all attributes and
+        functions defined by this hook script as is, ensuring sane behaviour in
+        hook functions _not_ expecting unplanned external modification. Instead,
+        this method copies public attributes defined by this hook script
+        (e.g., `binaries`) into private attributes of this object, which the
+        special `__getattr__()` and `__setattr__()` methods safely expose to
+        external callers. For public attributes _not_ defined by this hook
+        script, the corresponding private attributes will be assigned sane
+        defaults. For some public attributes defined by this hook script, the
+        corresponding private attributes will be transformed into objects more
+        readily and safely consumed elsewhere by external callers.
+
+        See Also
+        ----------
+        Class docstring for supported attributes.
+        """
+
+        # If this hook script module has already been loaded, noop.
+        if self._hook_module is not None:
+            return
+
+        # Load this hook script into a private in-memory module.
+        logger.info(
+            'Loading module hook "%s"...', os.path.basename(self.hook_filename))
+        self._hook_module = importlib_load_source(
+            self.hook_module_name, self.hook_filename)
+
+        # Copy hook script attributes into magic attributes exposed as instance
+        # variables of the current "ModuleHook" instance.
+        for attr_name, (default_type, sanitizer_func) in (
+            _MAGIC_MODULE_HOOK_ATTRS.items()):
+            # Unsanitized value of this attribute.
+            attr_value = getattr(self._hook_module, attr_name, None)
+
+            # If this attribute is undefined, expose a sane default instead.
+            if attr_value is None:
+                attr_value = default_type()
+            # Else if this attribute requires sanitization, do so.
+            elif sanitizer_func is not None:
+                attr_value = sanitizer_func(attr_value)
+            # Else, expose the unsanitized value of this attribute.
+
+            # Expose this attribute as an instance variable of the same name.
+            setattr(self, attr_name, attr_value)
+
+
+    ## Hooks
+
+    def post_graph(self):
+        """
+        Call the **post-graph hook** (i.e., `hook()` function) defined by this
+        hook script if any.
+
+        This method is intended to be called _after_ the module graph for this
+        application is constructed.
+        """
+
+        # Lazily load this hook script into an in-memory module.
+        self._load_hook_module()
+
+        # Call this hook script's hook() function, which modifies attributes
+        # accessed by subsequent methods and hence must be called first.
+        self._process_hook_func()
+
+        # Order is insignificant here.
+        self._process_hidden_imports()
+        self._process_excluded_imports()
+
+
+    def _process_hook_func(self):
+        """
+        Call this hook's `hook()` function if defined.
+        """
+
+        # If this hook script defines no hook() function, noop.
+        if not hasattr(self._hook_module, 'hook'):
+            return
+
+        # Call this hook() function.
+        hook_api = PostGraphAPI(
+            module_name=self.module_name, module_graph=self.module_graph)
+        self._hook_module.hook(hook_api)
+
+        # Update all magic attributes modified by the prior call.
+        self.datas.update(set(hook_api._added_datas))
+        self.binaries.update(set(hook_api._added_binaries))
+        self.hiddenimports.extend(hook_api._added_imports)
+
+        #FIXME: Deleted imports should be appended to
+        #"self.excludedimports" rather than handled here. However, see the
+        #_process_excluded_imports() FIXME below for a sensible alternative.
+        for deleted_module_name in hook_api._deleted_imports:
+            # Remove the graph link between the hooked module and item.
+            # This removes the 'item' node from the graph if no other
+            # links go to it (no other modules import it)
+            self.module_graph.removeReference(
+                hook_api.node, deleted_module_name)
+
+
+    def _process_hidden_imports(self):
+        """
+        Add all imports listed in this hook script's `hiddenimports` attribute
+        to the module graph as if directly imported by this hooked module.
+
+        These imports are typically _not_ implicitly detectable by PyInstaller
+        and hence must be explicitly defined by hook scripts.
+        """
+
+        # For each hidden import required by the module being hooked...
+        for import_module_name in self.hiddenimports:
+            try:
+                # Graph node for this module. Do not implicitly create namespace
+                # packages for non-existent packages.
+                caller = self.module_graph.findNode(
+                    self.module_name, create_nspkg=False)
+
+                # Manually import this hidden import from this module.
+                self.module_graph.import_hook(import_module_name, caller=caller)
+            # If this hidden import is unimportable, print a non-fatal warning.
+            # Hidden imports often become desynchronized from upstream packages
+            # and hence are only "soft" recommendations.
+            except ImportError:
+                logger.warn('Hidden import "%s" not found!', import_module_name)
+
+
+    #FIXME: This is pretty... intense. Attempting to cleanly "undo" prior module
+    #graph operations is a recipe for subtle edge cases and difficult-to-debug
+    #issues. It would be both safer and simpler to prevent these imports from
+    #being added to the graph in the first place. To do so:
+    #
+    #* Remove the _process_excluded_imports() method below.
+    #* Remove the PostGraphAPI.del_imports() method, which cannot reasonably be
+    #  supported by the following solution, appears to be currently broken, and
+    #  (in any case) is not called anywhere in the PyInstaller codebase.
+    #* Override the ModuleGraph._safe_import_hook() superclass method with a new
+    #  PyiModuleGraph._safe_import_hook() subclass method resembling:
+    #
+    #      def _safe_import_hook(
+    #          self, target_module_name, source_module, fromlist,
+    #          level=DEFAULT_IMPORT_LEVEL, attr=None):
+    #
+    #          if source_module.identifier in self._module_hook_cache:
+    #              for module_hook in self._module_hook_cache[
+    #                  source_module.identifier]:
+    #                  if target_module_name in module_hook.excludedimports:
+    #                      return []
+    #
+    #          return super(PyiModuleGraph, self)._safe_import_hook(
+    #              target_module_name, source_module, fromlist,
+    #              level=level, attr=attr)
+    def _process_excluded_imports(self):
+        """
+        'excludedimports' is a list of Python module names that PyInstaller
+        should not detect as dependency of this module name.
+
+        So remove all import-edges from the current module (and it's
+        submodules) to the given `excludedimports` (end their submodules).
+        """
+
+        def find_all_package_nodes(name):
+            mods = [name]
+            name += '.'
+            for subnode in self.module_graph.nodes():
+                if subnode.identifier.startswith(name):
+                    mods.append(subnode.identifier)
+            return mods
+
+        # If this hook excludes no imports, noop.
+        if not self.excludedimports:
+            return
+
+        # Collect all submodules of this module.
+        hooked_mods = find_all_package_nodes(self.module_name)
+
+        # Collect all dependencies and their submodules
+        # TODO: Optimize this by using a pattern and walking the graph
+        # only once.
+        for item in set(self.excludedimports):
+            excluded_node = self.module_graph.findNode(item, create_nspkg=False)
+            if excluded_node is None:
+                logger.info("Import to be excluded not found: %r", item)
+                continue
+            logger.info("Excluding import %r", item)
+            imports_to_remove = set(find_all_package_nodes(item))
+
+            # Remove references between module nodes, as though they would
+            # not be imported from 'name'.
+            # Note: Doing this in a nested loop is less efficient than
+            # collecting all import to remove first, but log messages
+            # are easier to understand since related to the "Excluding ..."
+            # message above.
+            for src in hooked_mods:
+                # modules, this `src` does import
+                references = set(
+                    node.identifier
+                    for node in self.module_graph.getReferences(src))
+
+                # Remove all of these imports which are also in
+                # "imports_to_remove".
+                for dest in imports_to_remove & references:
+                    self.module_graph.removeReference(src, dest)
+                    logger.warn(
+                        "  Removing import %s from module %s", src, dest)
+
+
+#!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+#FIXME: This class has been obsoleted by "ModuleHookCache" and will be removed.
+#!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 class HooksCache(dict):
     """
     Dictionary mapping from the fully-qualified names of each module hooked by
@@ -160,6 +692,9 @@ class AdditionalFilesCache(object):
         return self._datas[modname]
 
 
+#!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+#FIXME: This class has been obsoleted by "ModuleHook" and will be removed.
+#!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 class ImportHook(object):
     """
     Class encapsulating processing of hook attributes like hiddenimports, etc.

--- a/PyInstaller/building/imphookapi.py
+++ b/PyInstaller/building/imphookapi.py
@@ -85,11 +85,15 @@ class PreSafeImportModuleAPI(object):
         "Current module graph"
         return self._module_graph
 
+    #FIXME: Remove this property and publicize the "_module_name" attribute to
+    #"module_name". This attribute is intended to be modifiable by hooks.
     @property
     def module_name(self):
         "Fully-qualified name of this module (e.g., `email.mime.text`)."
         return self._module_name
 
+    #FIXME: Remove this property and publicize the "_module_basename" attribute
+    #to "module_basename". This attribute is intended to be modifiable by hooks.
     @property
     def module_basename(self):
         "Unqualified name of the module to be imported (e.g., `text`)."
@@ -315,6 +319,10 @@ class PostGraphAPI(object):
         # into an immutable tuple.
         self.___path__ = tuple(self.module.packagepath) \
             if self.module.packagepath is not None else None
+
+        #FIXME: Refactor "_added_datas", "_added_binaries", and
+        #"_deleted_imports" into sets. Since order of importation is
+        #significant, "_added_imports" must remain a list.
 
         # Private attributes.
         self._added_binaries = []

--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -87,6 +87,13 @@ if is_py2:
 else:
     from builtins import FileExistsError
 
+# Python 3 moved collections classes to more sensible packages.
+if is_py2:
+    from UserDict import UserDict
+    from collections import Sequence, Set
+else:
+    from collections import UserDict
+    from collections.abc import Sequence, Set
 
 # In Python 3 built-in function raw_input() was renamed to just 'input()'.
 try:
@@ -534,6 +541,7 @@ PY3_BASE_MODULES = {
     'weakref',
 }
 
+#FIXME: Reduce this pair of nested tests to "if sys.version_info >= (3, 4)".
 if sys.version_info[0] == 3:
     if sys.version_info[1] >= 4:
         PY3_BASE_MODULES.update({

--- a/PyInstaller/configure.py
+++ b/PyInstaller/configure.py
@@ -83,6 +83,8 @@ def _get_pyinst_cache_dir():
     return cache_dir
 
 
+#FIXME: Rename to get_official_hooks_dir().
+#FIXME: Remove the "hook_type" parameter after unifying hook types.
 def get_importhooks_dir(hook_type=None):
     from . import PACKAGEPATH
     if not hook_type:

--- a/PyInstaller/hooks/pre_find_module_path/hook-site.py
+++ b/PyInstaller/hooks/pre_find_module_path/hook-site.py
@@ -23,7 +23,10 @@ from PyInstaller.utils.hooks import logger
 from PyInstaller import PACKAGEPATH
 
 def pre_find_module_path(api):
+    #FIXME: For reusability, move this into a new
+    #PyInstaller.configure.get_fake_modules_dir() utility function.
     # Absolute path of the faked sub-package.
     fake_dir = os.path.join(PACKAGEPATH, 'fake-modules')
+
     api.search_dirs = [fake_dir]
     logger.info('site: retargeting to fake-dir %r', fake_dir)

--- a/PyInstaller/utils/tests.py
+++ b/PyInstaller/utils/tests.py
@@ -46,3 +46,16 @@ def importorskip(*modules):
     # Return pytest decorator.
     return skipif(not mods_avail,
                   reason='requires modules %s' % ', '.join(modules))
+
+
+def skip(reason):
+    """
+    Unconditionally skip the currently decorated test with the passed reason.
+
+    Parameters
+    ----------
+    reason : str
+        Human-readable message justifying the skipping of this test.
+    """
+
+    return skipif(True, reason=reason)

--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -380,20 +380,31 @@ def configure(ctx):
         #   Mac OS X 10.5 is UNIX 03 compliant.
         ctx.env.append_value('DEFINES', '_XOPEN_SOURCE=600')
         ctx.env.append_value('DEFINES', '_REENTRANT')
-        # Recent GCC 5.x complains about _BSD_SOURCE:
-        #  warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE"
-        if is_linux:
-            ctx.env.append_value('DEFINES', '_DEFAULT_SOURCE')
-        # Function 'mkdtemp' is available only if _BSD_SOURCE is defined.
+
+        # mkdtemp() is available only if _BSD_SOURCE is defined.
         ctx.env.append_value('DEFINES', '_BSD_SOURCE')
-        # On Mac OS X is 'mkdtemp' available only with _DARWIN_C_SOURCE.
-        if is_darwin:
+
+        if is_linux:
+            # Recent GCC 5.x complains about _BSD_SOURCE under Linux:
+            #     _BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE
+            ctx.env.append_value('DEFINES', '_DEFAULT_SOURCE')
+
+            # TODO What other platforms support _FORTIFY_SOURCE macro? OS X?
+            # TODO OS X's CLang appears to support this macro as well. See:
+            # http://permalink.gmane.org/gmane.comp.compilers.clang.devel/2442
+
+            # For security, enable the _FORTIFY_SOURCE macro detecting buffer
+            # overflows in various string and memory manipulation functions.
+            if ctx.env.CC_NAME == 'gcc':
+                # Undefine this macro if already defined by default to avoid
+                # "macro redefinition" errors.
+                ctx.env.append_value('CFLAGS', '-U_FORTIFY_SOURCE')
+
+                # Define this macro.
+                ctx.env.append_value('DEFINES', '_FORTIFY_SOURCE=2')
+        # On Mac OS X, mkdtemp() is available only with _DARWIN_C_SOURCE.
+        elif is_darwin:
             ctx.env.append_value('DEFINES', '_DARWIN_C_SOURCE')
-        # Macro _FORTIFY_SOURCE forces some checks to detect some buffer overflow errors
-        # in various string and memory manipulation functions.
-        # TODO What other platforms support _FORTIFY_SOURCE macro? OS X?
-        if is_linux and ctx.env.CC_NAME == 'gcc':
-            ctx.env.append_value('DEFINES', '_FORTIFY_SOURCE=2')
 
     if is_win:
         ctx.env.append_value('DEFINES', 'WIN32')

--- a/tests/functional/test_hooks/test_pil.py
+++ b/tests/functional/test_hooks/test_pil.py
@@ -1,0 +1,78 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2016, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+"""
+Functional tests for the Python Imaging Library (PIL).
+
+Note that the original unmaintained PIL has been obsoleted by the PIL-compatible
+fork Pillow, which retains the same Python package `PIL`.
+"""
+
+from PyInstaller.compat import modname_tkinter
+from PyInstaller.utils.tests import importorskip, skip
+
+
+# "excludedimports" support is currently non-deterministic and hence cannot be
+# marked as @xfail. If this test were marked as @xfail but succeeded, py.test
+# would record this test as an XPASS failure (i.e., an unexpected success).
+@importorskip('PIL')
+@importorskip(modname_tkinter)
+@skip(reason='"excludedimports" support is non-deterministically broken.')
+def test_pil_no_tkinter(pyi_builder):
+    """
+    Ensure that the Tkinter package excluded by `PIL` package hooks is
+    unimportable by frozen applications explicitly importing only the latter.
+    """
+
+    pyi_builder.test_source("""
+        import PIL.Image
+
+        # Dynamically importing the Tkinter package should fail with an
+        # "ImportError", implying "PIL" package hooks successfully excluded
+        # Tkinter. To prevent PyInstaller from parsing this import and thus
+        # freezing this extension with this test, this import is dynamic.
+        try:
+            __import__('{modname_tkinter}')
+            raise SystemExit('ERROR: Module {modname_tkinter} is bundled.')
+        except ImportError:
+            pass
+
+        # Dynamically importing the "_tkinter" shared library should also fail.
+        try:
+            __import__('_tkinter')
+            raise SystemExit('ERROR: Module _tkinter is bundled.')
+        except ImportError:
+            pass
+        """.format(modname_tkinter=modname_tkinter))
+
+
+@importorskip('PIL')
+@importorskip(modname_tkinter)
+def test_pil_tkinter(pyi_builder):
+    """
+    Ensure that the Tkinter package excluded by `PIL` package hooks is
+    importable by frozen applications explicitly importing both.
+
+    == See Also ==
+
+    * PyInstaller [issue #1584](https://github.com/pyinstaller/pyinstaller/issues/1584).
+    """
+
+    pyi_builder.test_source("""
+        import PIL.Image
+
+        # Statically importing the Tkinter package should succeed, implying this
+        # importation successfully overrode the exclusion of this package
+        # requested by "PIL" package hooks. To ensure PyInstaller parses this
+        # import and freezes this package with this test, this import is static.
+        try:
+            import {modname_tkinter}
+        except ImportError:
+            raise SystemExit('ERROR: Module {modname_tkinter} is NOT bundled.')
+        """.format(modname_tkinter=modname_tkinter))


### PR DESCRIPTION
Greetings again, earthbound meat suits.

Welcome to this first of three pull requests implementing [codewarrior0](https://github.com/codewarrior0)'s lazy hook loading scheme. I call it "The Lazy Hook Trilogy." You may call it "really, really pretentious."

In this first pull request, we:

* Define a new `PyInstaller.building.imphook.ModuleHook` class encapsulating a lazy loadable hook.
* Define a new `PyInstaller.building.imphook.ModuleHookCache` class caching all lazy loadable hooks.
* Refactor the `PyInstaller.building.build_main.Analysis.assemble()` method to leverage these new classes.

Let's shamble to it, shall we?

## Cracking Open the Shell of History

Six months ago, [tallforasmurf](http://github.com/tallforasmurf) noted my solution of isolating different hook functions to different hook scripts in different hook subdirectories and found it to be: **(A)** balls crazy, **(B)** overly complex, and **(C)** difficult to document, understand, and maintain. (Did we mention "balls crazy"?)

I emphatically agreed. I also had no idea what to do about it. Then [codewarrior0](http://github.com/codewarrior0) proposed a novel remedy: **lazy hook loading.** In [matysek](http://github.com/matysek)'s [proposed improvements](https://github.com/pyinstaller/pyinstaller/pull/1651) to `excludedimports`, codewarrior0 [reproposed](https://github.com/pyinstaller/pyinstaller/pull/1651#issuecomment-153747323) this remedy.

I emphatically agreed... _again._ The time has come to engender this beautiful dream.

## What's So Lazy About Lazy Loading?

Currently, hook scripts are temporarily loaded into memory as `ImportHook` objects directly at their point of use and then discarded. Instead, `ImportHook` objects could be pre-cached for all available hook scripts _without_ actually loading those scripts into memory. On the first use of an `ImportHook` object, that object could then silently load and retain the corresponding hook script into memory for efficient reuse.

Despite being called at different times during application analysis, all hook functions (e.g., `hook()`, `pre_find_module_path()`, `pre_safe_import_module()`) could then be moved into the existing hook scripts in the `PyInstaller/hooks/` directory and all subdirectories of that directory removed entirely.

It is nice.

## New Class #1: `ModuleHook`

The new `ModuleHook` class encapsulates **lazy loading for a single hook.** It defines a variety of private stuff (_the less said, the better for all_) and the following public stuff:

* `code`, a read-only property providing the interpreted contents of this hook's script. Here's where the bloated magic begins. On:
  * First accessing this property, this hook's script is dynamically loaded into an in-memory code object accessible via this property.
  * Subsequently accessing this property, the previously loaded code object is returned.
* `post_graph()`, a method running the "post-graph hook" (i.e., `hook()` function called _after_ `ModuleGraph` construction) for this hook if any.

Laziness shall set you free! _Maybe._

## New Class #2: `ModuleHookCache`

The new `ModuleHookCache` class encapsulates **all lazy loadable hooks for all modules,** mapping module names to lists of `ModuleHook` instances. This class parallels the behaviour of the existing non-lazy-loading `HooksCache` class – except with more awesome.

Here's how this shakes down. For each hook script (either official or custom) discovered by PyInstaller at startup, a `ModuleHook` instance encapsulating this hook is appended to the list of all hooks for the corresponding module in the current `ModuleHookCache`. This cache may then be operated on elsewhere in the codebase.

At the moment, we only iterate this cache to run post-graph hooks after `ModuleGraph` construction. In the frighteningly near future, we'll also perform dictionary lookups on this cache to run both pre-find module path hooks _and_ pre-safe import module hooks during `ModuleGraph` construction.

One small step for leycec; one even smaller step for PyInstaller.

## Newly Refactored: `Analysis.assemble()`

Finally, the `Analysis.assemble()` method has been refactored to leverage these classes in place of their non-lazy-loading variants `HooksCache` and `ImportHook` as follows:

1. The `ModuleHookCache` singleton (appropriately named – _wait for it_ – `module_hook_cache`) is instantiated immediately _before_ `ModuleGraph` construction, mapping all hooked modules to lists of lazy-loadable `ModuleHook` instances. Critically, note that **no hooks have actually been loaded from disk yet.**
1. This singleton is iterated immediately _after_ `ModuleGraph` construction to run post-graph hooks by calling the `post_graph()` method of all lazy-loadable `ModuleHook` instances whose corresponding modules were imported (i.e., added to the `ModuleGraph` during construction). Critically, note that **all such hooks will be implicitly loaded from disk here.**

"Implicitly" is the $1 keyword here.

## How You Too Can Profit from Lazy Hooks in Just 20,143 Easy Steps

Hooks no longer need to be explicitly loaded; they're magically loaded into existence when they need to be. (Isn't that nice? Don't answer that.)

At any time _after_ the instantiation of the `module_hook_cache` singleton in the `Analysis.assemble()` method, the contents of any hook are safely accessible and modifiable via that hook's `code` property. "At any time" means just that: before, during, and after `ModuleGraph` creation and all points in-between.

Let's say you wanted to collect the `excludedimports` attributes defined by the hooks of all importable modules into some giant list for subsequent processing (AKA, a dark and nefarious purpose). Here's how you'd do that in the `Analysis.assemble()` method:

```
# Giant list of all excluded imports.
all_excludedimports = []

# For each hooked module and corresponding list of hooks...
for module_name, module_hooks in module_hook_cache.items():
    # To improve space and time efficiency, ignore unimportable modules!
    # (Optional, but recommended. is_module_importable() is an imaginary
    # function, so insert uncontrolled hand-waving here.)
    if not is_module_importable(module_name):
        continue

    # For each hook for this importable module...
    for module_hook in module_hooks:
        # Record this hook's excluded imports if any. If this hook has not
        # already been lazily loaded, it will be now!
        all_excludedimports.extend(module_hook.code.excludedimports)
```

## The Future (_Now with More Shiny_)

I foresee a bright, new future for PyInstaller! Let's see what that's about.

### Lazy Hook II: Our Ill-fated Quest Continues

The second pull request in this trilogy will **unify post-graph hooks and pre-find module path hooks.** For each pre-find module path hook in the `PyInstaller/hooks/pre_find_module_path/` directory:

* If a post-graph hook with the same basename exists in the `PyInstaller/hooks/` directory:
  1. The contents of this pre-find module path hook will be appended onto the contents of this post-graph hook.
  1. This pre-find module path hook will be removed.
* Else:
  1. This pre-find module path hook will be moved into the `PyInstaller/hooks/` directory as is.

The `PyInstaller/hooks/pre_find_module_path/` directory will then be removed entirely. If PyInstaller is passed a custom hooks directory via the `--additional-hooks-dir` option containing a `pre_find_module_path/` subdirectory, a non-fatal warning informing the user that this subdirectory has been deprecated will be printed. <sup>**[Note:** I highly doubt any user applications _actually_ define custom pre-find module path hooks. However, I also doubted any U.S. president in the past thirty years would be reelected to a second term. Yet here we are.**]**</sup>

Thanks to lazy hook loading, this refactoring _should_ be mostly trivial. But it's the tedious sort of trivial, so I'm deferring it for a bit.

Following this refactoring, pre-find module path hooks will simply be functions named `pre_find_module_path_hook()` in unified hook scripts. A separate directory with separate scripts will be a relic of our once-shameful past, spoken of only in hushed whispers on archived GitHub threads.

### Lazy Hook III: The Wrath of Python Khan

The third and final pull request in this trilogy will **unify post-graph hooks and pre-safe import module hooks** – in the same exact way. It will also remove the existing non-lazy-loading `HooksCache` and `ImportHook` classes, which have been temporarily preserved for posterity until then.

Nothing lasts... but nothing is lost.