### PR TITLE
Add hook for pytest modules

### DIFF
--- a/PyInstaller/hooks/hook-pytest.py
+++ b/PyInstaller/hooks/hook-pytest.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013-2016, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+
+"""
+Hook for http://pypi.python.org/pypi/pytest/
+"""
+
+import pytest
+hiddenimports = pytest.freeze_includes()

--- a/tests/functional/test_hooks/test_pytest.py
+++ b/tests/functional/test_hooks/test_pytest.py
@@ -1,0 +1,12 @@
+
+
+def test_pytest_runner(pyi_builder):
+    """
+    Check if pytest runner builds correctly.
+    """
+    pyi_builder.test_source(
+        """
+        import pytest
+        import sys
+        sys.exit(pytest.main(['--help']))
+        """)


### PR DESCRIPTION
This hook makes it possible to embed the pytest runner into an executable using PyInstaller, making use of the `pytest.freeze_includes` function.

I decided to write this hook after converting pytest's own "freeze" testing environment from `cx_freeze` to `PyInstaller` (pytest-dev/pytest#1773) and seeing how much simpler is to use `PyInstaller`. Thanks for the excellent library!