### PR TITLE
Create hook-jira.py

### DIFF
--- a/PyInstaller/hooks/hook-jira.py
+++ b/PyInstaller/hooks/hook-jira.py
@@ -1,0 +1,4 @@
+from PyInstaller.utils.hooks import copy_metadata, collect_submodules
+
+datas = copy_metadata('jira')
+hiddenimports = collect_submodules('jira')

--- a/PyInstaller/hooks/hook-jira.py
+++ b/PyInstaller/hooks/hook-jira.py
@@ -1,3 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013-2016, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+"""
+Hook for https://pypi.python.org/pypi/jira/
+"""
+
 from PyInstaller.utils.hooks import copy_metadata, collect_submodules
 
 datas = copy_metadata('jira')


### PR DESCRIPTION
If user wants to use module [**jira**](https://pypi.python.org/pypi/jira/) in his program he will detect error  after creation of exe-file:

```
D:\s_litvinchuk\WorkLogger>worklogger\worklogger.exe
Traceback (most recent call last):
  File "main3.py", line 7, in <module>
    import jira
  File "c:\python27\lib\site-packages\PyInstaller-3.3.dev0+b78bfe5-py2.7.egg\PyInstaller\loader\pyimod03_importers.py", line 389, in load_module
    exec(bytecode, module.__dict__)
  File "site-packages\jira\__init__.py", line 6, in <module>
  File "site-packages\pkg_resources\__init__.py", line 559, in get_distribution
  File "site-packages\pkg_resources\__init__.py", line 433, in get_provider
  File "site-packages\pkg_resources\__init__.py", line 970, in require
  File "site-packages\pkg_resources\__init__.py", line 856, in resolve
pkg_resources.DistributionNotFound: The 'jira' distribution was not found and is required by the application
Failed to execute script main3
```

hook-jira.py file would solve this problem.
