### PR TITLE
Make grab version more polite on non-windows

### DIFF
--- a/PyInstaller/utils/cliutils/grab_version.py
+++ b/PyInstaller/utils/cliutils/grab_version.py
@@ -12,7 +12,6 @@ import codecs
 import os
 import argparse
 
-import PyInstaller.utils.win32.versioninfo
 import PyInstaller.log
 
 
@@ -33,6 +32,7 @@ def run():
     args = parser.parse_args()
 
     try:
+        import PyInstaller.utils.win32.versioninfo
         vs = PyInstaller.utils.win32.versioninfo.decode(args.exe_file)
         fp = codecs.open(args.out_filename, 'w', 'utf-8')
         fp.write(unicode(vs))

--- a/PyInstaller/utils/cliutils/set_version.py
+++ b/PyInstaller/utils/cliutils/set_version.py
@@ -11,7 +11,6 @@
 import os
 import argparse
 
-import PyInstaller.utils.win32.versioninfo
 import PyInstaller.log
 
 def run():
@@ -28,6 +27,7 @@ def run():
     exe_file = os.path.abspath(args.exe_file)
 
     try:
+        import PyInstaller.utils.win32.versioninfo
         vs = PyInstaller.utils.win32.versioninfo.SetVersion(exe_file, info_file)
         print(('Version info set in: %s' % exe_file))
     except KeyboardInterrupt:


### PR DESCRIPTION
Allow grab_version and set_version to respond to ```--help``` on non-windows
systems.

Quick change to help with #2052.