### PR TITLE
Add `tempdir` option to control where bootloader will extract files

### DIFF
--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -339,6 +339,7 @@ class EXE(Target):
         self.manifest = kwargs.get('manifest', None)
         self.resources = kwargs.get('resources', [])
         self.strip = kwargs.get('strip', False)
+        self.tempdir = kwargs.get('tempdir', None)
         # If ``append_pkg`` is false, the archive will not be appended
         # to the exe, but copied beside it.
         self.append_pkg = kwargs.get('append_pkg', True)
@@ -385,6 +386,9 @@ class EXE(Target):
                 self.toc.extend(arg.dependencies)
             else:
                 self.toc.extend(arg)
+
+        if self.tempdir is not None:
+            self.toc.append(("pyi-tempdir " + self.tempdir, "", "OPTION"))
 
         if is_win:
             filename = os.path.join(CONF['workpath'], CONF['specnm'] + ".exe.manifest")

--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -339,7 +339,7 @@ class EXE(Target):
         self.manifest = kwargs.get('manifest', None)
         self.resources = kwargs.get('resources', [])
         self.strip = kwargs.get('strip', False)
-        self.tempdir = kwargs.get('tempdir', None)
+        self.runtime_tmpdir = kwargs.get('runtime_tmpdir', None)
         # If ``append_pkg`` is false, the archive will not be appended
         # to the exe, but copied beside it.
         self.append_pkg = kwargs.get('append_pkg', True)
@@ -387,8 +387,8 @@ class EXE(Target):
             else:
                 self.toc.extend(arg)
 
-        if self.tempdir is not None:
-            self.toc.append(("pyi-tempdir " + self.tempdir, "", "OPTION"))
+        if self.runtime_tmpdir is not None:
+            self.toc.append(("pyi-runtime-tmpdir " + self.runtime_tmpdir, "", "OPTION"))
 
         if is_win:
             filename = os.path.join(CONF['workpath'], CONF['specnm'] + ".exe.manifest")

--- a/PyInstaller/building/makespec.py
+++ b/PyInstaller/building/makespec.py
@@ -172,6 +172,8 @@ def __add_options(parser):
     g.add_argument("--noupx", action="store_true", default=False,
                    help="Do not use UPX even if it is available "
                         "(works differently between Windows and *nix)")
