### PR TITLE
Dylib: Add vcruntime140.dll to_win_includes for Py 3.(5,6)

### DIFF
--- a/PyInstaller/depend/dylib.py
+++ b/PyInstaller/depend/dylib.py
@@ -92,6 +92,7 @@ _win_includes = set([
     r'api-ms-win-core.*',
     r'api-ms-win-crt.*',
     r'ucrtbase\.dll',
+    r'vcruntime140\.dll',
 
     # Allow pythonNN.dll, pythoncomNN.dll, pywintypesNN.dll
     r'py(?:thon(?:com(?:loader)?)?|wintypes)\d+\.dll',


### PR DESCRIPTION
Python 3.5 and Python 3.6 require `vcruntime140.dll` to be
available in Path. Otherwise, a python3x.dll error code
126 results.

For a related comment, see: https://github.com/pyinstaller/pyinstaller/issues/1566#issuecomment-284426877