### PR TITLE
Fix memory and resource leak

### DIFF
--- a/bootloader/src/pyi_archive.c
+++ b/bootloader/src/pyi_archive.c
@@ -161,6 +161,7 @@ pyi_arch_extract(ARCHIVE_STATUS *status, TOC *ptoc)
 
     if (fread(data, ntohl(ptoc->len), 1, status->fp) < 1) {
         OTHERERROR("Could not read from file\n");
+        free(data);
         return NULL;
     }
 

--- a/bootloader/src/pyi_utils.c
+++ b/bootloader/src/pyi_utils.c
@@ -526,6 +526,12 @@ pyi_copy_file(const char *src, const char *dst, const char *filename)
     int error = 0;
 
     if (in == NULL || out == NULL) {
+        if (in) {
+            fclose(in);
+        }
+        if (out) {
+            fclose(out);
+        }
         return -1;
     }
 


### PR DESCRIPTION
**Memory leak:**
Within `pyi_archive.c` in the function `pyi_arch_extract` the trough `malloc` allocated buffer `data` is not freed when the `fread` call fails. It immediately returns NULL.
Add `free(data)` to prevent a memory leak.

**Resource leak:**
Within `pyi_utils.c` in the function `pyi_copy_file` it is checked if `in` and `out` where correctly opened. Currently if `in` is successfully opened and `out` is not, `in` is never closed and vise versa.

These leaks where found using [Codacy](www.codacy.com).