### PR TITLE
Update requirements-libraries.txt

### DIFF
--- a/PyInstaller/hooks/hook-sphinx.py
+++ b/PyInstaller/hooks/hook-sphinx.py
@@ -59,6 +59,7 @@ hiddenimports = (
 #
 # So, include modules under "sphinx.websupport.search".
                   collect_submodules('sphinx.websupport.search') +
+                  collect_submodules('sphinx.domains') +
 #
 # From sphinx.util.inspect line 21:
 #

--- a/tests/functional/test_basic.py
+++ b/tests/functional/test_basic.py
@@ -426,12 +426,10 @@ def test_threading_module(pyi_builder):
     pyi_builder.test_source(
         """
         import threading
-        print(threading.__file__)
 
         def doit(nm):
             print(('%s started' % nm))
             import pyi_testmod_threading
-            print(pyi_testmod_threading.__file__)
             print(('%s %s' % (nm, pyi_testmod_threading.x)))
 
         t1 = threading.Thread(target=doit, args=('t1',))

--- a/tests/functional/test_basic.py
+++ b/tests/functional/test_basic.py
@@ -426,10 +426,12 @@ def test_threading_module(pyi_builder):
     pyi_builder.test_source(
         """
         import threading
+        print(threading.__file__)
 
         def doit(nm):
             print(('%s started' % nm))
             import pyi_testmod_threading
+            print(pyi_testmod_threading.__file__)
             print(('%s %s' % (nm, pyi_testmod_threading.x)))
 
         t1 = threading.Thread(target=doit, args=('t1',))

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -41,7 +41,7 @@ pyqt5 ; python_version >= '3.5'
 
 # dateutil.tz is a package in 2.5.0 and does not play nice with PyInstaller.
 python-dateutil>2.5.0
-pandas
+pandas ; python_version >= '3.4'
 
 # matplotlib 1.5+ does not provide binaries for python 3.3.
 # matplotlib 1.5.2+ does not provide binaries for Windows.

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -41,7 +41,7 @@ pyqt5 ; python_version >= '3.5'
 
 # dateutil.tz is a package in 2.5.0 and does not play nice with PyInstaller.
 python-dateutil>2.5.0
-pandas ; python_version >= '3.4'
+pandas ; (python_version >= '3.4') or (python_version == '2.7')
 
 # matplotlib 1.5+ does not provide binaries for python 3.3.
 # matplotlib 1.5.2+ does not provide binaries for Windows.


### PR DESCRIPTION
Pandas does not work on python version 3.3. Further changes will be required but this is simply to probe the tests.