### PR TITLE
Fix 1891 usb.core no backend error

### DIFF
--- a/PyInstaller/hooks/hook-usb.py
+++ b/PyInstaller/hooks/hook-usb.py
@@ -7,49 +7,79 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-
 import ctypes.util
 import os
+import usb.core
+import usb.backend
 
 from PyInstaller.depend.utils import _resolveCtypesImports
 from PyInstaller.compat import is_cygwin
+from PyInstaller.utils.hooks import logger
 
 
 # Include glob for library lookup in run-time hook.
 hiddenimports = ['glob']
 
+# https://github.com/walac/pyusb/blob/master/docs/faq.rst
+# https://github.com/walac/pyusb/blob/master/docs/tutorial.rst
 
-# Try to resolve your libusb libraries in the following order:
-#
-#   libusb-1.0, libusb-0.1, openusb
-#
-# NOTE: Mind updating run-time hook when adding further libs.
-libusb_candidates = (
-    # libusb10
-    'usb-1.0', 'usb', 'libusb-1.0',
-    # libusb01
-    'usb-0.1', 'libusb0',
-    # openusb
-    'openusb',
-)
+binaries=[]
 
-for candidate in libusb_candidates:
-    libname = ctypes.util.find_library(candidate)
-    if libname is not None:
-        break
+# first try to use pyusb library locator
+try:
+    # get the backend symbols before find
+    pyusb_backend_dir = set(dir(usb.backend))
 
-if libname is not None:
-    # Use basename here because Python returns full library path
-    # on Mac OSX when using ctypes.util.find_library.
-    bins = [os.path.basename(libname)]
-    binaries = _resolveCtypesImports(bins)
-elif is_cygwin:
-    bins = ['cygusb-1.0-0.dll', 'cygusb0.dll']
-    binaries = _resolveCtypesImports(bins)[:1]  # use only the first one if any
-else:
+    # perform find, which will load a usb library if found
+    usb.core.find()
+
+    # get the backend symbols which have been added (loaded)
+    backends = set(dir(usb.backend)) - pyusb_backend_dir
+
+    # for each of the loaded backends, see if they have a library
     binaries = []
-if binaries:
-    # `_resolveCtypesImports` returns a 3-tuple, but `binaries` are only
-    # 2-tuples, so remove the last element:
-    assert len(binaries[0]) == 3
-    binaries = [reversed(binaries[0][:2])]
+    for usblib in [getattr(usb.backend, be)._lib for be in backends]:
+        if usblib is not None:
+            binaries = [(usblib._name, '')]
+
+except (ValueError, usb.core.USBError) as exc:
+    logger.warn("%s", exc)
+
+
+# if nothing found, try to use our custom mechanism
+if not binaries:
+    # Try to resolve your libusb libraries in the following order:
+    #
+    #   libusb-1.0, libusb-0.1, openusb
+    #
+    # NOTE: Mind updating run-time hook when adding further libs.
+    libusb_candidates = (
+        # libusb10
+        'usb-1.0', 'usb', 'libusb-1.0',
+        # libusb01
+        'usb-0.1', 'libusb0',
+        # openusb
+        'openusb',
+    )
+
+    for candidate in libusb_candidates:
+        libname = ctypes.util.find_library(candidate)
+        if libname is not None:
+            break
+
+    if libname is not None:
+        # Use basename here because Python returns full library path
+        # on Mac OSX when using ctypes.util.find_library.
+        bins = [os.path.basename(libname)]
+        binaries = _resolveCtypesImports(bins)
+    elif is_cygwin:
+        bins = ['cygusb-1.0-0.dll', 'cygusb0.dll']
+        binaries = _resolveCtypesImports(bins)[:1] # use only the first one
+    else:
+        binaries = []
+
+    if binaries:
+        # `_resolveCtypesImports` returns a 3-tuple, but `binaries` are only
+        # 2-tuples, so remove the last element:
+        assert len(binaries[0]) == 3
+        binaries = [(binaries[0][1], '')]

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -33,6 +33,7 @@ twisted
 pyexcelerate
 Pillow
 future
+pyusb
 
 # dateutil.tz is a package in 2.5.0 and does not play nice with PyInstaller.
 python-dateutil>2.5.0

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -31,7 +31,8 @@ pytz
 sqlalchemy
 twisted
 pyexcelerate
-Pillow
+# Pillow 3.0+ does not compile on AppVeyor (Windows) w/o zlib
+Pillow==2.9.0
 future
 pyusb
 


### PR DESCRIPTION
Fix for #1891.

Fix custom locator to place found library in same directory as
executable.  (This was a regression from last September or so)

Added code to use pyusb's builtin library locator, before trying to use our custom locator.

Add pyusb to requirements so that tests are actually run. (This maybe why this bug was present for so long)

Also had to downgrade Pillow to 2.9.0 as 3.0.0 is not working on Appveyor