### PR TITLE
Correctly decode a bytes object produced by pefile

### DIFF
--- a/PyInstaller/depend/bindepend.py
+++ b/PyInstaller/depend/bindepend.py
@@ -118,9 +118,11 @@ def _getImports_pe(pth):
     if exportSymbols:
         for sym in exportSymbols.symbols:
             if sym.forwarder is not None:
+                # sym.forwarder is a bytes object. Convert it to a string.
+                forwarder = winutils.convert_dll_name_to_str(sym.forwarder)
                 # sym.forwarder is for example 'KERNEL32.EnterCriticalSection'
-                dll, _ = sym.forwarder.split('.')
-                dlls.add(winutils.convert_dll_name_to_str(dll) + ".dll")
+                dll, _ = forwarder.split('.')
+                dlls.add(dll + ".dll")
 
     return dlls
 


### PR DESCRIPTION
Following up on #1970, the failure concerns:

``` Python
    # We must also read the exports table to find forwarded symbols:
    # http://blogs.msdn.com/b/oldnewthing/archive/2006/07/19/671238.aspx
    exportSymbols = getattr(pe, 'DIRECTORY_ENTRY_EXPORT', None)
    if exportSymbols:
        for sym in exportSymbols.symbols:
            if sym.forwarder is not None:
                # sym.forwarder is for example 'KERNEL32.EnterCriticalSection'
                dll, _ = sym.forwarder.split('.')
                dlls.add(winutils.convert_dll_name_to_str(dll) + ".dll")
```

Per the [pefile source](https://github.com/erocarrera/pefile/blob/master/pefile.py#L2342), this invokes [self.parse_export_directory](https://github.com/erocarrera/pefile/blob/master/pefile.py#L3373), where [forwarder = forwarder_str](https://github.com/erocarrera/pefile/blob/master/pefile.py#L3484) is assigned as [forwarder_str = self.get_string_at_rva(symbol_address)](https://github.com/erocarrera/pefile/blob/master/pefile.py#L3521). [get_string_at_rva](https://github.com/erocarrera/pefile/blob/master/pefile.py#L4169) delegates to [get_string_from_data](https://github.com/erocarrera/pefile/blob/master/pefile.py#L4182), which returns a `bytes` object (compare this to the following [get_string_u_at_rva](https://github.com/erocarrera/pefile/blob/master/pefile.py#L4192), where the return value is encoded as an ASCII string).

@codewarrior0, since you added this in 7d841fa5a6e065b497370eea8fedeae8c7100118, would you comment?