### PR TITLE
Replace run-time search path keywords

### DIFF
--- a/PyInstaller/depend/bindepend.py
+++ b/PyInstaller/depend/bindepend.py
@@ -626,9 +626,14 @@ def _getImports_macholib(pth):
                 # Remove trailing '\x00' characters.
                 # e.g. '../lib\x00\x00'
                 rpath = rpath.rstrip('\x00')
+                # Replace the @executable_path and @loader_path keywords
+                # with the actual path to the binary.
+                executable_path = os.path.dirname(pth)
+                rpath = rpath.replace('@executable_path', executable_path)
+                rpath = rpath.replace('@loader_path', executable_path)
                 # Make rpath absolute. According to Apple doc LC_RPATH
                 # is always relative to the binary location.
-                rpath = os.path.normpath(os.path.join(os.path.dirname(pth), rpath))
+                rpath = os.path.normpath(os.path.join(executable_path, rpath))
                 run_paths.update([rpath])
             else:
                 # Frameworks that have this structure Name.framework/Versions/N/Name


### PR DESCRIPTION
Hi,

I would like to use PyInstaller on OS X with a Python interpreter installed in my home directory.

The interpreter is installed in `$HOME/pkg/bin` and is dynamically linked with the Python shared library in `$HOME/pkg/lib`. This is done using run-time search paths, like so:

    $ otool -L $HOME/pkg/bin/python
    /Users/foo/pkg/bin/python:
    	@rpath/lib/libpython2.7.dylib (compatibility version 2.7.0, current version 2.7.0)

    $ otool -l $HOME/pkg/bin/python
    ...
    Load command 15
              cmd LC_RPATH
          cmdsize 32
             path @loader_path/.. (offset 12)

The loader replaces `@loader_path` with the location of the interpreter, which is `$HOME/pkg/bin`, and finds the shared library at `$HOME/pkg/bin/../lib/libpython2.7.dylib`.

When I run PyInstaller, I get this error:

    1765 INFO: Building PKG (CArchive) out00-PKG.pkg
    3859 ERROR: Can not find path ./lib/libpython2.7.dylib (needed by /Users/foo/pkg/bin/python)

The problem is in the file `PyInstaller/depend/bindepend.py` in the function `_getImports_macholib` when the run-time search path is resolved to an absolute path. The `os.path.normpath` function simply ignores `@loader_path/..` and returns `.`.

The solution is to replace the `@loader_path` keyword (and similar `@executable_path`) with the path to the directory of the interpreter, before resolving to an absolute path. This works for me and shouldn't make any difference if those keywords are not present.

Thanks for your time.