### PR TITLE
Issue #2466: Adds PID to bootloader log messages

### DIFF
--- a/bootloader/src/pyi_global.c
+++ b/bootloader/src/pyi_global.c
@@ -33,6 +33,9 @@
     #include <direct.h>
     #include <process.h>
     #include <io.h>
+#else
+    #include <sys/types.h>
+    #include <unistd.h>
 #endif
 
 /* On Mac OS X send debug msg also to syslog for gui app in debug mode. */
@@ -113,6 +116,8 @@ void
 pyi_global_printf(const char *fmt, ...)
 {
     va_list v;
+
+    fprintf(stderr, "[%d] ", getpid());
 
     va_start(v, fmt);
     /* Sent 'LOADER text' messages to stderr. */

--- a/bootloader/src/pyi_global.c
+++ b/bootloader/src/pyi_global.c
@@ -96,9 +96,13 @@ mbvs(const char *fmt, ...)
 {
     char msg[MBTXTLEN];
     va_list args;
+    int pid_len;
+
+    /* Add pid to the message */
+    pid_len = sprintf(msg, "[%d] ", getpid());
 
     va_start(args, fmt);
-    vsnprintf(msg, MBTXTLEN, fmt, args);
+    vsnprintf(&msg[pid_len], MBTXTLEN-pid_len, fmt, args);
     /* Ensure message is trimmed to fit the buffer. */
     /* msg[MBTXTLEN-1] = '\0'; */
     va_end(args);


### PR DESCRIPTION
In issue #2466 it was requested to add the PID of the running process to the logging of the bootloader in the format:
`[PID] <log message>`

This pull request adds this functionality for the  for the console logging, and for the windowed mode in Windows trough the message box logging.

For OS X there is a special addition to the console logging, which prints to syslog using `vsyslog()`. Because syslog creates its own message format, it's not possible to simply print the PID before it. 
If the printing of the PID is also desired for the syslog messages on OS X, the course of action would probably be to add an `opensyslog()` call with the `LOG_PID` identifier.

I would be able to add a commit to this pull request where this is added if so desired.

This code was tested on:
Arch Linux with gcc version 6.3.1, Python 3.6
Windows 7 with MinGW-w64, gcc version 4.8.3, Python 3.6, pypiwin32 220