### PR TITLE
Fix cryptography module missing backend

### DIFF
--- a/PyInstaller/hooks/hook-cryptography.py
+++ b/PyInstaller/hooks/hook-cryptography.py
@@ -17,9 +17,16 @@ import glob
 
 from PyInstaller.compat import EXTENSION_SUFFIXES
 from PyInstaller.utils.hooks import collect_submodules, get_module_file_attribute
+from PyInstaller.utils.hooks import copy_metadata
+
+# get the package data so we can load the backends
+datas = copy_metadata('cryptography')
+
+# Add the backends as hidden imports
+hiddenimports = collect_submodules('cryptography.hazmat.backends')
 
 # Add the OpenSSL FFI binding modules as hidden imports
-hiddenimports = collect_submodules('cryptography.hazmat.bindings.openssl') + ['_cffi_backend']
+hiddenimports += collect_submodules('cryptography.hazmat.bindings.openssl') + ['_cffi_backend']
 
 
 # Include the cffi extensions as binaries in a subfolder named like the package.


### PR DESCRIPTION
Fix for *Pyinstaller interaction with cryptography module*. #2013