### PR TITLE
Add missing hidden import for Cryptography: _cffi_backend

### DIFF
--- a/PyInstaller/hooks/hook-cryptography.py
+++ b/PyInstaller/hooks/hook-cryptography.py
@@ -19,7 +19,7 @@ from PyInstaller.compat import EXTENSION_SUFFIXES
 from PyInstaller.utils.hooks import collect_submodules, get_module_file_attribute
 
 # Add the OpenSSL FFI binding modules as hidden imports
-hiddenimports = collect_submodules('cryptography.hazmat.bindings.openssl')
+hiddenimports = collect_submodules('cryptography.hazmat.bindings.openssl') + ['_cffi_backend']
 
 
 # Include the cffi extensions as binaries in a subfolder named like the package.


### PR DESCRIPTION
Related discussion: https://bitbucket.org/cffi/cffi/issues/247/listing-hidden-imports-when-freezing-a
Fixes #1425.