### PR TITLE
Implement PEP-451 ModuleSpec type import system

### DIFF
--- a/PyInstaller/loader/pyimod03_importers.py
+++ b/PyInstaller/loader/pyimod03_importers.py
@@ -463,7 +463,7 @@ class FrozenImporter(object):
         module.__file__ (or pkg.__path__ items)
         """
         assert path.startswith(SYS_PREFIX + pyi_os_path.os_sep)
-        fullname = path[len(SYS_PREFIX)+1:]
+        fullname = path[SYS_PREFIXLEN+1:]
         if fullname in self.toc:
             # If the file is in the archive, return this
             return self._pyz_archive.extract(fullname)[1]
@@ -517,7 +517,7 @@ class FrozenImporter(object):
             modname = fullname.rsplit('.')[-1]
 
             for p in path:
-                p = p[len(SYS_PREFIX):]
+                p = p[SYS_PREFIXLEN:]
                 parts = p.split(pyi_os_path.os_sep)
                 if not parts: continue
                 if not parts[0]:

--- a/PyInstaller/loader/pyimod03_importers.py
+++ b/PyInstaller/loader/pyimod03_importers.py
@@ -140,6 +140,7 @@ class BuiltinImporter(object):
             # ImportError should be raised if module not found.
             raise ImportError('No module named ' + fullname)
 
+
 class FrozenPackageImporter(object):
     """
     Wrapper class for FrozenImporter that imports one specific fullname from
@@ -516,12 +517,12 @@ class FrozenImporter(object):
             # Reverse the fake __path__ we added to the package module to a
             # dotted module name and add the tail module from fullname onto that
             # to synthesize a new fullname
-            modname = fullname.split('.')[-1]
+            modname = fullname.rsplit('.')[-1]
 
             for p in path:
-                p = p.replace(SYS_PREFIX, "")
+                p = p[len(SYS_PREFIX):]
                 parts = p.split(pyi_os_path.os_sep)
-                if not len(parts): continue
+                if not parts: continue
                 if not parts[0]:
                     parts = parts[1:]
                 parts.append(modname)
@@ -538,9 +539,8 @@ class FrozenImporter(object):
 
         is_pkg, bytecode = self._pyz_archive.extract(filename)
         if is_pkg:
-            origin = pyi_os_path.os_path_join(pyi_os_path.os_path_join(SYS_PREFIX, filename.replace('.',
-                                                                                                    pyi_os_path.os_sep)),
-                                              '__init__.pyc')
+            origin = pyi_os_path.os_path_join(pyi_os_path.os_path_join(
+                SYS_PREFIX, filename.replace('.', pyi_os_path.os_sep)), '__init__.pyc')
         else:
             origin = pyi_os_path.os_path_join(SYS_PREFIX, filename.replace('.', pyi_os_path.os_sep) + '.pyc')
 

--- a/PyInstaller/loader/pyimod03_importers.py
+++ b/PyInstaller/loader/pyimod03_importers.py
@@ -140,603 +140,472 @@ class BuiltinImporter(object):
             # ImportError should be raised if module not found.
             raise ImportError('No module named ' + fullname)
 
-if sys.version_info >= (3, 4):
-    class FrozenImporter(object):
-        def __init__(self):
-            """
-            Load, unzip and initialize the Zip archive bundled with the executable.
-            """
-            # Examine all items in sys.path and the one like /path/executable_name?117568
-            # is the correct executable with bundled zip archive. Use this value
-            # for the ZlibArchiveReader class and remove this item from sys.path.
-            # It was needed only for FrozenImporter class. Wrong path from sys.path
-            # Raises ArchiveReadError exception.
-            for pyz_filepath in sys.path:
-                try:
-                    # Unzip zip archive bundled with the executable.
-                    self._pyz_archive = ZlibArchiveReader(pyz_filepath)
-                    # Verify the integrity of the zip archive with Python modules.
-                    # This is already done when creating the ZlibArchiveReader instance.
-                    #self._pyz_archive.checkmagic()
+class FrozenPackageImporter(object):
+    """
+    Wrapper class for FrozenImporter that imports one specific fullname from
+    a module named by an alternate fullname. The alternate fullname is derived from the
+    __path__ of the package module containing that module.
 
-                    # End this method since no Exception was raised we can assume
-                    # ZlibArchiveReader was successfully loaded. Let's remove 'pyz_filepath'
-                    # from sys.path.
-                    sys.path.remove(pyz_filepath)
-                    # Some runtime hook might need access to the list of available
-                    # frozen module. Let's make them accessible as a set().
-                    self.toc = set(self._pyz_archive.toc.keys())
-                    # Return - no error was raised.
-                    trace("# PyInstaller: FrozenImporter(%s)", pyz_filepath)
-                    return
-                except IOError:
-                    # Item from sys.path is not ZlibArchiveReader let's try next.
-                    continue
-                except ArchiveReadError:
-                    # Item from sys.path is not ZlibArchiveReader let's try next.
-                    continue
-            # sys.path does not contain filename of executable with bundled zip archive.
-            # Raise import error.
-            raise ImportError("Can't load frozen modules.")
+    This is called by FrozenImporter.find_module whenever a module is found as a result
+    of searching module.__path__
+    """
+    def __init__(self, importer, fullname):
+        self._fullname = fullname
+        self._importer = importer
 
-        def __call__(self, path):
-            """
-            PEP-302 sys.path_hook processor.
+    def load_module(self, fullname):
+        return self._importer.load_module(fullname, self._fullname)
 
-            sys.path_hook is a list of callables, which will be checked in
-            sequence to determine if they can handle a given path item.
-            """
 
-            if path.startswith(SYS_PREFIX):
-                fullname = path[SYS_PREFIXLEN+1:].replace(pyi_os_path.os_sep, '.')
-                spec = self.find_spec(fullname)
-                if spec is not None:
-                    return self
-            raise ImportError(path)
+class FrozenImporter(object):
+    """
+    Load bytecode of Python modules from the executable created by PyInstaller.
 
-        def find_spec(self, fullname, path=None, target=None):
-            """
-            PEP-451 finder.find_spec() method for the ``sys.meta_path`` hook.
+    Python bytecode is zipped and appended to the executable.
 
-            fullname     fully qualified name of the module
-            path         None for a top-level module, or package.__path__ for submodules or subpackages.
+    NOTE: PYZ format cannot be replaced by zipimport module.
 
