### PR TITLE
Use pip instead of pip-accel for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ install:
 script:
   # Run tests and speed them up by sending them to multiple CPUs.
   # Run unitttest first.
-  - echo py.test -n 3 --maxfail 3 tests/unit/ tests/
+  - py.test -n 3 --maxfail 3 tests/unit/ tests/
 
 notifications:
     irc:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,6 @@ os:
   #- osx
 
 env:
-   # shorten logging of pip-accel
-   - PIP_ACCEL_LOG_FORMAT="%(name)-18s %(levelname)s %(message)s"
 #  - PYCRYPTO_VERSION=2.4.1
 #  - PYCRYPTO_VERSION=2.6.1
 
@@ -65,22 +63,19 @@ before_install:
 
 
 install:
+  # Update pip.
+  - python -m pip install -U pip
   # Install PyInstaller.
   - pip install -e .
 
-  # Install dependencies for tests. Use pip-accel to cache compiled
-  # packages and safe recompiling each time.
-  # Download-progress bars break Travis's log view. Disable them by
-  # piping output through another program (if output is not a tty, no
-  # progress bars)
-  - pip install pip-accel | cat
-  - pip-accel install -r tests/requirements-tools.txt | cat
-  - pip-accel install -r tests/requirements-linux.txt | cat
+  # Install dependencies for tests.
+  - pip install -U -r tests/requirements-tools.txt
+  - pip install -U -r tests/requirements-linux.txt
 
 script:
   # Run tests and speed them up by sending them to multiple CPUs.
   # Run unitttest first.
-  - py.test -n 5  --maxfail 3 tests/unit/ tests/
+  - echo py.test -n 3 --maxfail 3 tests/unit/ tests/
 
 notifications:
     irc:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
     # /E:ON and /V:ON options are not enabled in the batch script intepreter
     # See: http://stackoverflow.com/a/13751649/163740
     CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\tests\\scripts\\appveyor\\run_with_env.cmd"
-    PIP_ACCEL_LOG_FORMAT: "%(name)-18s %(levelname)s %(message)s"
+    APPVEYOR_SCHEDULED_BUILD: "True"
 
   matrix:
 
@@ -105,8 +105,6 @@ environment:
 cache:
   # 'pip-accel' requires caching of downloaded pip packages.
   - "C:\\Users\\appveyor\\AppData\\Local\\pip"
-  # Cache binary Python packages e.g. numpy, pycrypto
-  - "C:\\Users\\appveyor\\AppData\\Roaming\\.pip-accel"
   # Cache downloaded mingw-w64 - it might take 5 min. in appveyor.
   # TODO Remove mingw-w64 caching when it is natively supported by apppveyor:
   #    https://github.com/appveyor/ci/issues/466
@@ -153,17 +151,16 @@ install:
 
   ### Install the PyInsaller dependencies.
 
-  # Install pip-accel to cache pypi packages and avoid compiling some packages.
-  # (numpy or pycrypto take a lot of tome to compile).
-  - "%CMD_IN_ENV% python -m pip install -U pip-accel>=0.33"
+  # Upgrade to the latest pip.
+  - "%CMD_IN_ENV% python -m pip install -U pip"
 
   # Install lxml from anaconda.org channel since PyPI fails (or it takes too long).
   # See: https://github.com/pyinstaller/pyinstaller/pull/1638
-  - "%CMD_IN_ENV% pip-accel install -U -i https://pypi.anaconda.org/giumas/simple lxml"
+  - "%CMD_IN_ENV% pip install -U -i https://pypi.anaconda.org/giumas/simple lxml"
 
   # Install the PyInstaller test dependencies.
-  - "%CMD_IN_ENV% pip-accel install -U --disable-pip-version-check --timeout 5 --retries 2 -r tests/requirements-tools.txt"
-  - "%CMD_IN_ENV% pip-accel install -U --disable-pip-version-check --timeout 5 --retries 2 -r tests/requirements-win.txt"
+  - "%CMD_IN_ENV% pip install -U --disable-pip-version-check --timeout 5 --retries 2 -r tests/requirements-tools.txt"
+  - "%CMD_IN_ENV% pip install -U --disable-pip-version-check --timeout 5 --retries 2 -r tests/requirements-win.txt"
 
   # Install PyInstaller into virtualenv.
   - "%CMD_IN_ENV% pip install -e ."

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,6 @@ environment:
     # /E:ON and /V:ON options are not enabled in the batch script intepreter
     # See: http://stackoverflow.com/a/13751649/163740
     CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\tests\\scripts\\appveyor\\run_with_env.cmd"
