### PR TITLE
Issue #2094: Fix hook for botocore

### DIFF
--- a/PyInstaller/hooks/hook-botocore.py
+++ b/PyInstaller/hooks/hook-botocore.py
@@ -16,8 +16,14 @@
 #
 # https://botocore.readthedocs.org/en/latest/
 #
-# Tested with botocore 1.3.0
+# Tested with botocore 1.4.36
 
 from PyInstaller.utils.hooks import collect_data_files
+from PyInstaller.compat import is_py2
+
+if is_py2:
+    hiddenimports = ['HTMLParser']
+else:
+    hiddenimports = ['html.parser']
 
 datas = collect_data_files('botocore')

--- a/PyInstaller/hooks/hook-botocore.py
+++ b/PyInstaller/hooks/hook-botocore.py
@@ -19,11 +19,12 @@
 # Tested with botocore 1.4.36
 
 from PyInstaller.utils.hooks import collect_data_files
-from PyInstaller.compat import is_py2
+from PyInstaller.compat import is_py2, is_module_satisfies
 
-if is_py2:
-    hiddenimports = ['HTMLParser']
-else:
-    hiddenimports = ['html.parser']
+if is_module_satisfies('botocore >= 1.4.36'):
+    if is_py2:
+        hiddenimports = ['HTMLParser']
+    else:
+        hiddenimports = ['html.parser']
 
 datas = collect_data_files('botocore')


### PR DESCRIPTION
botocore requires html.parser (or HTMLParser in the case of python 2). This change adds them as a hidden import.