-            Finders must return ModuleSpec objects when find_spec() is called. This new method replaces find_module()
-            and find_loader() (in the PathEntryFinder case). If a loader does not have find_spec(), find_module() and
-            find_loader() are used instead, for backward-compatibility.
-            """
-            # Acquire the interpreter's import lock for the current thread. This
-            # lock should be used by import hooks to ensure thread-safety when
-            # importing modules.
+    The problem is that we have no control over zipimport; for instance,
+    it doesn't work if the zip file is embedded into a PKG appended
+    to an executable, like we create in one-file.
 
-            filename = None  # None means - no module found in this importer.
+    This is PEP-302 finder and loader class for the ``sys.meta_path`` hook.
+    A PEP-302 finder requires method find_module() to return loader
+    class with method load_module(). Both these methods are implemented
+    in one class.
 
-            if fullname in self.toc:
-                # Tell the import machinery to use self.load_module() to load the module.
-                filename = fullname
-                trace("import %s # PyInstaller PYZ", fullname)
-            elif path is not None:
-                # Try to handle module.__path__ modifications by the modules themselves
-                # Reverse the fake __path__ we added to the package module to a
-                # dotted module name and add the tail module from fullname onto that
-                # to synthesize a new fullname
-                modname = fullname.split('.')[-1]
 
-                for p in path:
-                    p = p.replace(SYS_PREFIX, "")
-                    parts = p.split(pyi_os_path.os_sep)
-                    if not len(parts): continue
-                    if not parts[0]:
-                        parts = parts[1:]
-                    parts.append(modname)
-                    path = ".".join(parts)
-                    if path in self.toc:
-                        filename = path
-                        trace("import %s as %s # PyInstaller PYZ (__path__ override: %s)",
-                              path, fullname, p)
-                        break
+    To use this class just call
 
-            if filename is None:
-                trace("# %s not found in PYZ", fullname)
-                return None
-
-            is_pkg, bytecode = self._pyz_archive.extract(filename)
-            if is_pkg:
-                origin = pyi_os_path.os_path_join(pyi_os_path.os_path_join(SYS_PREFIX, filename.replace('.',
-                                                  pyi_os_path.os_sep)), '__init__.pyc')
-            else:
-                origin = pyi_os_path.os_path_join(SYS_PREFIX, filename.replace('.', pyi_os_path.os_sep) + '.pyc')
-
-            if not hasattr(self, 'module_code'):
-                self.module_code = {}
-
-            self.module_code[fullname] = bytecode
-            return _frozen_importlib.ModuleSpec(fullname, self, is_package=is_pkg, origin=origin)
-
-        def create_module(self, spec):
-            """
-            PEP-451 loader.create_module() method for the ``sys.meta_path`` hook.
-
-            Loaders may also implement create_module() that will return a new module to exec. It may return None to
-            indicate that the default module creation code should be used. One use case, though atypical, for
-            create_module() is to provide a module that is a subclass of the builtin module type. Most loaders will not
-            need to implement create_module(),
-
-            create_module() should properly handle the case where it is called more than once for the same spec/module.
-            This may include returning None or raising ImportError.
-            """
-            return imp_new_module(spec.name)
-
-        def exec_module(self, module):
-            """
-            PEP-451 loader.exec_module() method for the ``sys.meta_path`` hook.
-
-            Loaders will have a new method, exec_module(). Its only job is to "exec" the module and consequently
-            populate the module's namespace. It is not responsible for creating or preparing the module object, nor
-            for any cleanup afterward. It has no return value. exec_module() will be used during both loading and
-            reloading.
-
-            exec_module() should properly handle the case where it is called more than once. For some kinds of modules
-            this may mean raising ImportError every time after the first time the method is called. This is
-            particularly relevant for reloading, where some kinds of modules do not support in-place reloading.
-            """
-            if hasattr(self, 'module_code') and module.__spec__.name in self.module_code:
-                bytecode = self.module_code[module.__spec__.name]
-                del self.module_code[module.__spec__.name]
-            else:
-                bytecode = self.get_code(module.__spec__.name)
-
-            if not hasattr(module, '__file__') and module.__spec__.origin:
-                module.__file__ = module.__spec__.origin
-
-            ### Set __path__  if 'fullname' is a package.
-            # Python has modules and packages. A Python package is container
-            # for several modules or packages.
-            if hasattr(module, '__file__') and module.__spec__.submodule_search_locations is not None:
-                # If a module has a __path__ attribute, the import mechanism
-                # will treat it as a package.
-                #
-                # Since PYTHONHOME is set in bootloader, 'sys.prefix' points to the
-                # correct path where PyInstaller should find bundled dynamic
-                # libraries. In one-file mode it points to the tmp directory where
-                # bundled files are extracted at execution time.
-                #
-                # __path__ cannot be empty list because 'wx' module prepends something to it.
-                # It cannot contain value 'sys.prefix' because 'xml.etree.cElementTree' fails
-                # Otherwise.
-                #
-                # Set __path__ to point to 'sys.prefix/package/subpackage'.
-                module.__path__ = [pyi_os_path.os_path_dirname(module.__file__)]
-
-            exec(bytecode, module.__dict__)
-
-        # Optional Extensions to the PEP-302 Importer Protocol
-        def is_package(self, fullname):
-            """
-            Return always False since built-in modules are never packages.
-            """
-            if fullname in self.toc:
-                try:
-                    is_pkg, bytecode = self._pyz_archive.extract(fullname)
-                    return bool(is_pkg)
-                except Exception:
-                    raise ImportError('Loader FrozenImporter cannot handle module ' + fullname)
-            else:
-                raise ImportError('Loader FrozenImporter cannot handle module ' + fullname)
-
-        def get_code(self, fullname):
-            """
-            Get the code object associated with the module.
-
-            ImportError should be raised if module not found.
-            """
-            if fullname in self.toc:
-                try:
-                    is_pkg, bytecode = self._pyz_archive.extract(fullname)
-                    return bytecode
-                except Exception:
-                    raise ImportError('Loader FrozenImporter cannot handle module ' + fullname)
-            else:
-                raise ImportError('Loader FrozenImporter cannot handle module ' + fullname)
-
-        def get_source(self, fullname):
-            """
-            Method should return the source code for the module as a string.
-            But frozen modules does not contain source code.
-
-            Return None.
-            """
-            if fullname in self.toc:
-                return None
-            else:
-                # ImportError should be raised if module not found.
-                raise ImportError('No module named ' + fullname)
-
-        def get_data(self, path):
-            """
-            This returns the data as a string, or raise IOError if the "file"
-            wasn't found. The data is always returned as if "binary" mode was used.
-
-            This method is useful getting resources with 'pkg_resources' that are
-            bundled with Python modules in the PYZ archive.
-
-            The 'path' argument is a path that can be constructed by munging
-            module.__file__ (or pkg.__path__ items)
-            """
-            assert path.startswith(SYS_PREFIX + pyi_os_path.os_sep)
-            fullname = path[len(SYS_PREFIX)+1:]
-            if fullname in self.toc:
-                # If the file is in the archive, return this
-                return self._pyz_archive.extract(fullname)[1]
-            else:
-                # Otherwise try to fetch it from the filesystem. Since
-                # __file__ attribute works properly just try to open and
-                # read it.
-                with open(path, 'rb') as fp:
-                    return fp.read()
-
-        def find_module(self, fullname, path=None):
-            """This method is deprecated.  Use exec_module() instead."""
-            spec = self.find_spec(fullname, path)
-            if spec is not None:
-                return spec.loader
-            else:
-                return None
-
-        def load_module(self, fullname):
-            """This module is deprecated."""
-            return _frozen_importlib._bootstrap._load_module_shim(self, fullname)
-else:
-
-    class FrozenPackageImporter(object):
+        FrozenImporter.install()
+    """
+    def __init__(self):
         """
-        Wrapper class for FrozenImporter that imports one specific fullname from
-        a module named by an alternate fullname. The alternate fullname is derived from the
-        __path__ of the package module containing that module.
-
-        This is called by FrozenImporter.find_module whenever a module is found as a result
-        of searching module.__path__
+        Load, unzip and initialize the Zip archive bundled with the executable.
         """
-        def __init__(self, importer, fullname):
-            self._fullname = fullname
-            self._importer = importer
-
-        def load_module(self, fullname):
-            return self._importer.load_module(fullname, self._fullname)
-
-
-    class FrozenImporter(object):
-        """
-        Load bytecode of Python modules from the executable created by PyInstaller.
-
-        Python bytecode is zipped and appended to the executable.
-
-        NOTE: PYZ format cannot be replaced by zipimport module.
-
-        The problem is that we have no control over zipimport; for instance,
-        it doesn't work if the zip file is embedded into a PKG appended
-        to an executable, like we create in one-file.
-
-        This is PEP-302 finder and loader class for the ``sys.meta_path`` hook.
-        A PEP-302 finder requires method find_module() to return loader
-        class with method load_module(). Both these methods are implemented
-        in one class.
-
-
-        To use this class just call
-
-            FrozenImporter.install()
-        """
-        def __init__(self):
-            """
-            Load, unzip and initialize the Zip archive bundled with the executable.
-            """
-            # Examine all items in sys.path and the one like /path/executable_name?117568
-            # is the correct executable with bundled zip archive. Use this value
-            # for the ZlibArchiveReader class and remove this item from sys.path.
-            # It was needed only for FrozenImporter class. Wrong path from sys.path
-            # Raises ArchiveReadError exception.
-            for pyz_filepath in sys.path:
-                # We need to acquire the interpreter's import lock here
-                # because ZlibArchiveReader() seeks through and reads from the
-                # zip archive.
-                imp_lock()
-                try:
-                    # Unzip zip archive bundled with the executable.
-                    self._pyz_archive = ZlibArchiveReader(pyz_filepath)
-                    # Verify the integrity of the zip archive with Python modules.
-                    # This is already done when creating the ZlibArchiveReader instance.
-                    #self._pyz_archive.checkmagic()
-
-                    # End this method since no Exception was raised we can assume
-                    # ZlibArchiveReader was successfully loaded. Let's remove 'pyz_filepath'
-                    # from sys.path.
-                    sys.path.remove(pyz_filepath)
-                    # Some runtime hook might need access to the list of available
-                    # frozen module. Let's make them accessible as a set().
-                    self.toc = set(self._pyz_archive.toc.keys())
-                    # Return - no error was raised.
-                    trace("# PyInstaller: FrozenImporter(%s)", pyz_filepath)
-                    return
-                except IOError:
-                    # Item from sys.path is not ZlibArchiveReader let's try next.
-                    continue
-                except ArchiveReadError:
-                    # Item from sys.path is not ZlibArchiveReader let's try next.
-                    continue
-                finally:
-                    imp_unlock()
-            # sys.path does not contain filename of executable with bundled zip archive.
-            # Raise import error.
-            raise ImportError("Can't load frozen modules.")
-
-
-        def __call__(self, path):
-            """
-            PEP-302 sys.path_hook processor.
-
-            sys.path_hook is a list of callables, which will be checked in
-            sequence to determine if they can handle a given path item.
-            """
-
-            if path.startswith(SYS_PREFIX):
-                fullname = path[SYS_PREFIXLEN+1:].replace(pyi_os_path.os_sep, '.')
-                loader = self.find_module(fullname)
-                if loader is not None:
-                    return loader
-            raise ImportError(path)
-
-
-        def find_module(self, fullname, path=None):
-            """
-            PEP-302 finder.find_module() method for the ``sys.meta_path`` hook.
-
-            fullname     fully qualified name of the module
-            path         None for a top-level module, or package.__path__ for submodules or subpackages.
-
-            Return a loader object if the module was found, or None if it wasn't. If find_module() raises
-            an exception, it will be propagated to the caller, aborting the import.
-            """
-            # Acquire the interpreter's import lock for the current thread. This
-            # lock should be used by import hooks to ensure thread-safety when
-            # importing modules.
-
+        # Examine all items in sys.path and the one like /path/executable_name?117568
+        # is the correct executable with bundled zip archive. Use this value
+        # for the ZlibArchiveReader class and remove this item from sys.path.
+        # It was needed only for FrozenImporter class. Wrong path from sys.path
+        # Raises ArchiveReadError exception.
+        for pyz_filepath in sys.path:
+            # We need to acquire the interpreter's import lock here
+            # because ZlibArchiveReader() seeks through and reads from the
+            # zip archive.
             imp_lock()
-            module_loader = None  # None means - no module found in this importer.
+            try:
+                # Unzip zip archive bundled with the executable.
+                self._pyz_archive = ZlibArchiveReader(pyz_filepath)
+                # Verify the integrity of the zip archive with Python modules.
+                # This is already done when creating the ZlibArchiveReader instance.
+                #self._pyz_archive.checkmagic()
 
-            if fullname in self.toc:
-                # Tell the import machinery to use self.load_module() to load the module.
-                module_loader = self
-                trace("import %s # PyInstaller PYZ", fullname)
-            elif path is not None:
-                # Try to handle module.__path__ modifications by the modules themselves
-                # Reverse the fake __path__ we added to the package module to a
-                # dotted module name and add the tail module from fullname onto that
-                # to synthesize a new fullname
-                modname = fullname.split('.')[-1]
+                # End this method since no Exception was raised we can assume
+                # ZlibArchiveReader was successfully loaded. Let's remove 'pyz_filepath'
+                # from sys.path.
+                sys.path.remove(pyz_filepath)
+                # Some runtime hook might need access to the list of available
+                # frozen module. Let's make them accessible as a set().
+                self.toc = set(self._pyz_archive.toc.keys())
+                # Return - no error was raised.
+                trace("# PyInstaller: FrozenImporter(%s)", pyz_filepath)
+                return
+            except IOError:
+                # Item from sys.path is not ZlibArchiveReader let's try next.
+                continue
+            except ArchiveReadError:
+                # Item from sys.path is not ZlibArchiveReader let's try next.
+                continue
+            finally:
+                imp_unlock()
+        # sys.path does not contain filename of executable with bundled zip archive.
+        # Raise import error.
+        raise ImportError("Can't load frozen modules.")
 
