### PR TITLE
Dissable processing win32com on non windows systems

### DIFF
--- a/PyInstaller/hooks/pre_safe_import_module/hook-win32com.py
+++ b/PyInstaller/hooks/pre_safe_import_module/hook-win32com.py
@@ -21,11 +21,13 @@ module 'win32com.shell' is in reality 'win32comext.shell'.
 import os
 
 from PyInstaller.utils.hooks import logger, get_module_file_attribute
+from PyInstaller.compat import is_win
 
 
 def pre_safe_import_module(api):
-    win32com_dir = os.path.dirname(get_module_file_attribute('win32com'))
-    comext_dir = os.path.join(os.path.dirname(win32com_dir), 'win32comext')
-    logger.debug('win32com: extending __path__ with dir %r' % comext_dir)
-    # Append the __path__ where PyInstaller will look for 'win32com' modules.'
-    api.append_package_path(comext_dir)
+    if is_win:
+        win32com_dir = os.path.dirname(get_module_file_attribute('win32com'))
+        comext_dir = os.path.join(os.path.dirname(win32com_dir), 'win32comext')
+        logger.debug('win32com: extending __path__ with dir %r' % comext_dir)
+        # Append the __path__ where PyInstaller will look for 'win32com' modules.'
+        api.append_package_path(comext_dir)


### PR DESCRIPTION
win32com hooks will skip adding path to process if not on windows. 
fixes #2462
Works fine for on my system. Mac and Ubuntu.

Note: I have not tested this on ``darwin + wine``  system or any other windows compatibility layer tools