### PR TITLE
Remove non-existant gi._gobject.option import

### DIFF
--- a/PyInstaller/hooks/hook-gi.repository.GObject.py
+++ b/PyInstaller/hooks/hook-gi.repository.GObject.py
@@ -19,4 +19,4 @@ from PyInstaller.utils.hooks import get_gi_typelibs
 
 binaries, datas, hiddenimports = get_gi_typelibs('GObject', '2.0')
 
-hiddenimports += ['gi._gobject.option', 'gi._gobject']
+hiddenimports += ['gi._gobject']


### PR DESCRIPTION
Fix #2338

`gi._gobject.option.py` does not exist. The correct file to import is `gi._option.py` which is already imported by `hook-gi.py`