### PR TITLE
Fix 1939: import queue (lowercase) does not work in python 2.7

### DIFF
--- a/PyInstaller/hooks/hook-queue.py
+++ b/PyInstaller/hooks/hook-queue.py
@@ -1,0 +1,22 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2016, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+"""
+Problem appears to be that pyinstaller cannot have two modules of the same
+name that differ only by lower/upper case.  The from the future 'queue' simply
+imports all of the 'Queue' module.  So, here we force the 'Queue' module to be
+imported.
+"""
+
+from PyInstaller.compat import is_py2
+
+if is_py2:
+    # force import of Python 2.7 Queue module
+    hiddenimports = ['Queue']
+

--- a/PyInstaller/hooks/pre_safe_import_module/hook-queue.py
+++ b/PyInstaller/hooks/pre_safe_import_module/hook-queue.py
@@ -1,0 +1,25 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2016, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+"""
+warning for 'import queue' in 2.7 from the future
+
+Problem appears to be that pyinstaller cannot have two modules of the same
+name that differ only by lower/upper case.  The from the future 'queue' simply
+imports all of the 'Queue' module.  So here we alias the 'queue' module to the
+'Queue' module.
+"""
+
+from PyInstaller.compat import is_py2
+from PyInstaller.utils.hooks import logger
+
+def pre_safe_import_module(api):
+    if is_py2:
+        logger.warning("import queue, not supported, will use Queue")
+        api.add_alias_module('Queue', 'queue')

--- a/tests/functional/test_Queue_queue.py
+++ b/tests/functional/test_Queue_queue.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2016, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+# Library imports
+# ---------------
+
+# Third-party imports
+# -------------------
+
+# Local imports
+# -------------
+from PyInstaller.compat import is_py2
+from PyInstaller.utils.tests import skipif
+
+@skipif(not is_py2, reason='Only needed on Python 2')
+def test_Queue_queue(pyi_builder):
+    pyi_builder.test_source("""
+        import queue
+        queue.Queue()
+        """)


### PR DESCRIPTION
Problem in #1939 appears to be that pyinstaller cannot have two modules of the same name that differ only by lower/upper case.  The from the future 'queue' simply imports all of the 'Queue' module.  So, by my reading, since 'queue' and 'Queue' can not coexist in a frozen app, and since 'queue' requires 'Queue', there is no way to use 'queue' module in a frozen 2.7 app.

This commit has:

1. a pre_safe_import_module hook to alias 'queue' to 'Queue'.
2. a hook to force the import of 'Queue' when importing 'queue'.
3. a hack to the loader to load 'Queue' when 'queue' is requested.
4. a test case for this functionality.

**HACK ALERT**

The changes to pyimod03_importers.py are the only way I could see to fix the problem short of making the TOC lookup case insensitive. That was a change I was not comfortable making, as it seems that it could be far reaching, and I don't know that much about this code base.  But I thought I would put the PR forward to help illustrate the problem.