-                for p in path:
-                    p = p.replace(SYS_PREFIX, "")
-                    parts = p.split(pyi_os_path.os_sep)
-                    if not len(parts): continue
-                    if not parts[0]:
-                        parts = parts[1:]
-                    parts.append(modname)
-                    real_fullname = ".".join(parts)
-                    if real_fullname in self.toc:
-                        module_loader = FrozenPackageImporter(self, real_fullname)
-                        trace("import %s as %s # PyInstaller PYZ (__path__ override: %s)",
-                              real_fullname, fullname, p)
-                        break
+
+    def __call__(self, path):
+        """
+        PEP-302 sys.path_hook processor.
+
+        sys.path_hook is a list of callables, which will be checked in
+        sequence to determine if they can handle a given path item.
+        """
+
+        if path.startswith(SYS_PREFIX):
+            fullname = path[SYS_PREFIXLEN+1:].replace(pyi_os_path.os_sep, '.')
+            loader = self.find_module(fullname)
+            if loader is not None:
+                return loader
+        raise ImportError(path)
+
+
+    def find_module(self, fullname, path=None):
+        """
+        PEP-302 finder.find_module() method for the ``sys.meta_path`` hook.
+
+        fullname     fully qualified name of the module
+        path         None for a top-level module, or package.__path__ for submodules or subpackages.
+
+        Return a loader object if the module was found, or None if it wasn't. If find_module() raises
+        an exception, it will be propagated to the caller, aborting the import.
+        """
+        # Acquire the interpreter's import lock for the current thread. This
+        # lock should be used by import hooks to ensure thread-safety when
+        # importing modules.
+
+        imp_lock()
+        module_loader = None  # None means - no module found in this importer.
+
+        if fullname in self.toc:
+            # Tell the import machinery to use self.load_module() to load the module.
+            module_loader = self
+            trace("import %s # PyInstaller PYZ", fullname)
+        elif path is not None:
+            # Try to handle module.__path__ modifications by the modules themselves
+            # Reverse the fake __path__ we added to the package module to a
+            # dotted module name and add the tail module from fullname onto that
+            # to synthesize a new fullname
+            modname = fullname.split('.')[-1]
+
+            for p in path:
+                p = p.replace(SYS_PREFIX, "")
+                parts = p.split(pyi_os_path.os_sep)
+                if not len(parts): continue
+                if not parts[0]:
+                    parts = parts[1:]
+                parts.append(modname)
+                real_fullname = ".".join(parts)
+                if real_fullname in self.toc:
+                    module_loader = FrozenPackageImporter(self, real_fullname)
+                    trace("import %s as %s # PyInstaller PYZ (__path__ override: %s)",
+                          real_fullname, fullname, p)
+                    break
+        # Release the interpreter's import lock.
+        imp_unlock()
+        if module_loader is None:
+            trace("# %s not found in PYZ", fullname)
+        return module_loader
+
+    def load_module(self, fullname, real_fullname=None):
+        """
+        PEP-302 loader.load_module() method for the ``sys.meta_path`` hook.
+
+        Return the loaded module (instance of imp_new_module()) or raises
+        an exception, preferably ImportError if an existing exception
+        is not being propagated.
+
+        When called from FrozenPackageImporter, `real_fullname` is the name of the
+        module as it is stored in the archive. This module will be loaded and installed
+        into sys.modules using `fullname` as its name
+        """
+        # Acquire the interpreter's import lock.
+        imp_lock()
+        module = None
+        if real_fullname is None:
+            real_fullname=fullname
+        try:
+            # PEP302 If there is an existing module object named 'fullname'
+            # in sys.modules, the loader must use that existing module.
+            module = sys.modules.get(fullname)
+
+            # Module not in sys.modules - load it and it to sys.modules.
+            if module is None:
+                # Load code object from the bundled ZIP archive.
+                is_pkg, bytecode = self._pyz_archive.extract(real_fullname)
+                # Create new empty 'module' object.
+                module = imp_new_module(fullname)
+
+                # TODO Replace bytecode.co_filename by something more meaningful:
+                # e.g. /absolute/path/frozen_executable/path/to/module/module_name.pyc
+                # Paths from developer machine are masked.
+
+                ### Set __file__ attribute of a module relative to the executable
+                # so that data files can be found. The absolute absolute path
+                # to the executable is taken from sys.prefix. In onefile mode it
+                # points to the temp directory where files are unpacked by PyInstaller.
+                # Then, append the appropriate suffix (__init__.pyc for a package, or just .pyc for a module).
+                if is_pkg:
+                    module.__file__ = pyi_os_path.os_path_join(pyi_os_path.os_path_join(SYS_PREFIX,
+                        fullname.replace('.', pyi_os_path.os_sep)), '__init__.pyc')
+                else:
+                    module.__file__ = pyi_os_path.os_path_join(SYS_PREFIX,
+                        fullname.replace('.', pyi_os_path.os_sep) + '.pyc')
+
+                ### Set __path__  if 'fullname' is a package.
+                # Python has modules and packages. A Python package is container
+                # for several modules or packages.
+                if is_pkg:
+
+                    # If a module has a __path__ attribute, the import mechanism
+                    # will treat it as a package.
+                    #
+                    # Since PYTHONHOME is set in bootloader, 'sys.prefix' points to the
+                    # correct path where PyInstaller should find bundled dynamic
+                    # libraries. In one-file mode it points to the tmp directory where
+                    # bundled files are extracted at execution time.
+                    #
+                    # __path__ cannot be empty list because 'wx' module prepends something to it.
+                    # It cannot contain value 'sys.prefix' because 'xml.etree.cElementTree' fails
+                    # Otherwise.
+                    #
+                    # Set __path__ to point to 'sys.prefix/package/subpackage'.
+                    module.__path__ = [pyi_os_path.os_path_dirname(module.__file__)]
+
+                ### Set __loader__
+                # The attribute __loader__ improves support for module 'pkg_resources' and
+                # with the frozen apps the following functions are working:
+                # pkg_resources.resource_string(), pkg_resources.resource_stream().
+                module.__loader__ = self
+
+                ### Set __package__
+                # Accoring to PEP302 this attribute must be set.
+                # When it is present, relative imports will be based on this
+                # attribute rather than the module __name__ attribute.
+                # More details can be found in PEP366.
+                # For ordinary modules this is set like:
+                #     'aa.bb.cc.dd'  ->  'aa.bb.cc'
+                if is_pkg:
+                    module.__package__ = fullname
+                else:
+                    module.__package__ = fullname.rsplit('.', 1)[0]
+
+                ### Set __spec__ for Python 3.4+
+                # In Python 3.4 was introduced module attribute __spec__ to
+                # consolidate all module attributes.
+                if sys.version_info[0:2] > (3, 3):
+                    module.__spec__ = _frozen_importlib.ModuleSpec(
+                        real_fullname, self, is_package=is_pkg)
+
+                ### Add module object to sys.modules dictionary.
+                # Module object must be in sys.modules before the loader
+                # executes the module code. This is crucial because the module
+                # code may (directly or indirectly) import itself; adding it
+                # to sys.modules beforehand prevents unbounded recursion in the
+                # worst case and multiple loading in the best.
+                sys.modules[fullname] = module
+
+                # Run the module code.
+                exec(bytecode, module.__dict__)
+                # Reread the module from sys.modules in case it's changed itself
+                module = sys.modules[fullname]
+
+        except Exception:
+            # Remove 'fullname' from sys.modules if it was appended there.
+            if fullname in sys.modules:
+                sys.modules.pop(fullname)
+            # TODO Do we need to raise different types of Exceptions for better debugging?
+            # PEP302 requires to raise ImportError exception.
+            #raise ImportError("Can't load frozen module: %s" % fullname)
+
+            raise
+
+        finally:
             # Release the interpreter's import lock.
             imp_unlock()
-            if module_loader is None:
-                trace("# %s not found in PYZ", fullname)
-            return module_loader
 
-        def load_module(self, fullname, real_fullname=None):
-            """
-            PEP-302 loader.load_module() method for the ``sys.meta_path`` hook.
 
-            Return the loaded module (instance of imp_new_module()) or raises
-            an exception, preferably ImportError if an existing exception
-            is not being propagated.
+        # Module returned only in case of no exception.
+        return module
 
-            When called from FrozenPackageImporter, `real_fullname` is the name of the
-            module as it is stored in the archive. This module will be loaded and installed
-            into sys.modules using `fullname` as its name
-            """
-            # Acquire the interpreter's import lock.
-            imp_lock()
-            module = None
-            if real_fullname is None:
-                real_fullname=fullname
+    ### Optional Extensions to the PEP-302 Importer Protocol
+
+    def is_package(self, fullname):
+        """
+        Return always False since built-in modules are never packages.
+        """
+        if fullname in self.toc:
             try:
