### PR TITLE
Fixes #2332: Hook for django.contrib.

### DIFF
--- a/PyInstaller/hooks/hook-django.contrib.py
+++ b/PyInstaller/hooks/hook-django.contrib.py
@@ -1,0 +1,12 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2016, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+
+from PyInstaller.utils.hooks import collect_submodules
+hiddenimports = collect_submodules('django.contrib')


### PR DESCRIPTION
I would expect the tests to fail due to sphinx (see #2323 ).