### PR TITLE
Appveyor fixes

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -66,6 +66,7 @@ cache:
 
 init:
   - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"
+  - ECHO "%APPVEYOR_SCHEDULED_BUILD%"
 
 install:
   - ECHO "Filesystem root:"
@@ -123,4 +124,5 @@ build: none
 test_script:
   # Split tests into several subprocesses.
   # Run unitttest first.
-  - "%CMD_IN_ENV% py.test -n 3 --maxfail 5 --durations=10 tests\\unit tests"
+  - if not "%APPVEYOR_SCHEDULED_BUILD%" == "True" (
+      %CMD_IN_ENV% py.test -n 3 --maxfail 5 --durations=10 tests\\unit tests)


### PR DESCRIPTION
- Implement a better way of cleaning up temp files from a test run that works cross platform.

- Allow a scheduled Appveyor build to only install dependencies and not run tests.
This allows the cache to be kept fresh even when the tests are failing. Requires the "Build schedule" setting to be set on appveyor. See https://ci.appveyor.com/project/springermac/pyinstaller/build/1.0.90 for an example of a scheduled run.