### PR TITLE
Repair failing sphinx tests.

### DIFF
--- a/PyInstaller/hooks/hook-sphinx.py
+++ b/PyInstaller/hooks/hook-sphinx.py
@@ -51,14 +51,8 @@ hiddenimports = (
 #
 # So, we need all the languages in "sphinx.search".
                   collect_submodules('sphinx.search') +
-#
-# From sphinx.websupport line 100:
-#
-#    mod = 'sphinx.websupport.search.' + mod
-#    SearchClass = getattr(__import__(mod, None, None, [cls]), cls)
-#
-# So, include modules under "sphinx.websupport.search".
                   collect_submodules('sphinx.websupport.search') +
+                  collect_submodules('sphinx.domains') +
 #
 # From sphinx.util.inspect line 21:
 #


### PR DESCRIPTION
This change repairs the sphinx tests that are currently failing because the script is unable to import "sphinx.domains.c". This change does not resolve any other test failures.