### PR TITLE
workaround for python 3 issue http://bugs.python.org/issue29778

### DIFF
--- a/bootloader/src/pyi_python.c
+++ b/bootloader/src/pyi_python.c
@@ -45,6 +45,7 @@ DECLPROC(Py_Finalize);
 DECLPROC(Py_IncRef);
 DECLPROC(Py_Initialize);
 DECLPROC(Py_SetPath);
+DECLPROC(Py_GetPath);
 DECLPROC(Py_SetProgramName);
 DECLPROC(Py_SetPythonHome);
 
@@ -107,6 +108,7 @@ pyi_python_map_names(HMODULE dll, int pyvers)
     if (pyvers >= 30) {
         /* new in Python 3 */
         GETPROC(dll, Py_SetPath);
+        GETPROC(dll, Py_GetPath);
     }
     ;
     GETPROC(dll, Py_SetProgramName);

--- a/bootloader/src/pyi_python.h
+++ b/bootloader/src/pyi_python.h
@@ -102,6 +102,7 @@ EXTDECLPROC(void, Py_DecRef, (PyObject *));
 EXTDECLPROC(void, Py_SetProgramName, (wchar_t *));
 EXTDECLPROC(void, Py_SetPythonHome, (wchar_t *));
 EXTDECLPROC(void, Py_SetPath, (wchar_t *));  /* new in Python 3 */
+EXTDECLPROC(wchar_t *, Py_GetPath, (void));  /* new in Python 3 */
 
 EXTDECLPROC(void, PySys_SetPath, (wchar_t *));
 EXTDECLPROC(int, PySys_SetArgvEx, (int, wchar_t **, int));

--- a/bootloader/src/pyi_pythonlib.c
+++ b/bootloader/src/pyi_pythonlib.c
@@ -454,6 +454,7 @@ pyi_pylib_start_python(ARCHIVE_STATUS *status)
             return -1;
         }
         VS("LOADER: Pre-init sys.path is %s\n", pypath);
+        PI_Py_GetPath();
         PI_Py_SetPath(pypath_w);
     }
     ;


### PR DESCRIPTION
PyInstaller package on Windows will load up python3.dll from c:\ and c:\DLLs location.
Patched pyi_pythonlib.c so that before it calls to Py_SetPath it will call Py_GetPath so the static dllpath from PC/getpathp.c will get set as a side effect.