### PR TITLE
Added a hook for pyopencl

### DIFF
--- a/PyInstaller/hooks/hook-pyopencl.py
+++ b/PyInstaller/hooks/hook-pyopencl.py
@@ -1,0 +1,7 @@
+"""
+pyopencl: https://mathema.tician.de/software/pyopencl/
+"""
+
+from PyInstaller.utils.hooks import copy_metadata, collect_data_files
+datas = copy_metadata('pyopencl')
+datas += collect_data_files('pyopencl')


### PR DESCRIPTION
This hook makes it possible to embed pyopencl.

Without this pyopencl complains:

`pkg_resources.DistributionNotFound: The 'pyopencl2' distribution was not found and is required by the application`