### PR TITLE
Fix: Run Appveyor library tests without xdist.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,39 +24,42 @@ environment:
 #      PYTHON_ARCH: "64"
 #      WAF_ARGS: ""
 
-    # TODO Enable Python 3.5 one day. Issue #1547.
     - PYTHON: "C:\\Python35"
       PYTHON_VERSION: "3.5"
       PYTHON_ARCH: "32"
-
-      # Nothing needed for part 2 of testing; everything is done in ``TEST1_CMD``.
-      TEST2_CMD: ""
       #WAF_ARGS: "--gcc"
       # TODO use temporily msvc to compile bootloader until mingw-w64 is natively supported by Appveyor.
       WAF_ARGS: ""
-
       # Break the tests into two runs, since together they exceed the 1 hour limit.
       # See https://github.com/pyinstaller/pyinstaller/issues/2024#issuecomment-224129520
       # for more discussion.
-      - TEST1_CMD: "py.test --maxfail 5 --durations=10 tests\\unit tests\\functional -k \"not tests/functional/test_libraries.py\""
-        TEST2_CMD: ""
+      TEST1_CMD: "py.test --maxfail 5 --durations=10 tests\\unit tests\\functional -k \"not tests/functional/test_libraries.py\""
+      TEST2_CMD: ""
 
-      - TEST1_CMD: ""
-        TEST2_CMD: "py.test --maxfail 5 --durations=10 tests\\functional\\test_libraries.py"
+    - PYTHON: "C:\\Python35"
+      PYTHON_VERSION: "3.5"
+      PYTHON_ARCH: "32"
+      #WAF_ARGS: "--gcc"
+      # TODO use temporily msvc to compile bootloader until mingw-w64 is natively supported by Appveyor.
+      WAF_ARGS: ""
+      TEST1_CMD: ""
+      TEST2_CMD: "py.test --maxfail 5 --durations=10 tests\\functional\\test_libraries.py"
 
     - PYTHON: "C:\\Python34"
       PYTHON_VERSION: "3.4"
       PYTHON_ARCH: "32"
-
-      - TEST1_CMD: "py.test --maxfail 5 --durations=10 tests\\unit tests\\functional -k \"not tests/functional/test_libraries.py\""
-        TEST2_CMD: ""
-
-      - TEST1_CMD: ""
-        TEST2_CMD: "py.test --maxfail 5 --durations=10 tests\\functional\\test_libraries.py"
-
       #WAF_ARGS: "--gcc"
       # TODO use temporily msvc to compile bootloader until mingw-w64 is natively supported by Appveyor.
       WAF_ARGS: ""
+      TEST1_CMD: "py.test --maxfail 5 --durations=10 tests\\unit tests\\functional -k \"not tests/functional/test_libraries.py\""
+      TEST2_CMD: ""
+
+    - PYTHON: "C:\\Python34"
+      PYTHON_VERSION: "3.4"
+      PYTHON_ARCH: "32"
+      TEST1_CMD: ""
+      TEST2_CMD: "py.test --maxfail 5 --durations=10 tests\\functional\\test_libraries.py"
+
 
     - PYTHON: "C:\\Python33"
       PYTHON_VERSION: "3.3"
@@ -65,12 +68,18 @@ environment:
       #WAF_ARGS: "--gcc"
       # TODO use temporily msvc to compile bootloader until mingw-w64 is natively supported by Appveyor.
       WAF_ARGS: ""
+      TEST1_CMD: "py.test --maxfail 5 --durations=10 tests\\unit tests\\functional -k \"not tests/functional/test_libraries.py\""
+      TEST2_CMD: ""
 
-      - TEST1_CMD: "py.test --maxfail 5 --durations=10 tests\\unit tests\\functional -k \"not tests/functional/test_libraries.py\""
-        TEST2_CMD: ""
-
-      - TEST1_CMD: ""
-        TEST2_CMD: "py.test --maxfail 5 --durations=10 tests\\functional\\test_libraries.py"
+    - PYTHON: "C:\\Python33"
+      PYTHON_VERSION: "3.3"
+      PYTHON_ARCH: "32"
+      # Same as Python 3.4; see comment there.
+      #WAF_ARGS: "--gcc"
+      # TODO use temporily msvc to compile bootloader until mingw-w64 is natively supported by Appveyor.
+      WAF_ARGS: ""
+      TEST1_CMD: ""
+      TEST2_CMD: "py.test --maxfail 5 --durations=10 tests\\functional\\test_libraries.py"
 
     - PYTHON: "C:\\Python27"
       PYTHON_VERSION: "2.7"
