### PR TITLE
Add hook ADIOS

### DIFF
--- a/PyInstaller/hooks/hook-adios.py
+++ b/PyInstaller/hooks/hook-adios.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013-2016, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+
+"""
+Hook for http://pypi.python.org/pypi/adios/
+"""
+
+
+hiddenimports = ['adios._hl.selections']


### PR DESCRIPTION
Adds a hook with hidden imports for [ADIOS](https://www.olcf.ornl.gov/center-projects/adios/)' [numpy wrapper](https://pypi.python.org/pypi/adios).

Required for HDF-Compass packaging, see
  https://github.com/HDFGroup/hdf-compass/pull/173

(side note: from a user, package & api perspective, this is all very close to the `h5py` package)