### PR TITLE
First argument to ctypes.CDLL can be None

### DIFF
--- a/PyInstaller/loader/pyiboot01_bootstrap.py
+++ b/PyInstaller/loader/pyiboot01_bootstrap.py
@@ -123,11 +123,16 @@ try:
     import os
     from ctypes import LibraryLoader, DEFAULT_MODE
 
-    class PyInstallerCDLL(ctypes.CDLL):
-        def __init__(self, name, *args, **kwargs):
+    def _frozen_name(name):
+        if name:
             frozen_name = os.path.join(sys._MEIPASS, os.path.basename(name))
             if os.path.exists(frozen_name):
                 name = frozen_name
+        return name
+
+    class PyInstallerCDLL(ctypes.CDLL):
+        def __init__(self, name, *args, **kwargs):
+            name = _frozen_name(name)
             super(PyInstallerCDLL, self).__init__(name, *args, **kwargs)
 
     ctypes.CDLL = PyInstallerCDLL
@@ -135,9 +140,7 @@ try:
 
     class PyInstallerPyDLL(ctypes.PyDLL):
         def __init__(self, name, *args, **kwargs):
-            frozen_name = os.path.join(sys._MEIPASS, os.path.basename(name))
-            if os.path.exists(frozen_name):
-                name = frozen_name
+            name = _frozen_name(name)
             super(PyInstallerPyDLL, self).__init__(name, *args, **kwargs)
 
     ctypes.PyDLL = PyInstallerPyDLL
@@ -146,9 +149,7 @@ try:
     if sys.platform.startswith('win'):
         class PyInstallerWinDLL(ctypes.WinDLL):
             def __init__(self, name,*args, **kwargs):
-                frozen_name = os.path.join(sys._MEIPASS, os.path.basename(name))
-                if os.path.exists(frozen_name):
-                    name = frozen_name
+                name = _frozen_name(name)
                 super(PyInstallerWinDLL, self).__init__(name, *args, **kwargs)
 
         ctypes.WinDLL = PyInstallerWinDLL
@@ -156,9 +157,7 @@ try:
 
         class PyInstallerOleDLL(ctypes.OleDLL):
             def __init__(self, name,*args, **kwargs):
-                frozen_name = os.path.join(sys._MEIPASS, os.path.basename(name))
-                if os.path.exists(frozen_name):
-                    name = frozen_name
+                name = _frozen_name(name)
                 super(PyInstallerOleDLL, self).__init__(name, *args, **kwargs)
 
         ctypes.OleDLL = PyInstallerOleDLL

--- a/tests/functional/test_import.py
+++ b/tests/functional/test_import.py
@@ -191,6 +191,17 @@ def test_ctypes_CDLL_c(pyi_builder):
         assert lib is not None
         """)
 
+@skipif_no_compiler
+def test_ctypes_CDLL_None(pyi_builder):
+    # Make sure we are able to load CDLL(None)
+    # -> pip does this for some reason
+    pyi_builder.test_source(
+        """
+        import ctypes, ctypes.util
+        lib = ctypes.CDLL(None)
+        assert lib is not None
+        """)
+
 import PyInstaller.depend.utils
 __orig_resolveCtypesImports = PyInstaller.depend.utils._resolveCtypesImports
 


### PR DESCRIPTION
If you try to wrap pip with pyinstaller on Ubuntu 14.04, it fails because it calls `ctypes.CDLL(None)` (see https://github.com/pypa/pip/blob/8.1.2/pip/pep425tags.py#L188).

This fixes that and adds a test.