-                # PEP302 If there is an existing module object named 'fullname'
-                # in sys.modules, the loader must use that existing module.
-                module = sys.modules.get(fullname)
-
-                # Module not in sys.modules - load it and it to sys.modules.
-                if module is None:
-                    # Load code object from the bundled ZIP archive.
-                    is_pkg, bytecode = self._pyz_archive.extract(real_fullname)
-                    # Create new empty 'module' object.
-                    module = imp_new_module(fullname)
-
-                    # TODO Replace bytecode.co_filename by something more meaningful:
-                    # e.g. /absolute/path/frozen_executable/path/to/module/module_name.pyc
-                    # Paths from developer machine are masked.
-
-                    ### Set __file__ attribute of a module relative to the executable
-                    # so that data files can be found. The absolute absolute path
-                    # to the executable is taken from sys.prefix. In onefile mode it
-                    # points to the temp directory where files are unpacked by PyInstaller.
-                    # Then, append the appropriate suffix (__init__.pyc for a package, or just .pyc for a module).
-                    if is_pkg:
-                        module.__file__ = pyi_os_path.os_path_join(pyi_os_path.os_path_join(SYS_PREFIX,
-                            fullname.replace('.', pyi_os_path.os_sep)), '__init__.pyc')
-                    else:
-                        module.__file__ = pyi_os_path.os_path_join(SYS_PREFIX,
-                            fullname.replace('.', pyi_os_path.os_sep) + '.pyc')
-
-                    ### Set __path__  if 'fullname' is a package.
-                    # Python has modules and packages. A Python package is container
-                    # for several modules or packages.
-                    if is_pkg:
-
-                        # If a module has a __path__ attribute, the import mechanism
-                        # will treat it as a package.
-                        #
-                        # Since PYTHONHOME is set in bootloader, 'sys.prefix' points to the
-                        # correct path where PyInstaller should find bundled dynamic
-                        # libraries. In one-file mode it points to the tmp directory where
-                        # bundled files are extracted at execution time.
-                        #
-                        # __path__ cannot be empty list because 'wx' module prepends something to it.
-                        # It cannot contain value 'sys.prefix' because 'xml.etree.cElementTree' fails
-                        # Otherwise.
-                        #
-                        # Set __path__ to point to 'sys.prefix/package/subpackage'.
-                        module.__path__ = [pyi_os_path.os_path_dirname(module.__file__)]
-
-                    ### Set __loader__
-                    # The attribute __loader__ improves support for module 'pkg_resources' and
-                    # with the frozen apps the following functions are working:
-                    # pkg_resources.resource_string(), pkg_resources.resource_stream().
-                    module.__loader__ = self
-
-                    ### Set __package__
-                    # Accoring to PEP302 this attribute must be set.
-                    # When it is present, relative imports will be based on this
-                    # attribute rather than the module __name__ attribute.
-                    # More details can be found in PEP366.
-                    # For ordinary modules this is set like:
-                    #     'aa.bb.cc.dd'  ->  'aa.bb.cc'
-                    if is_pkg:
-                        module.__package__ = fullname
-                    else:
-                        module.__package__ = fullname.rsplit('.', 1)[0]
-
-                    ### Set __spec__ for Python 3.4+
-                    # In Python 3.4 was introduced module attribute __spec__ to
-                    # consolidate all module attributes.
-                    if sys.version_info[0:2] > (3, 3):
-                        module.__spec__ = _frozen_importlib.ModuleSpec(
-                            real_fullname, self, is_package=is_pkg)
-
-                    ### Add module object to sys.modules dictionary.
-                    # Module object must be in sys.modules before the loader
-                    # executes the module code. This is crucial because the module
-                    # code may (directly or indirectly) import itself; adding it
-                    # to sys.modules beforehand prevents unbounded recursion in the
-                    # worst case and multiple loading in the best.
-                    sys.modules[fullname] = module
-
-                    # Run the module code.
-                    exec(bytecode, module.__dict__)
-                    # Reread the module from sys.modules in case it's changed itself
-                    module = sys.modules[fullname]
-
+                is_pkg, bytecode = self._pyz_archive.extract(fullname)
+                return bool(is_pkg)
             except Exception:
-                # Remove 'fullname' from sys.modules if it was appended there.
-                if fullname in sys.modules:
-                    sys.modules.pop(fullname)
-                # TODO Do we need to raise different types of Exceptions for better debugging?
-                # PEP302 requires to raise ImportError exception.
-                #raise ImportError("Can't load frozen module: %s" % fullname)
-
-                raise
-
-            finally:
-                # Release the interpreter's import lock.
-                imp_unlock()
-
-
-            # Module returned only in case of no exception.
-            return module
-
-        ### Optional Extensions to the PEP-302 Importer Protocol
-
-        def is_package(self, fullname):
-            """
-            Return always False since built-in modules are never packages.
-            """
-            if fullname in self.toc:
-                try:
-                    is_pkg, bytecode = self._pyz_archive.extract(fullname)
-                    return bool(is_pkg)
-                except Exception:
-                    raise ImportError('Loader FrozenImporter cannot handle module ' + fullname)
-            else:
                 raise ImportError('Loader FrozenImporter cannot handle module ' + fullname)
+        else:
+            raise ImportError('Loader FrozenImporter cannot handle module ' + fullname)
 
-        def get_code(self, fullname):
-            """
-            Get the code object associated with the module.
+    def get_code(self, fullname):
+        """
+        Get the code object associated with the module.
 
-            ImportError should be raised if module not found.
-            """
-            if fullname in self.toc:
-                try:
-                    is_pkg, bytecode = self._pyz_archive.extract(fullname)
-                    return bytecode
-                except Exception:
-                    raise ImportError('Loader FrozenImporter cannot handle module ' + fullname)
-            else:
+        ImportError should be raised if module not found.
+        """
+        if fullname in self.toc:
+            try:
+                is_pkg, bytecode = self._pyz_archive.extract(fullname)
+                return bytecode
+            except Exception:
                 raise ImportError('Loader FrozenImporter cannot handle module ' + fullname)
+        else:
+            raise ImportError('Loader FrozenImporter cannot handle module ' + fullname)
 
-        def get_source(self, fullname):
-            """
-            Method should return the source code for the module as a string.
-            But frozen modules does not contain source code.
+    def get_source(self, fullname):
+        """
+        Method should return the source code for the module as a string.
+        But frozen modules does not contain source code.
 
-            Return None.
-            """
-            if fullname in self.toc:
-                return None
-            else:
-                # ImportError should be raised if module not found.
-                raise ImportError('No module named ' + fullname)
+        Return None.
+        """
+        if fullname in self.toc:
+            return None
+        else:
+            # ImportError should be raised if module not found.
+            raise ImportError('No module named ' + fullname)
 
-        def get_data(self, path):
-            """
-            This returns the data as a string, or raise IOError if the "file"
-            wasn't found. The data is always returned as if "binary" mode was used.
+    def get_data(self, path):
+        """
+        This returns the data as a string, or raise IOError if the "file"
+        wasn't found. The data is always returned as if "binary" mode was used.
 
-            This method is useful getting resources with 'pkg_resources' that are
-            bundled with Python modules in the PYZ archive.
+        This method is useful getting resources with 'pkg_resources' that are
+        bundled with Python modules in the PYZ archive.
 
-            The 'path' argument is a path that can be constructed by munging
-            module.__file__ (or pkg.__path__ items)
-            """
-            assert path.startswith(SYS_PREFIX + pyi_os_path.os_sep)
-            fullname = path[len(SYS_PREFIX)+1:]
-            if fullname in self.toc:
-                # If the file is in the archive, return this
-                return self._pyz_archive.extract(fullname)[1]
-            else:
-                # Otherwise try to fetch it from the filesystem. Since
-                # __file__ attribute works properly just try to open and
-                # read it.
-                with open(path, 'rb') as fp:
-                    return fp.read()
+        The 'path' argument is a path that can be constructed by munging
+        module.__file__ (or pkg.__path__ items)
+        """
+        assert path.startswith(SYS_PREFIX + pyi_os_path.os_sep)
+        fullname = path[len(SYS_PREFIX)+1:]
+        if fullname in self.toc:
+            # If the file is in the archive, return this
+            return self._pyz_archive.extract(fullname)[1]
+        else:
+            # Otherwise try to fetch it from the filesystem. Since
+            # __file__ attribute works properly just try to open and
+            # read it.
+            with open(path, 'rb') as fp:
+                return fp.read()
 
