### PR TITLE
Make Target class an abstract base class. Fix comments in TOC class.

### DIFF
--- a/PyInstaller/building/datastruct.py
+++ b/PyInstaller/building/datastruct.py
@@ -9,6 +9,7 @@
 
 
 import os
+import abc
 
 from PyInstaller.utils import misc
 from PyInstaller.utils.misc import load_py_data_struct, save_py_data_struct
@@ -42,18 +43,18 @@ def unique_name(entry):
 class TOC(list):
     # TODO Simplify the representation and use directly Modulegraph objects.
     """
-    TOC (Table of Contents) class is a list of tuples of the form (name, path, tytecode).
+    TOC (Table of Contents) class is a list of tuples of the form (name, path, typecode).
 
-    typecode    name                   path                        description
+    name                    path                        typecode       description
     --------------------------------------------------------------------------------------
-    EXTENSION   Python internal name.  Full path name in build.    Extension module.
-    PYSOURCE    Python internal name.  Full path name in build.    Script.
-    PYMODULE    Python internal name.  Full path name in build.    Pure Python module (including __init__ modules).
-    PYZ         Runtime name.          Full path name in build.    A .pyz archive (ZlibArchive data structure).
-    PKG         Runtime name.          Full path name in build.    A .pkg archive (Carchive data structure).
-    BINARY      Runtime name.          Full path name in build.    Shared library.
-    DATA        Runtime name.          Full path name in build.    Arbitrary files.
-    OPTION      The option.            Unused.                     Python runtime option (frozen into executable).
+    Python internal name.   Full path name in build.    EXTENSION      Extension module.
+    Python internal name.   Full path name in build.    PYSOURCE       Script.
+    Python internal name.   Full path name in build.    PYMODULE       Pure Python module (including __init__ modules).
+    Runtime name.           Full path name in build.    PYZ            A .pyz archive (ZlibArchive data structure).
+    Runtime name.           Full path name in build.    PKG            A .pkg archive (Carchive data structure).
+    Runtime name.           Full path name in build.    BINARY         Shared library.
+    Runtime name.           Full path name in build.    DATA           Arbitrary files.
+    The option.             Unused.                     OPTION         Python runtime option (frozen into executable).
 
     A TOC contains various types of files. A TOC contains no duplicates and preserves order.
     PyInstaller uses TOC data type to collect necessary files bundle them into an executable.
@@ -118,7 +119,7 @@ class TOC(list):
         return result.__sub__(self)
 
 
-class Target(object):
+class Target(object, metaclass=abc.ABCMeta):
     invcnum = 0
 
     def __init__(self):
@@ -185,6 +186,10 @@ class Target(object):
         """
         data = tuple(getattr(self, g[0]) for g in self._GUTS)
         save_py_data_struct(self.tocfilename, data)
+
+    @abc.abstractmethod
+    def assemble(self):
+        return
 
 
 class Tree(Target, TOC):


### PR DESCRIPTION
Make Target class an abstract base class, and make assemble method an abstract method. In this way, users can see that derived classes implement assemble.

Put columns in table in comments of TOC class in same order as in tuple (name, path, typecode). Fix spelling mistake in same comments ("typecode", not "tytecode")