-    APPVEYOR_SCHEDULED_BUILD: "True"
 
   matrix:
 
@@ -103,7 +102,7 @@ environment:
       TEST2_CMD: "py.test --maxfail 5 --durations=10 tests\\functional\\test_libraries.py"
 
 cache:
-  # 'pip-accel' requires caching of downloaded pip packages.
+  # Cache downloaded pip packages.
   - "C:\\Users\\appveyor\\AppData\\Local\\pip"
   # Cache downloaded mingw-w64 - it might take 5 min. in appveyor.
   # TODO Remove mingw-w64 caching when it is natively supported by apppveyor:

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -41,6 +41,6 @@ pyusb
 python-dateutil>2.5.0
 pandas
 
-# matplotlib 1.5+ does not provide binaries for python 3.3
+# matplotlib 1.5+ does not provide binaries for python 3.3.
 matplotlib ; python_version < '2.8' or python_version >= '3.4'
 matplotlib==1.4.3 ; python_version >= '3.3' and python_version < '3.4'

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -33,16 +33,13 @@ pytz
 sqlalchemy
 twisted
 pyexcelerate
-# Pillow 3.0+ does not compile on AppVeyor (Windows) w/o zlib. See #2100.
-Pillow==2.9.0 ; sys_platform == 'win32'
-Pillow ; sys_platform != 'win32'
+Pillow
 future
 pyusb
 
 # dateutil.tz is a package in 2.5.0 and does not play nice with PyInstaller.
 python-dateutil>2.5.0
-# Pandas for Python 3.5 wants numpy 1.11.1 on Windows, which doesn't compile. See #2100.
-pandas ; (sys_platform == 'win32' and python_version < '3.5') or sys_platform != 'win32'
+pandas
 
 # matplotlib 1.5+ does not provide binaries for python 3.3
 matplotlib ; python_version < '2.8' or python_version >= '3.4'

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -22,9 +22,7 @@ simplejson # simplejson is used for text_c_extension
 sphinx
 pyzmq
 zope.interface  # Required for test_namespace_package
-# numpy 1.11 is broken and does not compile on AppVeyor (Windows). See #2100.
-numpy==1.10.4 ; sys_platform == 'win32'
-numpy ; sys_platform != 'win32'
+numpy
 # Windows binaries on lxml are only available for this version. See #2100.
 lxml==3.4.4 ; sys_platform == 'win32'
 lxml ; sys_platform != 'win32'

--- a/tests/requirements-tools.txt
+++ b/tests/requirements-tools.txt
@@ -21,4 +21,3 @@ chardet  # character encoding detector.
 readme  # Check PYPI description.
 twine  # For secure upload of tar.gz to PYPI.
 pycmd  # Contains 'py.cleanup' that removes all .pyc files and similar.
-pip-accel  # Caches compiled pip packages and speeds up env setup in Travis/AppVeyor.

--- a/tests/requirements-win.txt
+++ b/tests/requirements-win.txt
@@ -12,5 +12,5 @@
 pyreadline  # Colors in IPython on Windows. This is Windows-only package.
 pypiwin32  # This package is a pip-installable version of PyWin32.
 pyenchant
-# No wheel for python 3.5
+# No wheel for python 3.5.
 PySide==1.2.4 ; python_version <= '3.4'


### PR DESCRIPTION
Based on @jstewmon's idea at https://github.com/pyinstaller/pyinstaller/pull/2078#issuecomment-234361619, this moves from using `pip-accel` (which forces use of pip v7) to using `pip` (the current v8) to install packages, since newer pip can both cache installed packages and install some packages (numpy, Pillow) that old pip can't.

@htgoebel, @matysek, any concerns from the Unix/Mac side in moving in this direction?