### PR TITLE
Add: Example demonstrating a threading bug while processing imports.

### DIFF
--- a/tests/functional/test_libraries.py
+++ b/tests/functional/test_libraries.py
@@ -250,7 +250,6 @@ def test_pygments(pyi_builder):
         print(highlight(code, PythonLexer(), HtmlFormatter()))
         """)
 
-
 @importorskip('markdown')
 def test_markdown(pyi_builder):
     # Markdown uses __import__ed extensions. Make sure these work by

--- a/tests/unit/test_hookutils.py
+++ b/tests/unit/test_hookutils.py
@@ -11,12 +11,16 @@
 import os
 import pytest
 import shutil
-
 from os.path import join
+from threading import Thread
+from queue import Queue
+
 from PyInstaller.utils.hooks import collect_data_files, collect_submodules, \
   get_module_file_attribute, remove_prefix, remove_suffix, \
   remove_file_extension, is_module_or_submodule
 from PyInstaller.compat import exec_python
+from PyInstaller.loader.pyimod02_archive import ArchiveFile
+
 
 class TestRemovePrefix(object):
     # Verify that removing a prefix from an empty string is OK.

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -1,0 +1,60 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2016, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+
+import pytest
+from threading import Thread
+from queue import Queue
+
+from PyInstaller.loader.pyimod02_archive import ArchiveFile
+
+def test_threading_import(tmpdir):
+    """
+    On Python 3.3+, PyInstaller doesn't acquire a lock when performing an
+    import. Therefore, two thread could both be reading the .pyz archive at the
+    same time. At the core, the ArchiveFile class performs these reads. This
+    test verifies that multi-threaded reads work.
+
+    For more information, see https://github.com/pyinstaller/pyinstaller/pull/2010.
+    """
+
+    # Create a temporary file and use the ArchiveReader on it.
+    tmp_file = tmpdir.join('test.txt')
+    tmp_file.write('Testing')
+    ar = ArchiveFile(tmp_file.strpath, 'r')
+
+    # Use queues to synchronize threads.
+    q1 = Queue()
+    q2 = Queue()
+
+    # This function, which is run in a separate thread, works to ensure that
+    # both threads open a file at the same time.
+    def foo():
+        with ar:
+            # Wait until both threads have opened the file.
+            q1.put(1)
+            assert q2.get() == 2
+            # Wait until the other thread has closed the file before closing it
+            # here.
+            assert q2.get() == 3
+
+    thread = Thread(target=foo)
+    thread.start()
+
+    # This code works with ``foo`` above to open the same file from two threads.
+    with ar:
+        # Wait until both threads have opened the file.
+        q2.put(2)
+        assert q1.get() == 1
+    # Make the other thread wait until this thread has closed the file.
+    q2.put(3)
+
+    # Wait for the other thread to finish.
+    thread.join()
+


### PR DESCRIPTION
Running this via `py.test -k test_threading_import[onedir] -s` (note: the `-s` flag is essential) produces the output below. Note that, all though py.test believes all tests pass, there's a failure and an exception produced.

I assume that there's only one instance of the `ArchiveFile` class in `pyimod02_archive.py`, meaning that `import` statements from multiple threads can corrupt its state, as the failure below shows. It appears that one thread closes the `ArchiveFile.fd` while another assumes that this file is still open.

There are two problems with this pull request I'm hoping that other can help with:

1. To reproduce the bug involves an ugly modification of `pyimod02_archive.py`, introducing a delay in one thread (which imports `csv`) but not in the other. Is there some cleaner monkeypatch to insert this test code as a part of the test?

2. I'm not familiar enough with the `pyimod02_archive.py` internal to fix it. I assume the bug first appeared in 7650ec0cb18e3629a90123431682659c17410af8, which fixed #1145. @htgoebel, do you have any thoughts?

3. This isn't just an artificial case; I ran into this "in the wild" while trying to freeze an application.

4. Possibly unrelated, but why does `csv` apparently get extracted three times? I'd assumed that after it's in `sys.modules`, it wouldn't be re-imported (or re-extracted).

```
============================= test session starts =============================
platform win32 -- Python 3.4.4, pytest-2.9.1, py-1.4.31, pluggy-0.3.1 -- c:\users\bjones\downloads\winpython-32bit-3.4.4.1qt5\python-3.4.4\python.exe
cachedir: .cache
rootdir: E:\pyinstaller, inifile: setup.cfg
plugins: catchlog-1.2.2, drop-dup-tests-0.1.0, timeout-1.0.0, xdist-1.14
collected 433 items

tests/functional/test_libraries.py::test_threading_import[onedir] RUNNING:  'C:\\Users\\bjones\\AppData\\Local\\Temp\\pytest-of-bjones\\pytest-75\\test_threading_import_onedir_0\\dist\\test_threading_import\\test_threading_import.exe' , args:  ['.\\test_threading_import.exe']
PyInstaller Bootloader 3.x
LOADER: executable is C:\Users\bjones\AppData\Local\Temp\pytest-of-bjones\pytest-75\test_threading_import_onedir_0\dist\test_threading_import\test_threading_import.exe
LOADER: homepath is C:\Users\bjones\AppData\Local\Temp\pytest-of-bjones\pytest-75\test_threading_import_onedir_0\dist\test_threading_import
LOADER: _MEIPASS2 is NULL
LOADER: archivename is C:\Users\bjones\AppData\Local\Temp\pytest-of-bjones\pytest-75\test_threading_import_onedir_0\dist\test_threading_import\test_threading_import.exe
LOADER: No need to extract files to run; setting extractionpath to homepath
LOADER: SetDllDirectory(C:\Users\bjones\AppData\Local\Temp\pytest-of-bjones\pytest-75\test_threading_import_onedir_0\dist\test_threading_import)
LOADER: Already in the child - running user's code.
LOADER: Python library: C:\Users\bjones\AppData\Local\Temp\pytest-of-bjones\pytest-75\test_threading_import_onedir_0\dist\test_threading_import\python34.dll
LOADER: Loaded functions from Python library.
LOADER: Manipulating environment (sys.path, sys.prefix)
LOADER: Pre-init sys.path is C:\Users\bjones\AppData\Local\Temp\pytest-of-bjones\pytest-75\test_threading_import_onedir_0\dist\test_threading_import\base_library.zip;C:\Users\bjones\AppData\Local\Temp\pytest-of-bjones\pytest-75\test_threading_import_onedir_0\dist\test_threading_import
LOADER: sys.prefix is C:\Users\bjones\AppData\Local\Temp\pytest-of-bjones\pytest-75\test_threading_import_onedir_0\dist\test_threading_import
LOADER: Setting runtime options
LOADER: Initializing python
LOADER: Overriding Python's sys.path
LOADER: Post-init sys.path is C:\Users\bjones\AppData\Local\Temp\pytest-of-bjones\pytest-75\test_threading_import_onedir_0\dist\test_threading_import\base_library.zip;C:\Users\bjones\AppData\Local\Temp\pytest-of-bjones\pytest-75\test_threading_import_onedir_0\dist\test_threading_import
LOADER: Setting sys.argv
LOADER: setting sys._MEIPASS
LOADER: importing modules from CArchive
LOADER: extracted struct
LOADER: callfunction returned...
LOADER: extracted pyimod01_os_path
LOADER: callfunction returned...
LOADER: extracted pyimod02_archive
LOADER: callfunction returned...
LOADER: extracted pyimod03_importers
LOADER: callfunction returned...
LOADER: Installing PYZ archive with Python modules.
LOADER: PYZ archive: out00-PYZ.pyz
LOADER: Running pyiboot01_bootstrap.py
LOADER: Running test_threading_import.py
csv
xdrlib
Delaying...
Delaying...
Delaying...
Exception in thread Thread-1:
Traceback (most recent call last):
  File "e:\pyinstaller\PyInstaller\loader\pyimod02_archive.py", line 324, in extract
    self.lib.seek(self.start + pos)
  File "e:\pyinstaller\PyInstaller\loader\pyimod02_archive.py", line 61, in __getattr__
    assert self.fd
AssertionError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "threading.py", line 911, in _bootstrap_inner
  File "threading.py", line 859, in run
  File "test_threading_import.py", line 7, in foo
  File "<frozen importlib._bootstrap>", line 2237, in _find_and_load
  File "<frozen importlib._bootstrap>", line 2226, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 1191, in _load_unlocked
  File "<frozen importlib._bootstrap>", line 1161, in _load_backward_compatible
  File "E:\pyinstaller\PyInstaller\loader\pyimod03_importers.py", line 315, in load_module
    is_pkg, bytecode = self._pyz_archive.extract(real_fullname)
  File "e:\pyinstaller\PyInstaller\loader\pyimod02_archive.py", line 325, in extract
    obj = self.lib.read(length)
  File "e:\pyinstaller\PyInstaller\loader\pyimod02_archive.py", line 76, in __exit__
    assert self.fd
AssertionError

LOADER: OK.
LOADER: Cleaning up Python interpreter.
PASSED

========== 432 tests deselected by '-ktest_threading_import[onedir]' ==========
================== 1 passed, 432 deselected in 10.49 seconds ==================
```