-        # TODO Do we really need to implement this method?
-        def get_filename(self, fullname):
-            """
-            This method should return the value that __file__ would be set to
-            if the named module was loaded. If the module is not found, then
-            ImportError should be raised.
-            """
-            # Then, append the appropriate suffix (__init__.pyc for a package, or just .pyc for a module).
-            # Method is_package() will raise ImportError if module not found.
-            if self.is_package(fullname):
-                filename = pyi_os_path.os_path_join(pyi_os_path.os_path_join(SYS_PREFIX,
-                    fullname.replace('.', pyi_os_path.os_sep)), '__init__.pyc')
-            else:
-                filename = pyi_os_path.os_path_join(SYS_PREFIX,
-                    fullname.replace('.', pyi_os_path.os_sep) + '.pyc')
-            return filename
+    # TODO Do we really need to implement this method?
+    def get_filename(self, fullname):
+        """
+        This method should return the value that __file__ would be set to
+        if the named module was loaded. If the module is not found, then
+        ImportError should be raised.
+        """
+        # Then, append the appropriate suffix (__init__.pyc for a package, or just .pyc for a module).
+        # Method is_package() will raise ImportError if module not found.
+        if self.is_package(fullname):
+            filename = pyi_os_path.os_path_join(pyi_os_path.os_path_join(SYS_PREFIX,
+                fullname.replace('.', pyi_os_path.os_sep)), '__init__.pyc')
+        else:
+            filename = pyi_os_path.os_path_join(SYS_PREFIX,
+                fullname.replace('.', pyi_os_path.os_sep) + '.pyc')
+        return filename
+
+    def find_spec(self, fullname, path=None, target=None):
+        """
+        PEP-451 finder.find_spec() method for the ``sys.meta_path`` hook.
+
+        fullname     fully qualified name of the module
+        path         None for a top-level module, or package.__path__ for submodules or subpackages.
+
+        Finders must return ModuleSpec objects when find_spec() is called. This new method replaces find_module()
+        and find_loader() (in the PathEntryFinder case). If a loader does not have find_spec(), find_module() and
+        find_loader() are used instead, for backward-compatibility.
+        """
+        # Acquire the interpreter's import lock for the current thread. This
+        # lock should be used by import hooks to ensure thread-safety when
+        # importing modules.
+
+        filename = None  # None means - no module found in this importer.
+
+        if fullname in self.toc:
+            # Tell the import machinery to use self.load_module() to load the module.
+            filename = fullname
+            trace("import %s # PyInstaller PYZ", fullname)
+        elif path is not None:
+            # Try to handle module.__path__ modifications by the modules themselves
+            # Reverse the fake __path__ we added to the package module to a
+            # dotted module name and add the tail module from fullname onto that
+            # to synthesize a new fullname
+            modname = fullname.split('.')[-1]
+
+            for p in path:
+                p = p.replace(SYS_PREFIX, "")
+                parts = p.split(pyi_os_path.os_sep)
+                if not len(parts): continue
+                if not parts[0]:
+                    parts = parts[1:]
+                parts.append(modname)
+                path = ".".join(parts)
+                if path in self.toc:
+                    filename = path
+                    trace("import %s as %s # PyInstaller PYZ (__path__ override: %s)",
+                          path, fullname, p)
+                    break
+
+        if filename is None:
+            trace("# %s not found in PYZ", fullname)
+            return None
+
+        is_pkg, bytecode = self._pyz_archive.extract(filename)
+        if is_pkg:
+            origin = pyi_os_path.os_path_join(pyi_os_path.os_path_join(SYS_PREFIX, filename.replace('.',
+                                                                                                    pyi_os_path.os_sep)),
+                                              '__init__.pyc')
+        else:
+            origin = pyi_os_path.os_path_join(SYS_PREFIX, filename.replace('.', pyi_os_path.os_sep) + '.pyc')
+
+        if not hasattr(self, 'module_code'):
+            self.module_code = {}
+
+        self.module_code[fullname] = bytecode
+        return _frozen_importlib.ModuleSpec(fullname, self, is_package=is_pkg, origin=origin)
+
+    def create_module(self, spec):
+        """
+        PEP-451 loader.create_module() method for the ``sys.meta_path`` hook.
+
+        Loaders may also implement create_module() that will return a new module to exec. It may return None to
+        indicate that the default module creation code should be used. One use case, though atypical, for
+        create_module() is to provide a module that is a subclass of the builtin module type. Most loaders will not
+        need to implement create_module(),
+
+        create_module() should properly handle the case where it is called more than once for the same spec/module.
+        This may include returning None or raising ImportError.
+        """
+        return imp_new_module(spec.name)
+
+    def exec_module(self, module):
+        """
+        PEP-451 loader.exec_module() method for the ``sys.meta_path`` hook.
+
+        Loaders will have a new method, exec_module(). Its only job is to "exec" the module and consequently
+        populate the module's namespace. It is not responsible for creating or preparing the module object, nor
+        for any cleanup afterward. It has no return value. exec_module() will be used during both loading and
+        reloading.
+
+        exec_module() should properly handle the case where it is called more than once. For some kinds of modules
+        this may mean raising ImportError every time after the first time the method is called. This is
+        particularly relevant for reloading, where some kinds of modules do not support in-place reloading.
+        """
+        if hasattr(self, 'module_code') and module.__spec__.name in self.module_code:
+            bytecode = self.module_code[module.__spec__.name]
+            del self.module_code[module.__spec__.name]
+        else:
+            bytecode = self.get_code(module.__spec__.name)
+
+        if not hasattr(module, '__file__') and module.__spec__.origin:
+            module.__file__ = module.__spec__.origin
+
+        ### Set __path__  if 'fullname' is a package.
+        # Python has modules and packages. A Python package is container
+        # for several modules or packages.
+        if hasattr(module, '__file__') and module.__spec__.submodule_search_locations is not None:
+            # If a module has a __path__ attribute, the import mechanism
+            # will treat it as a package.
+            #
+            # Since PYTHONHOME is set in bootloader, 'sys.prefix' points to the
+            # correct path where PyInstaller should find bundled dynamic
+            # libraries. In one-file mode it points to the tmp directory where
+            # bundled files are extracted at execution time.
+            #
+            # __path__ cannot be empty list because 'wx' module prepends something to it.
+            # It cannot contain value 'sys.prefix' because 'xml.etree.cElementTree' fails
+            # Otherwise.
+            #
+            # Set __path__ to point to 'sys.prefix/package/subpackage'.
+            module.__path__ = [pyi_os_path.os_path_dirname(module.__file__)]
+
+        exec(bytecode, module.__dict__)
 
 
 class CExtensionImporter(object):

--- a/PyInstaller/loader/pyimod03_importers.py
+++ b/PyInstaller/loader/pyimod03_importers.py
@@ -502,9 +502,6 @@ class FrozenImporter(object):
         and find_loader() (in the PathEntryFinder case). If a loader does not have find_spec(), find_module() and
         find_loader() are used instead, for backward-compatibility.
         """
-        # Acquire the interpreter's import lock for the current thread. This
-        # lock should be used by import hooks to ensure thread-safety when
-        # importing modules.
 
         filename = None  # None means - no module found in this importer.
 

--- a/PyInstaller/loader/pyimod03_importers.py
+++ b/PyInstaller/loader/pyimod03_importers.py
@@ -140,356 +140,561 @@ class BuiltinImporter(object):
             # ImportError should be raised if module not found.
             raise ImportError('No module named ' + fullname)
 
+if sys.version_info >= (3, 4):
+    class FrozenImporter(object):
+        def __init__(self):
+            """
+            Load, unzip and initialize the Zip archive bundled with the executable.
+            """
+            # Examine all items in sys.path and the one like /path/executable_name?117568
+            # is the correct executable with bundled zip archive. Use this value
+            # for the ZlibArchiveReader class and remove this item from sys.path.
+            # It was needed only for FrozenImporter class. Wrong path from sys.path
+            # Raises ArchiveReadError exception.
+            for pyz_filepath in sys.path:
+                try:
+                    # Unzip zip archive bundled with the executable.
+                    self._pyz_archive = ZlibArchiveReader(pyz_filepath)
+                    # Verify the integrity of the zip archive with Python modules.
+                    # This is already done when creating the ZlibArchiveReader instance.
+                    #self._pyz_archive.checkmagic()
 
-class FrozenPackageImporter(object):
-    """
-    Wrapper class for FrozenImporter that imports one specific fullname from
-    a module named by an alternate fullname. The alternate fullname is derived from the
-    __path__ of the package module containing that module.
+                    # End this method since no Exception was raised we can assume
+                    # ZlibArchiveReader was successfully loaded. Let's remove 'pyz_filepath'
+                    # from sys.path.
+                    sys.path.remove(pyz_filepath)
+                    # Some runtime hook might need access to the list of available
+                    # frozen module. Let's make them accessible as a set().
+                    self.toc = set(self._pyz_archive.toc.keys())
+                    # Return - no error was raised.
+                    trace("# PyInstaller: FrozenImporter(%s)", pyz_filepath)
+                    return
+                except IOError:
+                    # Item from sys.path is not ZlibArchiveReader let's try next.
+                    continue
+                except ArchiveReadError:
+                    # Item from sys.path is not ZlibArchiveReader let's try next.
+                    continue
+            # sys.path does not contain filename of executable with bundled zip archive.
+            # Raise import error.
+            raise ImportError("Can't load frozen modules.")
 
-    This is called by FrozenImporter.find_module whenever a module is found as a result
-    of searching module.__path__
-    """
-    def __init__(self, importer, fullname):
-        self._fullname = fullname
-        self._importer = importer
+        def __call__(self, path):
+            """
+            PEP-302 sys.path_hook processor.
 
-    def load_module(self, fullname):
-        return self._importer.load_module(fullname, self._fullname)
+            sys.path_hook is a list of callables, which will be checked in
+            sequence to determine if they can handle a given path item.
+            """
+
+            if path.startswith(SYS_PREFIX):
+                fullname = path[SYS_PREFIXLEN+1:].replace(pyi_os_path.os_sep, '.')
+                spec = self.find_spec(fullname)
+                if spec is not None:
+                    return self
+            raise ImportError(path)
+
+        def find_spec(self, fullname, path, target=None):
+            """
+            PEP-451 finder.find_spec() method for the ``sys.meta_path`` hook.
+
+            fullname     fully qualified name of the module
+            path         None for a top-level module, or package.__path__ for submodules or subpackages.
+
+            Finders must return ModuleSpec objects when find_spec() is called. This new method replaces find_module() and
+            find_loader() (in the PathEntryFinder case). If a loader does not have find_spec(), find_module() and
+            find_loader() are used instead, for backward-compatibility.
+            """
+            # Acquire the interpreter's import lock for the current thread. This
+            # lock should be used by import hooks to ensure thread-safety when
+            # importing modules.
+
+            filename = None  # None means - no module found in this importer.
+
+            if fullname in self.toc:
+                # Tell the import machinery to use self.load_module() to load the module.
+                filename = fullname
+                trace("import %s # PyInstaller PYZ", fullname)
+            elif path is not None:
+                # Try to handle module.__path__ modifications by the modules themselves
+                # Reverse the fake __path__ we added to the package module to a
+                # dotted module name and add the tail module from fullname onto that
+                # to synthesize a new fullname
+                modname = fullname.split('.')[-1]
+
+                for p in path:
+                    p = p.replace(SYS_PREFIX, "")
+                    parts = p.split(pyi_os_path.os_sep)
+                    if not len(parts): continue
+                    if not parts[0]:
+                        parts = parts[1:]
+                    parts.append(modname)
+                    path = ".".join(parts)
+                    if path in self.toc:
+                        filename = path
+                        trace("import %s as %s # PyInstaller PYZ (__path__ override: %s)",
+                              path, fullname, p)
+                        break
+
+            if filename is None:
+                trace("# %s not found in PYZ", fullname)
+                return None
+
+            is_pkg, bytecode = self._pyz_archive.extract(filename)
+            if is_pkg:
+                origin = pyi_os_path.os_path_join(pyi_os_path.os_path_join(SYS_PREFIX, filename.replace('.',
+                                                  pyi_os_path.os_sep)), '__init__.pyc')
+            else:
+                origin = pyi_os_path.os_path_join(SYS_PREFIX, filename.replace('.', pyi_os_path.os_sep) + '.pyc')
+
+            return _frozen_importlib.ModuleSpec(filename, self, is_package=is_pkg, origin=filename,
+                                                loader_state=(bytecode, origin))
+
+        def create_module(self, spec):
+            """
+            PEP-451 loader.create_module() method for the ``sys.meta_path`` hook.
+
+            Loaders may also implement create_module() that will return a new module to exec. It may return None to
+            indicate that the default module creation code should be used. One use case, though atypical, for
+            create_module() is to provide a module that is a subclass of the builtin module type. Most loaders will not
+            need to implement create_module(),
+
+            create_module() should properly handle the case where it is called more than once for the same spec/module.
+            This may include returning None or raising ImportError.
+            """
+            return imp_new_module(spec.origin)
+
+        def exec_module(self, module):
+            """
+            PEP-451 loader.exec_module() method for the ``sys.meta_path`` hook.
+
+            Loaders will have a new method, exec_module(). Its only job is to "exec" the module and consequently populate
+            the module's namespace. It is not responsible for creating or preparing the module object, nor for any cleanup
+            afterward. It has no return value. exec_module() will be used during both loading and reloading.
+
+            exec_module() should properly handle the case where it is called more than once. For some kinds of modules this
+            may mean raising ImportError every time after the first time the method is called. This is particularly
+            relevant for reloading, where some kinds of modules do not support in-place reloading.
+            """
+            module.__file__ = module.__spec__.loader_state[1]
+            exec(module.__spec__.loader_state[0], module.__dict__)
 
 
-class FrozenImporter(object):
-    """
-    Load bytecode of Python modules from the executable created by PyInstaller.
+        # Optional Extensions to the PEP-302 Importer Protocol
+        def is_package(self, fullname):
+            """
+            Return always False since built-in modules are never packages.
+            """
+            if fullname in self.toc:
+                try:
+                    is_pkg, bytecode = self._pyz_archive.extract(fullname)
+                    return bool(is_pkg)
+                except Exception:
+                    raise ImportError('Loader FrozenImporter cannot handle module ' + fullname)
+            else:
+                raise ImportError('Loader FrozenImporter cannot handle module ' + fullname)
 
