### PR TITLE
Add hook for appdirs module.

### DIFF
--- a/PyInstaller/hooks/hook-appdirs.py
+++ b/PyInstaller/hooks/hook-appdirs.py
@@ -1,0 +1,20 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013-2017, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+
+"""
+Import hook for appdirs.
+
+On Windows, appdirs tries 2 different methods to get well-known directories
+from the system: First with win32com, then with ctypes. Excluding win32com here
+avoids including all the win32com related DLLs in programs that don't include
+them otherwise.
+"""
+
+excludedimports = ['win32com']


### PR DESCRIPTION
The appdirs module has multiple ways to get the user directories from the system. On win32, it tries win32com, cytpes, jna (for jython) and finally the registry.

win32com, ctypes and jna all call the same Win32 API function, so the result should be the same - but excluding win32com excludes all the win32com related DLLs in programs that don't include them otherwise, which saves about 2MB in my tests.