### PR TITLE
Update hook-PyQt5.py

### DIFF
--- a/PyInstaller/hooks/hook-PyQt5.py
+++ b/PyInstaller/hooks/hook-PyQt5.py
@@ -21,6 +21,7 @@ from PyInstaller.compat import getsitepackages, is_darwin, is_win
 if is_win:
     from PyInstaller.utils.win32.winutils import extend_system_path
     extend_system_path([os.path.join(x, 'PyQt5') for x in getsitepackages()])
+    extend_system_path([os.path.join(x, 'PyQt5\\Qt\\bin') for x in getsitepackages()])
 
 
 # In the new consolidated mode any PyQt depends on _qt

--- a/PyInstaller/hooks/hook-PyQt5.py
+++ b/PyInstaller/hooks/hook-PyQt5.py
@@ -21,7 +21,7 @@ from PyInstaller.compat import getsitepackages, is_darwin, is_win
 if is_win:
     from PyInstaller.utils.win32.winutils import extend_system_path
     extend_system_path([os.path.join(x, 'PyQt5') for x in getsitepackages()])
-    extend_system_path([os.path.join(x, 'PyQt5\\Qt\\bin') for x in getsitepackages()])
+    extend_system_path([os.path.join(x, 'PyQt5', 'Qt', 'bin') for x in getsitepackages()])
 
 
 # In the new consolidated mode any PyQt depends on _qt

--- a/PyInstaller/hooks/hook-PyQt5.py
+++ b/PyInstaller/hooks/hook-PyQt5.py
@@ -9,7 +9,7 @@
 
 
 import os
-import sys
+import platform
 
 from PyInstaller.utils.hooks import (
     get_module_attribute, is_module_satisfies, qt_menu_nib_dir)
@@ -22,7 +22,7 @@ from PyInstaller.compat import getsitepackages, is_darwin, is_win
 if is_win:
     from PyInstaller.utils.win32.winutils import extend_system_path
     extend_system_path([os.path.join(x, 'PyQt5') for x in getsitepackages()])
-    if sys.version_info[0] >= 3:
+    if platform.system() == 'Windows':
         extend_system_path([os.path.join(x, 'PyQt5', 'Qt', 'bin') for x in getsitepackages()])
 
 

--- a/PyInstaller/hooks/hook-PyQt5.py
+++ b/PyInstaller/hooks/hook-PyQt5.py
@@ -9,6 +9,7 @@
 
 
 import os
+import sys
 
 from PyInstaller.utils.hooks import (
     get_module_attribute, is_module_satisfies, qt_menu_nib_dir)
@@ -21,7 +22,8 @@ from PyInstaller.compat import getsitepackages, is_darwin, is_win
 if is_win:
     from PyInstaller.utils.win32.winutils import extend_system_path
     extend_system_path([os.path.join(x, 'PyQt5') for x in getsitepackages()])
-    extend_system_path([os.path.join(x, 'PyQt5', 'Qt', 'bin') for x in getsitepackages()])
+    if sys.version_info[0] >= 3:
+        extend_system_path([os.path.join(x, 'PyQt5', 'Qt', 'bin') for x in getsitepackages()])
 
 
 # In the new consolidated mode any PyQt depends on _qt


### PR DESCRIPTION
This change is necessary because pyinstaller does not automatically detect DLLs installed by PyQt5.