### PR TITLE
Added a hook for xsge_gui.

### DIFF
--- a/PyInstaller/hooks/hook-xsge_gui.py
+++ b/PyInstaller/hooks/hook-xsge_gui.py
@@ -1,0 +1,14 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2016, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+# Hook for the xsge_gui module: https://pypi.python.org/pypi/xsge_gui
+
+from PyInstaller.utils.hooks import collect_data_files
+datas = collect_data_files('xsge_gui')
+


### PR DESCRIPTION
Tested on Ubuntu 16.04, 64-bit.

This hook is to include the data files of xsge_gui so that it will work properly: https://pypi.python.org/pypi/xsge_gui

To test, use Pyinstaller on a game that uses it. The simplest such game is Kitten Command:

https://onpon4.itch.io/kitten-command