@@ -78,12 +87,17 @@ environment:
       #WAF_ARGS: "--gcc"
       # TODO use temporily msvc to compile bootloader until mingw-w64 is natively supported by Appveyor.
       WAF_ARGS: ""
+      TEST1_CMD: "py.test --maxfail 5 --durations=10 tests\\unit tests\\functional -k \"not tests/functional/test_libraries.py\""
+      TEST2_CMD: ""
 
-      - TEST1_CMD: "py.test --maxfail 5 --durations=10 tests\\unit tests\\functional -k \"not tests/functional/test_libraries.py\""
-        TEST2_CMD: ""
-
-      - TEST1_CMD: ""
-        TEST2_CMD: "py.test --maxfail 5 --durations=10 tests\\functional\\test_libraries.py"
+    - PYTHON: "C:\\Python27"
+      PYTHON_VERSION: "2.7"
+      PYTHON_ARCH: "32"
+      #WAF_ARGS: "--gcc"
+      # TODO use temporily msvc to compile bootloader until mingw-w64 is natively supported by Appveyor.
+      WAF_ARGS: ""
+      TEST1_CMD: ""
+      TEST2_CMD: "py.test --maxfail 5 --durations=10 tests\\functional\\test_libraries.py"
 
 cache:
   # 'pip-accel' requires caching of downloaded pip packages.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,7 +41,7 @@ environment:
       PYTHON_ARCH: "32"
       # Run unitttests first, then everything but test_libraries, which fails
       # with xdist.
-      TEST1_CMD: "%CMD_IN_ENV% py.test -n 3 --maxfail 5 --durations=10 tests\\unit tests\\functional -k \"not tests/functional/test_libraries.py\""
+      TEST1_CMD: "py.test -n 3 --maxfail 5 --durations=10 tests\\unit tests\\functional -k \"not tests/functional/test_libraries.py\""
       # Run without xdist for test_libraries. Some notes:
       #
       # 1. xdist works fine with Python 3.5. It will hopefully work with Python
@@ -53,7 +53,7 @@ environment:
       #
       # See https://github.com/pyinstaller/pyinstaller/issues/2024#issuecomment-224129520
       # for more discussion.
-      TEST2_CMD: "%CMD_IN_ENV% py.test --maxfail 5 --durations=10 tests\\functional\\test_libraries.py"
+      TEST2_CMD: "py.test --maxfail 5 --durations=10 tests\\functional\\test_libraries.py"
       #WAF_ARGS: "--gcc"
       # TODO use temporily msvc to compile bootloader until mingw-w64 is natively supported by Appveyor.
       WAF_ARGS: ""
@@ -62,8 +62,8 @@ environment:
       PYTHON_VERSION: "3.3"
       PYTHON_ARCH: "32"
       # Same as Python 3.4; see comment there.
-      TEST1_CMD: "%CMD_IN_ENV% py.test -n 3 --maxfail 5 --durations=10 tests\\unit tests\\functional -k \"not tests/functional/test_libraries.py\""
-      TEST2_CMD: "%CMD_IN_ENV% py.test --maxfail 5 --durations=10 tests\\functional\\test_libraries.py"
+      TEST1_CMD: "py.test -n 3 --maxfail 5 --durations=10 tests\\unit tests\\functional -k \"not tests/functional/test_libraries.py\""
+      TEST2_CMD: "py.test --maxfail 5 --durations=10 tests\\functional\\test_libraries.py"
       #WAF_ARGS: "--gcc"
       # TODO use temporily msvc to compile bootloader until mingw-w64 is natively supported by Appveyor.
       WAF_ARGS: ""
@@ -74,7 +74,7 @@ environment:
       # Python 2.7 has the same xdist problems as Python 3.3 and 3.4; see the
       # comments there. In addition, the tests run slower, meaning they must be
       # split between two separate Appveyor runs. See https://github.com/pyinstaller/pyinstaller/issues/2024#issuecomment-225273385.
