### PR TITLE
QtWebEngineWidgets: Add QtWebEngineCore to hiddenimports

### DIFF
--- a/PyInstaller/hooks/hook-PyQt5.QtWebEngineWidgets.py
+++ b/PyInstaller/hooks/hook-PyQt5.QtWebEngineWidgets.py
@@ -15,6 +15,7 @@ hiddenimports = ["sip",
                  "PyQt5.QtCore",
                  "PyQt5.QtGui",
                  "PyQt5.QtNetwork",
+                 "PyQt5.QtWebEngineCore",
                  "PyQt5.QtWebChannel",
                  ]
 

--- a/PyInstaller/utils/hooks/qt.py
+++ b/PyInstaller/utils/hooks/qt.py
@@ -157,7 +157,7 @@ def get_qmake_path(version=''):
 
     for directory in dirs:
         try:
-            qmake = os.path.join(directory, 'qmake')
+            qmake = os.path.join(directory, 'bin', 'qmake')
             versionstring = subprocess.check_output([qmake, '-query',
                                                      'QT_VERSION']).strip()
             if is_py3:


### PR DESCRIPTION
Add QtWebEngineCore to hiddenimports for QtWebEngineWidgets to fix the symptoms originally reported by @tallforasmurf in #1984. Please double check that this is appropriate, as I'm not a domain expert here.

Also fixes qmake detection for Qt installed via Homebrew on OS X.
