### PR TITLE
add html parser hidden import for botocore

### DIFF
--- a/PyInstaller/hooks/hook-botocore.py
+++ b/PyInstaller/hooks/hook-botocore.py
@@ -19,5 +19,23 @@
 # Tested with botocore 1.3.0
 
 from PyInstaller.utils.hooks import collect_data_files
+from PyInstaller.utils.hooks import is_py3
+from PyInstaller.utils.hooks import is_module_satisfies
+
+hiddenimports = []
+
+if is_module_satisfies('botocore >= 1.3.30'):
+    if is_py3:
+        hiddenimports.extend(
+            [
+                'html.parser'
+            ]
+        )
+    else:
+        hiddenimports.extend(
+            [
+                'HTMLParser'
+            ]
+        )
 
 datas = collect_data_files('botocore')

--- a/tests/functional/test_libraries.py
+++ b/tests/functional/test_libraries.py
@@ -31,7 +31,6 @@ def test_boto(pyi_builder):
     pyi_builder.test_script('pyi_lib_boto.py')
 
 
-@xfail(reason='Issue #1844.')
 @importorskip('boto3')
 def test_boto3(pyi_builder):
     pyi_builder.test_source(
@@ -49,7 +48,6 @@ def test_boto3(pyi_builder):
         """)
 
 
-@xfail(reason='Issue #1844.')
 @importorskip('botocore')
 def test_botocore(pyi_builder):
     pyi_builder.test_source(

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -12,7 +12,7 @@ Django<1.8.11 # PyInstaller doesn't yet work with Django 1.9
 babel>2.0  # Required by sphinx. Version 2.0 doesn't work on Windows.
 boto
 boto3
-botocore
+botocore>=1.4.31
 cherrypy
 gevent
 pygments

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -25,7 +25,7 @@ zope.interface  # Required for test_namespace_package
 # numpy 1.11 is broken and does not compile on AppVeyor (Windows)
 numpy==1.10.4
 lxml
-keyring
+keyring==9.0
 pycparser
 pytz
 sqlalchemy

--- a/tests/unit/test_hookutils.py
+++ b/tests/unit/test_hookutils.py
@@ -12,14 +12,11 @@ import os
 import pytest
 import shutil
 from os.path import join
-from threading import Thread
-from queue import Queue
 
 from PyInstaller.utils.hooks import collect_data_files, collect_submodules, \
   get_module_file_attribute, remove_prefix, remove_suffix, \
   remove_file_extension, is_module_or_submodule
 from PyInstaller.compat import exec_python
-from PyInstaller.loader.pyimod02_archive import ArchiveFile
 
 
 class TestRemovePrefix(object):

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -8,11 +8,16 @@
 #-----------------------------------------------------------------------------
 
 
-import pytest
 from threading import Thread
-from queue import Queue
 
+from PyInstaller.compat import is_py2
 from PyInstaller.loader.pyimod02_archive import ArchiveFile
+
+if is_py2:
+    from Queue import Queue
+else:
+    from queue import Queue
+
 
 def test_threading_import(tmpdir):
     """


### PR DESCRIPTION
The dependency on html parser was added to botcore in:
https://github.com/boto/botocore/commit/ec85db75c26d3bb81e1831e81191b98f37de9f27

Fixes #1844
