### PR TITLE
Point to proper readthedocs.org domain

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -160,5 +160,5 @@ or simply use it directly from the source (pyinstaller.py).
 
 
 .. _PyCrypto: https://www.dlitz.net/software/pycrypto/
-.. _`manual`: https://pyinstaller.rtfd.org/en/latest/
+.. _`manual`: https://pyinstaller.readthedocs.org/en/latest/
 


### PR DESCRIPTION
This avoids a discouraging SSL cert error in Chrome.