### PR TITLE
if it is in windows path should be in lib/site-packages directory.

### DIFF
--- a/PyInstaller/utils/hooks/gi.py
+++ b/PyInstaller/utils/hooks/gi.py
@@ -109,7 +109,11 @@ def gir_library_path_fix(path):
     # 'PyInstaller.config' cannot be imported as other top-level modules.
     from ...config import CONF
 
+    # if typelib file exist is not necessary to check gir file.
     path = os.path.abspath(path)
+    if os.path.exists(path):
+        return path, 'gi_typelibs'
+        
     common_path = os.path.commonprefix([base_prefix, path])
     # on windows the gir file is not in the same directory as linux.
     if is_win:

--- a/PyInstaller/utils/hooks/gi.py
+++ b/PyInstaller/utils/hooks/gi.py
@@ -111,6 +111,9 @@ def gir_library_path_fix(path):
 
     path = os.path.abspath(path)
     common_path = os.path.commonprefix([base_prefix, path])
+    # on windows the gir file is not in the same directory as linux.
+    if is_win:
+        common_path = os.path.join([common_path, "Lib", "site-packages", "gnome"])
     gir_path = os.path.join(common_path, 'share', 'gir-1.0')
 
     typelib_name = os.path.basename(path)


### PR DESCRIPTION
Path of gir directory on windows platform using PyGObject Win32 is wrong when using linux path.