-      TEST1_CMD: "%CMD_IN_ENV% py.test -n 3 --maxfail 5 --durations=10 tests\\unit tests\\functional -k \"not tests/functional/test_libraries.py\""
+      TEST1_CMD: "py.test -n 3 --maxfail 5 --durations=10 tests\\unit tests\\functional -k \"not tests/functional/test_libraries.py\""
       TEST2_CMD: ""
       #WAF_ARGS: "--gcc"
       # TODO use temporily msvc to compile bootloader until mingw-w64 is natively supported by Appveyor.
@@ -85,7 +85,7 @@ environment:
       PYTHON_VERSION: "2.7"
       PYTHON_ARCH: "32"
       TEST1_CMD: ""
-      TEST2_CMD: "%CMD_IN_ENV% py.test --maxfail 5 --durations=10 tests\\functional\\test_libraries.py"
+      TEST2_CMD: "py.test --maxfail 5 --durations=10 tests\\functional\\test_libraries.py"
       #WAF_ARGS: "--gcc"
       # TODO use temporily msvc to compile bootloader until mingw-w64 is natively supported by Appveyor.
       WAF_ARGS: ""
@@ -162,6 +162,6 @@ test_script:
   # Run the tests appropriate for this entry in the test matrix. Skip tests
   # if we're just updating the cache.
   - "if not \"%APPVEYOR_SCHEDULED_BUILD%\" == \"True\" (
-    %TEST1_CMD% )"
+    %CMD_IN_ENV% %TEST1_CMD% )"
   - "if not \"%APPVEYOR_SCHEDULED_BUILD%\" == \"True\" (
-    %TEST2_CMD% )"
+    %CMD_IN_ENV% %TEST2_CMD% )"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -162,6 +162,6 @@ test_script:
   # Run the tests appropriate for this entry in the test matrix. Skip tests
   # if we're just updating the cache.
   - "if not \"%APPVEYOR_SCHEDULED_BUILD%\" == \"True\" (
-    echo %CMD_IN_ENV% %TEST1_CMD% )"
+    %CMD_IN_ENV% %TEST1_CMD% )"
   - "if not \"%APPVEYOR_SCHEDULED_BUILD%\" == \"True\" (
-    echo %CMD_IN_ENV% %TEST2_CMD% )"
+    %CMD_IN_ENV% %TEST2_CMD% )"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,6 +28,10 @@ environment:
     - PYTHON: "C:\\Python35"
       PYTHON_VERSION: "3.5"
       PYTHON_ARCH: "32"
+      # On Python 3.5, xdist works. Run unit tests first, then functional tests.
+      TEST1_CMD: "py.test -n 3 --maxfail 5 --durations=10 tests\\unit tests\\functional"
+      # Nothing needed for part 2 of testing; everything is done in ``TEST1_CMD``.
+      TEST2_CMD: ""
       #WAF_ARGS: "--gcc"
       # TODO use temporily msvc to compile bootloader until mingw-w64 is natively supported by Appveyor.
       WAF_ARGS: ""
@@ -35,6 +39,21 @@ environment:
     - PYTHON: "C:\\Python34"
       PYTHON_VERSION: "3.4"
       PYTHON_ARCH: "32"
+      # Run unitttests first, then everything but test_libraries, which fails
+      # with xdist.
+      TEST1_CMD: "%CMD_IN_ENV% py.test -n 3 --maxfail 5 --durations=10 tests\\unit tests\\functional -k \"not tests/functional/test_libraries.py\""
+      # Run without xdist for test_libraries. Some notes:
+      #
+      # 1. xdist works fine with Python 3.5. It will hopefully work with Python
+      #    3.6 and higher.
+      # 2. xdist only fails while running test_libraries. I suspect that one or
+      #    more of the libraries tested somehow interfere with xdist. Perhaps
+      #    someone could identify the problem tests, allowing all other tests
+      #    to run with xdist.
+      #
+      # See https://github.com/pyinstaller/pyinstaller/issues/2024#issuecomment-224129520
+      # for more discussion.
+      TEST2_CMD: "%CMD_IN_ENV% py.test --maxfail 5 --durations=10 tests\\functional\\test_libraries.py"
       #WAF_ARGS: "--gcc"
       # TODO use temporily msvc to compile bootloader until mingw-w64 is natively supported by Appveyor.
       WAF_ARGS: ""
@@ -42,6 +61,9 @@ environment:
     - PYTHON: "C:\\Python33"
       PYTHON_VERSION: "3.3"
       PYTHON_ARCH: "32"
