### PR TITLE
Fix: Correct usage of multiprocessing test.

### DIFF
--- a/tests/functional/scripts/pyi_multiprocess.py
+++ b/tests/functional/scripts/pyi_multiprocess.py
@@ -23,22 +23,24 @@ import sys
 
 class SendeventProcess(multiprocessing.Process):
     def __init__(self, resultQueue):
-        self.resultQueue = resultQueue
-
         multiprocessing.Process.__init__(self)
+        self.resultQueue = resultQueue
         self.start()
 
     def run(self):
-        print('SendeventProcess')
+        print('SendeventProcess begins')
         self.resultQueue.put((1, 2))
-        print('SendeventProcess')
+        print('SendeventProcess ends')
 
 
 if __name__ == '__main__':
     # On Windows calling this function is necessary.
     if sys.platform.startswith('win'):
         multiprocessing.freeze_support()
-    print('main')
+    print('main begins')
     resultQueue = multiprocessing.Queue()
-    SendeventProcess(resultQueue)
-    print('main')
+    sp = SendeventProcess(resultQueue)
+    assert resultQueue.get() == (1, 2)
+    print('get ends')
+    sp.join()
+    print('main ends')

--- a/tests/functional/test_basic.py
+++ b/tests/functional/test_basic.py
@@ -20,9 +20,9 @@ import pytest
 
 # Local imports
 # -------------
-from PyInstaller.compat import is_darwin, is_win, is_py2
-from PyInstaller.utils.tests import importorskip, skipif_win, skipif_winorosx, \
-    skipif_notwin, skipif_notosx, skipif_no_compiler, xfail
+from PyInstaller.compat import is_darwin, is_win, is_py2, is_py27
+from PyInstaller.utils.tests import importorskip, skipif, skipif_win, \
+    skipif_winorosx, skipif_notwin, skipif_notosx, skipif_no_compiler, xfail
 
 
 def test_run_from_path_environ(pyi_builder):
@@ -199,6 +199,7 @@ def test_module_reload(pyi_builder):
 # TODO move 'multiprocessig' tests into 'test_multiprocess.py.
 
 
+@skipif(is_win and is_py27, reason="Issue #2116")
 @importorskip('multiprocessing')
 def test_multiprocess(pyi_builder):
     pyi_builder.test_script('pyi_multiprocess.py')


### PR DESCRIPTION
This pull request shows failures of the `multiprocessing` test on Python 2.7 under Windows. I haven't been able to find the root cause of this failure.