### PR TITLE
Run-time hooks: fix GST_PLUGIN_PATH separator being os dependant.

### DIFF
--- a/PyInstaller/loader/rthooks/pyi_rth_gstreamer.py
+++ b/PyInstaller/loader/rthooks/pyi_rth_gstreamer.py
@@ -17,7 +17,7 @@ import sys
 os.environ['GST_REGISTRY_FORK'] = 'no'
 
 gst_plugin_paths = [sys._MEIPASS, os.path.join(sys._MEIPASS, 'gst-plugins')]
-os.environ['GST_PLUGIN_PATH'] = ':'.join(gst_plugin_paths)
+os.environ['GST_PLUGIN_PATH'] = os.pathsep.join(gst_plugin_paths)
 
 # Prevent permission issues on Windows
 os.environ['GST_REGISTRY'] = os.path.join(sys._MEIPASS, 'registry.bin')


### PR DESCRIPTION
Fixed from https://github.com/pyinstaller/pyinstaller/pull/2214.