### PR TITLE
General Mac OS X tests fixups and Qt fixes

### DIFF
--- a/PyInstaller/hooks/hook-PyQt5.QtPrintSupport.py
+++ b/PyInstaller/hooks/hook-PyQt5.QtPrintSupport.py
@@ -1,0 +1,17 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013-2016, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+
+hiddenimports = ['sip', 'PyQt5.QtCore', 'PyQt5.QtGui', 'PyQt5.QtWidgets']
+
+from PyInstaller.utils.hooks import qt_plugins_binaries
+
+
+binaries = []
+binaries.extend(qt_plugins_binaries('printsupport', namespace='PyQt5'))

--- a/PyInstaller/utils/hooks/__init__.py
+++ b/PyInstaller/utils/hooks/__init__.py
@@ -260,6 +260,7 @@ def qt_menu_nib_dir(namespace):
     """
     if namespace not in ['PyQt4', 'PyQt5', 'PySide']:
         raise Exception('Invalid namespace: {0}'.format(namespace))
+    menu_dir = None
 
     path = exec_statement("""
     from {0}.QtCore import QLibraryInfo
@@ -267,14 +268,14 @@ def qt_menu_nib_dir(namespace):
     str = getattr(__builtins__, 'unicode', str)  # for Python 2
     print(str(path))
     """.format(namespace))
-    path = os.path.join(path, 'Resources')
-
-    # Check directory existence
-    path = os.path.join(path, 'qt_menu.nib')
-    if os.path.exists(path):
-        menu_dir = path
-        logger.debug('Found qt_menu.nib for {0} at {1}'.format(namespace, path))
-    else:
+    for location in [os.path.join(path, 'Resources'), os.path.join(path, 'QtGui.framework', 'Resources')]:
+        # Check directory existence
+        path = os.path.join(location, 'qt_menu.nib')
+        if os.path.exists(path):
+            menu_dir = path
+            logger.debug('Found qt_menu.nib for {0} at {1}'.format(namespace, path))
+            break
+    if not menu_dir:
         raise Exception("""
             Cannot find qt_menu.nib for {0}
             Path checked: {1}

--- a/tests/functional/test_libraries.py
+++ b/tests/functional/test_libraries.py
@@ -18,6 +18,7 @@ import os
 import sys
 
 from PyInstaller.compat import is_win, is_py3, is_darwin
+from PyInstaller.utils.hooks import get_module_attribute, is_module_satisfies
 from PyInstaller.utils.tests import importorskip, xfail
 
 # :todo: find a way to get this from `conftest` or such
@@ -267,10 +268,16 @@ def test_PyQt4_uic(tmpdir, pyi_builder, data_dir):
     # Note that including the data_dir fixture copies files needed by this test.
     pyi_builder.test_script('pyi_lib_PyQt4-uic.py')
 
+
+@pytest.mark.skipif(is_module_satisfies('Qt >= 5.6', get_module_attribute('PyQt5.QtCore', 'QT_VERSION_STR')),
+                    reason='QtWebKit is depreciated in Qt 5.6+')
 @importorskip('PyQt5')
 def test_PyQt5_QtWebKit(pyi_builder):
     pyi_builder.test_script('pyi_lib_PyQt5-QtWebKit.py')
 
+
+@pytest.mark.skipif(is_module_satisfies('Qt >= 5.6', get_module_attribute('PyQt5.QtCore', 'QT_VERSION_STR')),
+                    reason='QtWebKit is depreciated in Qt 5.6+')
 @importorskip('PyQt5')
 def test_PyQt5_uic(tmpdir, pyi_builder, data_dir):
     # Note that including the data_dir fixture copies files needed by this test.

--- a/tests/functional/test_libraries.py
+++ b/tests/functional/test_libraries.py
@@ -194,7 +194,6 @@ def test_pkgutil_get_data__main__(pyi_builder, monkeypatch):
 
 
 
-@xfail(is_darwin, reason='Issue #1895.')
 @importorskip('sphinx')
 def test_sphinx(tmpdir, pyi_builder, data_dir):
     # Note that including the data_dir fixture copies files needed by this test.
