### PR TITLE
Modulegraph: switch to enumerate_instructions.

### DIFF
--- a/PyInstaller/depend/utils.py
+++ b/PyInstaller/depend/utils.py
@@ -154,7 +154,7 @@ def __scan_code_instruction_for_ctypes(co, instructions):
         """
         instruction = next(instructions)
         if instruction.opname == 'LOAD_CONST':
-            soname = co.co_consts[instruction.arg]
+            soname = instruction.argval
             if isinstance(soname, str):
                 return soname
 
@@ -165,7 +165,7 @@ def __scan_code_instruction_for_ctypes(co, instructions):
     if instruction.opname not in expected_ops:
         return None
 
-    name = co.co_names[instruction.arg]
+    name = instruction.argval
     if name == "ctypes":
         # Guesses ctypes has been imported as `import ctypes` and
         # the members are accessed like: ctypes.CDLL("library.so")
@@ -180,7 +180,7 @@ def __scan_code_instruction_for_ctypes(co, instructions):
         instruction = next(instructions)
         if instruction.opname not in expected_ops:
             return None
-        name = co.co_names[instruction.arg]
+        name = instruction.argval
 
     if name in ("CDLL", "WinDLL", "OleDLL", "PyDLL"):
         # Guesses ctypes imports of this type: CDLL("library.so")
@@ -204,12 +204,12 @@ def __scan_code_instruction_for_ctypes(co, instructions):
         #     LOAD_CONST    1 ('library.so')
         instruction = next(instructions)
         if instruction.opname == 'LOAD_ATTR':
-            if co.co_names[instruction.arg] == "LoadLibrary":
+            if instruction.argval == "LoadLibrary":
                 # Second type, needs to fetch one more instruction
                 return _libFromConst()
             else:
                 # First type
-                return co.co_names[instruction.arg] + ".dll"
+                return instruction.argval + ".dll"
 
     elif instruction.opname == 'LOAD_ATTR' and name in ("util",):
         # Guesses ctypes imports of these types::
@@ -222,7 +222,7 @@ def __scan_code_instruction_for_ctypes(co, instructions):
         #     LOAD_CONST    1 ('gs')
         instruction = next(instructions)
         if instruction.opname == 'LOAD_ATTR':
-            if co.co_names[instruction.arg] == "find_library":
+            if instruction.argval == "find_library":
                 libname = _libFromConst()
                 if libname:
                     lib = ctypes.util.find_library(libname)

--- a/PyInstaller/depend/utils.py
+++ b/PyInstaller/depend/utils.py
@@ -127,7 +127,7 @@ def scan_code_for_ctypes(co):
 
 def __recursivly_scan_code_objects_for_ctypes(co, binaries):
     # Note: `binaries` is a list, which gets extended here.
-    instructions = modulegraph.get_instructions(co)
+    instructions = modulegraph.enumerate_instructions(co)
     while 1:
         # ctypes scanning requires a scope wider than one bytecode
         # instruction, so the code resides in a separate function
@@ -138,10 +138,6 @@ def __recursivly_scan_code_objects_for_ctypes(co, binaries):
                 binaries.append(bin)
         except StopIteration:
             break
-
-    for c in co.co_consts:
-        if isinstance(c, type(co)):
-            __recursivly_scan_code_objects_for_ctypes(c, binaries)
 
 
 def __scan_code_instruction_for_ctypes(co, instructions):

--- a/PyInstaller/lib/modulegraph/_compat.py
+++ b/PyInstaller/lib/modulegraph/_compat.py
@@ -1,9 +1,48 @@
 import sys
+import dis
+from collections import deque
 
 if sys.version_info[0] == 2:
+
     def Bchr(value):
         return chr(value)
 
+    def enumerate_instructions(module_code_object):
+        # Type of all code objects.
+        code_object_type = type(module_code_object)
+        code_objects = deque([module_code_object])
+        current_objects = deque()
+
+        while code_objects:
+            code_object = code_objects.pop()
+
+            for instruction in get_instructions(code_object):
+                yield instruction
+
+            # For each constant in this code object that is itself a code object,
+            # parse this constant in the same manner.
+            for constant in code_object.co_consts:
+                if isinstance(constant, code_object_type):
+                    current_objects.appendleft(constant)
+
+            code_objects += current_objects
+            current_objects = deque()
+
 else:
+
     def Bchr(value):
         return value
+
+
+if sys.version_info >= (3, 4):
+    # In Python 3.4 or later the dis module has a much nicer interface
+    # for working with bytecode, use that instead of peeking into the
+    # raw bytecode.
+    # Note: This nicely sidesteps any issues caused by moving from bytecode
+    # to wordcode in python 3.6.
+    get_instructions = dis.get_instructions
+
+else:
+    assert 'SET_LINENO' not in dis.opmap  # safety belt
+
+    from .dis3 import get_instructions

--- a/PyInstaller/lib/modulegraph/_py3compat.py
+++ b/PyInstaller/lib/modulegraph/_py3compat.py
@@ -1,0 +1,23 @@
+from collections import deque
+from ._compat import get_instructions
+
+
+def enumerate_instructions(module_code_object):
+    # Type of all code objects.
+    code_object_type = type(module_code_object)
+    code_objects = deque([module_code_object])
+    current_objects = deque()
+
+    while code_objects:
+        code_object = code_objects.pop()
+
+        yield from get_instructions(code_object)
+
+        # For each constant in this code object that is itself a code object,
+        # parse this constant in the same manner.
+        for constant in code_object.co_consts:
+            if isinstance(constant, code_object_type):
+                current_objects.appendleft(constant)
+
+        code_objects += current_objects
+        current_objects = deque()

--- a/PyInstaller/lib/modulegraph/dis3.py
+++ b/PyInstaller/lib/modulegraph/dis3.py
@@ -1,0 +1,482 @@
+from __future__ import print_function
+
+import sys
+import types
+import collections
+import io
+
+from opcode import *
+from opcode import __all__ as _opcodes_all
+
+if sys.version_info[0] == 3:
+    unicode = str
+
+__all__ = ["code_info", "dis", "disassemble", "distb", "disco",
+           "findlinestarts", "findlabels", "show_code",
+           "get_instructions", "Instruction", "Bytecode"] + _opcodes_all
+del _opcodes_all
+
+
+# From Python 3's opcode module
+hasnargs = [131, 140, 141, 142]
+__all__ += [hasnargs]
+
+
+_have_code = (types.MethodType, types.FunctionType, types.CodeType, type)
+
+def _try_compile(source, name):
+    """Attempts to compile the given source, first as an expression and
+       then as a statement if the first approach fails.
+
+       Utility function to accept strings in functions that otherwise
+       expect code objects
+    """
+    try:
+        c = compile(source, name, 'eval')
+    except SyntaxError:
+        c = compile(source, name, 'exec')
+    return c
+
+def dis(x=None, file=None):
+    """Disassemble classes, methods, functions, generators, or code.
+
+    With no argument, disassemble the last traceback.
+
+    """
+    if x is None:
+        distb(file=file)
+        return
+    if hasattr(x, '__func__'):  # Method
+        x = x.__func__
+    if hasattr(x, '__code__'):  # Function
+        x = x.__code__
+    if hasattr(x, 'gi_code'):  # Generator
+        x = x.gi_code
+    if hasattr(x, '__dict__'):  # Class or module
+        items = sorted(x.__dict__.items())
+        for name, x1 in items:
+            if isinstance(x1, _have_code):
+                print(u"Disassembly of %s:" % name, file=file)
+                try:
+                    dis(x1, file=file)
+                except TypeError as msg:
+                    print(u"Sorry:", msg, file=file)
+                print(u'', file=file)
+    elif hasattr(x, 'co_code'): # Code object
+        disassemble(x, file=file)
+    elif isinstance(x, (bytes, bytearray)): # Raw bytecode
+        _disassemble_bytes(x, file=file)
+    elif isinstance(x, unicode):    # Source code
+        _disassemble_str(x, file=file)
+    else:
+        raise TypeError("don't know how to disassemble %s objects" %
+                        type(x).__name__)
+
+def distb(tb=None, file=None):
+    """Disassemble a traceback (default: last traceback)."""
+    if tb is None:
+        try:
+            tb = sys.last_traceback
+        except AttributeError:
+            raise RuntimeError("no last traceback to disassemble")
+        while tb.tb_next: tb = tb.tb_next
+    disassemble(tb.tb_frame.f_code, tb.tb_lasti, file=file)
+
+# The inspect module interrogates this dictionary to build its
+# list of CO_* constants. It is also used by pretty_flags to
+# turn the co_flags field into a human readable list.
+COMPILER_FLAG_NAMES = {
+     1: "OPTIMIZED",
+     2: "NEWLOCALS",
+     4: "VARARGS",
+     8: "VARKEYWORDS",
+    16: "NESTED",
+    32: "GENERATOR",
+    64: "NOFREE",
+  8192: "FUTURE_DIVISION",
+ 16384: "FUTURE_ABSOLUTE_IMPORT",
+ 32768: "FUTURE_WITH_STATEMENT",
+ 65536: "FUTURE_PRINT_FUNCTION",
+131072: "FUTURE_UNICODE_LITERALS",
+}
+
+def pretty_flags(flags):
+    """Return pretty representation of code flags."""
+    names = []
+    for i in range(32):
+        flag = 1<<i
+        if flags & flag:
+            names.append(COMPILER_FLAG_NAMES.get(flag, hex(flag)))
+            flags ^= flag
+            if not flags:
+                break
+    else:
+        names.append(hex(flags))
+    return ", ".join(names)
+
+def _get_code_object(x):
+    """Helper to handle methods, functions, generators, strings and raw code objects"""
+    if hasattr(x, '__func__'): # Method
+        x = x.__func__
+    if hasattr(x, '__code__'): # Function
+        x = x.__code__
+    if hasattr(x, 'gi_code'):  # Generator
+        x = x.gi_code
+    if isinstance(x, unicode):     # Source code
+        x = _try_compile(x, "<disassembly>")
+    if hasattr(x, 'co_code'):  # Code object
+        return x
+    raise TypeError("don't know how to disassemble %s objects" %
+                    type(x).__name__)
+
+def code_info(x):
+    """Formatted details of methods, functions, or code."""
+    return _format_code_info(_get_code_object(x))
+
+def _format_code_info(co):
+    lines = []
+    lines.append(u"Name:              %s" % co.co_name)
+    lines.append(u"Filename:          %s" % co.co_filename)
+    lines.append(u"Argument count:    %s" % co.co_argcount)
+    lines.append(u"Number of locals:  %s" % co.co_nlocals)
+    lines.append(u"Stack size:        %s" % co.co_stacksize)
+    lines.append(u"Flags:             %s" % pretty_flags(co.co_flags))
+    if co.co_consts:
+        lines.append(u"Constants:")
+        for i_c in enumerate(co.co_consts):
+            lines.append(u"%4d: %r" % i_c)
+    if co.co_names:
+        lines.append(u"Names:")
+        for i_n in enumerate(co.co_names):
+            lines.append(u"%4d: %s" % i_n)
+    if co.co_varnames:
+        lines.append(u"Variable names:")
+        for i_n in enumerate(co.co_varnames):
+            lines.append(u"%4d: %s" % i_n)
+    if co.co_freevars:
+        lines.append(u"Free variables:")
+        for i_n in enumerate(co.co_freevars):
+            lines.append(u"%4d: %s" % i_n)
+    if co.co_cellvars:
+        lines.append(u"Cell variables:")
+        for i_n in enumerate(co.co_cellvars):
+            lines.append(u"%4d: %s" % i_n)
+    return u"\n".join(lines)
+
+def show_code(co, file=None):
+    """Print details of methods, functions, or code to *file*.
+
+    If *file* is not provided, the output is printed on stdout.
+    """
+    print(code_info(co), file=file)
+
+_Instruction = collections.namedtuple("_Instruction",
+     "opname opcode arg argval argrepr offset starts_line is_jump_target")
+
+class Instruction(_Instruction):
+    """Details for a bytecode operation
+
+       Defined fields:
+         opname - human readable name for operation
+         opcode - numeric code for operation
+         arg - numeric argument to operation (if any), otherwise None
+         argval - resolved arg value (if known), otherwise same as arg
+         argrepr - human readable description of operation argument
+         offset - start index of operation within bytecode sequence
+         starts_line - line started by this opcode (if any), otherwise None
+         is_jump_target - True if other code jumps to here, otherwise False
+    """
+    def __repr__(self):
+        # Hack since Python 2.7's namedtuple.__repr__ doesn't respect
+        # subclasses
+        return super(Instruction, self).__repr__()[1:]
+
+    def _disassemble(self, lineno_width=3, mark_as_current=False):
+        """Format instruction details for inclusion in disassembly output
+
+        *lineno_width* sets the width of the line number field (0 omits it)
+        *mark_as_current* inserts a '-->' marker arrow as part of the line
+        """
+        fields = []
+        # Column: Source code line number
+        if lineno_width:
+            if self.starts_line is not None:
+                lineno_fmt = u"%%%dd" % lineno_width
+                fields.append(lineno_fmt % self.starts_line)
+            else:
+                fields.append(u' ' * lineno_width)
+        # Column: Current instruction indicator
+        if mark_as_current:
+            fields.append(u'-->')
+        else:
+            fields.append(u'   ')
+        # Column: Jump target marker
+        if self.is_jump_target:
+            fields.append(u'>>')
+        else:
+            fields.append(u'  ')
+        # Column: Instruction offset from start of code sequence
+        fields.append(repr(self.offset).rjust(4))
+        # Column: Opcode name
+        fields.append(self.opname.ljust(20))
+        # Column: Opcode argument
+        if self.arg is not None:
+            fields.append(repr(self.arg).rjust(5))
+            # Column: Opcode argument details
+            if self.argrepr:
+                fields.append(u'(' + self.argrepr + u')')
+        return u' '.join(fields).rstrip()
+
+
+def get_instructions(x, first_line=None):
+    """Iterator for the opcodes in methods, functions or code
+
+    Generates a series of Instruction named tuples giving the details of
+    each operations in the supplied code.
+
+    If *first_line* is not None, it indicates the line number that should
+    be reported for the first source line in the disassembled code.
+    Otherwise, the source line information (if any) is taken directly from
+    the disassembled code object.
+    """
+    co = _get_code_object(x)
+    cell_names = co.co_cellvars + co.co_freevars
+    linestarts = dict(findlinestarts(co))
+    if first_line is not None:
+        line_offset = first_line - co.co_firstlineno
+    else:
+        line_offset = 0
+    return _get_instructions_bytes(co.co_code, co.co_varnames, co.co_names,
+                                   co.co_consts, cell_names, linestarts,
+                                   line_offset)
+
+def _get_const_info(const_index, const_list):
+    """Helper to get optional details about const references
+
+       Returns the dereferenced constant and its repr if the constant
+       list is defined.
+       Otherwise returns the constant index and its repr().
+    """
+    argval = const_index
+    if const_list is not None:
+        argval = const_list[const_index]
+    return argval, repr(argval)
+
+def _get_name_info(name_index, name_list):
+    """Helper to get optional details about named references
+
+       Returns the dereferenced name as both value and repr if the name
+       list is defined.
+       Otherwise returns the name index and its repr().
+    """
+    argval = name_index
+    if name_list is not None:
+        argval = name_list[name_index]
+        argrepr = argval
+    else:
+        argrepr = repr(argval)
+    return argval, argrepr
+
+
+def _get_instructions_bytes(code, varnames=None, names=None, constants=None,
+                      cells=None, linestarts=None, line_offset=0):
+    """Iterate over the instructions in a bytecode string.
+
+    Generates a sequence of Instruction namedtuples giving the details of each
+    opcode.  Additional information about the code's runtime environment
+    (e.g. variable names, constants) can be specified using optional
+    arguments.
+
+    """
+    code = bytearray(code)
+    labels = findlabels(code)
+    extended_arg = 0
+    starts_line = None
+    free = None
+    # enumerate() is not an option, since we sometimes process
+    # multiple elements on a single pass through the loop
+    n = len(code)
+    i = 0
+    while i < n:
+        op = code[i]
+        offset = i
+        if linestarts is not None:
+            starts_line = linestarts.get(i, None)
+            if starts_line is not None:
+                starts_line += line_offset
+        is_jump_target = i in labels
+        i = i+1
+        arg = None
+        argval = None
+        argrepr = ''
+        if op >= HAVE_ARGUMENT:
+            arg = code[i] + code[i+1]*256 + extended_arg
+            extended_arg = 0
+            i = i+2
+            if op == EXTENDED_ARG:
+                extended_arg = arg*65536
+            #  Set argval to the dereferenced value of the argument when
+            #  availabe, and argrepr to the string representation of argval.
+            #    _disassemble_bytes needs the string repr of the
+            #    raw name index for LOAD_GLOBAL, LOAD_CONST, etc.
+            argval = arg
+            if op in hasconst:
+                argval, argrepr = _get_const_info(arg, constants)
+            elif op in hasname:
+                argval, argrepr = _get_name_info(arg, names)
+            elif op in hasjrel:
+                argval = i + arg
+                argrepr = "to " + repr(argval)
+            elif op in haslocal:
+                argval, argrepr = _get_name_info(arg, varnames)
+            elif op in hascompare:
+                argval = cmp_op[arg]
+                argrepr = argval
+            elif op in hasfree:
+                argval, argrepr = _get_name_info(arg, cells)
+            elif op in hasnargs:
+                argrepr = "%d positional, %d keyword pair" % (code[i-2], code[i-1])
+        yield Instruction(opname[op], op,
+                          arg, argval, argrepr,
+                          offset, starts_line, is_jump_target)
+
+def disassemble(co, lasti=-1, file=None):
+    """Disassemble a code object."""
+    cell_names = co.co_cellvars + co.co_freevars
+    linestarts = dict(findlinestarts(co))
+    _disassemble_bytes(co.co_code, lasti, co.co_varnames, co.co_names,
+                       co.co_consts, cell_names, linestarts, file=file)
+
+def _disassemble_bytes(code, lasti=-1, varnames=None, names=None,
+                       constants=None, cells=None, linestarts=None,
+                       file=None, line_offset=0):
+    # Omit the line number column entirely if we have no line number info
+    show_lineno = linestarts is not None
+    # TODO?: Adjust width upwards if max(linestarts.values()) >= 1000?
+    lineno_width = 3 if show_lineno else 0
+    for instr in _get_instructions_bytes(code, varnames, names,
+                                         constants, cells, linestarts,
+                                         line_offset=line_offset):
+        new_source_line = (show_lineno and
+                           instr.starts_line is not None and
+                           instr.offset > 0)
+        if new_source_line:
+            print(u'', file=file)
+        is_current_instr = instr.offset == lasti
+        print(instr._disassemble(lineno_width, is_current_instr), file=file)
+
+def _disassemble_str(source, file=None):
+    """Compile the source string, then disassemble the code object."""
+    disassemble(_try_compile(source, '<dis>'), file=file)
+
+disco = disassemble                     # XXX For backwards compatibility
+
+def findlabels(code):
+    """Detect all offsets in a byte code which are jump targets.
+
+    Return the list of offsets.
+
+    """
+    code = bytearray(code)
+    labels = []
+    # enumerate() is not an option, since we sometimes process
+    # multiple elements on a single pass through the loop
+    n = len(code)
+    i = 0
+    while i < n:
+        op = code[i]
+        i = i+1
+        if op >= HAVE_ARGUMENT:
+            arg = code[i] + code[i+1]*256
+            i = i+2
+            label = -1
+            if op in hasjrel:
+                label = i+arg
+            elif op in hasjabs:
+                label = arg
+            if label >= 0:
+                if label not in labels:
+                    labels.append(label)
+    return labels
+
+def findlinestarts(code):
+    """Find the offsets in a byte code which are start of lines in the source.
+
+    Generate pairs (offset, lineno) as described in Python/compile.c.
+
+    """
+    byte_increments = bytearray(code.co_lnotab[0::2])
+    line_increments = bytearray(code.co_lnotab[1::2])
+
+    lastlineno = None
+    lineno = code.co_firstlineno
+    addr = 0
+    for byte_incr, line_incr in zip(byte_increments, line_increments):
+        if byte_incr:
+            if lineno != lastlineno:
+                yield (addr, lineno)
+                lastlineno = lineno
+            addr += byte_incr
+        lineno += line_incr
+    if lineno != lastlineno:
+        yield (addr, lineno)
+
+class Bytecode:
+    """The bytecode operations of a piece of code
+
+    Instantiate this with a function, method, string of code, or a code object
+    (as returned by compile()).
+
+    Iterating over this yields the bytecode operations as Instruction instances.
+    """
+    def __init__(self, x, first_line=None, current_offset=None):
+        self.codeobj = co = _get_code_object(x)
+        if first_line is None:
+            self.first_line = co.co_firstlineno
+            self._line_offset = 0
+        else:
+            self.first_line = first_line
+            self._line_offset = first_line - co.co_firstlineno
+        self._cell_names = co.co_cellvars + co.co_freevars
+        self._linestarts = dict(findlinestarts(co))
+        self._original_object = x
+        self.current_offset = current_offset
+
+    def __iter__(self):
+        co = self.codeobj
+        return _get_instructions_bytes(co.co_code, co.co_varnames, co.co_names,
+                                       co.co_consts, self._cell_names,
+                                       self._linestarts,
+                                       line_offset=self._line_offset)
+
+    def __repr__(self):
+        return "{}({!r})".format(self.__class__.__name__,
+                                 self._original_object)
+
+    @classmethod
+    def from_traceback(cls, tb):
+        """ Construct a Bytecode from the given traceback """
+        while tb.tb_next:
+            tb = tb.tb_next
+        return cls(tb.tb_frame.f_code, current_offset=tb.tb_lasti)
+
+    def info(self):
+        """Return formatted information about the code object."""
+        return _format_code_info(self.codeobj)
+
+    def dis(self):
+        """Return a formatted view of the bytecode operations."""
+        co = self.codeobj
+        if self.current_offset is not None:
+            offset = self.current_offset
+        else:
+            offset = -1
+        with io.StringIO() as output:
+            _disassemble_bytes(co.co_code, varnames=co.co_varnames,
+                               names=co.co_names, constants=co.co_consts,
+                               cells=self._cell_names,
+                               linestarts=self._linestarts,
+                               line_offset=self._line_offset,
+                               file=output,
+                               lasti=offset)
+            return output.getvalue()

--- a/PyInstaller/lib/modulegraph/modulegraph.py
+++ b/PyInstaller/lib/modulegraph/modulegraph.py
@@ -2595,12 +2595,7 @@ class ModuleGraph(ObjectGraph):
               parsing will have already parsed import statements, which this
               parsing must avoid repeating.
         """