-    Python bytecode is zipped and appended to the executable.
+        def get_code(self, fullname):
+            """
+            Get the code object associated with the module.
 
-    NOTE: PYZ format cannot be replaced by zipimport module.
+            ImportError should be raised if module not found.
+            """
+            if fullname in self.toc:
+                try:
+                    is_pkg, bytecode = self._pyz_archive.extract(fullname)
+                    return bytecode
+                except Exception:
+                    raise ImportError('Loader FrozenImporter cannot handle module ' + fullname)
+            else:
+                raise ImportError('Loader FrozenImporter cannot handle module ' + fullname)
 
-    The problem is that we have no control over zipimport; for instance,
-    it doesn't work if the zip file is embedded into a PKG appended
-    to an executable, like we create in one-file.
+        def get_source(self, fullname):
+            """
+            Method should return the source code for the module as a string.
+            But frozen modules does not contain source code.
 
-    This is PEP-302 finder and loader class for the ``sys.meta_path`` hook.
-    A PEP-302 finder requires method find_module() to return loader
-    class with method load_module(). Both these methods are implemented
-    in one class.
+            Return None.
+            """
+            if fullname in self.toc:
+                return None
+            else:
+                # ImportError should be raised if module not found.
+                raise ImportError('No module named ' + fullname)
 
+        def get_data(self, path):
+            """
+            This returns the data as a string, or raise IOError if the "file"
+            wasn't found. The data is always returned as if "binary" mode was used.
 
-    To use this class just call
+            This method is useful getting resources with 'pkg_resources' that are
+            bundled with Python modules in the PYZ archive.
 
-        FrozenImporter.install()
-    """
-    def __init__(self):
+            The 'path' argument is a path that can be constructed by munging
+            module.__file__ (or pkg.__path__ items)
+            """
+            assert path.startswith(SYS_PREFIX + pyi_os_path.os_sep)
+            fullname = path[len(SYS_PREFIX)+1:]
+            if fullname in self.toc:
+                # If the file is in the archive, return this
+                return self._pyz_archive.extract(fullname)[1]
+            else:
+                # Otherwise try to fetch it from the filesystem. Since
+                # __file__ attribute works properly just try to open and
+                # read it.
+                with open(path, 'rb') as fp:
+                    return fp.read()
+else:
+
+    class FrozenPackageImporter(object):
         """