@@ -218,7 +217,6 @@ def test_pylint(pyi_builder):
         """)
 
 
-@xfail(is_darwin, reason='Issue #1895.')
 @importorskip('pygments')
 def test_pygments(pyi_builder):
     pyi_builder.test_source(
@@ -233,7 +231,6 @@ def test_pygments(pyi_builder):
         """)
 
 
-@xfail(is_darwin, reason='Issue #1895.')
 @importorskip('markdown')
 def test_markdown(pyi_builder):
     # Markdown uses __import__ed extensions. Make sure these work by
@@ -305,7 +302,6 @@ def test_idlelib(pyi_builder):
         """)
 
 
-@xfail(is_darwin, reason='Issue #1895.')
 @importorskip('keyring')
 def test_keyring(pyi_builder):
     pyi_builder.test_source("import keyring")
@@ -321,7 +317,6 @@ def test_lxml_isoschematron(pyi_builder):
         """)
 
 
-@xfail(is_darwin, reason='Issue #1895.')
 @importorskip('numpy')
 def test_numpy(pyi_builder):
     pyi_builder.test_source(
@@ -345,7 +340,6 @@ def test_pyodbc(pyi_builder):
         """)
 
 
-@xfail(is_darwin, reason='Issue #1895.')
 @importorskip('pytz')
 def test_pytz(pyi_builder):
     pyi_builder.test_source(
@@ -508,7 +502,6 @@ def test_scipy(pyi_builder):
         """)
 
 
-@xfail(is_darwin, reason='Issue #1895.')
 @importorskip('sqlalchemy')
 def test_sqlalchemy(pyi_builder):
     pyi_builder.test_source(
@@ -552,7 +545,6 @@ for pkg in all_qt_pkgs:
     p = importorskip(pkg)(p)
     excludes.append(p)
 
-@xfail(is_darwin, reason='Issue #1895.')
 @importorskip('matplotlib')
 @pytest.mark.parametrize("excludes", excludes, ids=all_qt_pkgs)
 def test_matplotlib(pyi_builder, excludes):

--- a/tests/requirements-mac.txt
+++ b/tests/requirements-mac.txt
@@ -1,0 +1,5 @@
+# gevent wheels for mac os x cause pytest to crash on travis
+--no-binary gevent
+-r requirements.txt
+
+pyenchant

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -26,11 +26,9 @@ pycmd  # Contains 'py.cleanup' that removes all .pyc files and similar.
 # Test libraries
 # Url for downloading PyCrypto prebuilt Windows binaries:
 # http://www.voidspace.org.uk/python/pycrypto-2.6.1/
-pycrypto==2.6.1  # Required for crypto feature - encrypting bytecode.
-Django==1.8.3
-# Latest babel 1.3.1 fails with Python 3.3/3.4 on Windows:
-# https://github.com/mitsuhiko/babel/issues/174
-babel==1.3  # Required by sphinx. This version works on Windows.
+pycrypto  # Required for crypto feature - encrypting bytecode.
+Django<1.8.11 # PyInstaller doesn't yet work with Django 1.9
+babel>2.0  # Required by sphinx. Version 2.0 doesn't work on Windows.
 boto
 boto3
 botocore
@@ -53,8 +51,8 @@ twisted
 pyexcelerate
 Pillow
 
-# dateutil.tz in a package in 2.5.0 and does not play nice with PyInstaller.
-python-dateutil==2.4.2
+# dateutil.tz is a package in 2.5.0 and does not play nice with PyInstaller.
+python-dateutil>2.5.0
 pandas
 
 # matplotlib 1.5+ does not provide binaries for python 3.3


### PR DESCRIPTION
Needed for pyinstaller/pyinstaller-osx-tests#1:
- Add a requirements-mac.txt for pip
- Cleanup requirements.txt
- Delete temporary directory of tests that pass (to minimize space used on test machines)
- Skip QtWebKit dependent tests on Qt 5.6+
- Add an extra location for qt_menu.nib check

Add QtPrintSupport hook
Remove unnecessary Mac OS X specific xfails