-        constants = module_code_object.co_consts
-
-        level = None
-        fromlist = None
-
-        prev_insts = []
+        prev_insts = deque(maxlen=2)
 
         for inst in enumerate_instructions(module_code_object):
             # If this is an import statement originating from this module,
@@ -2677,7 +2672,6 @@ class ModuleGraph(ObjectGraph):
                 module.remove_global_attr_if_found(name)
 
             prev_insts.append(inst)
-            del prev_insts[:-2]
 
 
     def _process_imports(self, source_module):

--- a/PyInstaller/lib/modulegraph/modulegraph.py
+++ b/PyInstaller/lib/modulegraph/modulegraph.py
@@ -2614,11 +2614,11 @@ class ModuleGraph(ObjectGraph):
                 assert prev_insts[-1].opname == 'LOAD_CONST'
 
                 # Python >=2.5: LOAD_CONST flags, LOAD_CONST names, IMPORT_NAME name
-                level = module_code_object.co_consts[prev_insts[-2].arg]
-                fromlist = module_code_object.co_consts[prev_insts[-1].arg]
+                level = prev_insts[-2].argval
+                fromlist = prev_insts[-1].argval
 
                 assert fromlist is None or type(fromlist) is tuple
-                target_module_partname = module_code_object.co_names[inst.arg]
+                target_module_partname = inst.argval
 
                 #FIXME: The exact same logic appears in _collect_import(),
                 #which isn't particularly helpful. Instead, defer this logic
