### PR TITLE
(Re)add argv emulation for OSX, 64-bit

### DIFF
--- a/PyInstaller/depend/bindepend.py
+++ b/PyInstaller/depend/bindepend.py
@@ -662,6 +662,10 @@ def _getImports_macholib(pth):
                 if '.framework' in pth:
                     run_paths.update(['../../../'])
 
+    # for distributions like Anaconda, all of the dylibs are stored in the lib directory
+    # of the Python distribution, not alongside of the .so's in each module's subdirectory.
+    run_paths.add(os.path.join(base_prefix, 'lib'))
+
     ## Try to find files in file system.
 
     # In cases with @loader_path or @executable_path
@@ -669,6 +673,7 @@ def _getImports_macholib(pth):
     # This seems to work in most cases.
     exec_path = os.path.abspath(os.path.dirname(pth))
 
+ 
     for lib in seen:
 
         # Suppose that @rpath is not used for system libraries and

--- a/PyInstaller/depend/bindepend.py
+++ b/PyInstaller/depend/bindepend.py
@@ -890,12 +890,14 @@ def get_python_library_path():
         # and exec_prefix. That's why we can use just sys.prefix.
         # In virtualenv PyInstaller is not able to find Python library.
         # We need special care for this case.
-        py_prefix = compat.base_prefix
-
-        for name in PYDYLIB_NAMES:
-            full_path = os.path.join(py_prefix, name)
-            if os.path.exists(full_path):
-                return full_path
+        # Anaconda places the python library in the lib directory, so
+        # we search this one as well.
+        prefixes = [compat.base_prefix, os.path.join(compat.base_prefix, 'lib')]
+        for prefix in prefixes:
+            for name in PYDYLIB_NAMES:
+                full_path = os.path.join(prefix, name)
+                if os.path.exists(full_path):
+                    return full_path
 
     # Python library NOT found. Return just None.
     return None

--- a/bootloader/src/pyi_utils.c
+++ b/bootloader/src/pyi_utils.c
@@ -836,58 +836,57 @@ pyi_utils_create_child(const char *thisfile, const int argc, char *const argv[])
  */
     #if defined(__APPLE__) && defined(WINDOWED)
 
-/* TODO: Why is this commented out? */
+ static int gQuit = false;
+
+   static pascal OSErr handle_open_doc_ae(const AppleEvent *theAppleEvent, AppleEvent *reply, SRefCon handlerRefcon)
+   {
+   AEDescList docList;
+   long index;
+   long count = 0;
+   int i;
+   char *myFileName;
+   Size actualSize;
+   DescType returnedType;
+   AEKeyword keywd;
+   FSRef theRef;
+ 
+  VS("LOADER: handle_open_doc_ae called.\n");
+
+  OSErr err = AEGetParamDesc(theAppleEvent, keyDirectObject, typeAEList, &docList);
+  if (err != noErr) return err;
+
+   err = AECountItems(&docList, &count);
+   if (err != noErr) return err;
+   for (index = 1; index <= count; index++)
+   {
+     err = AEGetNthPtr(&docList, index, typeFSRef, &keywd, &returnedType, &theRef, sizeof(theRef), &actualSize);
+ 
+    CFURLRef fullURLRef;
+    fullURLRef = CFURLCreateFromFSRef(NULL, &theRef);
+     CFStringRef cfString = CFURLCopyFileSystemPath(fullURLRef, kCFURLPOSIXPathStyle);
+     CFRelease(fullURLRef);
+     CFMutableStringRef cfMutableString = CFStringCreateMutableCopy(NULL, 0, cfString);
+     CFRelease(cfString);
+     CFStringNormalize(cfMutableString, kCFStringNormalizationFormC);
+     int len = CFStringGetLength(cfMutableString);
+     const int bufferSize = (len+1)*6;  // in theory up to six bytes per Unicode code point, for UTF-8.
+     char* buffer = (char*)malloc(bufferSize);
+     CFStringGetCString(cfMutableString, buffer, bufferSize, kCFStringEncodingUTF8);
+ 
+    argv_pyi = (char**)realloc(argv_pyi,(argc_pyi+2)*sizeof(char*));
+    argv_pyi[argc_pyi++] = strdup(buffer);
+     argv_pyi[argc_pyi] = NULL;
+ 
+    free(buffer);
+   }
+ 
+  err = AEDisposeDesc(&docList);
+
+ 
+  return (err);
+   }
+ 
 /*
- *  static pascal OSErr handle_open_doc_ae(const AppleEvent *theAppleEvent, AppleEvent *reply, SRefCon handlerRefcon)
- *  {
- *  AEDescList docList;
- *  long index;
- *  long count = 0;
- *  int i;
- *  char *myFileName;
- *  Size actualSize;
- *  DescType returnedType;
- *  AEKeyword keywd;
- *  FSRef theRef;
- *
- *  VS("LOADER: handle_open_doc_ae called.\n");
- *
- *  OSErr err = AEGetParamDesc(theAppleEvent, keyDirectObject, typeAEList, &docList);
- *  if (err != noErr) return err;
- *
- *  err = AECountItems(&docList, &count);
- *  if (err != noErr) return err;
- *  for (index = 1; index <= count; index++)
- *  {
- *    err = AEGetNthPtr(&docList, index, typeFSRef, &keywd, &returnedType, &theRef, sizeof(theRef), &actualSize);
- *
- *    CFURLRef fullURLRef;
- *    fullURLRef = CFURLCreateFromFSRef(NULL, &theRef);
- *    CFStringRef cfString = CFURLCopyFileSystemPath(fullURLRef, kCFURLPOSIXPathStyle);
- *    CFRelease(fullURLRef);
- *    CFMutableStringRef cfMutableString = CFStringCreateMutableCopy(NULL, 0, cfString);
- *    CFRelease(cfString);
- *    CFStringNormalize(cfMutableString, kCFStringNormalizationFormC);
- *    int len = CFStringGetLength(cfMutableString);
- *    const int bufferSize = (len+1)*6;  // in theory up to six bytes per Unicode code point, for UTF-8.
- *    char* buffer = (char*)malloc(bufferSize);
- *    CFStringGetCString(cfMutableString, buffer, bufferSize, kCFStringEncodingUTF8);
- *
- *    argv_pyi = (char**)realloc(argv_pyi,(argc_pyi+2)*sizeof(char*));
- *    argv_pyi[argc_pyi++] = strdup(buffer);
- *    argv_pyi[argc_pyi] = NULL;
- *
- *    free(buffer);
- *  }
- *
- *  err = AEDisposeDesc(&docList);
- *
- *
- *  return (err);
- *  }
- *
- *  static int gQuit = false;
- *
  *  static void apple_main_event_loop()
  *  {
  *  OSErr err;
@@ -942,31 +941,37 @@ pyi_utils_create_child(const char *thisfile, const int argc, char *const argv[])
  * On Mac OS X converts files from kAEOpenDocuments events into sys.argv.
  * New implementation of handling Apple events - works even on 64bit Mac OS X.
  */
