### PR TITLE
Fix for issue #2215: hook-lib.wx.pubsub is not working.

### DIFF
--- a/PyInstaller/hooks/hook-wx.lib.pubsub.py
+++ b/PyInstaller/hooks/hook-wx.lib.pubsub.py
@@ -15,6 +15,8 @@
 from PyInstaller.utils.hooks import collect_submodules, collect_data_files
 
 hiddenimports = collect_submodules('wx.lib.pubsub')
+hiddenimports += collect_submodules('wx.lib.pubsub.core.kwargs')
+hiddenimports += collect_submodules('wx.lib.pubsub.core.arg1')
 
 # collect_submodules does not find `pubsub1` or `pubsub2` because
 # they are not packages, just folders without an `__init__.py`

--- a/PyInstaller/utils/hooks/__init__.py
+++ b/PyInstaller/utils/hooks/__init__.py
@@ -612,7 +612,15 @@ def collect_submodules(package, filter=lambda name: True):
                         ## This is the original Py3 code.
                         #yield from walk_packages(path, name+'.', onerror)
 
-        for module_loader, name, ispkg in walk_packages([{}], '{}.'):
+        def AllowRuntimeExceptions(exc):
+           # some modules, such as wx.lib.pubsub, are problematic in that they purposefully raise an exception
+           # if the user tries to import them directly.  In Pyinstaller, we are just querying, so we don't want
+           # to abort the search if the module doesn't want to play nice.  Partially addresses issue #2215.
+           typ, _, _ = sys.exc_info()
+           if typ == RuntimeError: return
+           else: raise
+
+        for module_loader, name, ispkg in walk_packages([{}], '{}.', onerror=AllowRuntimeExceptions):
             print(name)
         """.format(
                   # Use repr to escape Windows backslashes.


### PR DESCRIPTION
Two items:  
1) don't allow RuntimeErrors to terminate Pyinstaller's search
  2) add appropriate hidden imports for wx.lib.pubsub so that
     all of the package's modules make it into the TOC.

After these two fixes,  an application using wx.lib.pubsub can be successfully packaged and run.  There are still warnings in the Pyinstaller output, but they are expected, and I'm not sure how to suppress them.  This is because of the path manipulation that takes place within wx.lib.pubsub.core, which causes these imports to come from wx.lib.pubsub.core.kwargs or wx.lib.pubsub.core.arg1 as appropriate, not the locations listed below.

3755 WARNING: Hidden import "wx.lib.pubsub.core.listenerimpl" not found!
3756 WARNING: Hidden import "wx.lib.pubsub.core.publishermixin" not found!
3758 WARNING: Hidden import "wx.lib.pubsub.core.topicargspecimpl" not found!
3794 WARNING: Hidden import "wx.lib.pubsub.core.topicmgrimpl" not found!
3977 WARNING: Hidden import "wx.lib.pubsub.core.publisher" not found!
3982 WARNING: Hidden import "wx.lib.pubsub.core.datamsg" not found!
