### PR TITLE
Fix don't fail if directory already exists

### DIFF
--- a/PyInstaller/building/toc_conversion.py
+++ b/PyInstaller/building/toc_conversion.py
@@ -135,7 +135,8 @@ class DependencyProcessor(object):
         try:
             os.makedirs(workpath)
         except OSError as e:
-            if e.errno != 17:
+            import errno
+            if e.errno != errno.EEXIST:
                 raise
         # TODO extract only those file which whould then be included
         with zipfile.ZipFile(zipfilename) as zfh:

--- a/PyInstaller/building/toc_conversion.py
+++ b/PyInstaller/building/toc_conversion.py
@@ -134,7 +134,7 @@ class DependencyProcessor(object):
         workpath = os.path.join(CONF['workpath'], os.path.basename(zipfilename))
         try:
             os.makedirs(workpath)
-        except OSError, e:
+        except OSError as e:
             if e.errno != 17:
                 raise
         # TODO extract only those file which whould then be included

--- a/PyInstaller/building/toc_conversion.py
+++ b/PyInstaller/building/toc_conversion.py
@@ -132,7 +132,11 @@ class DependencyProcessor(object):
         # 'PyInstaller.config' cannot be imported as other top-level modules.
         from ..config import CONF
         workpath = os.path.join(CONF['workpath'], os.path.basename(zipfilename))
-        os.makedirs(workpath, exist_ok=True)
+        try:
+            os.makedirs(workpath)
+        except OSError, e:
+            if e.errno != 17:
+                raise
         # TODO extract only those file which whould then be included
         with zipfile.ZipFile(zipfilename) as zfh:
             zfh.extractall(workpath)

--- a/PyInstaller/building/toc_conversion.py
+++ b/PyInstaller/building/toc_conversion.py
@@ -132,7 +132,7 @@ class DependencyProcessor(object):
         # 'PyInstaller.config' cannot be imported as other top-level modules.
         from ..config import CONF
         workpath = os.path.join(CONF['workpath'], os.path.basename(zipfilename))
-        os.makedirs(workpath)
+        os.makedirs(workpath, exist_ok=True)
         # TODO extract only those file which whould then be included
         with zipfile.ZipFile(zipfilename) as zfh:
             zfh.extractall(workpath)


### PR DESCRIPTION
directory can already exist if there are dependency of multiple executables on setuptools or any other data files