### PR TITLE
Fix potential memory leak in the bootloader

### DIFF
--- a/bootloader/src/pyi_pythonlib.c
+++ b/bootloader/src/pyi_pythonlib.c
@@ -229,6 +229,18 @@ pyi_pylib_set_runtime_opts(ARCHIVE_STATUS *status)
     return 0;
 }
 
+void
+pyi_free_wargv(wchar_t ** wargv)
+{
+    wchar_t ** arg = wargv;
+
+    while (arg[0]) {
+        free(arg[0]);
+        arg++;
+    }
+    free(wargv);
+}
+
 /* Convert argv to wchar_t for Python 3. Based on code from Python's main().
  *
  * Uses 'Py_DecodeLocale' ('_Py_char2wchar' in 3.0-3.4) function from python lib,
@@ -266,6 +278,7 @@ pyi_wargv_from_argv(int argc, char ** argv)
         wargv[i] = PI_Py_DecodeLocale(argv[i], NULL);
 
         if (!wargv[i]) {
+            pyi_free_wargv(wargv);
             free(oldloc);
             FATALERROR("Fatal error: "
                        "unable to decode the command line argument #%i\n",
@@ -278,18 +291,6 @@ pyi_wargv_from_argv(int argc, char ** argv)
     setlocale(LC_CTYPE, oldloc);
     free(oldloc);
     return wargv;
-}
-
-void
-pyi_free_wargv(wchar_t ** wargv)
-{
-    wchar_t ** arg = wargv;
-
-    while (arg[0]) {
-        free(arg[0]);
-        arg++;
-    }
-    free(wargv);
 }
 
 /*

--- a/bootloader/src/pyi_pythonlib.c
+++ b/bootloader/src/pyi_pythonlib.c
@@ -55,7 +55,7 @@ pyi_pylib_load(ARCHIVE_STATUS *status)
     char dllname[64];
     int pyvers = ntohl(status->cookie.pyvers);
     char *p;
-    
+
     /* Are we going to load the Python 2.x library? */
     is_py2 = (pyvers / 10) == 2;
 

--- a/bootloader/src/pyi_pythonlib.c
+++ b/bootloader/src/pyi_pythonlib.c
@@ -264,7 +264,7 @@ pyi_wargv_from_argv(int argc, char ** argv)
         return NULL;
     }
 
-    wargv = (wchar_t **)malloc(sizeof(wchar_t*) * (argc + 1));
+    wargv = (wchar_t **)calloc(sizeof(wchar_t*) * (argc + 1), 1);
 
     if (!wargv) {
         FATALERROR("out of memory\n");


### PR DESCRIPTION
Within the `pyi_wargv_from_argv` function there is a condition which checks if `PI_Py_DecodeLocale` succeeded (for each argument). 
When this is not the case, the function terminates by returning `NULL`

Before exiting the function, `oldloc` is freed, but `wargv` and its content (added within the for loop) is never freed when the function is aborted.

This pull request adds the proper cleanup for `wargv` and its content before returning NULL , in the case that `PI_Py_DecodeLocale` fails.

Note: According to the [Python documentation](https://docs.python.org/3/c-api/sys.html):
> Decoding errors should never happen, unless there is a bug in the C library.

But it should still be handled gracefully as with the `oldloc` variable.

If I overlooked something or this behavior was desired/accepted for some reason, please let me know.

This bug was found using the [clang static analyzer](https://clang-analyzer.llvm.org/).