### PR TITLE
Tests: Appveyor: don't fail build on upload failure.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -173,4 +173,9 @@ on_success:
 
 
 on_finish:
-  - ps: 'if (Test-Path ".\junit-results.xml") { (new-object net.webclient).UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\junit-results.xml)) }'
+  - ps: |
+      (new-object net.webclient).UploadFile(
+        "https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)",
+        (Resolve-Path .\junit-results.xml)
+      )
+      $LastExitCode = 0


### PR DESCRIPTION
The tests API is now failing for some reason, but that shouldn't fail the build.

See appveyor/ci#1363.