@@ -2660,7 +2660,7 @@ class ModuleGraph(ObjectGraph):
                 # in "from foo import bar", which is either a non-ignorable
                 # submodule of "foo" or an ignorable global attribute of
                 # "foo.__init__").
-                name = module_code_object.co_names[inst.arg]
+                name = inst.argval
                 module.add_global_attr(name)
 
             elif inst.opname in ('DELETE_NAME', 'DELETE_GLOBAL'):
@@ -2668,7 +2668,7 @@ class ModuleGraph(ObjectGraph):
                 # attribute (e.g., class, variable) in this module, remove that
                 # declaration to prevent subsequent lookup. See method docstring
                 # for further details.
-                name = module_code_object.co_names[inst.arg]
+                name = inst.argval
                 module.remove_global_attr_if_found(name)
 
             prev_insts.append(inst)

--- a/PyInstaller/lib/modulegraph/modulegraph.py
+++ b/PyInstaller/lib/modulegraph/modulegraph.py
@@ -30,6 +30,7 @@ from struct import unpack
 
 from ..altgraph.ObjectGraph import ObjectGraph
 from ..altgraph import GraphError
+from .util import get_instructions
 
 from . import util
 from . import zipio
@@ -53,54 +54,6 @@ else:
 
 import codecs
 BOM = codecs.BOM_UTF8.decode('utf-8')
