### PR TITLE
Add hook for pyopencl and set default spec file encoding (fixes python 3.5 issue)

### DIFF
--- a/PyInstaller/building/build_main.py
+++ b/PyInstaller/building/build_main.py
@@ -28,7 +28,7 @@ from .. import HOMEPATH, DEFAULT_DISTPATH, DEFAULT_WORKPATH
 from .. import compat
 from .. import log as logging
 from ..utils.misc import absnormpath
-from ..compat import is_py2, is_win, PYDYLIB_NAMES, VALID_MODULE_TYPES
+from ..compat import is_py2, is_win, read_pysrc, PYDYLIB_NAMES, VALID_MODULE_TYPES
 from ..depend import bindepend
 from ..depend.analysis import initialize_modgraph
 from .api import PYZ, EXE, COLLECT, MERGE
@@ -728,9 +728,8 @@ def build(spec, distpath, workpath, clean_build):
     from ..config import CONF
     CONF['workpath'] = workpath
 
-    # Executing the specfile.
-    with open(spec, 'r') as f:
-        text = f.read()
+    # Executing the specfile
+    text = read_pysrc(spec)
     exec(text, spec_namespace)
 
 

--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -20,6 +20,7 @@ import platform
 import site
 import subprocess
 import sys
+from .lib.modulegraph.util import open_pysrc
 
 
 # Distinguish code for different major Python version.
@@ -889,3 +890,12 @@ def check_requirements():
             raise SystemExit('PyInstaller cannot check for assembly dependencies.\n'
                              'Please install PyWin32.\n\n'
                              'pip install pypiwin32\n')
+
+
+def read_pysrc(filename):
+    """
+    Read Python source file with proper detection of its encoding
+    """
+    with open_pysrc(filename) as fh:
+        code = fh.read().replace('\\r\\n', '\\n')
+    return code + '\n'

--- a/PyInstaller/hooks/hook-pyopencl.py
+++ b/PyInstaller/hooks/hook-pyopencl.py
@@ -1,0 +1,14 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2015-2016, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+# Hook for the pyopencl module: https://github.com/pyopencl/pyopencl
+
+from PyInstaller.utils.hooks import copy_metadata, collect_data_files
+datas = copy_metadata('pyopencl')
+datas += collect_data_files('pyopencl')

--- a/PyInstaller/lib/modulegraph/util.py
+++ b/PyInstaller/lib/modulegraph/util.py
@@ -1,11 +1,14 @@
 from __future__ import absolute_import
 
+import io
 import os
 import imp
 import sys
 import re
 import marshal
 import warnings
+import tokenize
+from contextlib import contextmanager
 
 try:
     unicode
@@ -117,3 +120,16 @@ def guess_encoding(fp):
             return m.group(1).decode('ascii')
 
     return default_encoding
+
+@contextmanager
+def open_pysrc(filename):
+    if getattr(tokenize, 'open', None) is not None:
+        pysrc_f = tokenize.open(filename)
+    else:
+        with io.open(filename, 'rb') as tmp_f:
+            encoding = guess_encoding(tmp_f)
+        pysrc_f = io.open(filename, 'r', encoding=encoding)
+
+    yield pysrc_f
+
+    pysrc_f.close()


### PR DESCRIPTION
- this adds necessary include paths that are part of the pyopencl
  metadata see (pyopencl/__init__.py::_find_pyopencl_include_path())

NOTE: it works with the latest pyopencl that has a typo fixed (merged just today: https://github.com/pyopencl/pyopencl/pull/157)

Thank you for including this.

Best regards,

Jan