-        Load, unzip and initialize the Zip archive bundled with the executable.
+        Wrapper class for FrozenImporter that imports one specific fullname from
+        a module named by an alternate fullname. The alternate fullname is derived from the
+        __path__ of the package module containing that module.
+
+        This is called by FrozenImporter.find_module whenever a module is found as a result
+        of searching module.__path__
         """
-        # Examine all items in sys.path and the one like /path/executable_name?117568
-        # is the correct executable with bundled zip archive. Use this value
-        # for the ZlibArchiveReader class and remove this item from sys.path.
-        # It was needed only for FrozenImporter class. Wrong path from sys.path
-        # Raises ArchiveReadError exception.
-        for pyz_filepath in sys.path:
-            # We need to acquire the interpreter's import lock here
-            # because ZlibArchiveReader() seeks through and reads from the
-            # zip archive.
+        def __init__(self, importer, fullname):
+            self._fullname = fullname
+            self._importer = importer
+
+        def load_module(self, fullname):
+            return self._importer.load_module(fullname, self._fullname)
+
+
+    class FrozenImporter(object):
+        """
+        Load bytecode of Python modules from the executable created by PyInstaller.
+
+        Python bytecode is zipped and appended to the executable.
+
+        NOTE: PYZ format cannot be replaced by zipimport module.
+
+        The problem is that we have no control over zipimport; for instance,
+        it doesn't work if the zip file is embedded into a PKG appended
+        to an executable, like we create in one-file.
+
+        This is PEP-302 finder and loader class for the ``sys.meta_path`` hook.
+        A PEP-302 finder requires method find_module() to return loader
+        class with method load_module(). Both these methods are implemented
+        in one class.
+
+
+        To use this class just call
+
+            FrozenImporter.install()
+        """
+        def __init__(self):
+            """
+            Load, unzip and initialize the Zip archive bundled with the executable.
+            """
+            # Examine all items in sys.path and the one like /path/executable_name?117568
+            # is the correct executable with bundled zip archive. Use this value
+            # for the ZlibArchiveReader class and remove this item from sys.path.
+            # It was needed only for FrozenImporter class. Wrong path from sys.path
+            # Raises ArchiveReadError exception.
+            for pyz_filepath in sys.path:
+                # We need to acquire the interpreter's import lock here
+                # because ZlibArchiveReader() seeks through and reads from the
+                # zip archive.
+                imp_lock()
+                try:
+                    # Unzip zip archive bundled with the executable.
+                    self._pyz_archive = ZlibArchiveReader(pyz_filepath)
+                    # Verify the integrity of the zip archive with Python modules.
+                    # This is already done when creating the ZlibArchiveReader instance.
+                    #self._pyz_archive.checkmagic()
+
+                    # End this method since no Exception was raised we can assume
+                    # ZlibArchiveReader was successfully loaded. Let's remove 'pyz_filepath'
+                    # from sys.path.
+                    sys.path.remove(pyz_filepath)
+                    # Some runtime hook might need access to the list of available
+                    # frozen module. Let's make them accessible as a set().
+                    self.toc = set(self._pyz_archive.toc.keys())
+                    # Return - no error was raised.
+                    trace("# PyInstaller: FrozenImporter(%s)", pyz_filepath)
+                    return
+                except IOError:
+                    # Item from sys.path is not ZlibArchiveReader let's try next.
+                    continue
+                except ArchiveReadError:
+                    # Item from sys.path is not ZlibArchiveReader let's try next.
+                    continue
+                finally:
+                    imp_unlock()
+            # sys.path does not contain filename of executable with bundled zip archive.
+            # Raise import error.
+            raise ImportError("Can't load frozen modules.")
+
+
+        def __call__(self, path):
+            """
+            PEP-302 sys.path_hook processor.
+
+            sys.path_hook is a list of callables, which will be checked in
+            sequence to determine if they can handle a given path item.
+            """
+
+            if path.startswith(SYS_PREFIX):
+                fullname = path[SYS_PREFIXLEN+1:].replace(pyi_os_path.os_sep, '.')
+                loader = self.find_module(fullname)
+                if loader is not None:
+                    return loader
+            raise ImportError(path)
+
+
+        def find_module(self, fullname, path=None):
+            """
+            PEP-302 finder.find_module() method for the ``sys.meta_path`` hook.
+
+            fullname     fully qualified name of the module
+            path         None for a top-level module, or package.__path__ for submodules or subpackages.
+
+            Return a loader object if the module was found, or None if it wasn't. If find_module() raises
+            an exception, it will be propagated to the caller, aborting the import.
+            """
+            # Acquire the interpreter's import lock for the current thread. This
+            # lock should be used by import hooks to ensure thread-safety when
+            # importing modules.
+
             imp_lock()
-            try:
-                # Unzip zip archive bundled with the executable.
-                self._pyz_archive = ZlibArchiveReader(pyz_filepath)
-                # Verify the integrity of the zip archive with Python modules.
-                # This is already done when creating the ZlibArchiveReader instance.
-                #self._pyz_archive.checkmagic()
+            module_loader = None  # None means - no module found in this importer.
 
-                # End this method since no Exception was raised we can assume
-                # ZlibArchiveReader was successfully loaded. Let's remove 'pyz_filepath'
-                # from sys.path.
-                sys.path.remove(pyz_filepath)
-                # Some runtime hook might need access to the list of available
-                # frozen module. Let's make them accessible as a set().
-                self.toc = set(self._pyz_archive.toc.keys())
-                # Return - no error was raised.
-                trace("# PyInstaller: FrozenImporter(%s)", pyz_filepath)
-                return
-            except IOError:
-                # Item from sys.path is not ZlibArchiveReader let's try next.
-                continue
-            except ArchiveReadError:
-                # Item from sys.path is not ZlibArchiveReader let's try next.
-                continue
-            finally:
-                imp_unlock()
-        # sys.path does not contain filename of executable with bundled zip archive.
-        # Raise import error.
-        raise ImportError("Can't load frozen modules.")
+            if fullname in self.toc:
+                # Tell the import machinery to use self.load_module() to load the module.
+                module_loader = self
+                trace("import %s # PyInstaller PYZ", fullname)
+            elif path is not None:
+                # Try to handle module.__path__ modifications by the modules themselves
+                # Reverse the fake __path__ we added to the package module to a
+                # dotted module name and add the tail module from fullname onto that
+                # to synthesize a new fullname
+                modname = fullname.split('.')[-1]
 
-
-    def __call__(self, path):
-        """
-        PEP-302 sys.path_hook processor.
-
-        sys.path_hook is a list of callables, which will be checked in
-        sequence to determine if they can handle a given path item.
-        """
-
-        if path.startswith(SYS_PREFIX):
-            fullname = path[SYS_PREFIXLEN+1:].replace(pyi_os_path.os_sep, '.')
-            loader = self.find_module(fullname)
-            if loader is not None:
-                return loader
-        raise ImportError(path)
-
-
-    def find_module(self, fullname, path=None):
-        """
-        PEP-302 finder.find_module() method for the ``sys.meta_path`` hook.
-
-        fullname     fully qualified name of the module
-        path         None for a top-level module, or package.__path__ for submodules or subpackages.
-
-        Return a loader object if the module was found, or None if it wasn't. If find_module() raises
-        an exception, it will be propagated to the caller, aborting the import.
-        """
-        # Acquire the interpreter's import lock for the current thread. This
-        # lock should be used by import hooks to ensure thread-safety when
-        # importing modules.
-
-        imp_lock()
-        module_loader = None  # None means - no module found in this importer.
-
-        if fullname in self.toc:
-            # Tell the import machinery to use self.load_module() to load the module.
-            module_loader = self
-            trace("import %s # PyInstaller PYZ", fullname)
-        elif path is not None:
-            # Try to handle module.__path__ modifications by the modules themselves
-            # Reverse the fake __path__ we added to the package module to a
-            # dotted module name and add the tail module from fullname onto that
-            # to synthesize a new fullname
-            modname = fullname.split('.')[-1]
-
-            for p in path:
-                p = p.replace(SYS_PREFIX, "")
-                parts = p.split(pyi_os_path.os_sep)
-                if not len(parts): continue
-                if not parts[0]:
-                    parts = parts[1:]
-                parts.append(modname)
-                real_fullname = ".".join(parts)
-                if real_fullname in self.toc:
-                    module_loader = FrozenPackageImporter(self, real_fullname)
-                    trace("import %s as %s # PyInstaller PYZ (__path__ override: %s)",
-                          real_fullname, fullname, p)
-                    break
-        # Release the interpreter's import lock.
-        imp_unlock()
-        if module_loader is None:
-            trace("# %s not found in PYZ", fullname)
-        return module_loader
-
-    def load_module(self, fullname, real_fullname=None):
-        """
-        PEP-302 loader.load_module() method for the ``sys.meta_path`` hook.
-
-        Return the loaded module (instance of imp_new_module()) or raises
-        an exception, preferably ImportError if an existing exception
-        is not being propagated.
-
-        When called from FrozenPackageImporter, `real_fullname` is the name of the
-        module as it is stored in the archive. This module will be loaded and installed
-        into sys.modules using `fullname` as its name
-        """
-        # Acquire the interpreter's import lock.
-        imp_lock()
-        module = None
-        if real_fullname is None:
-            real_fullname=fullname
-        try:
-            # PEP302 If there is an existing module object named 'fullname'
-            # in sys.modules, the loader must use that existing module.
-            module = sys.modules.get(fullname)
-
-            # Module not in sys.modules - load it and it to sys.modules.
-            if module is None:
-                # Load code object from the bundled ZIP archive.
-                is_pkg, bytecode = self._pyz_archive.extract(real_fullname)
-                # Create new empty 'module' object.
-                module = imp_new_module(fullname)
-
-                # TODO Replace bytecode.co_filename by something more meaningful:
-                # e.g. /absolute/path/frozen_executable/path/to/module/module_name.pyc
-                # Paths from developer machine are masked.
-
-                ### Set __file__ attribute of a module relative to the executable
-                # so that data files can be found. The absolute absolute path
-                # to the executable is taken from sys.prefix. In onefile mode it
-                # points to the temp directory where files are unpacked by PyInstaller.
-                # Then, append the appropriate suffix (__init__.pyc for a package, or just .pyc for a module).
-                if is_pkg:
-                    module.__file__ = pyi_os_path.os_path_join(pyi_os_path.os_path_join(SYS_PREFIX,
-                        fullname.replace('.', pyi_os_path.os_sep)), '__init__.pyc')
-                else:
-                    module.__file__ = pyi_os_path.os_path_join(SYS_PREFIX,
-                        fullname.replace('.', pyi_os_path.os_sep) + '.pyc')
-
-                ### Set __path__  if 'fullname' is a package.
-                # Python has modules and packages. A Python package is container
-                # for several modules or packages.
-                if is_pkg:
-
-                    # If a module has a __path__ attribute, the import mechanism
-                    # will treat it as a package.
-                    #
-                    # Since PYTHONHOME is set in bootloader, 'sys.prefix' points to the
-                    # correct path where PyInstaller should find bundled dynamic
-                    # libraries. In one-file mode it points to the tmp directory where
-                    # bundled files are extracted at execution time.
-                    #
-                    # __path__ cannot be empty list because 'wx' module prepends something to it.
-                    # It cannot contain value 'sys.prefix' because 'xml.etree.cElementTree' fails
-                    # Otherwise.
-                    #
-                    # Set __path__ to point to 'sys.prefix/package/subpackage'.
-                    module.__path__ = [pyi_os_path.os_path_dirname(module.__file__)]
-
-                ### Set __loader__
-                # The attribute __loader__ improves support for module 'pkg_resources' and
-                # with the frozen apps the following functions are working:
-                # pkg_resources.resource_string(), pkg_resources.resource_stream().
-                module.__loader__ = self
-
-                ### Set __package__
-                # Accoring to PEP302 this attribute must be set.
-                # When it is present, relative imports will be based on this
-                # attribute rather than the module __name__ attribute.
-                # More details can be found in PEP366.
-                # For ordinary modules this is set like:
-                #     'aa.bb.cc.dd'  ->  'aa.bb.cc'
-                if is_pkg:
-                    module.__package__ = fullname
-                else:
-                    module.__package__ = fullname.rsplit('.', 1)[0]
-
-                ### Set __spec__ for Python 3.4+
-                # In Python 3.4 was introduced module attribute __spec__ to
-                # consolidate all module attributes.
-                if sys.version_info[0:2] > (3, 3):
-                    module.__spec__ = _frozen_importlib.ModuleSpec(
-                        real_fullname, self, is_package=is_pkg)
-
-                ### Add module object to sys.modules dictionary.
-                # Module object must be in sys.modules before the loader
-                # executes the module code. This is crucial because the module
-                # code may (directly or indirectly) import itself; adding it
-                # to sys.modules beforehand prevents unbounded recursion in the
-                # worst case and multiple loading in the best.
-                sys.modules[fullname] = module
-
-                # Run the module code.
-                exec(bytecode, module.__dict__)
-                # Reread the module from sys.modules in case it's changed itself
-                module = sys.modules[fullname]
-
-        except Exception:
-            # Remove 'fullname' from sys.modules if it was appended there.
-            if fullname in sys.modules:
-                sys.modules.pop(fullname)
-            # TODO Do we need to raise different types of Exceptions for better debugging?
-            # PEP302 requires to raise ImportError exception.
-            #raise ImportError("Can't load frozen module: %s" % fullname)
-
-            raise
-
-        finally:
+                for p in path:
+                    p = p.replace(SYS_PREFIX, "")
+                    parts = p.split(pyi_os_path.os_sep)
+                    if not len(parts): continue
+                    if not parts[0]:
+                        parts = parts[1:]
+                    parts.append(modname)
+                    real_fullname = ".".join(parts)
+                    if real_fullname in self.toc:
+                        module_loader = FrozenPackageImporter(self, real_fullname)
+                        trace("import %s as %s # PyInstaller PYZ (__path__ override: %s)",
+                              real_fullname, fullname, p)
+                        break
             # Release the interpreter's import lock.
             imp_unlock()
+            if module_loader is None:
+                trace("# %s not found in PYZ", fullname)
+            return module_loader
 
+        def load_module(self, fullname, real_fullname=None):
+            """
+            PEP-302 loader.load_module() method for the ``sys.meta_path`` hook.
 
-        # Module returned only in case of no exception.
-        return module
+            Return the loaded module (instance of imp_new_module()) or raises
+            an exception, preferably ImportError if an existing exception
+            is not being propagated.
 