+      # Same as Python 3.4; see comment there.
+      TEST1_CMD: "%CMD_IN_ENV% py.test -n 3 --maxfail 5 --durations=10 tests\\unit tests\\functional -k \"not tests/functional/test_libraries.py\""
+      TEST2_CMD: "%CMD_IN_ENV% py.test --maxfail 5 --durations=10 tests\\functional\\test_libraries.py"
       #WAF_ARGS: "--gcc"
       # TODO use temporily msvc to compile bootloader until mingw-w64 is natively supported by Appveyor.
       WAF_ARGS: ""
@@ -49,6 +71,21 @@ environment:
     - PYTHON: "C:\\Python27"
       PYTHON_VERSION: "2.7"
       PYTHON_ARCH: "32"
+      # Python 2.7 has the same xdist problems as Python 3.3 and 3.4; see the
+      # comments there. In addition, the tests run slower, meaning they must be
+      # split between two separate Appveyor runs. See https://github.com/pyinstaller/pyinstaller/issues/2024#issuecomment-225273385.
+      TEST1_CMD: "%CMD_IN_ENV% py.test -n 3 --maxfail 5 --durations=10 tests\\unit tests\\functional -k \"not tests/functional/test_libraries.py\""
+      TEST2_CMD: ""
+      #WAF_ARGS: "--gcc"
+      # TODO use temporily msvc to compile bootloader until mingw-w64 is natively supported by Appveyor.
+      WAF_ARGS: ""
+
+    # Almost a duplicate of the Python 2.7 run, except that different tests are run. See comments on the other Python 2.7 matrix entry.
+    - PYTHON: "C:\\Python27"
+      PYTHON_VERSION: "2.7"
+      PYTHON_ARCH: "32"
+      TEST1_CMD: ""
+      TEST2_CMD: "%CMD_IN_ENV% py.test --maxfail 5 --durations=10 tests\\functional\\test_libraries.py"
       #WAF_ARGS: "--gcc"
       # TODO use temporily msvc to compile bootloader until mingw-w64 is natively supported by Appveyor.
       WAF_ARGS: ""
@@ -110,7 +147,7 @@ install:
 
   # Install lxml from anaconda.org channel since PyPI fails (or it takes too long).
   # See: https://github.com/pyinstaller/pyinstaller/pull/1638
-  - "%CMD_IN_ENV% pip-accel install -i https://pypi.anaconda.org/giumas/simple lxml" 
+  - "%CMD_IN_ENV% pip-accel install -i https://pypi.anaconda.org/giumas/simple lxml"
 
   # Install the PyInstaller test dependencies.
   - "%CMD_IN_ENV% pip-accel install --disable-pip-version-check --timeout 5 --retries 2 -r tests/requirements-tools.txt"
@@ -122,7 +159,9 @@ install:
 build: none
 
 test_script:
-  # Split tests into several subprocesses.
-  # Run unitttest first.
+  # Run the tests appropriate for this entry in the test matrix. Skip tests
+  # if we're just updating the cache.
   - if not "%APPVEYOR_SCHEDULED_BUILD%" == "True" (
-      %CMD_IN_ENV% py.test -n 3 --maxfail 5 --durations=10 tests\\unit tests)
+    "%TEST1_CMD%")
+  - if not "%APPVEYOR_SCHEDULED_BUILD%" == "True" (
+    "%TEST2_CMD%")

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -162,6 +162,6 @@ test_script:
   # Run the tests appropriate for this entry in the test matrix. Skip tests
   # if we're just updating the cache.
   - "if not \"%APPVEYOR_SCHEDULED_BUILD%\" == \"True\" (
-    %CMD_IN_ENV% %TEST1_CMD% )"
+    echo %CMD_IN_ENV% %TEST1_CMD% )"
   - "if not \"%APPVEYOR_SCHEDULED_BUILD%\" == \"True\" (
-    %CMD_IN_ENV% %TEST2_CMD% )"
+    echo %CMD_IN_ENV% %TEST2_CMD% )"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,32 +28,32 @@ environment:
     - PYTHON: "C:\\Python35"
       PYTHON_VERSION: "3.5"
       PYTHON_ARCH: "32"
-      # On Python 3.5, xdist works. Run unit tests first, then functional tests.
-      TEST1_CMD: "py.test -n 3 --maxfail 5 --durations=10 tests\\unit tests\\functional"
+
       # Nothing needed for part 2 of testing; everything is done in ``TEST1_CMD``.
       TEST2_CMD: ""
       #WAF_ARGS: "--gcc"
       # TODO use temporily msvc to compile bootloader until mingw-w64 is natively supported by Appveyor.
       WAF_ARGS: ""
 
