### PR TITLE
Fix django import finder to work with django < 1.7

### DIFF
--- a/PyInstaller/utils/hooks/subproc/django_import_finder.py
+++ b/PyInstaller/utils/hooks/subproc/django_import_finder.py
@@ -24,7 +24,9 @@ import os
 # and also reads the user settings from DJANGO_SETTINGS_MODULE.
 # https://stackoverflow.com/questions/24793351/django-appregistrynotready
 import django
-django.setup()
+if django.VERSION >= (1, 7, 0):
+    # setup() was introduced in Django 1.7
+    django.setup()
 
 # This allows to access all django settings even from the settings.py module.
 from django.conf import settings


### PR DESCRIPTION
`django.setup()` was introduced in [Django 1.7](https://docs.djangoproject.com/en/1.9/releases/1.7/#standalone-scripts)
Hence the freeze process fails when freezing previous versions of django (e.g. 1.6.5)

```
6978 INFO: Loading module hook "hook-django.py"...
6982 INFO: Django root directory /mnt/xxx
Traceback (most recent call last):
  File "/tmp/freeze.1/venv/lib/python2.7/site-packages/PyInstaller/utils/hooks/subproc/django_import_finder.py", line 27, in <module
>
    django.setup()
AttributeError: 'module' object has no attribute 'setup'
7104 INFO: Collecting Django migration scripts.
```

After the fix, the freeze process works.