-
-if sys.version_info >= (3,4):
-    # In Python 3.4 or later the dis module has a much nicer interface
-    # for working with bytecode, use that instead of peeking into the
-    # raw bytecode.
-    # Note: This nicely sidesteps any issues caused by moving from bytecode
-    # to wordcode in python 3.6.
-    get_instructions = dis.get_instructions
-else:
-    assert 'SET_LINENO' not in dis.opmap  # safty belt
-
-    def get_instructions(code):
-        """
-        Iterator parsing the bytecode into easy-usable minimal emulation of
-        Python 3.4 `dis.Instruction` instances.
-        """
-
-        # shortcuts
-        HAVE_ARGUMENT = dis.HAVE_ARGUMENT
-        EXTENDED_ARG = dis.EXTENDED_ARG
-
-        class Instruction:
-            # Minimal emulation of Python 3.4 dis.Instruction
-            def __init__(self, opcode, oparg):
-                self.opname = dis.opname[opcode]
-                self.arg = oparg
-                # opcode, argval, argrepr, offset, is_jump_target and
-                # starts_line are not used by our code, so we leave them away
-                # here.
-
-        code = code.co_code
-        extended_arg = 0
-        i = 0
-        n = len(code)
-        while i < n:
-            c = code[i]
-            i = i + 1
-            op = _cOrd(c)
-            if op >= HAVE_ARGUMENT:
-                oparg = _cOrd(code[i]) + _cOrd(code[i + 1]) * 256 + extended_arg
-                extended_arg = 0
-                i += 2
-                if op == EXTENDED_ARG:
-                    extended_arg = oparg*65536
-            else:
-                oparg = None
-            yield Instruction(op, oparg)
-
 
 #FIXME: Leverage this rather than magic numbers below.
 ABSOLUTE_OR_RELATIVE_IMPORT_LEVEL = -1

