### PR TITLE
qt: fix homebrew qmake path

### DIFF
--- a/PyInstaller/utils/hooks/qt.py
+++ b/PyInstaller/utils/hooks/qt.py
@@ -157,7 +157,7 @@ def get_qmake_path(version=''):
 
     for directory in dirs:
         try:
-            qmake = os.path.join(directory, 'qmake')
+            qmake = os.path.join(directory, 'bin', 'qmake')
             versionstring = subprocess.check_output([qmake, '-query',
                                                      'QT_VERSION']).strip()
             if is_py3:


### PR DESCRIPTION
it was missing bin/

This is a cherry pick of the unmerged commit from https://github.com/pyinstaller/pyinstaller/pull/2238