+#if 0
 static pascal OSStatus
 do_filenames_conversion_to_argv(EventHandlerCallRef next_handler,
                                 EventRef the_event,
                                 void* user_data)
 {
 
-/* /////////////// OLD implementation */
-/*
- *  AEDescList docList;
- *  long index;
- *  long count = 0;
- *  int i;
- *  char *myFileName;
- *  Size actualSize;
- *  DescType returnedType;
- *  AEKeyword keywd;
- *  FSRef theRef;
- *
- *  VS("LOADER: handle_open_doc_ae called.\n");
- *
- *  OSErr err = AEGetParamDesc(theAppleEvent, keyDirectObject, typeAEList, &docList);
- *  if (err != noErr) return err;
- *
- *  err = AECountItems(&docList, &count);
- *  if (err != noErr) return err;
+    VS("LOADER: AppleEvent - do_filenames_coversion_to_argv called.\n");
+
+    AEDescList docList;
+    long index;
+    long count = 0;
+    int i;
+    char *myFileName;
+    Size actualSize;
+    DescType returnedType;
+    AEKeyword keywd;
+    FSRef theRef;
+ 
+ 
+    OSErr err = AEGetParamDesc(theAppleEvent, keyDirectObject, typeAEList, &docList);
+
+    if (err != noErr) {
+      VS("LOADER: error from AEGetParamDesc");
+      return err;
+    }
+ 
+    err = AECountItems(&docList, &count);
+    if (err != noErr) return err;
+
+
  *  for (index = 1; index <= count; index++)
  *  {
  *    err = AEGetNthPtr(&docList, index, typeFSRef, &keywd, &returnedType, &theRef, sizeof(theRef), &actualSize);
@@ -995,7 +1000,6 @@ do_filenames_conversion_to_argv(EventHandlerCallRef next_handler,
 /* //////////////////////////////////////////// */
 
     /* Handle the kAEOpenDocuments event. */
-    VS("LOADER: AppleEvent - do_filenames_coversion_to_argv called.\n");
     /* Obtain filenames from event. */
     /* Every event type contains different additional information. */
     /* TODO */
@@ -1004,6 +1008,7 @@ do_filenames_conversion_to_argv(EventHandlerCallRef next_handler,
     /* Report success. */
     return noErr;
 }
+#endif
 
 /* TODO Unfinished, issue #1309. */
 static void
@@ -1011,64 +1016,67 @@ process_apple_events_new()
 {
     OSStatus handler_install_status;
     OSStatus handler_remove_status;
-    OSStatus event_received;
+    OSStatus rcv_status;
+    OSStatus pcs_status;
     EventTypeSpec event_types[1];  /*  List of event types to handle. */
-    EventHandlerUPP handler_open_doc;
+    AEEventHandlerUPP handler_open_doc;
     EventHandlerRef handler_ref; /* Reference for later removing the event handler. */
     EventRef event_ref;          /* Event that caused ReceiveNextEvent to return. */
     OSType ev_class;
     UInt32 ev_kind;
-    EventTimeout timeout = 3.0;  /* number of ticks (1/60th of a second) */
+    EventTimeout timeout = 2.0;  /* number of seconds */
 
     VS("LOADER: AppleEvent - processing...\n");
     /* Event types we are interested in. */
-    event_types[0].eventClass = kCoreEventClass;
-    event_types[0].eventKind = kAEOpenDocuments;
+    event_types[0].eventClass = kEventClassAppleEvent;
+    event_types[0].eventKind = kEventAppleEvent;
     /* Carbon Event Manager requires convert the function pointer to type EventHandlerUPP. */
     /* https://developer.apple.com/legacy/library/documentation/Carbon/Conceptual/Carbon_Event_Manager/Tasks/CarbonEventsTasks.html */
-    handler_open_doc = NewEventHandlerUPP(do_filenames_conversion_to_argv);
+    handler_open_doc = NewAEEventHandlerUPP(handle_open_doc_ae);
     /* Install the event handler. */
     /* InstallApplicationEventHandler is a macro for 'InstallEventHandler' where the event target */
     /* is Application. */
     /* We do not have any windows so having Application as event target should be fine. */
-    handler_install_status = InstallApplicationEventHandler(handler_open_doc, 1,
-                                                            event_types, NULL,
-                                                            &handler_ref);
+
+    //handler_install_status = InstallApplicationEventHandler(handler_open_doc, 1,
+     //                                                       event_types, NULL,
+      //                                                      &handler_ref);
+
+    handler_install_status = AEInstallEventHandler(kCoreEventClass, kAEOpenDocuments, handler_open_doc, 0, false);
 
     if (handler_install_status == noErr) {
+
         VS("LOADER: AppleEvent - installed handler.\n");
 
-        /* TODO */
-        /* ReceiveNextEvent(); */
-        /* RunCurrentEventLoop(timeout); */
-        /* RunApplicationEventLoop(); */
+        while(!gQuit) {
+           VS("LOADER: AppleEvent - calling ReceiveNextEvent\n");
+           rcv_status = ReceiveNextEvent(1, event_types, timeout, true, &event_ref); 
+           VS("LOADER: AppleEvent - back from ReceiveNextEvent\n");
 
-        /* Previous func WaitNextEvent() was deprecated and 32-bit only. */
-        /* Func ReceiveNextEvent() is threadsafe and available even for 64-bit OS X. */
-        /* gotEvent = WaitNextEvent(highLevelEventMask, &event, timeout, NULL); */
-        /* event_received = ReceiveNextEvent(1, event_types, kEventDurationForever, true, &event_ref); */
-        /* event_received = ReceiveNextEvent(0, NULL, kEventDurationNoWait, true, &event_ref); */
-        /* TODO */
-        /* handler_remove_status = RemoveEventHandler(handler_ref); */
-        /*
-         *  if (event_received == noErr)
-         *  {
-         *   VS("LOADER: AppleEvent - received event.\n");
-         *   ev_class = GetEventClass(event_ref);
-         *   ev_kind = GetEventKind(event_ref);
-         *   VS("LOADER: AppleEvent - event type: %u\n", ev_kind);
-         *   //if (GetEventKind(event_ref) == kAEOpenDocuments)
-         *   if (ev_class == kCoreEventClass)
-         *   {
-         *       VS("LOADER: AppleEvent - right class.\n");
-         *   }
-         *
-         *   ReleaseEvent(event_ref);
-         *  }
-         *  else
-         *  {
-         *   VS("LOADER: AppleEvent - ERROR receiving events code: %d\n", event_received);
-         *  }*/
+           if (rcv_status == eventLoopTimedOutErr) {
+              VS("LOADER: AppleEvent - with a timeout\n");
+              break;
+           }
+           else if (rcv_status != 0) {
+              VS("LOADER: AppleEvent argv emu: fetching events failed");
+              break;
+           }
+           else
+           {
+              VS("LOADER: AppleEvent argv emu: got an event");
+
+              pcs_status = AEProcessEvent(event_ref);
+              if (pcs_status != 0) {
+                 VS("LOADER: AppleEvent argv emu: processing events failed");
+                 break;
+              }
+
+           }
+        }
+
+        VS("LOADER: Out of the event loop.");
+
+        handler_remove_status = RemoveEventHandler(handler_ref); 
 
     }
     else {


### PR DESCRIPTION
To address issue #1309.  Somewhere along the way, argv emulation (which was originally authored by me for 32-bit) was broken for 64-bit.  This emulation has been reimplemented for 64-bit OSX.

argv emulation is what allows a program to be able to grab the filename of a drag/dropped file onto an app.