--- a/PyInstaller/lib/modulegraph/modulegraph.py
+++ b/PyInstaller/lib/modulegraph/modulegraph.py
@@ -30,7 +30,7 @@ from struct import unpack
 
 from ..altgraph.ObjectGraph import ObjectGraph
 from ..altgraph import GraphError
-from .util import get_instructions
+from .util import enumerate_instructions
 
 from . import util
 from . import zipio
@@ -2602,7 +2602,7 @@ class ModuleGraph(ObjectGraph):
 
         prev_insts = []
 
-        for inst in get_instructions(module_code_object):
+        for inst in enumerate_instructions(module_code_object):
             # If this is an import statement originating from this module,
             # parse this import.
             #
@@ -2678,15 +2678,6 @@ class ModuleGraph(ObjectGraph):
 
             prev_insts.append(inst)
             del prev_insts[:-2]
-
-        # Type of all code objects.
-        code_object_type = type(module_code_object)
-
-        # For each constant in this code object that is itself a code object,
-        # parse this constant in the same manner.
-        for constant in constants:
-            if isinstance(constant, code_object_type):
-                self._scan_bytecode(module, constant, is_scanning_imports)
 
 
     def _process_imports(self, source_module):

--- a/PyInstaller/lib/modulegraph/util.py
+++ b/PyInstaller/lib/modulegraph/util.py
@@ -131,44 +131,9 @@ if sys.version_info >= (3,4):
     get_instructions = dis.get_instructions
 
 else:
