### PR TITLE
Shadows over ModuleGraph: Scaling the Impenetrable Wall of Bugs

### DIFF
--- a/PyInstaller/building/imphook.py
+++ b/PyInstaller/building/imphook.py
@@ -465,7 +465,7 @@ class ModuleHook(object):
                     self.module_name, create_nspkg=False)
 
                 # Manually import this hidden import from this module.
-                self.module_graph.import_hook(import_module_name, caller=caller)
+                self.module_graph.import_hook(import_module_name, caller)
             # If this hidden import is unimportable, print a non-fatal warning.
             # Hidden imports often become desynchronized from upstream packages
             # and hence are only "soft" recommendations.

--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -808,6 +808,8 @@ SPECIAL_MODULE_TYPES = {
     'AliasNode',
     'BuiltinModule',
     'RuntimeModule',
+    'RuntimePackage',
+
     # PyInstaller handles scripts differently and not as standard Python modules.
     'Script',
 }
@@ -827,6 +829,13 @@ BAD_MODULE_TYPES = {
     'InvalidSourceModule',
     'InvalidCompiledModule',
     'MissingModule',
+
+    # Runtime modules and packages are technically valid rather than bad, but
+    # exist only in-memory rather than on-disk (typically due to
+    # pre_safe_import_module() hooks) and hence cannot be physically frozen.
+    # For simplicity, these nodes are categorized as bad rather than valid.
+    'RuntimeModule',
+    'RuntimePackage',
 }
 ALL_MODULE_TYPES = VALID_MODULE_TYPES | BAD_MODULE_TYPES
 # TODO Review this mapping to TOC, remove useless entries.