+    g.add_argument("--tempdir", dest="tempdir", metavar="PATH",
+                   help="Where to extract libraries while initializing bundled app.")
 
     g = parser.add_argument_group('Windows and Mac OS X specific options')
     g.add_argument("-c", "--console", "--nowindowed", dest="console",
@@ -243,7 +245,7 @@ def __add_options(parser):
 
 
 def main(scripts, name=None, onefile=None,
-         console=True, debug=False, strip=False, noupx=False,
+         console=True, debug=False, strip=False, noupx=False, tempdir=None,
          pathex=None, version_file=None, specpath=None,
          datas=None, binaries=None, icon_file=None, manifest=None, resources=None, bundle_identifier=None,
          hiddenimports=None, hookspath=None, key=None, runtime_hooks=None,
@@ -343,6 +345,7 @@ def main(scripts, name=None, onefile=None,
         'debug': debug,
         'strip': strip,
         'upx': not noupx,
+        'tempdir': repr(tempdir),
         'exe_options': exe_options,
         'cipher_init': cipher_init,
         # Directory with additional custom import hooks.

--- a/PyInstaller/building/makespec.py
+++ b/PyInstaller/building/makespec.py
@@ -345,7 +345,7 @@ def main(scripts, name=None, onefile=None,
         'debug': debug,
         'strip': strip,
         'upx': not noupx,
-        'tempdir': repr(tempdir),
+        'tempdir': tempdir,
         'exe_options': exe_options,
         'cipher_init': cipher_init,
         # Directory with additional custom import hooks.

--- a/PyInstaller/building/makespec.py
+++ b/PyInstaller/building/makespec.py
@@ -172,7 +172,7 @@ def __add_options(parser):
     g.add_argument("--noupx", action="store_true", default=False,
                    help="Do not use UPX even if it is available "
                         "(works differently between Windows and *nix)")
-    g.add_argument("--tempdir", dest="tempdir", metavar="PATH",
+    g.add_argument("--runtime-tmpdir", dest="runtime_tmpdir", metavar="PATH",
                    help="Where to extract libraries while initializing bundled app.")
 
     g = parser.add_argument_group('Windows and Mac OS X specific options')
@@ -245,7 +245,7 @@ def __add_options(parser):
 
 
 def main(scripts, name=None, onefile=None,
-         console=True, debug=False, strip=False, noupx=False, tempdir=None,
+         console=True, debug=False, strip=False, noupx=False, runtime_tmpdir=None,
          pathex=None, version_file=None, specpath=None,
          datas=None, binaries=None, icon_file=None, manifest=None, resources=None, bundle_identifier=None,
          hiddenimports=None, hookspath=None, key=None, runtime_hooks=None,
@@ -345,7 +345,7 @@ def main(scripts, name=None, onefile=None,
         'debug': debug,
         'strip': strip,
         'upx': not noupx,
-        'tempdir': tempdir,
+        'runtime_tmpdir': runtime_tmpdir,
         'exe_options': exe_options,
         'cipher_init': cipher_init,
         # Directory with additional custom import hooks.

--- a/PyInstaller/building/templates.py
+++ b/PyInstaller/building/templates.py
@@ -37,7 +37,7 @@ exe = EXE(pyz,
           debug=%(debug)s,
           strip=%(strip)s,
           upx=%(upx)s,
-          tempdir=%(tempdir)s,
+          tempdir=%(tempdir)r,
           console=%(console)s %(exe_options)s)
 """
 

--- a/PyInstaller/building/templates.py
+++ b/PyInstaller/building/templates.py
@@ -37,7 +37,7 @@ exe = EXE(pyz,
           debug=%(debug)s,
           strip=%(strip)s,
           upx=%(upx)s,
-          tempdir=%(tempdir)r,
+          runtime_tmpdir=%(runtime_tmpdir)r,
           console=%(console)s %(exe_options)s)
 """
 

--- a/PyInstaller/building/templates.py
+++ b/PyInstaller/building/templates.py
@@ -37,6 +37,7 @@ exe = EXE(pyz,
           debug=%(debug)s,
           strip=%(strip)s,
           upx=%(upx)s,
+          tempdir=%(tempdir)s,
           console=%(console)s %(exe_options)s)
 """
 

--- a/bootloader/src/pyi_utils.c
+++ b/bootloader/src/pyi_utils.c
@@ -226,33 +226,20 @@ pyi_get_temp_path(char *buffer, char *runtime_tmpdir)
     wchar_t *wchar_ret;
     wchar_t prefix[16];
     wchar_t wchar_buffer[PATH_MAX];
-    size_t requiredSize;
-    wchar_t *original_tmpdir;
-    wchar_t wruntime_tmpdir[PATH_MAX + 1];
-    wchar_t wruntime_tmpdir_abspath[PATH_MAX + 1];
+    char *original_tmpdir;
+    char runtime_tmpdir_abspath[PATH_MAX + 1];
 
-    if (NULL != runtime_tmpdir) {
+    if (runtime_tmpdir != NULL) {
       /*
        * Get original TMP environment variable so it can be restored
        * after this is done.
        */
-      _wgetenv_s(&requiredSize, NULL, 0, L"TMP");
-      if (requiredSize == 0) {
-        original_tmpdir = NULL;
-      } else {
-        original_tmpdir = (wchar_t *) malloc(requiredSize * sizeof(wchar_t));
-        if (!original_tmpdir) {
-          return 0;
-        }
-        _wgetenv_s(&requiredSize, original_tmpdir, requiredSize, L"TMP");
-      }
+      original_tmpdir = pyi_getenv("TMP");
       /*
        * Set TMP to runtime_tmpdir for _wtempnam() later
        */
-      pyi_win32_utils_from_utf8(wruntime_tmpdir, runtime_tmpdir, PATH_MAX);
-      _wfullpath(wruntime_tmpdir_abspath, wruntime_tmpdir, PATH_MAX);
-      _wputenv_s(L"TMP", wruntime_tmpdir_abspath);
-      //wchar_buffer = NULL;
+      pyi_path_fullpath(runtime_tmpdir_abspath, PATH_MAX, runtime_tmpdir);
+      pyi_setenv("TMP", runtime_tmpdir_abspath);
     }
 
     GetTempPathW(PATH_MAX, wchar_buffer);
@@ -271,30 +258,30 @@ pyi_get_temp_path(char *buffer, char *runtime_tmpdir)
         if (_wmkdir(wchar_ret) == 0) {
             pyi_win32_utils_to_utf8(buffer, wchar_ret, PATH_MAX);
             free(wchar_ret);
-            if (NULL != runtime_tmpdir) {
+            if (runtime_tmpdir != NULL) {
               /*
                * Restore TMP to what it was
                */
-              if (NULL != original_tmpdir) {
-                _wputenv_s(L"TMP", original_tmpdir);
+              if (original_tmpdir != NULL) {
+                pyi_setenv("TMP", original_tmpdir);
                 free(original_tmpdir);
               } else {
-                _wputenv_s(L"TMP", L"");
+                pyi_unsetenv("TMP");
               }
             }
             return 1;
         }
         free(wchar_ret);
     }
-    if (NULL != runtime_tmpdir) {
+    if (runtime_tmpdir != NULL) {
       /*
        * Restore TMP to what it was
        */
-      if (NULL != original_tmpdir) {
-        _wputenv_s(L"TMP", original_tmpdir);
+      if (original_tmpdir != NULL) {
+        pyi_setenv("TMP", original_tmpdir);
         free(original_tmpdir);
       } else {
-        _wputenv_s(L"TMP", L"");
+        pyi_unsetenv("TMP");
       }
     }
     return 0;
@@ -325,7 +312,7 @@ pyi_test_temp_path(char *buff)
 static int
 pyi_get_temp_path(char *buff, char *runtime_tmpdir)
 {
-    if (NULL != runtime_tmpdir) {
+    if (runtime_tmpdir != NULL) {
       strcpy(buff, runtime_tmpdir);
       if (pyi_test_temp_path(buff))
         return 1;
@@ -376,7 +363,7 @@ pyi_create_temp_path(ARCHIVE_STATUS *status)
 
     if (status->has_temp_directory != true) {
         runtime_tmpdir = pyi_arch_get_option(status, "pyi-runtime-tmpdir");
-        if(NULL != runtime_tmpdir) {
+        if(runtime_tmpdir != NULL) {
           VS("LOADER: Found runtime-tmpdir %s\n", runtime_tmpdir);
         }
 

--- a/bootloader/src/pyi_utils.c
+++ b/bootloader/src/pyi_utils.c
@@ -183,10 +183,14 @@ pyi_setenv(const char *variable, const char *value)
 
 #ifdef _WIN32
     wchar_t * wvar, *wval;
+
     wvar = pyi_win32_utils_from_utf8(NULL, variable, 0);
     wval = pyi_win32_utils_from_utf8(NULL, value, 0);
 
-    rc = SetEnvironmentVariableW(wvar, wval);
+    // Not sure why, but SetEnvironmentVariableW() didn't work for me
+    //rc = SetEnvironmentVariableW(wvar, wval);
+    rc = _wputenv_s(wvar, wval);
+
     free(wvar);
     free(wval);
 #else

--- a/bootloader/src/pyi_utils.c
+++ b/bootloader/src/pyi_utils.c
@@ -218,6 +218,48 @@ pyi_unsetenv(const char *variable)
 
 #ifdef _WIN32
 
+/*
+ * Generate random strings to use in temp filenames below
+ */
+void
+random_string(char *out, size_t n) {
+  char charset[] = "0123456789"
+                   "abcdefghijklmnopqrstuvwxyz"
+                   "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+  while (n-- > 0) {
+    size_t index = (double) rand() / RAND_MAX * (sizeof charset - 1);
+    *out++ = charset[index];
+  }
+
+  *out = '\0';
+}
+
+/*
+ * Like _wtempnam(), but use dir instead of TMP.
+ */
+wchar_t *
+wtempnam_in_dir(const wchar_t *dir, const wchar_t *prefix)
+{
+  wchar_t *wchar_ret;
+  size_t rnd_len = 4;
+  char rnd[4 + 1];
+  struct _stat buf;
+
+  for (int i = 0; i < TMP_MAX; i++) {
+    random_string(rnd, rnd_len);
+    wchar_ret = malloc((_scwprintf(L"%s\\%s%S", dir, prefix, rnd) + 1)*sizeof(wchar_t));
+    swprintf_s(wchar_ret, PATH_MAX, L"%s\\%s%S", dir, prefix, rnd);
+    /* Check if file exists */
+    if (0 != _wstat32(wchar_ret, &buf)) {
+      return wchar_ret;
+    } else {
+      free(wchar_ret);
+    }
+  }
+  return NULL;
+}
+
 /* TODO rename fuction and revisit */
 int
 pyi_get_temp_path(char *buffer, char *runtime_tmpdir)
@@ -249,8 +291,7 @@ pyi_get_temp_path(char *buffer, char *runtime_tmpdir)
     for (i = 0; i < 5; i++) {
         /* TODO use race-free fuction - if any exists? */
         if (NULL != runtime_tmpdir) {
-          wchar_ret = malloc((_scwprintf(L"%s\\%s", wruntime_tmpdir_abspath, prefix) + 1)*sizeof(wchar_t));
-          swprintf_s(wchar_ret, PATH_MAX, L"%s\\%s", wruntime_tmpdir_abspath, prefix);
+          wchar_ret = wtempnam_in_dir(wruntime_tmpdir_abspath, prefix);
         } else {
           wchar_ret = _wtempnam(wchar_buffer, prefix);
         }

--- a/bootloader/src/pyi_utils.c
+++ b/bootloader/src/pyi_utils.c
@@ -187,8 +187,8 @@ pyi_setenv(const char *variable, const char *value)
     wvar = pyi_win32_utils_from_utf8(NULL, variable, 0);
     wval = pyi_win32_utils_from_utf8(NULL, value, 0);
 
-    // Not sure why, but SetEnvironmentVariableW() didn't work for me
-    //rc = SetEnvironmentVariableW(wvar, wval);
+    // Not sure why, but SetEnvironmentVariableW() didn't work with _wtempnam()
+    // Replaced it with _wputenv_s()
     rc = _wputenv_s(wvar, wval);
 
     free(wvar);

--- a/bootloader/src/pyi_utils.c
+++ b/bootloader/src/pyi_utils.c
@@ -229,7 +229,7 @@ pyi_get_temp_path(char *buffer, char *runtime_tmpdir)
     wchar_t wruntime_tmpdir[PATH_MAX + 1];
 
     if (NULL != runtime_tmpdir) {
-      pyi_win32_utils_from_utf8(wtempdir, runtime_tmpdir, PATH_MAX);
+      pyi_win32_utils_from_utf8(wruntime_tmpdir, runtime_tmpdir, PATH_MAX);
       wcscpy(wchar_buffer, wruntime_tmpdir);
     } else {
       /*

--- a/bootloader/src/pyi_utils.c
+++ b/bootloader/src/pyi_utils.c
@@ -226,9 +226,11 @@ pyi_get_temp_path(char *buffer, char *tempdir)
     wchar_t *wchar_ret;
     wchar_t prefix[16];
     wchar_t wchar_buffer[PATH_MAX];
+    wchar_t wtempdir[PATH_MAX + 1];
 
     if (NULL != tempdir) {
-      wcscpy(wchar_buffer, tempdir);
+      pyi_win32_utils_from_utf8(wtempdir, tempdir, PATH_MAX);
+      wcscpy(wchar_buffer, wtempdir);
     } else {
       /*
        * Get path to Windows temporary directory.

--- a/bootloader/src/pyi_utils.c
+++ b/bootloader/src/pyi_utils.c
@@ -220,17 +220,17 @@ pyi_unsetenv(const char *variable)
 
 /* TODO rename fuction and revisit */
 int
-pyi_get_temp_path(char *buffer, char *tempdir)
+pyi_get_temp_path(char *buffer, char *runtime_tmpdir)
 {
     int i;
     wchar_t *wchar_ret;
     wchar_t prefix[16];
     wchar_t wchar_buffer[PATH_MAX];
-    wchar_t wtempdir[PATH_MAX + 1];
+    wchar_t wruntime_tmpdir[PATH_MAX + 1];
 
-    if (NULL != tempdir) {
-      pyi_win32_utils_from_utf8(wtempdir, tempdir, PATH_MAX);
-      wcscpy(wchar_buffer, wtempdir);
+    if (NULL != runtime_tmpdir) {
+      pyi_win32_utils_from_utf8(wtempdir, runtime_tmpdir, PATH_MAX);
+      wcscpy(wchar_buffer, wruntime_tmpdir);
     } else {
       /*
        * Get path to Windows temporary directory.
@@ -282,10 +282,10 @@ pyi_test_temp_path(char *buff)
 
 /* TODO merge this function with windows version. */
 static int
-pyi_get_temp_path(char *buff, char *tempdir)
+pyi_get_temp_path(char *buff, char *runtime_tmpdir)
 {
-    if (NULL != tempdir) {
-      strcpy(buff, tempdir);
+    if (NULL != runtime_tmpdir) {
+      strcpy(buff, runtime_tmpdir);
       if (pyi_test_temp_path(buff))
         return 1;
     } else {
@@ -331,15 +331,15 @@ pyi_get_temp_path(char *buff, char *tempdir)
 int
 pyi_create_temp_path(ARCHIVE_STATUS *status)
 {
-    char *tempdir = NULL;
+    char *runtime_tmpdir = NULL;
 
     if (status->has_temp_directory != true) {
-        tempdir = pyi_arch_get_option(status, "pyi-tempdir");
-        if(NULL != tempdir) {
-          VS("LOADER: Found tempdir %s\n", tempdir);
+        runtime_tmpdir = pyi_arch_get_option(status, "pyi-runtime-tmpdir");
+        if(NULL != runtime_tmpdir) {
+          VS("LOADER: Found runtime-tmpdir %s\n", runtime_tmpdir);
         }
 
-        if (!pyi_get_temp_path(status->temppath, tempdir)) {
+        if (!pyi_get_temp_path(status->temppath, runtime_tmpdir)) {
             FATALERROR("INTERNAL ERROR: cannot create temporary directory!\n");
             return -1;
         }

--- a/doc/operating-mode.rst
+++ b/doc/operating-mode.rst
@@ -225,6 +225,12 @@ or is killed (kill -9 on Unix, killed by the Task Manager on Windows,
 Thus if your app crashes frequently, your users will lose disk space to
 multiple :file:`_MEI{xxxxxx}` temporary folders.
 
+It is possible to control the location of the ``_MEI``\ *xxxxxx* folder
+when creating a one-file app by using the ``--runtime-tmpdir`` command
+line option. The specified path is stored in the executable, and
+the bootloader will create the ``_MEI``\ *xxxxxx* folder inside of the
+specified folder.
+
 .. Note::
 
     Do *not* give administrator privileges to a one-file executable

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -134,6 +134,25 @@ The *key-string* is a string of 16 characters which is used to
 encrypt each file of Python byte-code before it is stored in
 the archive inside the executable file.
 
+.. _extracting libraries:
+
+Extracting Libraries
+~~~~~~~~~~~~~~~~~~~~
+
+When building an executable using ``--onefile``, |PyInstaller| generates a single
+executable file with all the required Python libraries and modules packaged
+inside it. When the executable is run, a bootloader will extract all the libraries
+into a temporary directory, and will run the application from the temporary directory.
+
+The default location for the temporary directory is the system temporary directory.
+Some operating systems allow you to configure the system temporary directory as
+non-executable, which will prevent the extracted application from executing.
+
+In order to work around that, there are two options. One is to set the environment
+variable ``TMPDIR`` to point to a location which allows executing programs. In
+case there is no way to set the environment variable, you can use the ``--tempdir``
+command line option to configure the bootloader to use a different location.
+
 
 .. _supporting multiple platforms:
 
@@ -221,14 +240,14 @@ Under Linux, |PyInstaller| does not bundle ``libc``
 (the C standard library, usually ``glibc``, the Gnu version) with the app.
 Instead, the app expects to link dynamically to the ``libc`` from the
 local OS where it runs.
-The interface between any app and ``libc`` is forward compatible to 
+The interface between any app and ``libc`` is forward compatible to
 newer releases, but it is not backward compatible to older releases.
 
 For this reason, if you bundle your app on the current version of Linux,
 it may fail to execute (typically with a runtime dynamic link error) if
 it is executed on an older version of Linux.
 
-The solution is to always build your app on the *oldest* version of 
+The solution is to always build your app on the *oldest* version of
 Linux you mean to support.
 It should continue to work with the ``libc`` found on newer versions.
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -134,25 +134,26 @@ The *key-string* is a string of 16 characters which is used to
 encrypt each file of Python byte-code before it is stored in
 the archive inside the executable file.
 
-.. _extracting libraries:
+.. _extracting files:
 
-Extracting Libraries
-~~~~~~~~~~~~~~~~~~~~
+Extracting Files Added to Bundle
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When building an executable using ``--onefile``, |PyInstaller| generates a single
-executable file with all the required Python libraries and modules packaged
-inside it. When the executable is run, a bootloader will extract all the libraries
-into a temporary directory, and will run the application from the temporary directory.
+When you bundle to a single executable (see :ref:`Bundling to One File`),
+copies of added files are compressed into the executable, and expanded to the
+``_MEI``\ *xxxxxx* temporary folder before execution.
 
-The default location for the temporary directory is the system temporary directory.
-Some operating systems allow you to configure the system temporary directory as
-non-executable, which will prevent the extracted application from executing.
+By default the temporary ``_MEI``\ *xxxxxx* folder will be created in the system
+configured temporary directory. At run time the location of the temporary directory
+can be configured by using the appropriate environment variables for the target
+operating system.
 
-In order to work around that, there are two options. One is to set the environment
-variable ``TMPDIR`` to point to a location which allows executing programs. In
-case there is no way to set the environment variable, you can use the ``--tempdir``
-command line option to configure the bootloader to use a different location.
-
+Sometimes you may want to control the location of the temporary directory at
+compile time. You may not want your application to depend on specific properties
+of the target environment, or you may not want to require the end-user to change
+their system configuration. In order to control the location of the temporary
+directory at compile time, the ``--tempdir`` allows setting the temporary
+directory when building the application bundle.
 
 .. _supporting multiple platforms:
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -152,7 +152,7 @@ Sometimes you may want to control the location of the temporary directory at
 compile time. You may not want your application to depend on specific properties
 of the target environment, or you may not want to require the end-user to change
 their system configuration. In order to control the location of the temporary
-directory at compile time, the ``--tempdir`` allows setting the temporary
+directory at compile time, the ``--runtime-tmpdir`` allows setting the temporary
 directory when building the application bundle.
 
 .. _supporting multiple platforms:

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -134,26 +134,15 @@ The *key-string* is a string of 16 characters which is used to
 encrypt each file of Python byte-code before it is stored in
 the archive inside the executable file.
 
-.. _extracting files:
+.. _defining the extraction location:
 
-Extracting Files Added to Bundle
+Defining the Extraction Location
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When you bundle to a single executable (see :ref:`Bundling to One File`),
-copies of added files are compressed into the executable, and expanded to the
-``_MEI``\ *xxxxxx* temporary folder before execution.
-
-By default the temporary ``_MEI``\ *xxxxxx* folder will be created in the system
-configured temporary directory. At run time the location of the temporary directory
-can be configured by using the appropriate environment variables for the target
-operating system.
-
-Sometimes you may want to control the location of the temporary directory at
-compile time. You may not want your application to depend on specific properties
-of the target environment, or you may not want to require the end-user to change
-their system configuration. In order to control the location of the temporary
-directory at compile time, the ``--runtime-tmpdir`` allows setting the temporary
-directory when building the application bundle.
+When you bundle to a single executable
+(see :ref:Bundling to One File and :ref:how the one-file program works),
+you sometimes may want to control the location of the temporary directory
+at compile time. This can be done using the --runtime-tmpdir option.
 
 .. _supporting multiple platforms:
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -240,14 +240,14 @@ Under Linux, |PyInstaller| does not bundle ``libc``
 (the C standard library, usually ``glibc``, the Gnu version) with the app.
 Instead, the app expects to link dynamically to the ``libc`` from the
 local OS where it runs.
-The interface between any app and ``libc`` is forward compatible to
+The interface between any app and ``libc`` is forward compatible to 
 newer releases, but it is not backward compatible to older releases.
 
 For this reason, if you bundle your app on the current version of Linux,
 it may fail to execute (typically with a runtime dynamic link error) if
 it is executed on an older version of Linux.
 
-The solution is to always build your app on the *oldest* version of
+The solution is to always build your app on the *oldest* version of 
 Linux you mean to support.
 It should continue to work with the ``libc`` found on newer versions.
 

--- a/tests/functional/test_basic.py
+++ b/tests/functional/test_basic.py
@@ -555,8 +555,12 @@ def test_option_runtime_tmpdir(pyi_builder):
         print('test - runtime_tmpdir - custom runtime temporary directory')
         import os
         import sys
+        if sys.platform == 'win32':
+            import win32api
         cwd = os.path.abspath(os.getcwd())
         runtime_tmpdir = os.path.abspath(sys._MEIPASS)
+        if sys.platform == 'win32' and sys.version_info.major == 2 and sys.version_info.minor == 7:
+            runtime_tmpdir = win32api.GetShortPathName(runtime_tmpdir)
         # for onedir mode, runtime_tmpdir == cwd
         # for onefile mode, os.path.dirname(runtime_tmpdir) == cwd
         if not runtime_tmpdir == cwd and not os.path.dirname(runtime_tmpdir) == cwd:

--- a/tests/functional/test_basic.py
+++ b/tests/functional/test_basic.py
@@ -558,7 +558,7 @@ def test_option_runtime_tmpdir(pyi_builder):
         if sys.platform == 'win32':
             import win32api
         cwd = os.path.abspath(os.getcwd())
-        if sys.platform == 'win32' and sys.version_info.major == 2 and sys.version_info.minor == 7:
+        if sys.platform == 'win32' and sys.version_info < (3,):
             cwd = win32api.GetShortPathName(cwd)
         runtime_tmpdir = os.path.abspath(sys._MEIPASS)
         # for onedir mode, runtime_tmpdir == cwd

--- a/tests/functional/test_basic.py
+++ b/tests/functional/test_basic.py
@@ -558,9 +558,9 @@ def test_option_runtime_tmpdir(pyi_builder):
         if sys.platform == 'win32':
             import win32api
         cwd = os.path.abspath(os.getcwd())
-        runtime_tmpdir = os.path.abspath(sys._MEIPASS)
         if sys.platform == 'win32' and sys.version_info.major == 2 and sys.version_info.minor == 7:
-            runtime_tmpdir = win32api.GetShortPathName(runtime_tmpdir)
+            cwd = win32api.GetShortPathName(cwd)
+        runtime_tmpdir = os.path.abspath(sys._MEIPASS)
         # for onedir mode, runtime_tmpdir == cwd
         # for onefile mode, os.path.dirname(runtime_tmpdir) == cwd
         if not runtime_tmpdir == cwd and not os.path.dirname(runtime_tmpdir) == cwd:

--- a/tests/functional/test_basic.py
+++ b/tests/functional/test_basic.py
@@ -546,3 +546,22 @@ def test_hook_collect_submodules(pyi_builder, script_dir):
 # Test that PyInstaller can handle a script with an arbitrary extension.
 def test_arbitrary_ext(pyi_builder):
     pyi_builder.test_script('pyi_arbitrary_ext.foo')
+    
+def test_option_runtime_tmpdir(pyi_builder):
+    "Test to ensure that option `runtime_tmpdir` can be set and has effect."
+
+    pyi_builder.test_source(
+        """
+        print('test - runtime_tmpdir - custom runtime temporary directory')
+        import os
+        import sys
+        cwd = os.path.abspath(os.getcwd())
+        runtime_tmpdir = os.path.abspath(sys._MEIPASS)
+        # for onedir mode, runtime_tmpdir == cwd
+        # for onefile mode, os.path.dirname(runtime_tmpdir) == cwd
+        if not runtime_tmpdir == cwd and not os.path.dirname(runtime_tmpdir) == cwd:
+            raise SystemExit('Expected sys._MEIPASS to be under current working dir.'
+                             ' sys._MEIPASS = ' + runtime_tmpdir + ', cwd = ' + cwd)
+        print('test - done')
+        """,
+        ['--runtime-tmpdir=.']) # set runtime-tmpdir to current working dir


### PR DESCRIPTION
- Add `--tempdir` command line option to generate spec file
- Add `tempdir` option to spec file
- Store `tempdir` option in TOC
- Extract files to `tempdir` instead of system temporary directory when `tempdir` defined