-    assert 'SET_LINENO' not in dis.opmap  # safty belt
+    assert 'SET_LINENO' not in dis.opmap  # safety belt
 
-    def get_instructions(code):
-        """
-        Iterator parsing the bytecode into easy-usable minimal emulation of
-        Python 3.4 `dis.Instruction` instances.
-        """
-
-        # shortcuts
-        HAVE_ARGUMENT = dis.HAVE_ARGUMENT
-        EXTENDED_ARG = dis.EXTENDED_ARG
-
-        class Instruction:
-            # Minimal emulation of Python 3.4 dis.Instruction
-            def __init__(self, opcode, oparg):
-                self.opname = dis.opname[opcode]
-                self.arg = oparg
-                # opcode, argval, argrepr, offset, is_jump_target and
-                # starts_line are not used by our code, so we leave them away
-                # here.
-
-        code = code.co_code
-        extended_arg = 0
-        i = 0
-        n = len(code)
-        while i < n:
-            c = code[i]
-            i = i + 1
-            op = _cOrd(c)
-            if op >= HAVE_ARGUMENT:
-                oparg = _cOrd(code[i]) + _cOrd(code[i + 1]) * 256 + extended_arg
-                extended_arg = 0
-                i += 2
-                if op == EXTENDED_ARG:
-                    extended_arg = oparg*65536
-            else:
-                oparg = None
-            yield Instruction(op, oparg)
+    from .dis3 import get_instructions
 
 
 def enumerate_instructions(module_code_object):

