### PR TITLE
Add install hooks for numba and llvmlite

### DIFF
--- a/PyInstaller/hooks/hook-llvmlite.py
+++ b/PyInstaller/hooks/hook-llvmlite.py
@@ -1,0 +1,18 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013-2016, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+#
+# A lightweight LLVM python binding for writing JIT compilers
+# https://github.com/numba/llvmlite
+#
+# Tested with:
+# llvmlite 0.11 (Anaconda 4.1.1, Windows), llvmlite 0.13 (Linux)
+
+from PyInstaller.utils.hooks import collect_dynamic_libs
+
+binaries = collect_dynamic_libs("llvmlite")

--- a/PyInstaller/hooks/hook-numba.py
+++ b/PyInstaller/hooks/hook-numba.py
@@ -1,0 +1,17 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013-2016, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+#
+# NumPy aware dynamic Python compiler using LLVM
+# https://github.com/numba/numba
+#
+# Tested with:
+# numba 0.26 (Anaconda 4.1.1, Windows), numba 0.28 (Linux)
+
+excludedimports = ["IPython", "scipy"]
+hiddenimports = ["llvmlite"]


### PR DESCRIPTION
Add install hooks for numba and llvmlite.

Numba has some optional support for IPython and scipy, so I'm excluding those if the application isn't using them elsewhere.

Numba requires llvmlite, which in turn comes with a binary lib that needs to be installed too.

Tested with Anaconda for Windows as well as numba self compiled on Linux.