### PR TITLE
Change checking of package name in collect_submodules() to allow unicode

### DIFF
--- a/PyInstaller/utils/hooks/__init__.py
+++ b/PyInstaller/utils/hooks/__init__.py
@@ -560,7 +560,7 @@ def collect_submodules(package, subdir=None, pattern=None, endswith=False):
     PyInstaller.
     """
     # Accept only strings as packages.
-    if type(package) is not str:
+    if not (type(package) is str or type(package) is unicode):
         raise ValueError
 
     logger.debug('Collecting submodules for %s' % package)


### PR DESCRIPTION
I import some python modules that include that include:

from __future__ import unicode_literals

which results in a package name being of type unicode instead of str.  This causes pyInstaller to raise a ValueError in the utils/hooks/__init__.py:collect_submodules function.  This patch changes the check to allow unicode strings.