### PR TITLE
Add hook for redmine

### DIFF
--- a/PyInstaller/hooks/hook-redmine.py
+++ b/PyInstaller/hooks/hook-redmine.py
@@ -1,0 +1,11 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013-2016, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+
+hiddenimports = ['redmine.resources']


### PR DESCRIPTION
When access some redmine attr in exe file will have following error
```
  File "site-packages\redmine\__init__.py", line 47, in __getattr__
  File "site-packages\redmine\managers.py", line 40, in __init__
redmine.exceptions.ResourceError: Unsupported Redmine resource
```
in `redmine/managers.py ResourceManager __init__` function will import
resource from redmine.resources