@@ -835,10 +844,11 @@ MODULE_TYPES_TO_TOC_DICT = {
     # Pure modules.
     'AliasNode': 'PYMODULE',
     'Script': 'PYSOURCE',
-    'RuntimeModule': 'PYMODULE',
     'SourceModule': 'PYMODULE',
     'CompiledModule': 'PYMODULE',
     'Package': 'PYMODULE',
+    'FlatPackage': 'PYMODULE',
+    'ArchiveModule': 'PYMODULE',
     # Binary modules.
     'Extension': 'EXTENSION',
     # Special valid modules.
@@ -850,9 +860,9 @@ MODULE_TYPES_TO_TOC_DICT = {
     'InvalidSourceModule': 'invalid',
     'InvalidCompiledModule': 'invalid',
     'MissingModule': 'missing',
+    'RuntimeModule': 'runtime',
+    'RuntimePackage': 'runtime',
     # Other.
-    'FlatPackage': 'PYMODULE',
-    'ArchiveModule': 'PYMODULE',
     'does not occur': 'BINARY',
 }
 

--- a/PyInstaller/lib/modulegraph/modulegraph.py
+++ b/PyInstaller/lib/modulegraph/modulegraph.py
@@ -4,24 +4,29 @@ Find modules used by a script, using bytecode analysis.
 Based on the stdlib modulefinder by Thomas Heller and Just van Rossum,
 but uses a graph data structure and 2.3 features
 
-XXX: Verify all calls to import_hook (and variants) to ensure that
+XXX: Verify all calls to _import_hook (and variants) to ensure that
 imports are done in the right way.
 """
 from __future__ import absolute_import, print_function
 
+#FIXME: To decrease the likelihood of ModuleGraph exceeding the recursion limit
+#and hence unpredictably raising fatal exceptions, increase the recursion
+#limit at PyInstaller startup (i.e., in the
+#PyInstaller.building.build_main.build() function). For details, see:
+#    https://github.com/pyinstaller/pyinstaller/issues/1919#issuecomment-216016176
+
 import pkg_resources
 
+import ast
 import dis
 import imp
 import marshal
 import os
 import pkgutil
 import sys
-import struct
 import re
 from collections import deque, namedtuple
-import ast
-import zipfile
+from struct import unpack
 
 from ..altgraph.ObjectGraph import ObjectGraph
 from ..altgraph import GraphError
@@ -35,7 +40,6 @@ if sys.version_info[0] == 2:
     from  urllib import pathname2url
     def _Bchr(value):
         return chr(value)
-
 else:
     from urllib.request  import pathname2url
     from io import BytesIO, StringIO
@@ -49,6 +53,127 @@ if sys.version_info[0] == 2:
     _READ_MODE = "rU"
 else:
     _READ_MODE = "r"
+
+
+_HAVE_ARGUMENT_OPCODE = _Bchr(dis.HAVE_ARGUMENT)
+"""
+Minimum value of opcodes accepting arguments.
+
+All opcodes greater than or equal to this value accept arguments. Contrariwise,
+all opcodes less than this value accept _no_ arguments.
+"""
+
+
+_LOAD_CONST_OPCODE = _Bchr(dis.opname.index('LOAD_CONST'))
+"""
+Opcode signifying the `LOAD_CONST(consti)` operation, where `consti` is the
+index of the constant in the attribute `co_consts` of this module's code
+object.
+
+This operation pushes `co_consts[consti]` onto the stack.
+"""
+
+
+_IMPORT_NAME_OPCODE = _Bchr(dis.opname.index('IMPORT_NAME'))
+"""
+Opcode signifying the `IMPORT_NAME(namei)` operation, where `namei` is the
+index of the name in the attribute `co_names` of this module's code object.
+
+This operation imports the module `co_names[namei]`. TOS and TOS1 are popped
+and provide the _fromlist_ and _level_ arguments of `__import__()`. The module
+object is pushed onto the stack. The current namespace is not affected: for a
+proper import statement, a subsequent `STORE_FAST` instruction modifies the
+namespace.
+"""
+
+
+_STORE_NAME_OPCODE = _Bchr(dis.opname.index('STORE_NAME'))
+"""
+Opcode signifying the `STORE_NAME(namei)` operation, where `namei` is the
+index of the name in the attribute `co_names` of this module's code object.
+
+This operation implements `name = TOS` when compile-time analysis _cannot_
+infer that the `name` variable is:
+
+* Referenced and bound only in the local namespace (e.g., function), instead
+  implemented by the more efficient `STORE_FAST` operation.
+* Referenced but _not_ bound in the local namespace (e.g., function), instead
+  implemented by the more efficient `STORE_GLOBAL` operation.
+
+See Also
+----------
+https://tech.blog.aknin.name/2010/06/05/pythons-innards-naming
+    Human-readable discussion of the subtle differences between the
+    `STORE_NAME`, `STORE_GLOBAL`, and `STORE_FAST` opcodes.
+"""
+
+
+_STORE_GLOBAL_OPCODE = _Bchr(dis.opname.index('STORE_GLOBAL'))
+"""
+Opcode signifying the `STORE_GLOBAL(namei)` operation, where `namei` is the
+index of the name in the attribute `co_names` of this module's code object.
+
+This operation implements `name = TOS` when compile-time analysis can infer
+that the `name` variable is referenced but _not_ bound in the local namespace
+(e.g., function).
+"""
+
+
+_DELETE_NAME_OPCODE = _Bchr(dis.opname.index('DELETE_NAME'))
+"""
+Opcode signifying the `DELETE_NAME(namei)` operation, where `namei` is the
+index of the name in the attribute `co_names` of this module's code object.
+
+This operation implements `del name` when compile-time analysis _cannot_
+infer that the `name` variable is:
+
+* Referenced and bound only in the local namespace (e.g., function), instead
+  implemented by the more efficient `DELETE_FAST` operation.
+* Referenced but _not_ bound in the local namespace (e.g., function), instead
+  implemented by the more efficient `DELETE_GLOBAL` operation.
+"""
+
+
+_DELETE_GLOBAL_OPCODE = _Bchr(dis.opname.index('DELETE_GLOBAL'))
+"""
+Opcode signifying the `DELETE_GLOBAL(namei)` operation, where `namei` is the
+index of the name in the attribute `co_names` of this module's code object.
+
+This operation implements `del name` when compile-time analysis can infer that
+the `name` variable is referenced but _not_ bound in the local namespace (e.g.,
+function).
+"""
+
+
+#FIXME: Leverage this rather than magic numbers below.
+ABSOLUTE_OR_RELATIVE_IMPORT_LEVEL = -1
+"""
+Constant instructing the builtin `__import__()` function to attempt both
+absolute and relative imports.
+"""
+
+
+#FIXME: Leverage this rather than magic numbers below.
+ABSOLUTE_IMPORT_LEVEL = 0
+"""
+Constant instructing the builtin `__import__()` function to attempt only
+absolute imports.
+"""
+
+
+#FIXME: Leverage this rather than magic numbers below.
+DEFAULT_IMPORT_LEVEL = (
+    ABSOLUTE_OR_RELATIVE_IMPORT_LEVEL if sys.version_info[0] == 2 else
+    ABSOLUTE_IMPORT_LEVEL)
+"""
+Constant instructing the builtin `__import__()` function to attempt the default
+import style specific to the active Python interpreter.
+
+Specifically, under:
+
+* Python 2, this defaults to attempting both absolute and relative imports.
+* Python 3, this defaults to attempting only absolute imports.
+"""
 
 # TODO: Refactor all uses of explicit filetypes in this module *AND* of the
 # imp.get_suffixes() function to use this dictionary instead. Unfortunately,
@@ -220,6 +345,10 @@ def replacePackage(oldname, newname):
     _replacePackageMap[oldname] = newname
 
 
+#FIXME: What is this? Do we actually need this? This appears to provide
+#significantly more fine-grained metadata than PyInstaller will ever require.
+#It consumes a great deal of space (slots or no slots), since we store an
+#instance of this class for each edge of the graph.
 class DependencyInfo (namedtuple("DependencyInfo", ["conditional", "function", "tryexcept", "fromlist"])):
     __slots__ = ()
 
@@ -236,38 +365,331 @@ class DependencyInfo (namedtuple("DependencyInfo", ["conditional", "function", "
                     fromlist=self.fromlist and other.fromlist)
 
 
+#FIXME: Shift the following Node class hierarchy into a new
+#"PyInstaller.lib.modulegraph.node" module. This module is much too long.
+#FIXME: Refactor "_deferred_imports" from a tuple into a proper lightweight
+#class leveraging "__slots__". If not for backward compatibility, we'd just
+#leverage a named tuple -- but this should do just as well.
+#FIXME: Move the "packagepath" attribute into the "Package" class. Only
+#packages define the "__path__" special attribute. The codebase currently
+#erroneously tests whether "module.packagepath is not None" to determine
+#whether a node is a package or not. However, "isinstance(module, Package)" is
+#a significantly more reliable test. Refactor the former into the latter.
 class Node(object):
+    """
+    Abstract base class (ABC) of all objects added to a `ModuleGraph`.
+
+    Attributes
+    ----------
+    code : codeobject
+        Code object of the pure-Python module corresponding to this graph node
+        if any _or_ `None` otherwise.
+    graphident : str
+        Synonym of `identifier` required by the `ObjectGraph` superclass of the
+        `ModuleGraph` class. For readability, the `identifier` attribute should
+        typically be used instead.
+    filename : str
+        Absolute path of this graph node's corresponding module, package, or C
+        extension if any _or_ `None` otherwise.
+    identifier : str
+        Fully-qualified name of this graph node's corresponding module,
+        package, or C extension.
+    packagepath : str
+        List of the absolute paths of all directories comprising this graph
+        node's corresponding package. If this is a:
+        * Non-namespace package, this list contains exactly one path.
+        * Namespace package, this list contains one or more paths.
+    _deferred_imports : list
+        List of all target modules imported by the source module corresponding
+        to this graph node whole importations have been deferred for subsequent
+        processing in between calls to the `_ModuleGraph._scan_code()` and
+        `_ModuleGraph._process_imports()` methods for this source module _or_
+        `None` otherwise. Each element of this list is a 3-tuple
+        `(have_star, _safe_import_hook_args, _safe_import_hook_kwargs)`
+        collecting the importation of a target module from this source module
+        for subsequent processing, where:
+        * `have_star` is a boolean `True` only if this is a `from`-style star
+          import (e.g., resembling `from {target_module_name} import *`).
+        * `_safe_import_hook_args` is a (typically non-empty) sequence of all
+          positional arguments to be passed to the `_safe_import_hook()` method
+          to add this importation to the graph.
+        * `_safe_import_hook_kwargs` is a (typically empty) dictionary of all
+          keyword arguments to be passed to the `_safe_import_hook()` method
+          to add this importation to the graph.
+        Unlike functional languages, Python imposes a maximum depth on the
+        interpreter stack (and hence recursion). On breaching this depth,
+        Python raises a fatal `RuntimeError` exception. Since `ModuleGraph`
+        parses imports recursively rather than iteratively, this depth _was_
+        commonly breached before the introduction of this list. Python
+        environments installing a large number of modules (e.g., Anaconda) were
+        particularly susceptible. Why? Because `ModuleGraph` concurrently
+        descended through both the abstract syntax trees (ASTs) of all source
+        modules being parsed _and_ the graph of all target modules imported by
+        these source modules being built. The stack thus consisted of
+        alternating layers of AST and graph traversal. To unwind such
+        alternation and effectively halve the stack depth, `ModuleGraph` now
+        descends through the abstract syntax tree (AST) of each source module
+        being parsed and adds all importations originating within this module
+        to this list _before_ descending into the graph of these importations.
+        See pyinstaller/pyinstaller/#1289 for further details.
+    _global_attr_names : set
+        Set of the unqualified names of all global attributes (e.g., classes,
+        variables) defined in the pure-Python module corresponding to this
+        graph node if any _or_ the empty set otherwise. This includes the names
+        of all attributes imported via `from`-style star imports from other
+        existing modules (e.g., `from {target_module_name} import *`). This
+        set is principally used to differentiate the non-ignorable importation
+        of non-existent submodules in a package from the ignorable importation
+        of existing global attributes defined in that package's pure-Python
+        `__init__` submodule in `from`-style imports (e.g., `bar` in
+        `from foo import bar`, which may be either a submodule or attribute of
+        `foo`), as such imports ambiguously allow both. This set is _not_ used
+        to differentiate submodules from attributes in `import`-style imports
+        (e.g., `bar` in `import foo.bar`, which _must_ be a submodule of
+        `foo`), as such imports unambiguously allow only submodules.
+    _starimported_ignored_module_names : set
+        Set of the fully-qualified names of all existing unparsable modules
+        that the existing parsable module corresponding to this graph node
+        attempted to perform one or more "star imports" from. If this module
+        either does _not_ exist or does but is unparsable, this is the empty
+        set. Equivalently, this set contains each fully-qualified name
+        `{trg_module_name}` for which:
+        * This module contains an import statement of the form
+          `from {trg_module_name} import *`.
+        * The module whose name is `{trg_module_name}` exists but is _not_
+          parsable by `ModuleGraph` (e.g., due to _not_ being pure-Python).
+        **This set is currently defined but otherwise ignored.**
+    _submodule_basename_to_node : dict
+        Dictionary mapping from the unqualified name of each submodule
+        contained by the parent module corresponding to this graph node to that
+        submodule's graph node. If this dictionary is non-empty, this parent
+        module is typically but _not_ always a package (e.g., the non-package
+        `os` module containing the `os.path` submodule).
+    """
+
     def __init__(self, identifier):
-        self.debug = 0
+        """
+        Initialize this graph node.
+
+        Parameters
+        ----------
+        identifier : str
+            Fully-qualified name of this graph node's corresponding module,
+            package, or C extension.
+        """
+
+        self.code = None
+        self.filename = None
         self.graphident = identifier
         self.identifier = identifier
-        self._namespace = {}
-        self.filename = None
         self.packagepath = None
-        self.code = None
-        # The set of global names that are assigned to in the module.
-        # This includes those names imported through starimports of
-        # Python modules.
-        # These are only relevant when looking up the from-list in
-        # `from xxx import yyy`, since `import xxx.yyy` requires `yyy`
-        # to be a module and thus the globalnames need not to be
-        # checked.
-        self.globalnames = set()
-        # The set of starimports this module did that could not be
-        # resolved, ie. a starimport from a non-Python module.
-        self.starimports = set()
+        self._deferred_imports = None
+        self._global_attr_names = set()
+        self._starimported_ignored_module_names = set()
+        self._submodule_basename_to_node = dict()
 
-    def __contains__(self, name):
-        return name in self._namespace
 
-    def __getitem__(self, name):
-        return self._namespace[name]
+    def is_global_attr(self, attr_name):
+        """
+        `True` only if the pure-Python module corresponding to this graph node
+        defines a global attribute (e.g., class, variable) with the passed
+        name.
 
-    def __setitem__(self, name, value):
-        self._namespace[name] = value
+        If this module is actually a package, this method instead returns
+        `True` only if this package's pure-Python `__init__` submodule defines
+        such a global attribute. In this case, note that this package may still
+        contain an importable submodule of the same name. Callers should
+        attempt to import this attribute as a submodule of this package
+        _before_ assuming this attribute to be an ignorable global. See
+        "Examples" below for further details.
 
-    def get(self, *args):
-        return self._namespace.get(*args)
+        Parameters
+        ----------
+        attr_name : str
+            Unqualified name of the attribute to be tested.
+
+        Returns
+        ----------
+        bool
+            `True` only if this module defines this global attribute.
+
+        Examples
+        ----------
+        Consider a hypothetical module `foo` containing submodules `bar` and
+        `__init__` where the latter assigns `bar` to be a global variable
+        (possibly star-exported via the special `__all__` global variable):
+
+        >>> # In "foo.__init__":
+        >>> bar = 3.1415
+
+        Python 2 and 3 both permissively permit this. This method returns
+        `True` in this case (i.e., when called on the `foo` package's graph
+        node, passed the attribute name `bar`) despite the importability of the
+        `foo.bar` submodule.
+        """
+
+        return attr_name in self._global_attr_names
+
+
+    def is_submodule(self, submodule_basename):
+        """
+        `True` only if the parent module corresponding to this graph node
+        contains the submodule with the passed name.
+
+        If `True`, this parent module is typically but _not_ always a package
+        (e.g., the non-package `os` module containing the `os.path` submodule).
+
+        Parameters
+        ----------
+        submodule_basename : str
+            Unqualified name of the submodule to be tested.
+
+        Returns
+        ----------
+        bool
+            `True` only if this parent module contains this submodule.
+        """
+
+        return submodule_basename in self._submodule_basename_to_node
+
+
+    def add_global_attr(self, attr_name):
+        """
+        Record the global attribute (e.g., class, variable) with the passed
+        name to be defined by the pure-Python module corresponding to this
+        graph node.
+
+        If this module is actually a package, this method instead records this
+        attribute to be defined by this package's pure-Python `__init__`
+        submodule.
+
+        Parameters
+        ----------
+        attr_name : str
+            Unqualified name of the attribute to be added.
+        """
+
+        self._global_attr_names.add(attr_name)
+
+
+    def add_global_attrs_from_module(self, target_module):
+        """
+        Record all global attributes (e.g., classes, variables) defined by the
+        target module corresponding to the passed graph node to also be defined
+        by the source module corresponding to this graph node.
+
+        If the source module is actually a package, this method instead records
+        these attributes to be defined by this package's pure-Python `__init__`
+        submodule.
+
+        Parameters
+        ----------
+        target_module : Node
+            Graph node of the target module to import attributes from.
+        """
+
+        self._global_attr_names.update(target_module._global_attr_names)
+
+
+    def add_submodule(self, submodule_basename, submodule_node):
+        """
+        Add the submodule with the passed name and previously imported graph
+        node to the parent module corresponding to this graph node.
+
+        This parent module is typically but _not_ always a package (e.g., the
+        non-package `os` module containing the `os.path` submodule).
+
+        Parameters
+        ----------
+        submodule_basename : str
+            Unqualified name of the submodule to add to this parent module.
+        submodule_node : Node
+            Graph node of this submodule.
+        """
+
+        self._submodule_basename_to_node[submodule_basename] = submodule_node
+
+
+    def get_submodule(self, submodule_basename):
+        """
+        Graph node of the submodule with the passed name in the parent module
+        corresponding to this graph node.
+
+        If this parent module does _not_ contain this submodule, an exception
+        is raised. Else, this parent module is typically but _not_ always a
+        package (e.g., the non-package `os` module containing the `os.path`
+        submodule).
+
+        Parameters
+        ----------
+        module_basename : str
+            Unqualified name of the submodule to retrieve.
+
+        Returns
+        ----------
+        Node
+            Graph node of this submodule.
+        """
+
+        return self._submodule_basename_to_node[submodule_basename]
+
+
+    def get_submodule_or_none(self, submodule_basename):
+        """
+        Graph node of the submodule with the passed unqualified name in the
+        parent module corresponding to this graph node if this module contains
+        this submodule _or_ `None`.
+
+        This parent module is typically but _not_ always a package (e.g., the
+        non-package `os` module containing the `os.path` submodule).
+
+        Parameters
+        ----------
+        submodule_basename : str
+            Unqualified name of the submodule to retrieve.
+
+        Returns
+        ----------
+        Node
+            Graph node of this submodule if this parent module contains this
+            submodule _or_ `None`.
+        """
+
+        return self._submodule_basename_to_node.get(submodule_basename)
+
+
+    def remove_global_attr_if_found(self, attr_name):
+        """
+        Record the global attribute (e.g., class, variable) with the passed
+        name if previously recorded as defined by the pure-Python module
+        corresponding to this graph node to be subsequently undefined by the
+        same module.
+
+        If this module is actually a package, this method instead records this
+        attribute to be undefined by this package's pure-Python `__init__`
+        submodule.
+
+        This method is intended to be called on globals previously defined by
+        this module that are subsequently undefined via the `del` built-in by
+        this module, thus "forgetting" or "undoing" these globals.
+
+        For safety, there exists no corresponding `remove_global_attr()`
+        method. While defining this method is trivial, doing so would invite
+        `KeyError` exceptions on scanning valid Python that lexically deletes a
+        global in a scope under this module's top level (e.g., in a function)
+        _before_ defining this global at this top level. Since `ModuleGraph`
+        cannot and should not (re)implement a full-blown Python interpreter,
+        ignoring out-of-order deletions is the only sane policy.
+
+        Parameters
+        ----------
+        attr_name : str
+            Unqualified name of the attribute to be removed.
+        """
+
+        if self.is_global_attr(attr_name):
+            self._global_attr_names.remove(attr_name)
+
 
     def __cmp__(self, other):
         try:
@@ -335,17 +757,61 @@ class Node(object):
     def __repr__(self):
         return '%s%r' % (type(self).__name__, self.infoTuple())
 
+
+# TODO: This indirection is, frankly, unnecessary. The
+# ModuleGraph.alias_module() should directly add the desired AliasNode instance
+# to the graph rather than indirectly adding an Alias instance to the
+# "lazynodes" dictionary.
 class Alias(str):
-    pass
+    """
+    Placeholder aliasing an existing source module to a non-existent target
+    module (i.e., the desired alias).
+
+    For obscure reasons, this class subclasses `str`. Each instance of this
+    class is the fully-qualified name of the existing source module being
+    aliased. Unlike the related `AliasNode` class, instances of this class are
+    _not_ actual nodes and hence _not_ added to the graph; they only facilitate
+    communication between the `ModuleGraph.alias_module()` and
+    `ModuleGraph.findNode()` methods.
+    """
+
 
 class AliasNode(Node):
+    """
+    Graph node representing the aliasing of an existing source module under a
+    non-existent target module name (i.e., the desired alias).
+    """
+
     def __init__(self, name, node):
+        """
+        Initialize this alias.
+
+        Parameters
+        ----------
+        name : str
+            Fully-qualified name of the non-existent target module to be
+            created (as an alias of the existing source module).
+        node : Node
+            Graph node of the existing source module being aliased.
+        """
         super(AliasNode, self).__init__(name)
-        for k in 'identifier', 'packagepath', '_namespace', 'globalnames', 'starimports':
-            setattr(self, k, getattr(node, k, None))
+
+        #FIXME: Why only some? Why not *EVERYTHING* except "graphident", which
+        #must remain equal to "name" for lookup purposes? This is, after all,
+        #an alias. The idea is for the two nodes to effectively be the same.
+
+        # Copy some attributes from this source module into this target alias.
+        for attr_name in (
+            'identifier', 'packagepath',
+            '_global_attr_names', '_starimported_ignored_module_names',
+            '_submodule_basename_to_node'):
+            if hasattr(node, attr_name):
+                setattr(self, attr_name, getattr(node, attr_name))
+
 
     def infoTuple(self):
         return (self.graphident, self.identifier)
+
 
 class BadModule(Node):
     pass
@@ -376,20 +842,6 @@ class BaseModule(Node):
 class BuiltinModule(BaseModule):
     pass
 
-class RuntimeModule(MissingModule):
-    """
-    Graph node representing a Python module dynamically defined at runtime.
-
-    Most modules are statically defined at creation time in external Python
-    files. Some modules, however, are dynamically defined at runtime (e.g.,
-    `six.moves`, dynamically defined by the statically defined `six` module).
-
-    This node represents such a module. To ensure that the parent module of
-    this module is also imported and added to the graph, this node is typically
-    added to the graph by calling the `ModuleGraph.add_module()` method.
-    """
-    pass
-
 class SourceModule(BaseModule):
     pass
 
@@ -402,26 +854,84 @@ class CompiledModule(BaseModule):
 class InvalidCompiledModule(BaseModule):
     pass
 
-class Package(BaseModule):
-    pass
-
-class NamespacePackage(Package):
-    pass
-
 class Extension(BaseModule):
     pass
 
+
+class Package(BaseModule):
+    """
+    Graph node representing a non-namespace package.
+    """
+    pass
+
+
+class NamespacePackage(Package):
+    """
+    Graph node representing a namespace package.
+    """
+    pass
+
+
+class RuntimeModule(BaseModule):
+    """
+    Graph node representing a non-package Python module dynamically defined at
+    runtime.
+
+    Most modules are statically defined on-disk as standard Python files.
+    Some modules, however, are dynamically defined in-memory at runtime
+    (e.g., `gi.repository.Gst`, dynamically defined by the statically
+    defined `gi.repository.__init__` module).
+
+    This node represents such a runtime module. Since this is _not_ a package,
+    all attempts to import submodules from this module in `from`-style import
+    statements (e.g., the `queue` submodule in `from six.moves import queue`)
+    will be silently ignored.
+
+    To ensure that the parent package of this module if any is also imported
+    and added to the graph, this node is typically added to the graph by
+    calling the `ModuleGraph.add_module()` method.
+    """
+    pass
+
+
+class RuntimePackage(Package):
+    """
+    Graph node representing a non-namespace Python package dynamically defined
+    at runtime.
+
+    Most packages are statically defined on-disk as standard subdirectories
+    containing `__init__.py` files. Some packages, however, are dynamically
+    defined in-memory at runtime (e.g., `six.moves`, dynamically defined by
+    the statically defined `six` module).
+
+    This node represents such a runtime package. All attributes imported from
+    this package in `from`-style import statements that are submodules of this
+    package (e.g., the `queue` submodule in `from six.moves import queue`) will
+    be imported rather than ignored.
+
+    To ensure that the parent package of this package if any is also imported
+    and added to the graph, this node is typically added to the graph by
+    calling the `ModuleGraph.add_module()` method.
+    """
+    pass
+
+
+#FIXME: Safely removable. We don't actually use this anywhere. After removing
+#this class, remove the corresponding entry from "compat".
 class FlatPackage(BaseModule): # nocoverage
     def __init__(self, *args, **kwds):
         warnings.warn("This class will be removed in a future version of modulegraph",
             DeprecationWarning)
         super(FlatPackage, *args, **kwds)
 
+#FIXME: Safely removable. We don't actually use this anywhere. After removing
+#this class, remove the corresponding entry from "compat".
 class ArchiveModule(BaseModule): # nocoverage
     def __init__(self, *args, **kwds):
         warnings.warn("This class will be removed in a future version of modulegraph",
             DeprecationWarning)
         super(FlatPackage, *args, **kwds)
+
 
 # HTML templates for ModuleGraph generator
 header = """\
@@ -471,14 +981,10 @@ if sys.version_info[0] == 2:
 else:
     DEFAULT_IMPORT_LEVEL= 0
 
-class _Visitor (ast.NodeVisitor):
+class _Visitor(ast.NodeVisitor):
     def __init__(self, graph, module):
         self._graph = graph
         self._module = module
-        # Importing a module twice *may* happen, e.g. with
-        # replacePackage or `_xmlplus` as `xml`
-        #assert module._imported_modules is None, module
-        module._imported_modules = []
         self._level = DEFAULT_IMPORT_LEVEL
         self._in_if = [False]
         self._in_def = [False]
@@ -496,8 +1002,8 @@ class _Visitor (ast.NodeVisitor):
     def in_tryexcept(self):
         return self._in_tryexcept[-1]
 
-    def _collect_import(self, name, fromlist, level):
 
+    def _collect_import(self, name, fromlist, level):
         if sys.version_info[0] == 2:
             if name == '__future__' and 'absolute_import' in (fromlist or ()):
                 self._level = 0
@@ -509,15 +1015,17 @@ class _Visitor (ast.NodeVisitor):
                 fromlist.remove('*')
                 have_star = True
 
-        # Collect this import to belong to this module
-        self._module._imported_modules.append(
+        # Record this import as originating from this module for subsequent
+        # handling by the _process_imports() method.
+        self._module._deferred_imports.append(
             (have_star,
              (name, self._module, fromlist, level),
-             {'attr': DependencyInfo(
+             {'edge_attr': DependencyInfo(
                  conditional=self.in_if,
                  tryexcept=self.in_tryexcept,
                  function=self.in_def,
                  fromlist=False)}))
+
 
     def visit_Import(self, node):
         for nm in _ast_names(node.names):
@@ -548,11 +1056,6 @@ class _Visitor (ast.NodeVisitor):
         self._in_tryexcept.pop()
 
     def visit_TryExcept(self, node):
-        self._in_tryexcept.append(True)
-        self.generic_visit(node)
-        self._in_tryexcept.pop()
-
-    def visit_ExceptHandler(self, node):
         self._in_tryexcept.append(True)
         self.generic_visit(node)
         self._in_tryexcept.pop()
@@ -589,13 +1092,16 @@ class ModuleGraph(ObjectGraph):
     dependencies between these modules.
     """
 
+
     def createNode(self, cls, name, *args, **kw):
         m = self.findNode(name)
+
         if m is None:
             #assert m is None, m
             m = super(ModuleGraph, self).createNode(cls, name, *args, **kw)
-            m._imported_modules = None
+
         return m
+
 
     def __init__(self, path=None, excludes=(), replace_paths=(), implies=(), graph=None, debug=0):
         super(ModuleGraph, self).__init__(graph=graph, debug=debug)
@@ -683,22 +1189,23 @@ class ModuleGraph(ObjectGraph):
 
         return pkgmap
 
+
     def implyNodeReference(self, node, other, edge_data=None):
         """
         Create a reference from the passed source node to the passed other node,
         implying the former to depend upon the latter.
 
-        While the source node *must* be an existing graph node, the target node
-        may be either an existing graph node *or* a fully-qualified module name.
+        While the source node _must_ be an existing graph node, the target node
+        may be either an existing graph node _or_ a fully-qualified module name.
         In the latter case, the module with that name and all parent packages of
-        that module will be imported *without* raising exceptions and for each
+        that module will be imported _without_ raising exceptions and for each
         newly imported module or package:
 
         * A new graph node will be created for that module or package.
         * A reference from the passed source node to that module or package will
           be created.
 
-        This method allows dependencies between Python objects *not* importable
+        This method allows dependencies between Python objects _not_ importable
         with standard techniques (e.g., module aliases, C extensions).
 
         Parameters
@@ -706,12 +1213,12 @@ class ModuleGraph(ObjectGraph):
         node : str
             Graph node for this reference's source module or package.
         other : {Node, str}
-            Either a graph node *or* fully-qualified name for this reference's
+            Either a graph node _or_ fully-qualified name for this reference's
             target module or package.
         """
+
         if isinstance(other, Node):
             self._updateReference(node, other, edge_data)
-
         else:
             if isinstance(other, tuple):
                 raise ValueError(other)
@@ -723,12 +1230,14 @@ class ModuleGraph(ObjectGraph):
 
     def getReferences(self, fromnode):
         """
-        Yield all nodes that 'fromnode' dependes on (that is,
-        all modules that 'fromnode' imports.
+        Yield all nodes that `fromnode` dependes on (that is,
+        all modules that `fromnode` imports.
         """
+
         node = self.findNode(fromnode)
         out_edges, _ = self.get_edges(node)
         return out_edges
+
 
     def getReferers(self, tonode, collapse_missing_modules=True):
         node = self.findNode(tonode)
@@ -747,6 +1256,7 @@ class ModuleGraph(ObjectGraph):
             for n in in_edges:
                 yield n
 
+
     def hasEdge(self, fromnode, tonode):
         """ Return True iff there is an edge from 'fromnode' to 'tonode' """
         fromnode = self.findNode(fromnode)
@@ -757,10 +1267,11 @@ class ModuleGraph(ObjectGraph):
 
     def foldReferences(self, packagenode):
         """
-        Create edges to/from 'packagenode' based on the
-        edges to/from modules in package. The module nodes
-        are then hidden.
+        Create edges to/from `packagenode` based on the edges to/from all
+        submodules of that package _and_ then hide the graph nodes
+        corresponding to those submodules.
         """
+
         pkg = self.findNode(packagenode)
 
         for n in self.nodes():
@@ -810,27 +1321,50 @@ class ModuleGraph(ObjectGraph):
         """
         return super(ModuleGraph, self).createReference(fromnode, tonode, edge_data=edge_data)
 
+
     def findNode(self, name, create_nspkg=True):
         """
-        Find a node by identifier.  If a node by that identifier exists,
-        it will be returned.
+        Graph node uniquely identified by the passed fully-qualified module
+        name if this module has been added to the graph _or_ `None` otherwise.
 
-        If a lazy node exists by that identifier with no dependencies (excluded),
-        it will be instantiated and returned.
+        If (in order):
 
-        If a lazy node exists by that identifier with dependencies, it and its
-        dependencies will be instantiated and scanned for additional dependencies.
+        . A namespace package with this identifier exists _and_ the passed
+          `create_nspkg` parameter is `True`, this package will be
+          instantiated and returned.
+        . A lazy node with this identifier and:
+          * No dependencies exists, this node will be instantiated and
+            returned.
+          * Dependencies exists, this node and all transitive dependencies of
+            this node be instantiated and this node returned.
+        . A non-lazy node with this identifier exists, this node will be
+          returned as is.
 
-        If a namespace package exists by that identifier, it will be instantiated
-        and returned.
+        Parameters
+        ----------
+        name : str
+            Fully-qualified name of the module whose graph node is to be found.
+        create_nspkg : bool
+            Whether or not to implicitly instantiate namespace packages. If
+            `True` _and_ this name is that of a previously registered namespace
+            package (i.e., in `self.nspackages`) not already added to the
+            graph, this package will be added to the graph. Defaults to `True`.
 
-        If `create_nspkg` is False, no namespace package will be instantiated.
+        Returns
+        ----------
+        Node
+            Graph node of this module if added to the graph _or_ `None`
+            otherwise.
         """
+
         data = super(ModuleGraph, self).findNode(name)
+
         if data is not None:
             return data
+
         if name in self.lazynodes:
             deps = self.lazynodes.pop(name)
+
             if deps is None:
                 # excluded module
                 m = self.createNode(ExcludedModule, name)
@@ -838,11 +1372,11 @@ class ModuleGraph(ObjectGraph):
                 other = self._safe_import_hook(deps, None, None).pop()
                 m = self.createNode(AliasNode, name, other)
                 self.implyNodeReference(m, other)
-
             else:
                 m = self._safe_import_hook(name, None, None).pop()
                 for dep in deps:
                     self.implyNodeReference(m, dep)
+
             return m
 
         if name in self.nspackages and create_nspkg:
@@ -863,12 +1397,14 @@ class ModuleGraph(ObjectGraph):
 
         return None
 
+
     def run_script(self, pathname, caller=None):
         """
         Create a node by path (not module name).  It is expected to be a Python
         source file, and will be scanned for dependencies.
         """
         self.msg(2, "run_script", pathname)
+
         pathname = os.path.realpath(pathname)
         m = self.findNode(pathname)
         if m is not None:
@@ -895,30 +1431,108 @@ class ModuleGraph(ObjectGraph):
             m.code = self._replace_paths_in_code(m.code)
         return m
 
-    def import_hook(self, name, caller=None, fromlist=None, level=DEFAULT_IMPORT_LEVEL, attr=None):
-        """
-        Import a module
 
-        Return the set of modules that are imported
+    #FIXME: For safety, the "source_module" parameter should default to the
+    #root node of the current graph if unpassed. This parameter currently
+    #defaults to None, thus disconnected modules imported in this manner (e.g.,
+    #hidden imports imported by depend.analysis.initialize_modgraph()).
+    def import_hook(
+        self,
+        target_module_partname,
+        source_module=None,
+        target_attr_names=None,
+        level=DEFAULT_IMPORT_LEVEL,
+        edge_attr=None,
+    ):
         """
-        self.msg(3, "import_hook", name, caller, fromlist, level)
-        parent = self._determine_parent(caller)
-        q, tail = self._find_head_package(parent, name, level)
-        m = self._load_tail(q, tail)
-        modules = [m]
-        if fromlist and m.packagepath:
-            for s in self._ensure_fromlist(m, fromlist):
-                if s not in modules:
-                    modules.append(s)
-        for m in modules:
-            self._updateReference(caller, m, edge_data=attr)
-        return modules
+        Import the module with the passed name, all parent packages of this
+        module, _and_ all submodules and attributes in this module with the
+        passed names from the previously imported caller module signified by
+        the passed graph node.
+
+        Unlike most import methods (e.g., `_safe_import_hook()`), this method
+        is designed to be publicly called by both external and internal
+        callers and hence is public.
+
+        Parameters
+        ----------
+        target_module_partname : str
+            Partially-qualified name of the target module to be imported. See
+            `_safe_import_hook()` for further details.
+        source_module : Node
+            Graph node for the previously imported **source module** (i.e.,
+            module containing the `import` statement triggering the call to
+            this method) _or_ `None` if this module is to be imported in a
+            "disconnected" manner. **Passing `None` is _not_ recommended.**
+            Doing so produces a disconnected graph in which the graph node
+            created for the module to be imported will be disconnected and
+            hence unreachable from all other nodes -- which frequently causes
+            subtle issues in external callers (namely PyInstaller, which
+            silently ignores unreachable nodes).
+        target_attr_names : list
+            List of the unqualified names of all submodules and attributes to
+            be imported from the module to be imported if this is a "from"-
+            style import (e.g., `[encode_base64, encode_noop]` for the import
+            `from email.encoders import encode_base64, encode_noop`) _or_
+            `None` otherwise.
+        level : int
+            Whether to perform an absolute or relative import. See
+            `_safe_import_hook()` for further details.
+
+        Returns
+        ----------
+        list
+            List of the graph nodes created for all modules explicitly imported
+            by this call, including the passed module and all submodules listed
+            in `target_attr_names` _but_ excluding all parent packages
+            implicitly imported by this call. If `target_attr_names` is `None`
+            or the empty list, this is guaranteed to be a list of one element:
+            the graph node created for the passed module.
+
+        Raises
+        ----------
+        ImportError
+            If the target module to be imported is unimportable.
+        """
+        self.msg(3, "_import_hook", target_module_partname, source_module, source_module, level)
+
+        source_package = self._determine_parent(source_module)
+        target_package, target_module_partname = self._find_head_package(
+            source_package, target_module_partname, level)
+        target_module = self._load_tail(target_package, target_module_partname)
+        target_modules = [target_module]
+
+        # If this is a "from"-style import *AND* this target module is
+        # actually a package, import all submodules of this package specified
+        # by the "import" half of this import (e.g., the submodules "bar" and
+        # "car" of the target package "foo" in "from foo import bar, car").
+        #
+        # If this target module is a non-package, it could still contain
+        # importable submodules (e.g., the non-package `os` module containing
+        # the `os.path` submodule). In this case, these submodules are already
+        # imported by this target module's pure-Python code. Since our import
+        # scanner already detects such imports, these submodules need *NOT* be
+        # reimported here.
+        if target_attr_names and isinstance(target_module, Package):
+            for target_submodule in self._import_importable_package_submodules(
+                target_module, target_attr_names):
+                if target_submodule not in target_modules:
+                    target_modules.append(target_submodule)
+
+        # Add an edge from this source module to each target module.
+        for target_module in target_modules:
+            self._updateReference(
+                source_module, target_module, edge_data=edge_attr)
+
+        return target_modules
+
 
     def _determine_parent(self, caller):
         """
-        Determine the package containing a node
+        Determine the package containing a node.
         """
         self.msgin(4, "determine_parent", caller)
+
         parent = None
         if caller:
             pname = caller.identifier
@@ -939,113 +1553,345 @@ class ModuleGraph(ObjectGraph):
         self.msgout(4, "determine_parent ->", parent)
         return parent
 
-    def _find_head_package(self, parent, name, level=DEFAULT_IMPORT_LEVEL):
+
+    def _find_head_package(
+        self,
+        source_package,
+        target_module_partname,
+        level=DEFAULT_IMPORT_LEVEL):
         """
-        Given a calling parent package and an import name determine the containing
-        package for the name
+        Import the target package providing the target module with the passed
+        name to be subsequently imported from the previously imported source
+        package corresponding to the passed graph node.
+
+        Parameters
+        ----------
+        source_package : Package
+            Graph node for the previously imported **source package** (i.e.,
+            package containing the module containing the `import` statement
+            triggering the call to this method) _or_ `None` if this module is
+            to be imported in a "disconnected" manner. **Passing `None` is
+            _not_ recommended.** See the `_import_hook()` method for further
+            details.
+        target_module_partname : str
+            Partially-qualified name of the target module to be imported. See
+            `_safe_import_hook()` for further details.
+        level : int
+            Whether to perform absolute or relative imports. See the
+            `_safe_import_hook()` method for further details.
+
+        Returns
+        ----------
+        (target_package, target_module_tailname)
+            2-tuple describing the imported target package, where:
+            * `target_package` is the graph node created for this package.
+            * `target_module_tailname` is the unqualified name of the target
+              module to be subsequently imported (e.g., `text` when passed a
+              `target_module_partname` of `email.mime.text`).
+
+        Raises
+        ----------
+        ImportError
+            If the package to be imported is unimportable.
         """
-        self.msgin(4, "find_head_package", parent, name, level)
-        if '.' in name:
-            head, tail = name.split('.', 1)
+        self.msgin(4, "find_head_package", source_package, target_module_partname, level)
+
+        #FIXME: Rename all local variable names to something sensible. No,
+        #"p_fqdn" is not a sensible name.
+
+        # If this target module is a submodule...
+        if '.' in target_module_partname:
+            target_module_headname, target_module_tailname = (
+                target_module_partname.split('.', 1))
+        # Else, this target module is a top-level module.
         else:
-            head, tail = name, ''
+            target_module_headname = target_module_partname
+            target_module_tailname = ''
 
-        if level == -1:
-            if parent:
-                qname = parent.identifier + '.' + head
+        # If attempting both absolute and relative imports...
+        if level == ABSOLUTE_OR_RELATIVE_IMPORT_LEVEL:
+            if source_package:
+                target_package_name = source_package.identifier + '.' + target_module_headname
             else:
-                qname = head
-
-        elif level == 0:
-            qname = head
+                target_package_name = target_module_headname
+        # Else if attempting only absolute imports...
+        elif level == ABSOLUTE_IMPORT_LEVEL:
+            target_package_name = target_module_headname
 
             # Absolute import, ignore the parent
-            parent = None
-
+            source_package = None
+        # Else if attempting only relative imports...
         else:
-            if parent is None:
+            if source_package is None:
                 self.msg(2, "Relative import outside of package")
-                raise ImportError("Relative import outside of package (name=%r, parent=%r, level=%r)"%(name, parent, level))
+                raise ImportError("Relative import outside of package (name=%r, parent=%r, level=%r)"%(target_module_partname, source_package, level))
 
-            for i in range(level-1):
-                if '.' not in parent.identifier:
+            for i in range(level - 1):
+                if '.' not in source_package.identifier:
                     self.msg(2, "Relative import outside of package")
-                    raise ImportError("Relative import outside of package (name=%r, parent=%r, level=%r)"%(name, parent, level))
+                    raise ImportError("Relative import outside of package (name=%r, parent=%r, level=%r)"%(target_module_partname, source_package, level))
 
-                p_fqdn = parent.identifier.rsplit('.', 1)[0]
+                p_fqdn = source_package.identifier.rsplit('.', 1)[0]
                 new_parent = self.findNode(p_fqdn)
                 if new_parent is None:
+                    #FIXME: Repetition detected. Exterminate. Exterminate.
                     self.msg(2, "Relative import outside of package")
-                    raise ImportError("Relative import outside of package (name=%r, parent=%r, level=%r)"%(name, parent, level))
+                    raise ImportError("Relative import outside of package (name=%r, parent=%r, level=%r)"%(target_module_partname, source_package, level))
 
-                assert new_parent is not parent, (new_parent, parent)
-                parent = new_parent
+                assert new_parent is not source_package, (
+                    new_parent, source_package)
+                source_package = new_parent
 
-            if head:
-                qname = parent.identifier + '.' + head
+            if target_module_headname:
+                target_package_name = (
+                    source_package.identifier + '.' + target_module_headname)
             else:
-                qname = parent.identifier
+                target_package_name = source_package.identifier
+
+        # Graph node of this target package.
+        target_package = self._safe_import_module(
+            target_module_headname, target_package_name, source_package)
+
+        #FIXME: Why exactly is this necessary again? This doesn't quite seem
+        #right but maybe it is. Shouldn't absolute imports only be performed if
+        #the passed "level" is either "ABSOLUTE_IMPORT_LEVEL" or
+        #"ABSOLUTE_OR_RELATIVE_IMPORT_LEVEL" -- or, more succinctly:
+        #
+        #    if level < 1:
+
+        # If this target package is *NOT* importable and a source package was
+        # passed, attempt to import this target package as an absolute import.
+        if target_package is None and source_package is not None:
+            target_package_name = target_module_headname
+            source_package = None
+
+            # Graph node for the target package, again.
+            target_package = self._safe_import_module(
+                target_module_headname, target_package_name, source_package)
+
+        # If this target package is importable, return this package.
+        if target_package is not None:
+            self.msgout(4, "find_head_package ->", (target_package, target_module_tailname))
+            return target_package, target_module_tailname
+
+        # Else, raise an exception.
+        self.msgout(4, "raise ImportError: No module named", target_package_name)
+        raise ImportError("No module named " + target_package_name)
 
 
-        q = self._safe_import_module(head, qname, parent)
-        if q:
-            self.msgout(4, "find_head_package ->", (q, tail))
-            return q, tail
-        if parent:
-            qname = head
-            parent = None
-            q = self._safe_import_module(head, qname, parent)
-            if q:
-                self.msgout(4, "find_head_package ->", (q, tail))
-                return q, tail
-        self.msgout(4, "raise ImportError: No module named", qname)
-        raise ImportError("No module named " + qname)
+    def _load_tail(self, package, submodule_name):
+        """
+        Import the submodule with the passed name and all parent packages of
+        this module from the previously imported parent package corresponding
+        to the passed graph node.
 
-    def _load_tail(self, mod, tail):
-        self.msgin(4, "load_tail", mod, tail)
-        result = mod
-        while tail:
-            i = tail.find('.')
-            if i < 0: i = len(tail)
-            head, tail = tail[:i], tail[i+1:]
-            mname = "%s.%s" % (result.identifier, head)
-            result = self._safe_import_module(head, mname, result)
-            if result is None:
+        Parameters
+        ----------
+        package : Package
+            Graph node of the previously imported package containing this
+            submodule.
+        submodule_name : str
+            Name of the submodule to be imported in either qualified (e.g.,
+            `email.mime.base`) or unqualified (e.g., `base`) form.
+
+        Returns
+        ----------
+        Node
+            Graph node created for this submodule.
+
+        Raises
+        ----------
+        ImportError
+            If this submodule is unimportable.
+        """
+        self.msgin(4, "load_tail", package, submodule_name)
+
+        submodule = package
+        while submodule_name:
+            i = submodule_name.find('.')
+            if i < 0: i = len(submodule_name)
+            head, submodule_name = submodule_name[:i], submodule_name[i+1:]
+            mname = "%s.%s" % (submodule.identifier, head)
+            submodule = self._safe_import_module(head, mname, submodule)
+
+            if submodule is None:
                 # result = self.createNode(MissingModule, mname)
                 self.msgout(4, "raise ImportError: No module named", mname)
                 raise ImportError("No module named " + repr(mname))
-        self.msgout(4, "load_tail ->", result)
-        return result
 
-    def _ensure_fromlist(self, m, fromlist):
-        fromlist = set(fromlist)
-        self.msg(4, "ensure_fromlist", m, fromlist)
-        if '*' in fromlist:
-            fromlist.update(self._find_all_submodules(m))
-            fromlist.remove('*')
-        for sub in fromlist:
-            submod = m.get(sub)
-            if submod is None:
-                if sub in m.globalnames:
-                    # Name is a global in the module
-                    self.msg(4, 'Global name found:', m.identifier, sub)
-                    continue
-                # XXX: ^^^ need something simular for names imported
-                #      by 'm'.
+        self.msgout(4, "load_tail ->", submodule)
+        return submodule
 
-                fullname = m.identifier + '.' + sub
-                submod = self._safe_import_module(sub, fullname, m)
-                if submod is None:
-                    raise ImportError("No module named " + fullname)
-            yield submod
+
+    #FIXME: Refactor from a generator yielding graph nodes into a non-generator
+    #returning a list or tuple of all yielded graph nodes. This method is only
+    #called once above and the return value of that call is only iterated over
+    #as a list or tuple. There's no demonstrable reason for this to be a
+    #generator. Generators are great for their intended purposes (e.g., as
+    #continuations). This isn't one of those purposes.
+    def _import_importable_package_submodules(self, package, attr_names):
+        """
+        Generator importing and yielding each importable submodule (of the
+        previously imported package corresponding to the passed graph node)
+        whose unqualified name is in the passed list.
+
+        Elements of this list that are _not_ importable submodules of this
+        package are either:
+
+        * Ignorable attributes (e.g., classes, globals) defined at the top
+          level of this package's `__init__` submodule, which will be ignored.
+        * Else, unignorable unimportable submodules, in which case an
+          exception is raised.
+
+        Parameters
+        ----------
+        package : Package
+            Graph node of the previously imported package containing the
+            modules to be imported and yielded.
+
+        attr_names : list
+            List of the unqualified names of all attributes of this package to
+            attempt to import as submodules. This list will be internally
+            converted into a set, safely ignoring any duplicates in this list
+            (e.g., reducing the "from"-style import
+            `from foo import bar, car, far, bar, car, far` to merely
+            `from foo import bar, car, far`).
+
+        Yields
+        ----------
+        Node
+            Graph node created for the currently imported submodule.
+
+        Raises
+        ----------
+        ImportError
+            If any attribute whose name is in `attr_names` is neither:
+            * An importable submodule of this package.
+            * An ignorable global attribute (e.g., class, variable) defined at
+              the top level of this package's `__init__` submodule.
+            In this case, this attribute _must_ be an unimportable submodule of
+            this package.
+        """
+
+        # Ignore duplicate submodule names in the passed list.
+        attr_names = set(attr_names)
+        self.msgin(4, "_import_importable_package_submodules", package, attr_names)
+
+        #FIXME: This test *SHOULD* be superfluous and hence safely removable.
+        #The higher-level _scan_bytecode() and _collect_import() methods
+        #already guarantee "*" characters to be removed from fromlists.
+        if '*' in attr_names:
+            attr_names.update(self._find_all_submodules(package))
+            attr_names.remove('*')
+
+        # self.msg(4, '_import_importable_package_submodules (global attrs)', package.identifier, package._global_attr_names)
+
+        # For the name of each attribute to be imported from this package...
+        for attr_name in attr_names:
+            # self.msg(4, '_import_importable_package_submodules (fromlist attr)', package.identifier, attr_name)
+
+            # Graph node of this attribute if this attribute is a previously
+            # imported module or None otherwise.
+            submodule = package.get_submodule_or_none(attr_name)
+
+            # If this attribute is *NOT* a previously imported module, attempt
+            # to import this attribute as a submodule of this package.
+            if submodule is None:
+                # Fully-qualified name of this submodule.
+                submodule_name = package.identifier + '.' + attr_name
+
+                # Graph node of this submodule if importable or None otherwise.
+                submodule = self._safe_import_module(
+                    attr_name, submodule_name, package)
+
+                # If this submodule is unimportable...
+                if submodule is None:
+                    # If this attribute is a global (e.g., class, variable)
+                    # defined at the top level of this package's "__init__"
+                    # submodule, this importation is safely ignorable. Do so
+                    # and skip to the next attribute.
+                    #
+                    # This behaviour is non-conformant with Python behaviour,
+                    # which is bad, but is required to sanely handle all
+                    # possible edge cases, which is good. In Python, a global
+                    # attribute defined at the top level of a package's
+                    # "__init__" submodule shadows a submodule of the same name
+                    # in that package. Attempting to import that submodule
+                    # instead imports that attribute; thus, that submodule is
+                    # effectively unimportable. In this method and elsewhere,
+                    # that submodule is tested for first and hence shadows that
+                    # attribute -- the opposite logic. Attempts to import that
+                    # attribute are mistakenly seen as attempts to import that
+                    # submodule! Why?
+                    #
+                    # Edge cases. PyInstaller (and by extension ModuleGraph)
+                    # only cares about module imports. Global attribute imports
+                    # are parsed only as the means to this ends and are
+                    # otherwise ignorable. The cost of erroneously shadowing:
+                    #
+                    # * Submodules by attributes is significant. Doing so
+                    #   prevents such submodules from being frozen and hence
+                    #   imported at application runtime.
+                    # * Attributes by submodules is insignificant. Doing so
+                    #   could erroneously freeze such submodules despite their
+                    #   never being imported at application runtime. However,
+                    #   ModuleGraph is incapable of determining with certainty
+                    #   that Python logic in another module other than the
+                    #   "__init__" submodule containing these attributes does
+                    #   *NOT* delete these attributes and hence unshadow these
+                    #   submodules, which would then become importable at
+                    #   runtime and require freezing. Hence, ModuleGraph *MUST*
+                    #   permissively assume submodules of the same name as
+                    #   attributes to be unshadowed elsewhere and require
+                    #   freezing -- even if they do not.
+                    #
+                    # It is practically difficult (albeit technically feasible)
+                    # for ModuleGraph to determine whether or not the target
+                    # attribute names of "from"-style import statements (e.g.,
+                    # "bar" and "car" in "from foo import bar, car") refer to
+                    # non-ignorable submodules or ignorable non-module globals
+                    # during opcode scanning. Distinguishing these two cases
+                    # during opcode scanning would require a costly call to the
+                    # _find_module() method, which would subsequently be
+                    # repeated during import-graph construction. This could be
+                    # ameliorated with caching, which itself would require
+                    # costly space consumption and developer time.
+                    #
+                    # Since opcode scanning fails to distinguish these two
+                    # cases, this and other methods subsequently called at
+                    # import-graph construction time (e.g.,
+                    # _safe_import_hook()) must do so. Since submodules of the
+                    # same name as attributes must assume to be unshadowed
+                    # elsewhere and require freezing, the only solution is to
+                    # attempt to import an attribute as a non-ignorable module
+                    # *BEFORE* assuming an attribute to be an ignorable
+                    # non-module. Which is what this and other methods do.
+                    #
+                    # See Package.is_global_attr() for similar discussion.
+                    if package.is_global_attr(attr_name):
+                        self.msg(4, '_import_importable_package_submodules: ignoring from-imported global', package.identifier, attr_name)
+                        continue
+                    # Else, this attribute is an unimportable submodule. Since
+                    # this is *NOT* safely ignorable, raise an exception.
+                    else:
+                        raise ImportError("No module named " + submodule_name)
+
+            # Yield this submodule's graph node to the caller.
+            yield submodule
+
+        self.msgin(4, "_import_importable_package_submodules ->")
+
 
     def _find_all_submodules(self, m):
         if not m.packagepath:
             return
+
+        # TODO: Unused and hence safely removable.
         # 'suffixes' used to be a list hardcoded to [".py", ".pyc", ".pyo"].
         # But we must also collect Python extension modules - although
         # we cannot separate normal dlls from Python extensions.
-        suffixes = [triple[0] for triple in imp.get_suffixes()]
+        # suffixes = [triple[0] for triple in imp.get_suffixes()]
+
         for path in m.packagepath:
             try:
                 names = zipio.listdir(path)
@@ -1056,6 +1902,7 @@ class ModuleGraph(ObjectGraph):
                 if info is None: continue
                 if info[0] != '__init__':
                     yield info[0]
+
 
     def alias_module(self, src_module_name, trg_module_name):
         """
@@ -1091,6 +1938,7 @@ class ModuleGraph(ObjectGraph):
         # See findNode() for details.
         self.lazynodes[trg_module_name] = Alias(src_module_name)
 
+
     def add_module(self, module):
         """
         Add the passed module node to the graph if not already added.
@@ -1100,15 +1948,15 @@ class ModuleGraph(ObjectGraph):
         parent node and adds this module node to its parent node's namespace.
 
         This high-level method wraps the low-level `addNode()` method, but is
-        typically *only* called by graph hooks adding runtime module nodes. For
+        typically _only_ called by graph hooks adding runtime module nodes. For
         all other node types, the `import_module()` method should be called.
 
         Parameters
         ----------
         module : BaseModule
-            Graph node for the module to be added.
+            Graph node of the module to be added.
         """
-        self.msg(3, 'import_module_runtime', module)
+        self.msg(3, 'add_module', module)
 
         # If no node exists for this module, add such a node.
         module_added = self.findNode(module.identifier)
@@ -1123,30 +1971,38 @@ class ModuleGraph(ObjectGraph):
         if parent_name:
             parent = self.findNode(parent_name)
             if parent is None:
-                self.msg(4, 'import_module_runtime parent not found:', parent_name)
+                self.msg(4, 'add_module parent not found:', parent_name)
             else:
                 self.createReference(module, parent)
-                parent[module_basename] = module
+                parent.add_submodule(module_basename, module)
+
 
     def append_package_path(self, package_name, directory):
         """
         Modulegraph does a good job at simulating Python's, but it can not
-        handle packagepath __path__ modifications packages make at runtime.
+        handle packagepath '__path__' modifications packages make at runtime.
+
         Therefore there is a mechanism whereby you can register extra paths
         in this map for a package, and it will be honored.
 
         NOTE: This method has to be called before a package is resolved by
               modulegraph.
 
-        :param module: fully qualified module name
-        :param directory: directory to append to the  __path__ attribute.
+        Parameters
+        ----------
+        module : str
+            Fully-qualified module name.
+        directory : str
+            Absolute or relative path of the directory to append to the
+            '__path__' attribute.
         """
+
         paths = self._package_path_map.setdefault(package_name, [])
         paths.append(directory)
 
 
     def _safe_import_module(
-        self, module_basename, module_name, parent_package):
+        self, module_partname, module_name, parent_module):
         """
         Create a new graph node for the module with the passed name under the
         parent package signified by the passed graph node _without_ raising
@@ -1161,25 +2017,27 @@ class ModuleGraph(ObjectGraph):
 
         Parameters
         ----------
-        module_basename : str
+        module_partname : str
             Unqualified name of the module to be imported (e.g., `text`).
         module_name : str
             Fully-qualified name of this module (e.g., `email.mime.text`).
-        parent_package : Package
-            Graph node for the previously imported package containing this
-            module _or_ `None` if this module is a **top-level module** (i.e.,
-            `fqname` contains no `.` delimiters).
+        parent_module : Package
+            Graph node of the previously imported parent module containing this
+            submodule _or_ `None` if this is a top-level module (i.e.,
+            `module_name` contains no `.` delimiters). This parent module is
+            typically but _not_ always a package (e.g., the `os.path` submodule
+            contained by the `os` module).
 
         Returns
         ----------
         Node
-            Graph node created for this module or `None` if this module is
+            Graph node created for this module _or_ `None` if this module is
             unimportable.
         """
-        self.msgin(3, "safe_import_module", module_basename, module_name, parent_package)
-        module = self.findNode(module_name)
+        self.msgin(3, "safe_import_module", module_partname, module_name, parent_module)
 
         # If this module has *NOT* already been imported, do so.
+        module = self.findNode(module_name)
         if module is None:
             # List of the absolute paths of all directories to be searched for
             # this module. This effectively defaults to "sys.path".
@@ -1189,11 +2047,11 @@ class ModuleGraph(ObjectGraph):
             file_handle = None
 
             # If this module has a parent package...
-            if parent_package is not None:
+            if parent_module is not None:
                 # ...with a list of the absolute paths of all directories
                 # comprising this package, prefer that to "sys.path".
-                if parent_package.packagepath is not None:
-                    search_dirs = parent_package.packagepath
+                if parent_module.packagepath is not None:
+                    search_dirs = parent_module.packagepath
                 # Else, something is horribly wrong. Return emptiness.
                 else:
                     self.msgout(3, "safe_import_module -> None (parent_parent.packagepath is None)")
@@ -1202,7 +2060,7 @@ class ModuleGraph(ObjectGraph):
             try:
                 try:
                     file_handle, pathname, metadata = self._find_module(
-                        module_basename, search_dirs, parent_package)
+                        module_partname, search_dirs, parent_module)
                 except ImportError as exc:
                     self.msgout(3, "safe_import_module -> None (%r)" % exc)
                     return None
@@ -1213,23 +2071,29 @@ class ModuleGraph(ObjectGraph):
                 if file_handle is not None:
                     file_handle.close()
 
-        # If this module has a parent package, add an edge from the former to
-        # the latter regardless of whether this module has already been
-        # imported or not.
-        if parent_package is not None:
-            self.msg(4, "safe_import_module create reference", module, "->", parent_package)
+        # If this is a submodule rather than top-level module...
+        if parent_module is not None:
+            self.msg(4, "safe_import_module create reference", module, "->", parent_module)
+
+            # Add an edge from this submodule to its parent module.
             self._updateReference(
-                module, parent_package, edge_data=DependencyInfo(
+                module, parent_module, edge_data=DependencyInfo(
                     conditional=False,
                     fromlist=False,
                     function=False,
                     tryexcept=False,
             ))
-            parent_package[module_basename] = module
 
+            # Add this submodule to its parent module.
+            parent_module.add_submodule(module_partname, module)
+
+        # Return this module.
         self.msgout(3, "safe_import_module ->", module)
         return module
 
+
+    #FIXME: For clarity, rename method parameters to:
+    #    def _load_module(self, module_name, file_handle, pathname, imp_info):
     def _load_module(self, fqname, fp, pathname, info):
         suffix, mode, typ = info
         self.msgin(2, "load_module", fqname, fp and "fp", pathname)
@@ -1301,21 +2165,111 @@ class ModuleGraph(ObjectGraph):
         self.msgout(2, "load_module ->", m)
         return m
 
-    def _safe_import_hook(self, name, caller, fromlist, level=DEFAULT_IMPORT_LEVEL, attr=None):
-        # wrapper for self.import_hook() that won't raise ImportError
 
-        # List of graph nodes created for the modules imported by this call.
-        mods = None
+    def _safe_import_hook(
+        self, target_module_partname, source_module, target_attr_names,
+        level=DEFAULT_IMPORT_LEVEL, edge_attr=None):
+        """
+        Import the module with the passed name and all parent packages of this
+        module from the previously imported caller module signified by the
+        passed graph node _without_ raising `ImportError` exceptions.
+
+        This method wraps the lowel-level `_import_hook()` method. On catching
+        an `ImportError` exception raised by that method, this method creates
+        and adds a `MissingNode` instance describing the unimportable module to
+        the graph instead.
+
+        Parameters
+        ----------
+        target_module_partname : str
+            Partially-qualified name of the module to be imported. If `level`
+            is:
+            * `ABSOLUTE_OR_RELATIVE_IMPORT_LEVEL` (e.g., the Python 2 default)
+              or a positive integer (e.g., an explicit relative import), the
+              fully-qualified name of this module is the concatenation of the
+              fully-qualified name of the caller module's package and this
+              parameter.
+            * `ABSOLUTE_IMPORT_LEVEL` (e.g., the Python 3 default), this name
+              is already fully-qualified.
+            * A non-negative integer (e.g., `1`), this name is typically the
+              empty string. In this case, this is a "from"-style relative
+              import (e.g., "from . import bar") and the fully-qualified name
+              of this module is dynamically resolved by import machinery.
+        source_module : Node
+            Graph node for the previously imported **caller module** (i.e.,
+            module containing the `import` statement triggering the call to
+            this method) _or_ `None` if this module is to be imported in a
+            "disconnected" manner. **Passing `None` is _not_ recommended.**
+            Doing so produces a disconnected graph in which the graph node
+            created for the module to be imported will be disconnected and
+            hence unreachable from all other nodes -- which frequently causes
+            subtle issues in external callers (e.g., PyInstaller, which
+            silently ignores unreachable nodes).
+        target_attr_names : list
+            List of the unqualified names of all submodules and attributes to
+            be imported via a `from`-style import statement from this target
+            module if any (e.g., the list `[encode_base64, encode_noop]` for
+            the import `from email.encoders import encode_base64, encode_noop`)
+            _or_ `None` otherwise. Ignored unless `source_module` is the graph
+            node of a package (i.e., is an instance of the `Package` class).
+            Why? Because:
+            * Consistency. The `_import_importable_package_submodules()`
+              method accepts a similar list applicable only to packages.
+            * Efficiency. Unlike packages, modules cannot physically contain
+              submodules. Hence, any target module imported via a `from`-style
+              import statement as an attribute from another target parent
+              module must itself have been imported in that target parent
+              module. The import statement responsible for that import must
+              already have been previously parsed by `ModuleGraph`, in which
+              case that target module will already be frozen by PyInstaller.
+              These imports are safely ignorable here.
+        level : int
+            Whether to perform an absolute or relative import. This parameter
+            corresponds exactly to the parameter of the same name accepted by
+            the `__import__()` built-in: "The default is -1 which indicates
+            both absolute and relative imports will be attempted. 0 means only
+            perform absolute imports. Positive values for level indicate the
+            number of parent directories to search relative to the directory of
+            the module calling `__import__()`." Defaults to -1 under Python 2
+            and 0 under Python 3. Since this default depends on the major
+            version of the current Python interpreter, depending on this
+            default can result in unpredictable and non-portable behaviour.
+            Callers are strongly recommended to explicitly pass this parameter
+            rather than implicitly accept this default.
+
+        Returns
+        ----------
+        list
+            List of the graph nodes created for all modules explicitly imported
+            by this call, including the passed module and all submodules listed
+            in `target_attr_names` _but_ excluding all parent packages
+            implicitly imported by this call. If `target_attr_names` is either
+            `None` or the empty list, this is guaranteed to be a list of one
+            element: the graph node created for the passed module. As above,
+            `MissingNode` instances are created for all unimportable modules.
+        """
+        self.msg(3, "_safe_import_hook", target_module_partname, source_module, target_attr_names, level)
+
+        # List of the graph nodes created for all target modules both
+        # imported by and returned from this call, whose:
+        #
+        # * First element is the graph node for the core target module
+        #   specified by the "target_module_partname" parameter.
+        # * Remaining elements are the graph nodes for all target submodules
+        #   specified by the "target_attr_names" parameter.
+        target_modules = None
 
         # True if this is a Python 2-style implicit relative import of a
         # SWIG-generated C extension.
         is_swig_import = False
 
-        # Attempt to import the module with Python's standard module importers.
+        # Attempt to import this target module in the customary way.
         try:
-            mods = self.import_hook(name, caller, level=level, attr=attr)
+            target_modules = self.import_hook(
+                target_module_partname, source_module,
+                target_attr_names=None, level=level, edge_attr=edge_attr)
         # Failing that, defer to custom module importers handling non-standard
-        # import schemes (e.g., SWIG, six).
+        # import schemes (namely, SWIG).
         except ImportError as msg:
             # If this is an absolute top-level import under Python 3 and if the
             # name to be imported is the caller's name prefixed by "_", this
@@ -1347,252 +2301,607 @@ class ModuleGraph(ObjectGraph):
             # "When linking the module, the name of the output file has to match
             #  the name of the module prefixed by an underscore."
             #
-            # A MissingModule is not a SWIG import candidate.
-            if caller is not None and type(caller) is not MissingModule and \
-                            fromlist is None and level == 0 and \
-                            caller.filename.endswith('.py') and \
-                            name == '_' + caller.identifier.rpartition('.')[2] and \
-                            sys.version_info[0] == 3:
-                self.msg(4, 'SWIG import candidate (name=%r, caller=%r, level=%r)' % (name, caller, level))
+            # Only source modules (e.g., ".py"-suffixed files) are SWIG import
+            # candidates. All other node types are safely ignorable.
+            if (
+                source_module is not None and
+                target_attr_names is None and
+                level == ABSOLUTE_IMPORT_LEVEL and
+                type(source_module) is SourceModule and
+                target_module_partname ==
+                    '_' + source_module.identifier.rpartition('.')[2] and
+                sys.version_info[0] == 3):
+                self.msg(4, 'SWIG import candidate (name=%r, caller=%r, level=%r)' % (target_module_partname, source_module, level))
 
                 # TODO Define a new function util.open_text_file() performing
                 # this logic, which is repeated numerous times in this module.
-                with open(caller.filename, 'rb') as caller_file:
-                    encoding = util.guess_encoding(caller_file)
-                with open(caller.filename, _READ_MODE, encoding=encoding) as caller_file:
-                    first_line = caller_file.readline()
+                # FIXME: Actually, can't we just use the new compat.open()
+                # function to reliably open text files in a portable manner?
+                with open(source_module.filename, 'rb') as source_module_file:
+                    encoding = util.guess_encoding(source_module_file)
+                with open(
+                    source_module.filename, _READ_MODE, encoding=encoding) as (
+                    source_module_file):
+                    first_line = source_module_file.readline()
                     self.msg(5, 'SWIG import candidate shebang: %r' % (first_line))
+
                     if "automatically generated by SWIG" in first_line:
                         is_swig_import = True
 
-                        # Convert this Python 2-style implicit relative import
-                        # into a Python 3-style explicit relative import for
-                        # the duration of this function call by overwriting
-                        # the original parameters passed to this call.
-                        fromlist = [name]
-                        name = ''
+                        # Convert this Python 2-compliant implicit relative
+                        # import prohibited by Python 3 into a Python
+                        # 3-compliant explicit relative "from"-style import for
+                        # the duration of this function call by overwriting the
+                        # original parameters passed to this call.
+                        target_attr_names = [target_module_partname]
+                        target_module_partname = ''
                         level = 1
-                        self.msg(2, 'SWIG import (caller=%r, fromlist=%r, level=%r)' % (caller, fromlist, level))
+                        self.msg(2, 'SWIG import (caller=%r, fromlist=%r, level=%r)' % (source_module, target_attr_names, level))
 
-                        # Import the caller module importing this library.
+                        # Import this target SWIG C extension's package.
                         try:
-                            mods = self.import_hook(
-                                name, caller, level=level, attr=attr)
+                            target_modules = self.import_hook(
+                                target_module_partname, source_module,
+                                target_attr_names=None,
+                                level=level,
+                                edge_attr=edge_attr)
                         except ImportError as msg:
                             self.msg(2, "SWIG ImportError:", str(msg))
 
-            # If this module remains unimportable, add a MissingModule node.
-            if mods is None:
+            # If this module remains unimportable...
+            if target_modules is None:
                 self.msg(2, "ImportError:", str(msg))
 
-                m = self.createNode(MissingModule, _path_from_importerror(msg, name))
-                self._updateReference(caller, m, edge_data=attr)
+                # Add this module as a MissingModule node.
+                target_module = self.createNode(
+                    MissingModule,
+                    _path_from_importerror(msg, target_module_partname))
+                self._updateReference(
+                    source_module, target_module, edge_data=edge_attr)
 
-        # If this module was successfully imported, get its graph node.
-        if mods is not None:
-            assert len(mods) == 1, 'Expected import_hook() to return only one module but received: %r' % str(mods)
-            m = list(mods)[0]
+                # Initialize this list to this node.
+                target_modules = [target_module]
 
-        subs = [m]
-        if isinstance(attr, DependencyInfo):
-            attr = attr._replace(fromlist=True)
-        for sub in (fromlist or ()):
-            # If this name is in the module namespace already,
-            # then add the entry to the list of substitutions
-            if sub in m:
-                sm = m[sub]
-                if sm is not None:
-                    if sm not in subs:
-                        self._updateReference(caller, sm, edge_data=attr)
-                        subs.append(sm)
-                    continue
+        # Ensure that the above logic imported exactly one target module.
+        assert len(target_modules) == 1, (
+            'Expected import_hook() to'
+            'return only one module but received: {}'.format(target_modules))
 
-            elif sub in m.globalnames:
-                # Global variable in the module, ignore
-                self.msg(4, 'Global name found:', m.identifier, sub)
-                continue
+        # Target module imported above.
+        target_module = target_modules[0]
+
+        if isinstance(edge_attr, DependencyInfo):
+            edge_attr = edge_attr._replace(fromlist=True)
+
+        # If this is a "from"-style import *AND* this target module is a
+        # package, import all attributes listed by the "import" clause of this
+        # import that are submodules of this package. If this target module is
+        # *NOT* a package, these attributes are always ignorable globals (e.g.,
+        # classes, variables) defined at the top level of this module.
+        #
+        # If this target module is a non-package, it could still contain
+        # importable submodules (e.g., the non-package `os` module containing
+        # the `os.path` submodule). In this case, these submodules are already
+        # imported by this target module's pure-Python code. Since our import
+        # scanner already detects these imports, these submodules need *NOT* be
+        # reimported here. (Doing so would be harmless but inefficient.)
+        if target_attr_names and isinstance(target_module, Package):
+            # For the name of each attribute imported from this target package
+            # into this source module...
+            for target_submodule_partname in target_attr_names:
+                #FIXME: Is this optimization *REALLY* an optimization or at all
+                #necessary? The findNode() method called below should already
+                #be heavily optimized, in which case this optimization here is
+                #premature, senseless, and should be eliminated.
+
+                # If this attribute is a previously imported submodule of this
+                # target module, optimize this edge case.
+                if target_module.is_submodule(target_submodule_partname):
+                    # Graph node for this submodule.
+                    target_submodule = target_module.get_submodule(
+                        target_submodule_partname)
+
+                    #FIXME: What? Shouldn't "target_submodule" *ALWAYS* be
+                    #non-None here? Assert this to be non-None instead.
+                    if target_submodule is not None:
+                        #FIXME: Why does duplication matter? List searches are
+                        #mildly expensive.
+
+                        # If this submodule has not already been added to the
+                        # list of submodules to be returned, do so.
+                        if target_submodule not in target_modules:
+                            self._updateReference(
+                                source_module,
+                                target_submodule,
+                                edge_data=edge_attr)
+                            target_modules.append(target_submodule)
+                        continue
+
+                # Fully-qualified name of this submodule.
+                target_submodule_name = (
+                    target_module.identifier + '.' + target_submodule_partname)
+
+                # Graph node of this submodule if previously imported or None.
+                target_submodule = self.findNode(target_submodule_name)
+
+                # If this submodule has not been imported, do so as if this
+                # submodule were the only attribute listed by the "import"
+                # clause of this import (e.g., as "from foo import bar" rather
+                # than "from foo import car, far, bar").
+                if target_submodule is None:
+                    # Attempt to import this submodule.
+                    try:
+                        # Ignore the list of graph nodes returned by this
+                        # method. If both this submodule's package and this
+                        # submodule are importable, this method returns a
+                        # 2-element list whose second element is this
+                        # submodule's graph node. However, if this submodule's
+                        # package is importable but this submodule is not,
+                        # this submodule is either:
+                        #
+                        # * An ignorable global attribute defined at the top
+                        #   level of this package's "__init__" submodule. In
+                        #   this case, this method returns a 1-element list
+                        #   without raising an exception.
+                        # * A non-ignorable unimportable submodule. In this
+                        #   case, this method raises an "ImportError".
+                        #
+                        # While the first two cases are disambiguatable by the
+                        # length of this list, doing so would render this code
+                        # dependent on import_hook() details subject to change.
+                        # Instead, call findNode() to decide the truthiness.
+                        self.import_hook(
+                            target_module_partname, source_module,
+                            target_attr_names=[target_submodule_partname],
+                            level=level,
+                            edge_attr=edge_attr)
+
+                        # Graph node of this submodule imported by the prior
+                        # call if importable or None otherwise.
+                        target_submodule = self.findNode(target_submodule_name)
+
+                        # If this submodule does not exist, this *MUST* be an
+                        # ignorable global attribute defined at the top level
+                        # of this package's "__init__" submodule.
+                        if target_submodule is None:
+                            # Assert this to actually be the case.
+                            assert target_module.is_global_attr(
+                                target_submodule_partname), (
+                                'No global named {} in {}.__init__'.format(
+                                    target_submodule_partname,
+                                    target_module.identifier))
+
+                            # Skip this safely ignorable importation to the
+                            # next attribute. See similar logic in the body of
+                            # _import_importable_package_submodules().
+                            self.msg(4, '_safe_import_hook', 'ignoring imported non-module global', target_module.identifier, target_submodule_partname)
+                            continue
+
+                        # If this is a SWIG C extension, instruct PyInstaller
+                        # to freeze this extension under its unqualified rather
+                        # than qualified name (e.g., as "_csr" rather than
+                        # "scipy.sparse.sparsetools._csr"), permitting the
+                        # implicit relative import in its parent SWIG module to
+                        # successfully find this extension.
+                        if is_swig_import:
+                            # If a graph node with this name already exists,
+                            # avoid collisions by emitting an error instead.
+                            if self.findNode(target_submodule_partname):
+                                self.msg(2, 'SWIG import error: %r basename %r already exists' % (target_submodule_name, target_submodule_partname))
+                            else:
+                                self.msg(4, 'SWIG import renamed from %r to %r' % (target_submodule_name, target_submodule_partname))
+                                target_submodule.identifier = (
+                                    target_submodule_partname)
+                    # If this submodule is unimportable, add a MissingModule.
+                    except ImportError as msg:
+                        self.msg(2, "ImportError:", str(msg))
+                        #sm = self.createNode(MissingModule, _path_from_importerror(msg, fullname))
+                        target_submodule = self.createNode(
+                            MissingModule, target_submodule_name)
+
+                # Add this submodule to its package.
+                target_module.add_submodule(
+                    target_submodule_partname, target_submodule)
+                if target_submodule is not None:
+                    self._updateReference(
+                        target_module, target_submodule, edge_data=edge_attr)
+                    self._updateReference(
+                        source_module, target_submodule, edge_data=edge_attr)
+
+                    if target_submodule not in target_modules:
+                        target_modules.append(target_submodule)
+
+        # Return the list of all target modules imported by this call.
+        return target_modules
 
 
-            # See if we can load it
-            #    fullname = name + '.' + sub
-            fullname = m.identifier + '.' + sub
-            #else:
-            #    print("XXX", repr(name), repr(sub), repr(caller), repr(m))
-            sm = self.findNode(fullname)
-            if sm is None:
-                try:
-                    sm = self.import_hook(name, caller, fromlist=[sub], level=level, attr=attr)
-                except ImportError as msg:
-                    self.msg(2, "ImportError:", str(msg))
-                    #sm = self.createNode(MissingModule, _path_from_importerror(msg, fullname))
-                    sm = self.createNode(MissingModule, fullname)
-                else:
-                    sm = self.findNode(fullname)
-                    if sm is None:
-                        sm = self.createNode(MissingModule, fullname)
+    def _scan_code(
+        self,
+        module,
+        module_code_object,
+        module_code_object_ast=None):
+        """
+        Parse and add all import statements from the passed code object of the
+        passed source module to this graph, recursively.
 
-                    # If this is a SWIG C extension, instruct downstream
-                    # freezers (py2app, PyInstaller) to freeze this extension
-                    # under its unqualified rather than qualified name (e.g.,
-                    # as "_csr" rather than "scipy.sparse.sparsetools._csr"),
-                    # permitting the implicit relative import in its parent
-                    # SWIG module to successfully find this extension.
-                    if is_swig_import:
-                        # If a graph node with that name already exists, avoid
-                        # collisions by emitting an error instead.
-                        if self.findNode(sub):
-                            self.msg(2, 'SWIG import error: %r basename %r already exists' % (fullname, sub))
-                        else:
-                            self.msg(4, 'SWIG import renamed from %r to %r' % (fullname, sub))
-                            sm.identifier = sub
+        **This method is at the root of all `ModuleGraph` recursion.**
+        Recursion begins here and ends when all import statements in all code
+        objects of all modules transitively imported by the source module
+        passed to the first call to this method have been added to the graph.
+        Specifically, this method:
 
-            m[sub] = sm
-            if sm is not None:
-                self._updateReference(m, sm, edge_data=attr)
-                self._updateReference(caller, sm, edge_data=attr)
-                if sm not in subs:
-                    subs.append(sm)
-        return subs
+        1. If the passed `module_code_object_ast` parameter is non-`None`,
+           parses all import statements from this object.
+        2. Else, parses all import statements from the passed
+           `module_code_object` parameter.
+        1. For each such import statement:
+           1. Adds to this `ModuleGraph` instance:
+              1. Nodes for all target modules of these imports.
+              1. Directed edges from this source module to these target
+                 modules.
+           2. Recursively calls this method with these target modules.
 
-    def _scan_code(self, m, co, co_ast=None):
-        if co_ast is not None:
-            self._scan_ast(co_ast, m)
-            self._scan_bytecode_stores(co, m)
+        Parameters
+        ----------
+        module : Node
+            Graph node of the module to be parsed.
+        module_code_object : PyCodeObject
+            Code object providing this module's disassembled Python bytecode.
+            Ignored unless `module_code_object_ast` is `None`.
+        module_code_object_ast : optional[ast.AST]
+            Optional abstract syntax tree (AST) of this module if any or `None`
+            otherwise. Defaults to `None`, in which case the passed
+            `module_code_object` is parsed instead.
+        """
+
+        # For safety, guard against multiple scans of the same module by
+        # resetting this module's list of deferred target imports. While
+        # uncommon, this edge case can occur due to:
+        #
+        # * Dynamic package replacement via the replacePackage() function. For
+        #   example, the real "_xmlplus" package dynamically replaces itself
+        #   with the fake "xml" package into the "sys.modules" cache of all
+        #   currently loaded modules at runtime.
+        module._deferred_imports = []
+
+        # Parse all imports from this module *BEFORE* adding these imports to
+        # the graph. If an AST is provided, parse that rather than this
+        # module's code object.
+        if module_code_object_ast is not None:
+            # Parse this module's AST for imports.
+            self._scan_ast(module, module_code_object_ast)
+
+            # Parse this module's code object for all relevant non-imports
+            # (e.g., global variable declarations and undeclarations).
+            self._scan_bytecode(
+                module, module_code_object, is_scanning_imports=False)
+        # Else, parse this module's code object for imports.
         else:
-            m._imported_modules = []
-            self._scan_bytecode(co, m)
+            self._scan_bytecode(
+                module, module_code_object, is_scanning_imports=True)
 
-        # Actually import the modules collected while scanning.
-        # We need to suspend the globalnames as otherwise
-        # `_safe_import_hook()` would take identfiers imported via
-        # `from . import abc` as existing global names and not try to
-        # import them. Please note: This only effects this form of
-        # import where relative_module is "." For all other cases, the
-        # imported module is already processed and all global names
-        # are in place anyway.
-        globalnames = m.globalnames
-        m.globalnames = set()
-        self._process_imports(m)
-        m.globalnames = globalnames
+        # Add all imports parsed above to this graph.
+        self._process_imports(module)
 
 
-    def _scan_ast(self, co, m):
-        visitor = _Visitor(self, m)
-        visitor.visit(co)
+    def _scan_ast(self, module, module_code_object_ast):
+        """
+        Parse and add all import statements from the passed abstract syntax
+        tree (AST) of the passed source module to this graph, non-recursively.
 
-    def _scan_bytecode_stores(self, co, m,
-            STORE_NAME=_Bchr(dis.opname.index('STORE_NAME')),
-            STORE_GLOBAL=_Bchr(dis.opname.index('STORE_GLOBAL')),
-            HAVE_ARGUMENT=_Bchr(dis.HAVE_ARGUMENT),
-            unpack=struct.unpack):
+        Parameters
+        ----------
+        module : Node
+            Graph node of the module to be parsed.
+        module_code_object_ast : ast.AST
+            Abstract syntax tree (AST) of this module to be parsed.
+        """
 
-        extended_import = bool(sys.version_info[:2] >= (2,5))
+        visitor = _Visitor(self, module)
+        visitor.visit(module_code_object_ast)
 
-        code = co.co_code
-        constants = co.co_consts
-        n = len(code)
-        i = 0
 
-        while i < n:
-            c = code[i]
-            i += 1
-            if c >= HAVE_ARGUMENT:
-                i = i+2
+    #FIXME: Optimize. Global attributes added by this method are tested by
+    #other methods *ONLY* for packages, implying this method should scan and
+    #handle opcodes pertaining to global attributes (e.g.,
+    #"_STORE_NAME_OPCODE", "_DELETE_GLOBAL_OPCODE") only if the passed "module"
+    #object is an instance of the "Package" class. For all other module types,
+    #these opcodes should simply be ignored.
+    #
+    #After doing so, the "Node._global_attr_names" attribute and all methods
+    #using this attribute (e.g., Node.is_global()) should be moved from the
+    #"Node" superclass to the "Package" subclass.
+    def _scan_bytecode(
+        self, module, module_code_object, is_scanning_imports):
+        """
+        Parse and add all import statements from the passed code object of the
+        passed source module to this graph, non-recursively.
 
-            if c == STORE_NAME or c == STORE_GLOBAL:
-                # keep track of all global names that are assigned to
-                oparg = unpack('<H', code[i - 2:i])[0]
-                name = co.co_names[oparg]
-                m.globalnames.add(name)
+        This method parses all reasonably parsable operations (i.e., operations
+        that are both syntactically and semantically parsable _without_
+        requiring Turing-complete interpretation) directly or indirectly
+        involving module importation from this code object. This includes:
 
-        cotype = type(co)
-        for c in constants:
-            if isinstance(c, cotype):
-                self._scan_bytecode_stores(c, m)
+        * `_IMPORT_NAME_OPCODE`, denoting an import statement. Ignored unless
+          the passed `is_scanning_imports` parameter is `True`.
+        * `_STORE_NAME_OPCODE` and `_STORE_GLOBAL_OPCODE`, denoting the
+          declaration of a global attribute (e.g., class, variable) in this
+          module. This method stores each such declaration for subsequent
+          lookup. While global attributes are usually irrelevant to import
+          parsing, they remain the only means of distinguishing erroneous
+          non-ignorable attempts to import non-existent submodules of a package
+          from successful ignorable attempts to import existing global
+          attributes of a package's `__init__` submodule (e.g., the `bar` in
+          `from foo import bar`, which is either a non-ignorable submodule of
+          `foo` or an ignorable global attribute of `foo.__init__`).
+        * `_DELETE_NAME_OPCODE` and `_DELETE_GLOBAL_OPCODE`, denoting the
+          undeclaration of a previously declared global attribute in this
+          module.
 
-    def _scan_bytecode(self, co, m,
-            HAVE_ARGUMENT=_Bchr(dis.HAVE_ARGUMENT),
-            LOAD_CONST=_Bchr(dis.opname.index('LOAD_CONST')),
-            IMPORT_NAME=_Bchr(dis.opname.index('IMPORT_NAME')),
-            IMPORT_FROM=_Bchr(dis.opname.index('IMPORT_FROM')),
-            STORE_NAME=_Bchr(dis.opname.index('STORE_NAME')),
-            STORE_GLOBAL=_Bchr(dis.opname.index('STORE_GLOBAL')),
-            unpack=struct.unpack):
+        Since `ModuleGraph` is _not_ intended to replicate the behaviour of a
+        full-featured Turing-complete Python interpreter, this method ignores
+        operations that are _not_ reasonably parsable from this code object --
+        even those directly or indirectly involving module importation. This
+        includes:
+
+        * `STORE_ATTR(namei)`, implementing `TOS.name = TOS1`. If `TOS` is the
+          name of a target module currently imported into the namespace of the
+          passed source module, this opcode would ideally be parsed to add that
+          global attribute to that target module. Since this addition only
+          conditionally occurs on the importation of this source module and
+          execution of the code branch in this module performing this addition,
+          however, that global _cannot_ be unconditionally added to that target
+          module. In short, only Turing-complete behaviour suffices.
+        * `DELETE_ATTR(namei)`, implementing `del TOS.name`. If `TOS` is the
+          name of a target module currently imported into the namespace of the
+          passed source module, this opcode would ideally be parsed to remove
+          that global attribute from that target module. Again, however, only
+          Turing-complete behaviour suffices.
+
+        Parameters
+        ----------
+        module : Node
+            Graph node of the module to be parsed.
+        module_code_object : PyCodeObject
+            Code object of the module to be parsed.
+        is_scanning_imports : bool
+            `True` only if this method is parsing import statements from
+            `IMPORT_NAME` opcodes. If `False`, no import statements will be
+            parsed. This parameter is typically:
+            * `True` when parsing this module's code object for such imports.
+            * `False` when parsing this module's abstract syntax tree (AST)
+              (rather than code object) for such imports. In this case, that
+              parsing will have already parsed import statements, which this
+              parsing must avoid repeating.
+        """
+
+        #FIXME: Since PyInstaller requires Python >= 2.7, "extended_import" is
+        #guaranteed to *ALWAYS* be "True". Therefore:
+        #
+        #* Remove this boolean.
+        #* Reduce the conditional testing this boolean below to only the body
+        #  of the "if extended_import:" branch.
 
         # Python >=2.5: LOAD_CONST flags, LOAD_CONST names, IMPORT_NAME name
         # Python < 2.5: LOAD_CONST names, IMPORT_NAME name
         extended_import = bool(sys.version_info[:2] >= (2,5))
 
-        code = co.co_code
-        constants = co.co_consts
-        n = len(code)
-        i = 0
+        # List of all bytes comprising this source module's compiled bytecode.
+        code_bytes = module_code_object.co_code
 
-        level = None
-        fromlist = None
+        # Number of such bytes.
+        num_code_bytes = len(code_bytes)
 
-        while i < n:
-            c = code[i]
-            i += 1
-            if c >= HAVE_ARGUMENT:
-                i = i+2
+        # Index of the current byte in this list being parsed.
+        code_byte_index = 0
 
-            if c == IMPORT_NAME:
+        #FIXME: Repeating "code_byte_index - 2" everywhere below to obtain the
+        #first byte of this opcode's argument is silly, obfuscatory, and
+        #inefficient. Instead:
+        #
+        #* Define a new "code_byte_arg_index" integer local.
+        #* Set "code_byte_arg_index = code_byte_index" here.
+        #* Use "code_byte_arg_index" in lieu of "code_byte_index - 2" below.
+        #
+        #No other changes are required, which is relieving to us all.
+
+        def get_operation_arg():
+            """
+            Get the argument passed to the current bytecode operation as an
+            unsigned short (i.e., 2-byte integer).
+            """
+            return unpack(
+                '<H', code_bytes[code_byte_index - 2:code_byte_index])[0]
+
+        def get_operation_arg_name():
+            """
+            Get the name from this module's code object whose index in this
+            list of names is the unsigned short (i.e., 2-byte integer) argument
+            passed to the current bytecode operation.
+            """
+            co_names_index = get_operation_arg()
+            return module_code_object.co_names[co_names_index]
+
+        # For each byte index into this list of bytecode bytes...
+        while code_byte_index < num_code_bytes:
+            # Opcode signifying the current type of operation being performed.
+            code_byte = code_bytes[code_byte_index]
+
+            # Iterate the current byte index past this 1-byte opcode.
+            code_byte_index += 1
+
+            # If this opcode accepts an argument, this argument is guaranteed
+            # by design to be two bytes in size. As the current byte index is
+            # at the first of these two bytes, iterating this index past both
+            # bytes guarantees this index to now point at another opcode.
+            #
+            # To obtain the index of the first byte of this argument, simply
+            # decrement "2" from this index (e.g., "code_byte_index - 2").
+            #
+            # Note, however, that this brute-force approach effectively ignores
+            # extended arguments. While most opcodes accepting an argument only
+            # require a 2-byte argument, some require a 4-byte argument. To
+            # seamlessly support both, the most significant two bytes of such
+            # 4-byte arguments are split into a preceding "EXTENDED_ARG"
+            # opcode. For the moment, no opcode below requires such arguments.
+            #
+            # For further details, see:
+            #     https://docs.python.org/3/library/dis.html#opcode-HAVE_ARGUMENT
+            #     https://docs.python.org/3/library/dis.html#opcode-EXTENDED_ARG
+            if code_byte >= _HAVE_ARGUMENT_OPCODE:
+                code_byte_index = code_byte_index+2
+
+            # If this is an import statement originating from this module,
+            # parse this import.
+            #
+            # Note that the related "IMPORT_FROM" opcode need *NOT* be parsed.
+            # "IMPORT_NAME" suffices. For further details, see
+            #     http://probablyprogramming.com/2008/04/14/python-import_name
+            if code_byte == _IMPORT_NAME_OPCODE:
+                # If this method is ignoring import statements, skip to the
+                # next opcode.
+                if not is_scanning_imports:
+                    continue
+
                 if extended_import:
-                    assert code[i-9] == LOAD_CONST
-                    assert code[i-6] == LOAD_CONST
-                    arg1, arg2 = unpack('<xHxH', code[i-9:i-3])
-                    level = co.co_consts[arg1]
-                    fromlist = co.co_consts[arg2]
+                    assert code_bytes[code_byte_index-9] == _LOAD_CONST_OPCODE
+                    assert code_bytes[code_byte_index-6] == _LOAD_CONST_OPCODE
+                    arg1, arg2 = unpack('<xHxH', code_bytes[code_byte_index-9:code_byte_index-3])
+                    level = module_code_object.co_consts[arg1]
+                    target_attr_names = module_code_object.co_consts[arg2]
                 else:
-                    assert code[-6] == LOAD_CONST
-                    arg1, = unpack('<xH', code[i-6:i-3])
+                    assert code_bytes[-6] == _LOAD_CONST_OPCODE
+                    arg1, = unpack(
+                        '<xH', code_bytes[code_byte_index-6:code_byte_index-3])
                     level = -1
-                    fromlist = co.co_consts[arg1]
+                    target_attr_names = module_code_object.co_consts[arg1]
 
-                assert fromlist is None or type(fromlist) is tuple
-                oparg, = unpack('<H', code[i - 2:i])
-                name = co.co_names[oparg]
+                assert target_attr_names is None or type(target_attr_names) is tuple
+                target_module_partname = get_operation_arg_name()
+
+                #FIXME: The exact same logic appears in _collect_import(),
+                #which isn't particularly helpful. Instead, defer this logic
+                #until later by:
+                #
+                #* Refactor the "_deferred_imports" list to contain 2-tuples
+                #  "(_safe_import_hook_args, _safe_import_hook_kwargs)" rather
+                #  than 3-tuples "(have_star, _safe_import_hook_args,
+                #  _safe_import_hook_kwargs)".
+                #* Stop prepending these tuples by a "have_star" boolean both
+                #  here, in _collect_import(), and in _process_imports().
+                #* Shift the logic below to _process_imports().
+                #* Remove the same logic from _collect_import().
                 have_star = False
-                if fromlist is not None:
-                    fromlist = set(fromlist)
-                    if '*' in fromlist:
-                        fromlist.remove('*')
+                if target_attr_names is not None:
+                    target_attr_names = set(target_attr_names)
+                    if '*' in target_attr_names:
+                        target_attr_names.remove('*')
                         have_star = True
 
-                # Collect this import to belong to this module
-                m._imported_modules.append((have_star,
-                                            (name, m, fromlist, level),
-                                            {}))
+                # Record this import as originating from this module for
+                # subsequent handling by the _process_imports() method.
+                module._deferred_imports.append((
+                    have_star,
+                    (target_module_partname, module, target_attr_names, level),
+                    {}
+                ))
+            # Else if this is the declaration of a global attribute (e.g.,
+            # class, variable) in this module, store this declaration for
+            # subsequent lookup. See method docstring for further details.
+            #
+            # Global attributes are usually irrelevant to import parsing, but
+            # remain the only means of distinguishing erroneous non-ignorable
+            # attempts to import non-existent submodules of a package from
+            # successful ignorable attempts to import existing global
+            # attributes of a package's "__init__" submodule (e.g., the "bar"
+            # in "from foo import bar", which is either a non-ignorable
+            # submodule of "foo" or an ignorable global attribute of
+            # "foo.__init__").
+            elif (
+                code_byte == _STORE_NAME_OPCODE or
+                code_byte == _STORE_GLOBAL_OPCODE):
+                global_attr_name = get_operation_arg_name()
+                module.add_global_attr(global_attr_name)
+            # Else if this is the undeclaration of a previously declared global
+            # attribute (e.g., class, variable) in this module, remove that
+            # declaration to prevent subsequent lookup. See method docstring
+            # for further details.
+            elif (
+                code_byte == _DELETE_NAME_OPCODE or
+                code_byte == _DELETE_GLOBAL_OPCODE):
+                global_attr_name = get_operation_arg_name()
+                module.remove_global_attr_if_found(global_attr_name)
 
-            elif c == STORE_NAME or c == STORE_GLOBAL:
-                # keep track of all global names that are assigned to
-                oparg = unpack('<H', code[i - 2:i])[0]
-                name = co.co_names[oparg]
-                m.globalnames.add(name)
+        #FIXME: This should really be a global constant declared at the top of
+        #this module instead.
 
-        cotype = type(co)
-        for c in constants:
-            if isinstance(c, cotype):
-                self._scan_bytecode(c, m)
+        # Type of all code objects.
+        code_object_type = type(module_code_object)
+
+        # List of all constants in this code object.
+        constants = module_code_object.co_consts
+
+        # For each constant in this code object that is itself a code object,
+        # parse this constant in the same manner.
+        for constant in constants:
+            if isinstance(constant, code_object_type):
+                self._scan_bytecode(module, constant, is_scanning_imports)
 
 
-    def _process_imports(self, m):
+    def _process_imports(self, source_module):
         """
-        Actally import the modules collected in _scan_code (resp.
-        _scan_ast, _scan_bytecode, and _scan_bytecode_stores).
+        Graph all target modules whose importations were previously parsed from
+        the passed source module by a prior call to the `_scan_code()` method
+        and methods call by that method (e.g., `_scan_ast()`,
+        `_scan_bytecode()`, `_scan_bytecode_stores()`).
+
+        Parameters
+        ----------
+        source_module : Node
+            Graph node of the source module to graph target imports for.
         """
-        if m._imported_modules is None:
+
+        # If this source module imported no target modules, noop.
+        if not source_module._deferred_imports:
             return
-        for have_star, import_info, kwargs in m._imported_modules:
-            imported_module = self._safe_import_hook(*import_info, **kwargs)[0]
 
+        # For each target module imported by this source module...
+        for have_star, import_info, kwargs in source_module._deferred_imports:
+            # Graph node of the target module specified by the "from" portion
+            # of this "from"-style star import (e.g., an import resembling
+            # "from {target_module_name} import *") or ignored otherwise.
+            target_module = self._safe_import_hook(*import_info, **kwargs)[0]
+
+            # If this is a "from"-style star import, process this import.
             if have_star:
-                m.globalnames.update(imported_module.globalnames)
-                m.starimports.update(imported_module.starimports)
-                if imported_module.code is None:
-                    name = import_info[0]
-                    m.starimports.add(name)
+                #FIXME: Sadly, the current approach to importing attributes
+                #from "from"-style star imports is... simplistic. This should
+                #be revised as follows. If this target module is:
+                #
+                #* A package:
+                #  * Whose "__init__" submodule defines the "__all__" global
+                #    attribute, only attributes listed by this attribute should
+                #    be imported.
+                #  * Else, *NO* attributes should be imported.
+                #* A non-package:
+                #  * Defining the "__all__" global attribute, only attributes
+                #    listed by this attribute should be imported.
+                #  * Else, only public attributes whose names are *NOT*
+                #    prefixed by "_" should be imported.
+                source_module.add_global_attrs_from_module(target_module)
+
+                source_module._starimported_ignored_module_names.update(
+                    target_module._starimported_ignored_module_names)
+
+                # If this target module has no code object and hence is
+                # unparsable, record its name for posterity.
+                if target_module.code is None:
+                    target_module_name = import_info[0]
+                    source_module._starimported_ignored_module_names.add(
+                        target_module_name)
+
+        # For safety, prevent these imports from being reprocessed.
+        source_module._deferred_imports = None
 
 
     def _load_package(self, fqname, pathname, pkgpath):
@@ -1638,11 +2947,11 @@ class ModuleGraph(ObjectGraph):
         self.msgout(2, "load_package ->", m)
         return m
 
+
     def _find_module(self, name, path, parent=None):
         """
-        Get a 3-tuple detailing the physical location of the Python module with
-        the passed name if that module is found *or* raise `ImportError`
-        otherwise.
+        3-tuple describing the physical location of the module with the passed
+        name if this module is physically findable _or_ raise `ImportError`.
 
         This high-level method wraps the low-level `modulegraph.find_module()`
         function with additional support for graph-based module caching.
@@ -1653,17 +2962,23 @@ class ModuleGraph(ObjectGraph):
             Fully-qualified name of the Python module to be found.
         path : list
             List of the absolute paths of all directories to search for this
-            module *or* `None` if the default path list `self.path` is to be
+            module _or_ `None` if the default path list `self.path` is to be
             searched.
         parent : Node
-            Optional parent module of this module if this module is a submodule
-            of another module *or* `None` if this module is a top-level module.
+            Package containing this module if this module is a submodule of a
+            package _or_ `None` if this is a top-level module.
 
         Returns
         ----------
         (file_handle, filename, metadata)
             See `modulegraph._find_module()` for details.
+
+        Raises
+        ----------
+        ImportError
+            If this module is _not_ found.
         """
+
         if parent is not None:
             # assert path is not None
             fullname = parent.identifier + '.' + name
@@ -1683,10 +2998,11 @@ class ModuleGraph(ObjectGraph):
 
         return self._find_module_path(fullname, name, path)
 
+
     def _find_module_path(self, fullname, module_name, search_dirs):
         """
-        Get a 3-tuple detailing the physical location of the module with the
-        passed name if that module exists _or_ raise `ImportError` otherwise.
+        3-tuple describing the physical location of the module with the passed
+        name if this module is physically findable _or_ raise `ImportError`.
 
         This low-level function is a variant on the standard `imp.find_module()`
         function with additional support for:

--- a/tests/functional/modules/pyi_testmod_submodule_global_shadowed/__init__.py
+++ b/tests/functional/modules/pyi_testmod_submodule_global_shadowed/__init__.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2016, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+'''
+Mock package defining a global variable of the same name as a mock submodule of
+this package.
+
+This package is exercised by the `test_import_submodule_global_shadowed`
+functional test.
+'''
+
+
+submodule = 'That is not dead which can eternal lie.'
+'''
+Global variable of the same name as a mock submodule of this package.
+
+This variable's value is arbitrary. This variable's type, however, is asserted
+to be `str` by this test.
+'''

--- a/tests/functional/modules/pyi_testmod_submodule_global_shadowed/submodule.py
+++ b/tests/functional/modules/pyi_testmod_submodule_global_shadowed/submodule.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2016, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+'''
+Mock module of the same name as _and_ shadowed by a global variable defined by
+the `__init__` submodule of this package.
+
+This module is exercised by the `test_import_submodule_global_shadowed`
+functional test.
+'''

--- a/tests/functional/modules/pyi_testmod_submodule_global_unshadowed/__init__.py
+++ b/tests/functional/modules/pyi_testmod_submodule_global_unshadowed/__init__.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2016, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+'''
+Mock package defining and then deleting a global variable of the same name as a
+mock submodule of this package.
+
+This package is exercised by the `test_import_submodule_global_unshadowed`
+functional test.
+'''
+
+
+submodule = 'And with strange aeons even death may die.'
+'''
+Global variable of the same name as a mock submodule of this package.
+
+This variable's value is both arbitrary _and_ always ignored by this test.
+'''
+
+
+# Permit the "submodule" submodule to be imported. Since globals take precedence
+# over submodules of the same name, failing to undefine this global would
+# prevent this submodule from being imported.
+#
+# PyInstaller explicitly detects both the definition and undefinition of globals
+# in the modules containing those globals -- namely, here. PyInstaller does not,
+# however, detect either the definition or undefinition of these globals from
+# other modules. In particular, PyInstaller ignores attempts to undefine this
+# global from the functional test exercising this module (e.g., using
+# "del pyi_testmod_submodule_global.submodule").
+del submodule

--- a/tests/functional/modules/pyi_testmod_submodule_global_unshadowed/submodule.py
+++ b/tests/functional/modules/pyi_testmod_submodule_global_unshadowed/submodule.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2016, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+'''
+Mock module of the same name as but _not_ shadowed by a global variable defined
+by the `__init__` submodule of this package.
+
+This module is exercised by the `test_import_submodule_global_unshadowed`
+functional test.
+'''

--- a/tests/functional/test_hooks/test_scipy.py
+++ b/tests/functional/test_hooks/test_scipy.py
@@ -45,7 +45,6 @@ def test_scipy(pyi_builder):
         """)
 
 
-@skip(reason='Issue #1919.')
 @xfail(is_win, reason='Issue scipy/scipy#5461.')
 @xfail(is_darwin, reason='Issue #1895.')
 @importorskip('scipy')


### PR DESCRIPTION
Welcome to another pompously entitled pull request. In this family- and eco-friendly series of harmless commits, we:

* Fix #1919, a newly unveiled edge-case in `ModuleGraph` import detection.
* Add functional tests exercising this fix.
* __Document, comment, and refactor `modulegraph`__ for readability, maintainability, and consistency.

The future begins tomorrow.

## #1919: The Issue That Should Not Be

To explain #1919, I should probably first explain a curious edge-case in CPython behaviour. I didn't know about it. You might not either! <sup>_...unless you're the sort of faceless mongoloid Pythonista who gets off on obscure_ `__init__.py` _abuse._</sup>

### Official Python Behaviour (_Believe It or Not_)

Consider a hypothetical package `ran` containing:

* A submodule `min`.
* A submodule `__init__` defining a global string variable `min` like so:

        # In `ran.__init__`:
        min = 'He shall hold a blade of light in his hands, and the three shall be one.'

Well, isn't that simple. <sup>..._and prophetic!_ <sup>_Don't Google that string._</sup></sup></sup>

Now consider importing the `min` attribute from the `ran` package. Python provides two superficially similar but ultimately dissimilar means of doing so:

1. A `from`-style import statement (e.g., `from ran import min`).
1. An `import`-style import statement (e.g., `import ran.min as min`).

Ideally, `min` should be the same object in both cases. Is this actually the case? If not, what is `min` in each case? Is it a submodule, a global, or something much too hideous to contemplate? Let's find out.

    >>> from ran import min
    >>> print(min)
    He shall hold a blade of light in his hands, and the three shall be one.
    >>> import ran.min as min
    >>> print(min)
    <module 'min' from '/usr/lib64/python3.5/site-packages/ran/min.py'>

Well, isn't that special... _and hideous!_

`min` is _not_ the same object in both cases. The object to which `min` refers conditionally depends on the way in which `min` is imported. If `min` is imported using:

* A `from`-style import statement, `min` is the `min` global defined by the `ran.__init__` submodule.
* An `import`-style import statement, `min` is the `ran.min` submodule.

For the remainder of this pull request, we refer to this (frankly insane) behaviour as "shadowing." The `min` global is said to "shadow" the `from`-style importation of the `min` submodule, preventing that submodule's importation.

Ideally, this recklessly drunken behaviour should be reversible by deleting the `min` global from the `ran.__init__` submodule _before_ importing the `min` attribute in a `from`-style import statement. Is this actually the case? Let's find out.

    >>> import ran
    >>> del ran.min
    >>> from ran import min
    >>> print(min)
    <module 'min' from '/usr/lib64/python3.5/site-packages/ran/min.py'>

Thank the melon-headed Gods. At least _something_ works.

We refer to this somewhat sane behaviour as "unshadowing." The deletion of the `min` global is said to "unshadow" the `from`-style importation of the `min` submodule, permitting that submodule to be imported.

**This is horrible.** This should not be in a sane language. Yet it is.

### SciPy: The First Up Against the Wall When the Revolution Comes

SciPy does everything described in the prior subsection. Specifically, the `scipy` package contains:

* A `linalg` submodule.
* An `__init__` submodule that (in order):
  1. Defines a `linalg` global variable initialized to `None`, thus shadowing the `linalg` submodule.
  1. Undefines this variable, thus unshadowing the `linalg` submodule.

In my local copy of SciPy 0.16.1, this resembles:

```
# In "scipy.__init__":

# Global variable shadowing the "scipy.linalg" package.
linalg = None

# Replace this global variable with the "numpy.linalg" package exported by
# "numpy.__init__.__all__".
from numpy import *

# Remove the linalg imported from numpy so that the scipy.linalg package can be
# imported.
del linalg
```

It's happening.

### Why Are You Still Talking?

I don't know. <sup>I'm voluble, O.K.?</sup>

To the point, then. `ModuleGraph` currently fails to handle three codestuffs. Let's start with the worst.

#### Shadowings – Consistently, Anyway

`ModuleGraph` resolves _some_ attempts to import a shadowed submodule as the global shadowing that submodule and _other_ such attempts as that submodule – presumably depending on import order, random noise, and acid reflux. Much like my stomache after two rounds of lukewarm beer, week-old poutine pizza, and the discount seafood platter, `ModuleGraph` behaviour is inconsistent here.

This inconsistency is thanks to two criminal elements in the codebase:

1. A hack in `ModuleGraph._scan_code()` temporarily coercing the `Node.globalattrs` set (recording the global attributes declared by each module) to `{}`, the empty set. This forces other `ModuleGraph` methods to treat all submodules of the currently scanned package as unshadowed by any globals and hence importable – but only for the duration of that package's scanning. Unfortunately, this hack fails to apply to submodules of _other_ packages, which `ModuleGraph` methods still treat as possibly shadowed by some global and hence unimportable. This was our fault, but it wasn't our fault. Why? Because we did our best with an undocumented, uncommented, unmaintainable codebase. It was a shameless hack, but it worked. (_Until now._)
2. A conditional in `ModuleGraph._safe_import_hook()` testing whether the current submodule to be imported is shadowed _after_ testing whether that submodule is cached in its `Package` graph node but _before_ testing whether that submodule is importable. Ideally, submodule shadowing should be tested for either strictly before or after all other tests of submodule importability – but certainly not in the _middle_ of those tests. This inconsistency complicates life further. This was Ron's fault. 

In short, everybody and nobody is to blame. I doubt anyone truly grokked the terrifying nature of the CPython interpreter, including Guido. I personally blame the uncaring Universe in all of its cosmic splendour and horror. :stars:

#### Unshadowings

`ModuleGraph._scan_code()` fails to scan and handle the deletion of global attributes (i.e., the `DELETE_NAME` and `DELETE_GLOBAL` bytecode opcodes). That's a problem. If you're going to go to all the trouble of remembering something (like global attribute declarations), you _also_ need to go all the trouble of forgetting that something (like global attribute deletions). It's no use doing just one or the other.

When a global previously shadowing a submodule is deleted (thus unshadowing that submodule), `ModuleGraph` should no longer treat that submodule as shadowed by a now-deleted global. Since deletions are ignored, however, so are unshadowings.

In SciPy's case, `ModuleGraph` correctly detects the `scipy.linalg` subpackage as initially shadowed by the `scipy.__init__.linalg` global but fails to correctly detect that subpackage's unshadowing when that global is subsequently deleted. Hence, all attempts to import the `scipy.linalg` package in `from`-style import statements (e.g., `from scipy import linalg`) are currently ignored.

### Did You Actually Do Something?

_Yup!_ This pull request fixes both deficiencies. `ModuleGraph` now handles:

#### Shadowings – Which Is to Say, Not At All

When a global shadows a submodule, `ModuleGraph` now mostly ignores that shadowing.

**Wait.** _What_?

You heard us right! Ignores! Although `ModuleGraph` _can_ reliably detect shadowings and unshadowings performed directly by a package's `__init__` submodule, it _cannot_ reliably detect shadowings and unshadowings performed by other packages and modules. Consider the following nightmare code leveraging the hypothetical `ran` package described above:

```
import ran, random

# Randomly delete the "ran.__init__.min" global variable.
if random.choice([True, False]):
    del ran.min

# Import and print the "ran.min" attribute.
from ran import min
print(min)
```

What is `min`? What is printed? It depends on the benevolence of the bearded random number generator (RNG) in the sky. Sometimes it's a submodule. Sometimes it's a string. Those sound like different things.

The above example highlights the core issue here: `ModuleGraph` isn't a Turing-complete Python interpreter. It doesn't interpret Python code and hence has no means of reliably sorting out timing issues between module importations and global variable declarations and deletions (to say nothing of importations, declarations, and deletions embedded in callables and conditionals) – which we should all be thankful for, because a Turing-complete `ModuleGraph` would immediately blow up the Galactic Center of the Milky Way galaxy.

If you can't do something right, you shouldn't do that something. In this case, the problem of deciding if and when a submodule is or is not shadowed by a global is probably **[undecidable](https://en.wikipedia.org/wiki/Undecidable_problem)**. Why? Because the [halting problem](https://en.wikipedia.org/wiki/Halting_problem) is undecidable and solving the submodule shadowing problem probably requires first solving the halting problem. <sup>Momma always said I should've become an academic instead of a code monkey. _What does she know!_</sup>

The only sane approach is to assume that:

* All shadowed submodules will at some point in the runtime of this application be unshadowed.
* Equivalently, **all submodules are always unshadowed.**
* Equivalently, **no submodules are ever shadowed.**

This means that all attributes in `from`-style import statements _must_ be assumed to be importable submodules until proven otherwise – even if globals appear to shadow those submodules and hence prevent those imports, superficially.

Scanning and storing globals _is_ still useful, however. Just less so. Without scanning and storing globals, `ModuleGraph` has no means of detecting errors in `from`-style import statements. That would be bad. So, we still scan and store globals.

Before, `ModuleGraph` tested globals to decide whether an import should be skipped _before_ attempting that import. This is now known to be unsafe to PyInstaller code and pregnant mothers by the State of California.

Now, `ModuleGraph` tests globals only as a last-ditch fallback to decide whether an import error occurred _after_ failing to import a submodule. This is always safe.

Here's how this plays out. Given a hypothetical import `from lan import nynaeve`:

* If `lan` is a package _and_ `nynaeve` is not an importable submodule of this package (i.e., `lan.nynaeve` does _not_ exist), then:
  * If `nynaeve` is a global of this package's `__init__` submodule (i.e., `lan.__init__.nynaeve` exists), then this import is now safely ignored.
  * Else, this import is erroneous. Depending on which `ModuleGraph` method is being called, either:
    * A fatal exception is now raised.
    * A `MissingModule` is now added to the graph for the missing `lan.nynaeve` submodule.

#### Unshadowings – Now Actually Handled

When a global previously shadowing a submodule is deleted (thus unshadowing that submodule), `ModuleGraph` no longer treats that submodule as shadowed by a now-deleted global. To do so, the `DELETE_NAME` and `DELETE_GLOBAL` bytecode opcodes signifying global attribute deletions are now scanned and properly handled.

_Booooooooring._

#### `RuntimePackage` – It Is Time

We're almost done. <sup>I swear it on [Brodin](https://www.reddit.com/r/swoleacceptance) himself.</sup>

There's one last inconsistency in `ModuleGraph`'s handling of `from`-style imports addressed by this pull request:

* The `_ensure_fromlist()` method handles `from`-style imports from _only_ packages, thus ignoring `from`-style imports from modules.
* The `_safe_import_hook()` method handles `from`-style imports from both packages and modules.

Which is it? They can't both be right. Either `from`-style imports from modules are ignorable or they aren't. I shall now explicate the truth.

**`_ensure_fromlist()` is right.** `from`-style imports from modules are always ignorable. Why? Because modules cannot physically contain submodules. That's what packages do. No attributes imported in `from`-style imports from modules can ever be submodules of those modules, which means those attributes are ignorable with respect to PyInstaller. With one exception.

**Pre-safe import module hooks.** PyInstaller hooks can do whatever they like, including adding `RuntimeModule` nodes to the graph that masquerade as modules but are actually packages containing importable submodules. Like, say, `six.moves`.

To support this bold form of old hackery:

* A new `RuntimePackage` node type has been added to the `modulegraph` module.
* A new `add_runtime_package()` method has been added to the `PreSafeImportModuleAPI` class.
* The `pre_safe_import_module/hook-six.moves.py` hook has been refactored to call this method rather than the existing `add_runtime_method()` method.

Following these trivial changes, the `ModuleGraph._safe_import_hook()` method has been refactored to ignore `from`-style imports from modules. Consistency with `ModuleGraph._ensure_fromlist()` is achieved. Efficiency is also improved, as futilely attempting to import submodules from modules adds a stupid number of ignorable `MissingModule` nodes to the graph.

## Functional Tests for Great Glory

Two functional tests exercising these uncanny changes have been added to `test_import.py`:

* `test_import_submodule_global_unshadowed()`, successfully importing a submodule:
  * Shadowed by a global in that package's `__init__` submodule.
  * Unshadowed by that global's deletion in that same submodule.
* `test_import_submodule_global_shadowed()`, unsuccessfully importing a submodule shadowed by a global in that package's `__init__` submodule. To ensure that this submodule is nonetheless frozen into the test application:
  1. This global is externally deleted, which unshadows this submodule. `ModuleGraph` can't parse external deletions, as doing so would probably require a Turing-complete Python interpreter – or at least something _much, much_ more intelligent and scary that could probably beat me at Go.
  1. This submodule is then successfully imported.

## `modulegraph`: Why You Unmaintainable?

I consider the current version of `modulegraph` to be unreadable, unmaintainable, and unsupportable in the whole. All documentation and comments that exist in `modulegraph` are there because a PyInstaller developer put them there. But they're _not_ enough.

They weren't enough to even debug – let alone fix – the strangely entangled issues detailed above. After several days of viscious stick fighting with nonsensically ambiguous parameter and local variable names like `c`, `co`, `m`, `mname`, `p`, `p_fqdn`, `q`, `qname`, `s`, `sm`, and `sub`, I confirmed **I'd finally had enough.**

I took matters into my own hands. I went vigilante. I had my ugly way with `modulegraph`. It felt good. It _was_ good. Here's what happened:

* I documented most remaining classes and methods in the `modulegraph` module likely to be of interest to PyInstaller developers. This includes:
  * NumpyDoc-formatted docstrings delineating attribute types, method parameters, return values, and raised exceptions.
  * Internal line-by-line commentary on method operation.
  * Copious `FIXME` comments littered everywhere like so much mental trash.
* I renamed various non-human-readable method parameters and local variables for readability and disambiguity, particularly those that previously had single- and double-letter names. <sup>_See above list of doom._</sup>
* I replaced various non-human-readable magic numbers with human-readable global constants declared at the top of this module, also sporting NumpyDoc-formatted docstrings.
* I eliminated various repetitious methods and repetitious logic in these methods, including:
  * The replacement of the `_scan_bytecode_stores()` method by a single new boolean parameter passed to the existing `_scan_bytecode()` method. _Yup._ `_scan_bytecode_stores()` was a lame copy-and-paste of `_scan_bytecode()`.
  
In short, `ModuleGraph` is now maintainable by human beings. Well, _more_ maintainable... anyway.

## Thus Ends Another Thesis That Could Have Gotten Me a Doctorate

This is my eternal fate. At least I don't have to read my own writing.

![The Future Begins Tomorrow](https://i80.photobucket.com/albums/j182/swiftian/101706/yoyodine10.jpg)