### PR TITLE
GST_PLUGIN_PATH is colon separated.

### DIFF
--- a/PyInstaller/loader/rthooks/pyi_rth_gstreamer.py
+++ b/PyInstaller/loader/rthooks/pyi_rth_gstreamer.py
@@ -16,7 +16,7 @@ import sys
 # causes 100% CPU load. (Tested on OSX.)
 os.environ['GST_REGISTRY_FORK'] = 'no'
 
-os.environ['GST_PLUGIN_PATH'] = '{};{}'.format(
+os.environ['GST_PLUGIN_PATH'] = '{}:{}'.format(
     sys._MEIPASS, os.path.join(sys._MEIPASS, 'gst-plugins'))
 
 # Prevent permission issues on Windows

--- a/PyInstaller/loader/rthooks/pyi_rth_gstreamer.py
+++ b/PyInstaller/loader/rthooks/pyi_rth_gstreamer.py
@@ -16,8 +16,8 @@ import sys
 # causes 100% CPU load. (Tested on OSX.)
 os.environ['GST_REGISTRY_FORK'] = 'no'
 
-os.environ['GST_PLUGIN_PATH'] = '{}:{}'.format(
-    sys._MEIPASS, os.path.join(sys._MEIPASS, 'gst-plugins'))
+gst_plugin_paths = [sys._MEIPASS, os.path.join(sys._MEIPASS, 'gst-plugins')]
+os.environ['GST_PLUGIN_PATH'] = ':'.join(gst_plugin_paths)
 
 # Prevent permission issues on Windows
 os.environ['GST_REGISTRY'] = os.path.join(sys._MEIPASS, 'registry.bin')


### PR DESCRIPTION
The previous code separated the paths placed in GST_PLUGIN_PATH
using a semicolon, leading to failures trying to load plugins, as the paths are colon separated.
Instead, the paths were interpreted as a single path.

This commit replaces the semicolon with a colon, as per[1].

[1] https://gstreamer.freedesktop.org/data/doc/gstreamer/head/gstreamer/html/gst-running.html

Please note that, related to this issue, at least for me, the gstreamer hook-gst._gst.py does not work. It seems to attempt to copy from incomplete/relative paths and it also attempts to put the plugins in a directory called "gst_plugins", instead of "gst-plugins". (underscore vs dash)
I'm hopeful that someone who I work with can fix the gstreamer hook and send those upstream as well. But this branch/pull-request can safely be merged now.