### PR TITLE
fix: buffer overflow under win32 wchar multibyte string convert

### DIFF
--- a/bootloader/src/pyi_win32_utils.c
+++ b/bootloader/src/pyi_win32_utils.c
@@ -147,7 +147,7 @@ pyi_win32_wcs_to_mbs(const wchar_t *wstr)
 
     if (0 == len) {
         FATALERROR("Failed to get ANSI buffer size"
-                   "(WideCharToMultiByte: %s)",
+                   "(WideCharToMultiByte: %s)\n",
                    GetWinErrorString()
                    );
         return NULL;
@@ -167,7 +167,7 @@ pyi_win32_wcs_to_mbs(const wchar_t *wstr)
 
     if (0 == ret) {
         FATALERROR("Failed to encode filename as ANSI"
-                   "(WideCharToMultiByte: %s)",
+                   "(WideCharToMultiByte: %s)\n",
                    GetWinErrorString()
                    );
         return NULL;
@@ -206,7 +206,7 @@ pyi_win32_wcs_to_mbs_sfn(const wchar_t *wstr)
     }
 
     if (!str) {
-        VS("Failed to get short path name for filename. GetShortPathNameW: \n%s",
+        VS("Failed to get short path name for filename. GetShortPathNameW: \n%s\n",
            GetWinErrorString()
            );
         str = pyi_win32_wcs_to_mbs(wstr);
@@ -362,7 +362,7 @@ pyi_win32_utils_to_utf8(char *str, const wchar_t *wstr, size_t len)
                                   );
 
         if (0 == len) {
-            FATALERROR("Failed to get UTF-8 buffer size (WideCharToMultiByte: %s)",
+            FATALERROR("Failed to get UTF-8 buffer size (WideCharToMultiByte: %s)\n",
                        GetWinErrorString()
                        );
             return NULL;
@@ -385,7 +385,7 @@ pyi_win32_utils_to_utf8(char *str, const wchar_t *wstr, size_t len)
                               );
 
     if (len == 0) {
-        FATALERROR("Failed to encode wchar_t as UTF-8 (WideCharToMultiByte: %s)",
+        FATALERROR("Failed to encode wchar_t as UTF-8 (WideCharToMultiByte: %s)\n",
                    GetWinErrorString()
                    );
         return NULL;
@@ -425,7 +425,7 @@ pyi_win32_utils_from_utf8(wchar_t *wstr, const char *str, size_t wlen)
                                    );
 
         if (0 == wlen) {
-            FATALERROR("Failed to get UTF-8 buffer size (WideCharToMultiByte: %s)",
+            FATALERROR("Failed to get UTF-8 buffer size (WideCharToMultiByte: %s)\n",
                        GetWinErrorString()
                        );
             return NULL;
@@ -446,7 +446,7 @@ pyi_win32_utils_from_utf8(wchar_t *wstr, const char *str, size_t wlen)
                                );
 
     if (wlen == 0) {
-        FATALERROR("Failed to encode wchar_t as UTF-8 (WideCharToMultiByte: %s)",
+        FATALERROR("Failed to encode wchar_t as UTF-8 (WideCharToMultiByte: %s)\n",
                    GetWinErrorString()
                    );
         return NULL;

--- a/bootloader/src/pyi_win32_utils.c
+++ b/bootloader/src/pyi_win32_utils.c
@@ -153,7 +153,7 @@ pyi_win32_wcs_to_mbs(const wchar_t *wstr)
         return NULL;
     }
 
-    str = (char *)malloc(sizeof(char) * wcslen(wstr) + 1);
+    str = (char *)calloc(wcslen(wstr) + 1, sizeof(char));
 
     ret = WideCharToMultiByte(CP_ACP,    /* CodePage */
                               0,         /* dwFlags */
@@ -196,7 +196,7 @@ pyi_win32_wcs_to_mbs_sfn(const wchar_t *wstr)
     wsfnlen = GetShortPathNameW(wstr, NULL, 0);
 
     if (wsfnlen) {
-        wstr_sfn = (wchar_t *)malloc(sizeof(wchar_t) * wsfnlen + 1);
+        wstr_sfn = (wchar_t *)calloc(wsfnlen + 1, sizeof(wchar_t));
         ret = GetShortPathNameW(wstr, wstr_sfn, wsfnlen);
 
         if (ret) {
@@ -276,7 +276,7 @@ pyi_win32_argv_to_utf8(int argc, wchar_t **wargv)
     int i, j;
     char ** argv;
 
-    argv = (char **)malloc(sizeof(char *) * (argc + 1));
+    argv = (char **)calloc(argc + 1, sizeof(char *));
 
     for (i = 0; i < argc; i++) {
         argv[i] = pyi_win32_utils_to_utf8(NULL, wargv[i], 0);
@@ -307,7 +307,7 @@ pyi_win32_wargv_from_utf8(int argc, char **argv)
     int i, j;
     wchar_t ** wargv;
 
-    wargv = (wchar_t **)malloc(sizeof(wchar_t *) * (argc + 1));
+    wargv = (wchar_t **)calloc(argc + 1, sizeof(wchar_t *));
 
     for (i = 0; i < argc; i++) {
         wargv[i] = pyi_win32_utils_from_utf8(NULL, argv[i], 0);
@@ -368,7 +368,7 @@ pyi_win32_utils_to_utf8(char *str, const wchar_t *wstr, size_t len)
             return NULL;
         }
 
-        output = (char *)malloc(sizeof(char) * len + 1);
+        output = (char *)calloc(len + 1, sizeof(char));
     }
     else {
         output = str;
@@ -431,7 +431,7 @@ pyi_win32_utils_from_utf8(wchar_t *wstr, const char *str, size_t wlen)
             return NULL;
         }
 
-        output = (wchar_t *)malloc(sizeof(wchar_t) * wlen + 1);
+        output = (wchar_t *)calloc(wlen + 1, sizeof(wchar_t));
     }
     else {
         output = wstr;
@@ -520,7 +520,7 @@ pyi_win32_argv_mbcs_from_utf8_ex(int argc, char **argv, int sfn)
     int i, j;
     char ** argv_mbcs;
 
-    argv_mbcs = (char **)malloc(sizeof(char *) * (argc + 1));
+    argv_mbcs = (char **)calloc(argc + 1, sizeof(char *));
 
     for (i = 0; i < argc; i++) {
         argv_mbcs[i] = pyi_win32_utf8_to_mbs_ex(NULL, argv[i], 0, sfn);

--- a/bootloader/src/pyi_win32_utils.c
+++ b/bootloader/src/pyi_win32_utils.c
@@ -153,7 +153,7 @@ pyi_win32_wcs_to_mbs(const wchar_t *wstr)
         return NULL;
     }
 
-    str = (char *)calloc(wcslen(wstr) + 1, sizeof(char));
+    str = (char *)calloc(len + 1, sizeof(char));
 
     ret = WideCharToMultiByte(CP_ACP,    /* CodePage */
                               0,         /* dwFlags */


### PR DESCRIPTION
first few is just some cosmetic change that can be ignore,
the point is e5cd9cb

I found that malloc the wrong size which result in random 
> Failed to get ANSI buffer size error

![screenshot](http://i.imgur.com/L6ViaEa.png)
as the screenshot shows although the mainpath passed in is nothing related to multibyte, it's been effect by the buffer overflow cause false result

to trigger this require longer CJK in path that will overflow a lot to make something broken,

here is some report probably related

https://github.com/docker/compose/issues/2779

http://stackoverflow.com/questions/34449674/exe-file-produced-by-pyinstaller-cannot-be-used-in-others-pc