### PR TITLE
bootloader: do not overwrite/lose LD_LIBRARY_PATH

### DIFF
--- a/bootloader/src/pyi_utils.c
+++ b/bootloader/src/pyi_utils.c
@@ -102,17 +102,11 @@ pyi_strjoin(const char *first, const char *sep, const char *second){
      * returns a null-terminated string which the caller is responsible
      * for freeing. Returns NULL if memory could not be allocated.
      */
-    int first_len=0, sep_len=0, second_len=0;
+    int first_len, sep_len, second_len;
     char *result;
-    if (first) {
-        first_len = strlen(first);
-    }
-    if (sep) {
-        sep_len = strlen(sep);
-    }
-    if (second) {
-        second_len = strlen(second);
-    }
+    first_len = first ? strlen(first) : 0;
+    sep_len = sep ? strlen(sep) : 0;
+    second_len = second ? strlen(second) : 0;
     result = malloc(first_len + sep_len + second_len + 1);
     if (!result) {
         return NULL;

--- a/bootloader/src/pyi_utils.c
+++ b/bootloader/src/pyi_utils.c
@@ -103,7 +103,7 @@ pyi_strjoin(const char *first, const char *sep, const char *second){
      * for freeing. Returns NULL if memory could not be allocated.
      */
     int first_len, sep_len, second_len;
-    char *result;
+    char *result, *tmp;
     first_len = first ? strlen(first) : 0;
     sep_len = sep ? strlen(sep) : 0;
     second_len = second ? strlen(second) : 0;
@@ -111,16 +111,20 @@ pyi_strjoin(const char *first, const char *sep, const char *second){
     if (!result) {
         return NULL;
     }
-    *result = '\0';
+    tmp = result;
     if (first_len) {
-        strcat(result, first);
+        memcpy(tmp, first, first_len);
+        tmp += first_len;
     }
     if (sep_len && first_len && second_len) {
-        strcat(result, sep);
+        memcpy(tmp, sep, sep_len);
+        tmp += sep_len;
     }
     if (second_len) {
-        strcat(result, second);
+        memcpy(tmp, second, second_len);
+        tmp += second_len;
     }
+    *tmp = '\0';
     return result;
 }
 

--- a/doc/advanced-topics.rst
+++ b/doc/advanced-topics.rst
@@ -38,9 +38,14 @@ A. First process: bootloader starts.
 
     1. If one-file mode, extract bundled files to *temppath*\ ``_MEI``\ *xxxxxx*
 
-    2. Set/unset various environment variables,
-       e.g. override LD_LIBRARY_PATH on Linux or LIBPATH on AIX;
-       unset DYLD_LIBRARY_PATH on OSX.
+    2. Modify various environment variables:
+
+       - Linux: save original value of LD_LIBRARY_PATH into LD_LIBRARY_PATH_ORIG,
+         prepend our path to LD_LIBRARY_PATH.
+
+       - AIX: same thing, but using LIBPATH and LIBPATH_ORIG.
+
+       - OSX: unset DYLD_LIBRARY_PATH.
 
     3. Set up to handle signals for both processes.
 


### PR DESCRIPTION
rather:
- prepend our path to the existing path
- save the original path in the environment

also:
implement pyi_strjoin (oh the joys of string processing in C!)

for more info, see #625, #1759 and the comments in the changeset.