+      # Break the tests into two runs, since together they exceed the 1 hour limit.
+      # See https://github.com/pyinstaller/pyinstaller/issues/2024#issuecomment-224129520
+      # for more discussion.
+      - TEST1_CMD: "py.test --maxfail 5 --durations=10 tests\\unit tests\\functional -k \"not tests/functional/test_libraries.py\""
+        TEST2_CMD: ""
+
+      - TEST1_CMD: ""
+        TEST2_CMD: "py.test --maxfail 5 --durations=10 tests\\functional\\test_libraries.py"
+
     - PYTHON: "C:\\Python34"
       PYTHON_VERSION: "3.4"
       PYTHON_ARCH: "32"
-      # Run unitttests first, then everything but test_libraries, which fails
-      # with xdist.
-      TEST1_CMD: "py.test -n 3 --maxfail 5 --durations=10 tests\\unit tests\\functional -k \"not tests/functional/test_libraries.py\""
-      # Run without xdist for test_libraries. Some notes:
-      #
-      # 1. xdist works fine with Python 3.5. It will hopefully work with Python
-      #    3.6 and higher.
-      # 2. xdist only fails while running test_libraries. I suspect that one or
-      #    more of the libraries tested somehow interfere with xdist. Perhaps
-      #    someone could identify the problem tests, allowing all other tests
-      #    to run with xdist.
-      #
-      # See https://github.com/pyinstaller/pyinstaller/issues/2024#issuecomment-224129520
-      # for more discussion.
-      TEST2_CMD: "py.test --maxfail 5 --durations=10 tests\\functional\\test_libraries.py"
+
+      - TEST1_CMD: "py.test --maxfail 5 --durations=10 tests\\unit tests\\functional -k \"not tests/functional/test_libraries.py\""
+        TEST2_CMD: ""
+
+      - TEST1_CMD: ""
+        TEST2_CMD: "py.test --maxfail 5 --durations=10 tests\\functional\\test_libraries.py"
+
       #WAF_ARGS: "--gcc"
       # TODO use temporily msvc to compile bootloader until mingw-w64 is natively supported by Appveyor.
       WAF_ARGS: ""
@@ -62,33 +62,28 @@ environment:
       PYTHON_VERSION: "3.3"
       PYTHON_ARCH: "32"
       # Same as Python 3.4; see comment there.
-      TEST1_CMD: "py.test -n 3 --maxfail 5 --durations=10 tests\\unit tests\\functional -k \"not tests/functional/test_libraries.py\""
-      TEST2_CMD: "py.test --maxfail 5 --durations=10 tests\\functional\\test_libraries.py"
       #WAF_ARGS: "--gcc"
       # TODO use temporily msvc to compile bootloader until mingw-w64 is natively supported by Appveyor.
       WAF_ARGS: ""
 
+      - TEST1_CMD: "py.test --maxfail 5 --durations=10 tests\\unit tests\\functional -k \"not tests/functional/test_libraries.py\""
+        TEST2_CMD: ""
+
+      - TEST1_CMD: ""
+        TEST2_CMD: "py.test --maxfail 5 --durations=10 tests\\functional\\test_libraries.py"
+
     - PYTHON: "C:\\Python27"
       PYTHON_VERSION: "2.7"
       PYTHON_ARCH: "32"
-      # Python 2.7 has the same xdist problems as Python 3.3 and 3.4; see the
-      # comments there. In addition, the tests run slower, meaning they must be
-      # split between two separate Appveyor runs. See https://github.com/pyinstaller/pyinstaller/issues/2024#issuecomment-225273385.
-      TEST1_CMD: "py.test -n 3 --maxfail 5 --durations=10 tests\\unit tests\\functional -k \"not tests/functional/test_libraries.py\""
-      TEST2_CMD: ""
       #WAF_ARGS: "--gcc"
       # TODO use temporily msvc to compile bootloader until mingw-w64 is natively supported by Appveyor.
       WAF_ARGS: ""
 
