### PR TITLE
Changes to work with python 2.7 built with gcc on AIX platform

### DIFF
--- a/bootloader/src/mkdtemp.h
+++ b/bootloader/src/mkdtemp.h
@@ -14,6 +14,10 @@
 #ifndef __MKDTEMP__
 #define __MKDTEMP__
 
+#if defined(_AIX) && defined(__GNUC__)
+/* mkdtemp() is defined by gnu C compiler */
+#else
+
 static char*
 mkdtemp(char *template)
 {
@@ -26,5 +30,7 @@ mkdtemp(char *template)
     }
     return template;
 }
+
+#endif
 
 #endif /* ifndef __MKDTEMP__ */

--- a/bootloader/src/pyi_pythonlib.c
+++ b/bootloader/src/pyi_pythonlib.c
@@ -54,6 +54,9 @@ pyi_pylib_load(ARCHIVE_STATUS *status)
     char dllpath[PATH_MAX];
     char dllname[64];
     int pyvers = ntohl(status->cookie.pyvers);
+#ifdef AIX
+    char *p;
+#endif
 
     /* Are we going to load the Python 2.x library? */
     is_py2 = (pyvers / 10) == 2;
@@ -62,6 +65,8 @@ pyi_pylib_load(ARCHIVE_STATUS *status)
  * On AIX Append the shared object member to the library path
  * to make it look like this:
  *   libpython2.6.a(libpython2.6.so)
+ * or
+ *   libpython2.6.so
  */
 #ifdef AIX
     /*

--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -274,9 +274,9 @@ def set_arch_flags(ctx):
     # AIX specific flags
     elif is_aix:
         if ctx.env.CC_NAME == 'gcc':
-            ctx.check_cc(ccflags='-m32', msg='Checking for flags -m32')
-            ctx.env.append_value('CFLAGS', '-m32')
-            ctx.env.append_value('LINKFLAGS', '-m32')
+            ctx.check_cc(ccflags='-maix32', msg='Checking for flags -maix32')
+            ctx.env.append_value('CFLAGS', '-maix32')
+            ctx.env.append_value('LINKFLAGS', '-maix32')
         else:
             # We use xlc compiler
             pass


### PR DESCRIPTION
1. For gcc 4.8.3, to compile for 32bit mode, the correct flag is '-maix32';
2. On AIX, mkdtemp() is defined by gcc 4.8.3