-    ### Optional Extensions to the PEP-302 Importer Protocol
-
-    def is_package(self, fullname):
-        """
-        Return always False since built-in modules are never packages.
-        """
-        if fullname in self.toc:
+            When called from FrozenPackageImporter, `real_fullname` is the name of the
+            module as it is stored in the archive. This module will be loaded and installed
+            into sys.modules using `fullname` as its name
+            """
+            # Acquire the interpreter's import lock.
+            imp_lock()
+            module = None
+            if real_fullname is None:
+                real_fullname=fullname
             try:
-                is_pkg, bytecode = self._pyz_archive.extract(fullname)
-                return bool(is_pkg)
+                # PEP302 If there is an existing module object named 'fullname'
+                # in sys.modules, the loader must use that existing module.
+                module = sys.modules.get(fullname)
+
+                # Module not in sys.modules - load it and it to sys.modules.
+                if module is None:
+                    # Load code object from the bundled ZIP archive.
+                    is_pkg, bytecode = self._pyz_archive.extract(real_fullname)
+                    # Create new empty 'module' object.
+                    module = imp_new_module(fullname)
+
+                    # TODO Replace bytecode.co_filename by something more meaningful:
+                    # e.g. /absolute/path/frozen_executable/path/to/module/module_name.pyc
+                    # Paths from developer machine are masked.
+
+                    ### Set __file__ attribute of a module relative to the executable
+                    # so that data files can be found. The absolute absolute path
+                    # to the executable is taken from sys.prefix. In onefile mode it
+                    # points to the temp directory where files are unpacked by PyInstaller.
+                    # Then, append the appropriate suffix (__init__.pyc for a package, or just .pyc for a module).
+                    if is_pkg:
+                        module.__file__ = pyi_os_path.os_path_join(pyi_os_path.os_path_join(SYS_PREFIX,
+                            fullname.replace('.', pyi_os_path.os_sep)), '__init__.pyc')
+                    else:
+                        module.__file__ = pyi_os_path.os_path_join(SYS_PREFIX,
+                            fullname.replace('.', pyi_os_path.os_sep) + '.pyc')
+
+                    ### Set __path__  if 'fullname' is a package.
+                    # Python has modules and packages. A Python package is container
+                    # for several modules or packages.
+                    if is_pkg:
+
+                        # If a module has a __path__ attribute, the import mechanism
+                        # will treat it as a package.
+                        #
+                        # Since PYTHONHOME is set in bootloader, 'sys.prefix' points to the
+                        # correct path where PyInstaller should find bundled dynamic
+                        # libraries. In one-file mode it points to the tmp directory where
+                        # bundled files are extracted at execution time.
+                        #
+                        # __path__ cannot be empty list because 'wx' module prepends something to it.
+                        # It cannot contain value 'sys.prefix' because 'xml.etree.cElementTree' fails
+                        # Otherwise.
+                        #
+                        # Set __path__ to point to 'sys.prefix/package/subpackage'.
+                        module.__path__ = [pyi_os_path.os_path_dirname(module.__file__)]
+
+                    ### Set __loader__
+                    # The attribute __loader__ improves support for module 'pkg_resources' and
+                    # with the frozen apps the following functions are working:
+                    # pkg_resources.resource_string(), pkg_resources.resource_stream().
+                    module.__loader__ = self
+
+                    ### Set __package__
+                    # Accoring to PEP302 this attribute must be set.
+                    # When it is present, relative imports will be based on this
+                    # attribute rather than the module __name__ attribute.
+                    # More details can be found in PEP366.
+                    # For ordinary modules this is set like:
+                    #     'aa.bb.cc.dd'  ->  'aa.bb.cc'
+                    if is_pkg:
+                        module.__package__ = fullname
+                    else:
+                        module.__package__ = fullname.rsplit('.', 1)[0]
+
+                    ### Set __spec__ for Python 3.4+
+                    # In Python 3.4 was introduced module attribute __spec__ to
+                    # consolidate all module attributes.
+                    if sys.version_info[0:2] > (3, 3):
+                        module.__spec__ = _frozen_importlib.ModuleSpec(
+                            real_fullname, self, is_package=is_pkg)
+
+                    ### Add module object to sys.modules dictionary.
+                    # Module object must be in sys.modules before the loader
+                    # executes the module code. This is crucial because the module
+                    # code may (directly or indirectly) import itself; adding it
+                    # to sys.modules beforehand prevents unbounded recursion in the
+                    # worst case and multiple loading in the best.
+                    sys.modules[fullname] = module
+
+                    # Run the module code.
+                    exec(bytecode, module.__dict__)
+                    # Reread the module from sys.modules in case it's changed itself
+                    module = sys.modules[fullname]
+
             except Exception:
+                # Remove 'fullname' from sys.modules if it was appended there.
+                if fullname in sys.modules:
+                    sys.modules.pop(fullname)
+                # TODO Do we need to raise different types of Exceptions for better debugging?
+                # PEP302 requires to raise ImportError exception.
+                #raise ImportError("Can't load frozen module: %s" % fullname)
+
+                raise
+
+            finally:
+                # Release the interpreter's import lock.
+                imp_unlock()
+
+
+            # Module returned only in case of no exception.
+            return module
+
+        ### Optional Extensions to the PEP-302 Importer Protocol
+
+        def is_package(self, fullname):
+            """
+            Return always False since built-in modules are never packages.
+            """
+            if fullname in self.toc:
+                try:
+                    is_pkg, bytecode = self._pyz_archive.extract(fullname)
+                    return bool(is_pkg)
+                except Exception:
+                    raise ImportError('Loader FrozenImporter cannot handle module ' + fullname)
+            else:
                 raise ImportError('Loader FrozenImporter cannot handle module ' + fullname)
-        else:
-            raise ImportError('Loader FrozenImporter cannot handle module ' + fullname)
 
-    def get_code(self, fullname):
-        """
-        Get the code object associated with the module.
+        def get_code(self, fullname):
+            """
+            Get the code object associated with the module.
 
-        ImportError should be raised if module not found.
-        """
-        if fullname in self.toc:
-            try:
-                is_pkg, bytecode = self._pyz_archive.extract(fullname)
-                return bytecode
-            except Exception:
+            ImportError should be raised if module not found.
+            """
+            if fullname in self.toc:
+                try:
+                    is_pkg, bytecode = self._pyz_archive.extract(fullname)
+                    return bytecode
+                except Exception:
+                    raise ImportError('Loader FrozenImporter cannot handle module ' + fullname)
+            else:
                 raise ImportError('Loader FrozenImporter cannot handle module ' + fullname)
-        else:
-            raise ImportError('Loader FrozenImporter cannot handle module ' + fullname)
 
-    def get_source(self, fullname):
-        """
-        Method should return the source code for the module as a string.
-        But frozen modules does not contain source code.
+        def get_source(self, fullname):
+            """
+            Method should return the source code for the module as a string.
+            But frozen modules does not contain source code.
 
-        Return None.
-        """
-        if fullname in self.toc:
-            return None
-        else:
-            # ImportError should be raised if module not found.
-            raise ImportError('No module named ' + fullname)
+            Return None.
+            """
+            if fullname in self.toc:
+                return None
+            else:
+                # ImportError should be raised if module not found.
+                raise ImportError('No module named ' + fullname)
 
-    def get_data(self, path):
-        """
-        This returns the data as a string, or raise IOError if the "file"
-        wasn't found. The data is always returned as if "binary" mode was used.
+        def get_data(self, path):
+            """
+            This returns the data as a string, or raise IOError if the "file"
+            wasn't found. The data is always returned as if "binary" mode was used.
 
-        This method is useful getting resources with 'pkg_resources' that are
-        bundled with Python modules in the PYZ archive.
+            This method is useful getting resources with 'pkg_resources' that are
+            bundled with Python modules in the PYZ archive.
 
-        The 'path' argument is a path that can be constructed by munging
-        module.__file__ (or pkg.__path__ items)
-        """
-        assert path.startswith(SYS_PREFIX + pyi_os_path.os_sep)
-        fullname = path[len(SYS_PREFIX)+1:]
-        if fullname in self.toc:
-            # If the file is in the archive, return this
-            return self._pyz_archive.extract(fullname)[1]
-        else:
-            # Otherwise try to fetch it from the filesystem. Since
-            # __file__ attribute works properly just try to open and
-            # read it.
-            with open(path, 'rb') as fp:
-                return fp.read()
+            The 'path' argument is a path that can be constructed by munging
+            module.__file__ (or pkg.__path__ items)
+            """
+            assert path.startswith(SYS_PREFIX + pyi_os_path.os_sep)
+            fullname = path[len(SYS_PREFIX)+1:]
+            if fullname in self.toc:
+                # If the file is in the archive, return this
+                return self._pyz_archive.extract(fullname)[1]
+            else:
+                # Otherwise try to fetch it from the filesystem. Since
+                # __file__ attribute works properly just try to open and
+                # read it.
+                with open(path, 'rb') as fp:
+                    return fp.read()
 
-    # TODO Do we really need to implement this method?
-    def get_filename(self, fullname):
-        """
-        This method should return the value that __file__ would be set to
-        if the named module was loaded. If the module is not found, then
-        ImportError should be raised.
-        """
-        # Then, append the appropriate suffix (__init__.pyc for a package, or just .pyc for a module).
-        # Method is_package() will raise ImportError if module not found.
-        if self.is_package(fullname):
-            filename = pyi_os_path.os_path_join(pyi_os_path.os_path_join(SYS_PREFIX,
-                fullname.replace('.', pyi_os_path.os_sep)), '__init__.pyc')
-        else:
-            filename = pyi_os_path.os_path_join(SYS_PREFIX,
-                fullname.replace('.', pyi_os_path.os_sep) + '.pyc')
-        return filename
+        # TODO Do we really need to implement this method?
+        def get_filename(self, fullname):
+            """
+            This method should return the value that __file__ would be set to
+            if the named module was loaded. If the module is not found, then
+            ImportError should be raised.
+            """
+            # Then, append the appropriate suffix (__init__.pyc for a package, or just .pyc for a module).
+            # Method is_package() will raise ImportError if module not found.
+            if self.is_package(fullname):
+                filename = pyi_os_path.os_path_join(pyi_os_path.os_path_join(SYS_PREFIX,
+                    fullname.replace('.', pyi_os_path.os_sep)), '__init__.pyc')
+            else:
+                filename = pyi_os_path.os_path_join(SYS_PREFIX,
+                    fullname.replace('.', pyi_os_path.os_sep) + '.pyc')
+            return filename
 
 
 class CExtensionImporter(object):


### PR DESCRIPTION
This resolves the mentioned issue. 

@htgoebel The tests are again failing due to the addition of async functions to jinja2, but the fix for that is located in my py36 PR, which is done at this point. Long story short; the provisional API changed. Also I put the fix for py33 in that one. I also probably went overkill on the commits.