-    # Almost a duplicate of the Python 2.7 run, except that different tests are run. See comments on the other Python 2.7 matrix entry.
-    - PYTHON: "C:\\Python27"
-      PYTHON_VERSION: "2.7"
-      PYTHON_ARCH: "32"
-      TEST1_CMD: ""
-      TEST2_CMD: "py.test --maxfail 5 --durations=10 tests\\functional\\test_libraries.py"
-      #WAF_ARGS: "--gcc"
-      # TODO use temporily msvc to compile bootloader until mingw-w64 is natively supported by Appveyor.
-      WAF_ARGS: ""
+      - TEST1_CMD: "py.test --maxfail 5 --durations=10 tests\\unit tests\\functional -k \"not tests/functional/test_libraries.py\""
+        TEST2_CMD: ""
+
+      - TEST1_CMD: ""
+        TEST2_CMD: "py.test --maxfail 5 --durations=10 tests\\functional\\test_libraries.py"
 
 cache:
   # 'pip-accel' requires caching of downloaded pip packages.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,6 +57,9 @@ environment:
     - PYTHON: "C:\\Python34"
       PYTHON_VERSION: "3.4"
       PYTHON_ARCH: "32"
+      #WAF_ARGS: "--gcc"
+      # TODO use temporily msvc to compile bootloader until mingw-w64 is natively supported by Appveyor.
+      WAF_ARGS: ""
       TEST1_CMD: ""
       TEST2_CMD: "py.test --maxfail 5 --durations=10 tests\\functional\\test_libraries.py"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -92,27 +92,27 @@ environment:
 
 cache:
   # 'pip-accel' requires caching of downloaded pip packages.
-  - C:\Users\appveyor\AppData\Local\pip
+  - "C:\\Users\\appveyor\\AppData\\Local\\pip"
   # Cache binary Python packages e.g. numpy, pycrypto
-  - C:\Users\appveyor\AppData\Roaming\.pip-accel
+  - "C:\\Users\\appveyor\\AppData\\Roaming\\.pip-accel"
   # Cache downloaded mingw-w64 - it might take 5 min. in appveyor.
   # TODO Remove mingw-w64 caching when it is natively supported by apppveyor:
   #    https://github.com/appveyor/ci/issues/466
   # TODO mingw-w64 caching takes a lot of time - unpacking/zipping 15000 files.
-  #- C:\tools\mingw32
+  #- "C:\\tools\\mingw32"
 
 init:
   - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"
-  - ECHO "%APPVEYOR_SCHEDULED_BUILD%"
+  - "ECHO \"%APPVEYOR_SCHEDULED_BUILD%\""
 
 install:
-  - ECHO "Filesystem root:"
+  - "ECHO Filesystem root:"
   - ps: "ls \"C:/\""
 
-  - ECHO "Chocolatey tools:"
+  - "ECHO Chocolatey tools:"
   - ps: "ls \"C:/Tools\""
 
-  - ECHO "Installed SDKs:"
+  - "ECHO Installed SDKs:"
   - ps: "ls \"C:/Program Files/Microsoft SDKs/Windows\""
 
   # Prepend newly installed Python to the PATH of this build (this cannot be
@@ -135,9 +135,9 @@ install:
 
   # Compile bootloader, use 32bit mingw-w64.
   - "SET PATH=C:\\tools\\mingw32\\bin;%PATH%"
-  - cd bootloader
+  - "cd bootloader"
   - "python waf --msvc_version=\"msvc 12.0\" distclean all %WAF_ARGS%"
-  - cd ..
+  - "cd .."
 
   ### Install the PyInsaller dependencies.
 
@@ -161,7 +161,7 @@ build: none
 test_script:
   # Run the tests appropriate for this entry in the test matrix. Skip tests
   # if we're just updating the cache.
-  - if not "%APPVEYOR_SCHEDULED_BUILD%" == "True" (
-    "%TEST1_CMD%")
-  - if not "%APPVEYOR_SCHEDULED_BUILD%" == "True" (
-    "%TEST2_CMD%")
+  - "if not \"%APPVEYOR_SCHEDULED_BUILD%\" == \"True\" (
+    %TEST1_CMD% )"
+  - "if not \"%APPVEYOR_SCHEDULED_BUILD%\" == \"True\" (
+    %TEST2_CMD% )"


### PR DESCRIPTION
This will hopefully help fix failures on Python 3.4, 3.3, and 2.7 with Appveyor, in which xdist seems to inject failures.

It doesn't run to completion on my personal Appveyor account, so I'm submitting this as a pull request to get a better build.