--- a/PyInstaller/lib/modulegraph/util.py
+++ b/PyInstaller/lib/modulegraph/util.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 import os
 import imp
-import dis
 import sys
 import re
 import marshal
@@ -14,7 +13,6 @@ try:
     unicode
 except NameError:
     unicode = str
-
 
 if sys.version_info[0] == 2:
     from StringIO import StringIO as BytesIO
@@ -40,6 +38,7 @@ def imp_find_module(name, path=None):
         path = [result[1]]
     return result
 
+
 def _check_importer_for_path(name, path_item):
     try:
         importer = sys.path_importer_cache[path_item]
@@ -54,7 +53,6 @@ def _check_importer_for_path(name, path_item):
             importer = None
         sys.path_importer_cache.setdefault(path_item, importer)
 
-
     if importer is None:
         try:
             return imp.find_module(name, [path_item])
@@ -62,13 +60,15 @@ def _check_importer_for_path(name, path_item):
             return None
     return importer.find_module(name)
 
+
 def imp_walk(name):
     """
     yields namepart, tuple_or_importer for each path item
 
     raise ImportError if a name can not be found.
     """
-    warnings.warn("imp_walk will be removed in a future version", DeprecationWarning)
+    warnings.warn("imp_walk will be removed in a future version",
+                  DeprecationWarning)
 
     if name in sys.builtin_module_names:
         yield name, (None, None, ("", "", imp.C_BUILTIN))
@@ -83,12 +83,15 @@ def imp_walk(name):
                     fp = StringIO(res.get_source(namepart))
                     res = (fp, res.path, ('.py', 'rU', imp.PY_SOURCE))
                 elif res.path.endswith('.pyc') or res.path.endswith('.pyo'):
-                    co  = res.get_code(namepart)
-                    fp = BytesIO(imp.get_magic() + b'\0\0\0\0' + marshal.dumps(co))
+                    co = res.get_code(namepart)
+                    fp = BytesIO(imp.get_magic() + b'\0\0\0\0' +
+                                 marshal.dumps(co))
                     res = (fp, res.path, ('.pyc', 'rb', imp.PY_COMPILED))
 
                 else:
-                    res = (None, loader.path, (os.path.splitext(loader.path)[-1], 'rb', imp.C_EXTENSION))
+                    res = (None, loader.path,
+                           (os.path.splitext(loader.path)[-1], 'rb',
+                            imp.C_EXTENSION))
 
                 break
             elif isinstance(res, tuple):
@@ -101,7 +104,7 @@ def imp_walk(name):
     else:
         return
 
-    raise ImportError('No module named %s' % (name,))
+    raise ImportError('No module named %s' % (name, ))
 
 
 cookie_re = re.compile(b"coding[:=]\s*([-\w.]+)")
