### PR TITLE
ImportError: No module named is_module_satisfies #2304

### DIFF
--- a/PyInstaller/hooks/hook-botocore.py
+++ b/PyInstaller/hooks/hook-botocore.py
@@ -19,7 +19,8 @@
 # Tested with botocore 1.4.36
 
 from PyInstaller.utils.hooks import collect_data_files
-from PyInstaller.compat import is_py2, is_module_satisfies
+from PyInstaller.compat import is_py2
+from PyInstaller.utils.hooks import is_module_satisfies
 
 if is_module_satisfies('botocore >= 1.4.36'):
     if is_py2:


### PR DESCRIPTION
Pyinstaller is unable to bundle a package which imports boto3.
 It fails with import error
`ImportError: No module named is_module_satisfies`

this issue occur after fix of issue #2304 

occurs with pyinstaller version 3.2.1

