### PR TITLE
Changes to work with python 2.7 built with gcc on AIX platform

### DIFF
--- a/bootloader/src/pyi_pythonlib.c
+++ b/bootloader/src/pyi_pythonlib.c
@@ -54,7 +54,8 @@ pyi_pylib_load(ARCHIVE_STATUS *status)
     char dllpath[PATH_MAX];
     char dllname[64];
     int pyvers = ntohl(status->cookie.pyvers);
-
+    char *p;
+    
     /* Are we going to load the Python 2.x library? */
     is_py2 = (pyvers / 10) == 2;
 

--- a/bootloader/src/pyi_utils.c
+++ b/bootloader/src/pyi_utils.c
@@ -61,7 +61,9 @@
  *   the runtime platform at compile time, so we always include our own implementation on AIX.
  */
 #if defined(SUNOS) || defined(AIX)
+    #if !defined(HAVE_MKDTEMP)
     #include "mkdtemp.h"
+    #endif
 #endif
 
 /* PyInstaller headers. */

--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -274,9 +274,9 @@ def set_arch_flags(ctx):
     # AIX specific flags
     elif is_aix:
         if ctx.env.CC_NAME == 'gcc':
-            ctx.check_cc(ccflags='-m32', msg='Checking for flags -m32')
-            ctx.env.append_value('CFLAGS', '-m32')
-            ctx.env.append_value('LINKFLAGS', '-m32')
+            ctx.check_cc(ccflags='-maix32', msg='Checking for flags -maix32')
+            ctx.env.append_value('CFLAGS', '-maix32')
+            ctx.env.append_value('LINKFLAGS', '-maix32')
         else:
             # We use xlc compiler
             pass

--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -480,6 +480,7 @@ def configure(ctx):
 
     # unsetenv not available on AIX, maybe others.
     ctx.check_cc(function_name='unsetenv', header_name="stdlib.h", mandatory=False)
+    ctx.check_cc(function_name='mkdtemp', header_name="stdlib.h", mandatory=False)
 
     ### CFLAGS
 


### PR DESCRIPTION
Added HAVE_MKDTEMP flag for AIX with GCC compiler