@@ -109,6 +112,7 @@ if sys.version_info[0] == 2:
     default_encoding = 'ascii'
 else:
     default_encoding = 'utf-8'
+
 
 def guess_encoding(fp):
 
@@ -122,37 +126,7 @@ def guess_encoding(fp):
     return default_encoding
 
 
-if sys.version_info >= (3,4):
-    # In Python 3.4 or later the dis module has a much nicer interface
-    # for working with bytecode, use that instead of peeking into the
-    # raw bytecode.
-    # Note: This nicely sidesteps any issues caused by moving from bytecode
-    # to wordcode in python 3.6.
-    get_instructions = dis.get_instructions
-
+if sys.version_info[0] == 2:
+    from ._compat import enumerate_instructions
 else:
-    assert 'SET_LINENO' not in dis.opmap  # safety belt
-
-    from .dis3 import get_instructions
-
-
-def enumerate_instructions(module_code_object):
-    # Type of all code objects.
-    code_object_type = type(module_code_object)
-    code_objects = deque([module_code_object])
-    current_objects = deque()
-
-    while code_objects:
-        code_object = code_objects.pop()
-
-        for instruction in get_instructions(code_object):
-            yield instruction
-
-        # For each constant in this code object that is itself a code object,
-        # parse this constant in the same manner.
-        for constant in code_object.co_consts:
-            if isinstance(constant, code_object_type):
-                current_objects.appendleft(constant)
-
-        code_objects += current_objects
-        current_objects = deque()
+    from ._py3compat import enumerate_instructions

--- a/PyInstaller/lib/modulegraph/util.py
+++ b/PyInstaller/lib/modulegraph/util.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import os
 import imp
+import dis
 import sys
 import re
 import marshal
@@ -117,3 +118,51 @@ def guess_encoding(fp):
             return m.group(1).decode('ascii')
 
     return default_encoding
+
+
+if sys.version_info >= (3,4):
+    # In Python 3.4 or later the dis module has a much nicer interface
+    # for working with bytecode, use that instead of peeking into the
+    # raw bytecode.
+    # Note: This nicely sidesteps any issues caused by moving from bytecode
+    # to wordcode in python 3.6.
+    get_instructions = dis.get_instructions
+else:
+    assert 'SET_LINENO' not in dis.opmap  # safty belt
+
+    def get_instructions(code):
+        """
+        Iterator parsing the bytecode into easy-usable minimal emulation of
+        Python 3.4 `dis.Instruction` instances.
+        """
+
+        # shortcuts
+        HAVE_ARGUMENT = dis.HAVE_ARGUMENT
+        EXTENDED_ARG = dis.EXTENDED_ARG
+
+        class Instruction:
+            # Minimal emulation of Python 3.4 dis.Instruction
+            def __init__(self, opcode, oparg):
+                self.opname = dis.opname[opcode]
+                self.arg = oparg
+                # opcode, argval, argrepr, offset, is_jump_target and
+                # starts_line are not used by our code, so we leave them away
+                # here.
+
+        code = code.co_code
+        extended_arg = 0
+        i = 0
+        n = len(code)
+        while i < n:
+            c = code[i]
+            i = i + 1
+            op = _cOrd(c)
+            if op >= HAVE_ARGUMENT:
+                oparg = _cOrd(code[i]) + _cOrd(code[i + 1]) * 256 + extended_arg
+                extended_arg = 0
+                i += 2
+                if op == EXTENDED_ARG:
+                    extended_arg = oparg*65536
+            else:
+                oparg = None
+            yield Instruction(op, oparg)

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -16,8 +16,8 @@ boto3
 botocore
 
 # Prohibit "gevent" wheels, which cause py.test to crash on Travis under OS X.
-gevent             ; sys_platform != "darwin"
 --no-binary gevent ; sys_platform == "darwin"
+gevent             ; sys_platform != "darwin"
 
 pygments
 pylint>=1.5

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -16,8 +16,8 @@ boto3
 botocore
 
 # Prohibit "gevent" wheels, which cause py.test to crash on Travis under OS X.
---no-binary gevent ; sys_platform == "darwin"
 gevent             ; sys_platform != "darwin"
+--no-binary gevent ; sys_platform == "darwin"
 
 pygments
 pylint>=1.5


### PR DESCRIPTION
So this doesn't to everything, but I've decided to try smaller pull requests which have a more manageable discussion. The main idea is that before we can proceed on #2488, complexity should be hidden from the bytecode parser such that it should only look at `Instruction`s. In order to do that, I included dis3 in the pull request (which has MIT license, which is GPL and modulegraph compatible), to be able to access argval in the instruction arguments. This is forward-looking in that future maintainers will only need to read the docs on instruction objects if they need to add functionality rather than messing around with `co_consts` and `co_names`.