### PR TITLE
Runtime hooks: fix "spawn" multiprocessing on mac

### DIFF
--- a/PyInstaller/loader/rthooks.dat
+++ b/PyInstaller/loader/rthooks.dat
@@ -23,4 +23,5 @@
     'twisted.internet.reactor':        ['pyi_rth_twisted.py'],
     'usb':        ['pyi_rth_usb.py'],
     'win32com':   ['pyi_rth_win32comgenpy.py'],
+    'multiprocessing': ['pyi_rth_multiprocessing.py'],
 }

--- a/PyInstaller/loader/rthooks/pyi_rth_multiprocessing.py
+++ b/PyInstaller/loader/rthooks/pyi_rth_multiprocessing.py
@@ -1,0 +1,66 @@
+from sys import platform as _platform
+
+# 'spawn' multiprocessing needs some adjustments on osx
+if _platform == 'darwin':
+    import sys
+    import os
+    import re
+    import multiprocessing
+    import multiprocessing.spawn as spawn
+
+    # prevent spawn from trying to read __main__ in from the main script
+    multiprocessing.process.ORIGINAL_DIR = None
+
+    def _freeze_support():
+        if 'multiprocessing.semaphore_tracker' in sys.argv[-1]:
+            m = re.compile('.*main\((\d+)\)$').match(sys.argv[-1])
+            fd = int(m.group(1))
+            import multiprocessing.semaphore_tracker
+            multiprocessing.semaphore_tracker.main(fd)
+            sys.exit()
+
+        if spawn.is_forking(sys.argv):
+            kwds = {}
+            for arg in sys.argv[2:]:
+                name, value = arg.split('=')
+                if value == 'None':
+                    kwds[name] = None
+                else:
+                    kwds[name] = int(value)
+            spawn.spawn_main(**kwds)
+            sys.exit()
+
+    multiprocessing.freeze_support = spawn.freeze_support = _freeze_support
+
+    # Module multiprocessing is organized differently in Python 3.4+
+    try:
+        # Python 3.4+
+        if sys.platform.startswith('win'):
+            import multiprocessing.popen_spawn_win32 as forking
+        else:
+            import multiprocessing.popen_fork as forking
+    except ImportError:
+        import multiprocessing.forking as forking
+
+    # First define a modified version of Popen.
+    class _Popen(forking.Popen):
+        def __init__(self, *args, **kw):
+            if hasattr(sys, 'frozen'):
+                # We have to set original _MEIPASS2 value from sys._MEIPASS
+                # to get --onefile mode working.
+                os.putenv('_MEIPASS2', sys._MEIPASS)  # @UndefinedVariable
+            try:
+                super(_Popen, self).__init__(*args, **kw)
+            finally:
+                if hasattr(sys, 'frozen'):
+                    # On some platforms (e.g. AIX) 'os.unsetenv()' is not
+                    # available. In those cases we cannot delete the variable
+                    # but only set it to the empty string. The bootloader
+                    # can handle this case.
+                    if hasattr(os, 'unsetenv'):
+                        os.unsetenv('_MEIPASS2')
+                    else:
+                        os.putenv('_MEIPASS2', '')
+
+    forking.Popen = _Popen
+   

--- a/tests/functional/test_runtime.py
+++ b/tests/functional/test_runtime.py
@@ -8,14 +8,52 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
+import sys
 import pytest
 
-def test_ctypes_cdll_unknown_dll(pyi_builder,capfd):
+from PyInstaller.utils.tests import skipif_notosx, xfail_py2
+
+
+def test_ctypes_cdll_unknown_dll(pyi_builder, capfd):
     with pytest.raises(AssertionError):
-        pyi_builder.test_source(
-            """
+        pyi_builder.test_source("""
             import ctypes
             ctypes.cdll.LoadLibrary('non-existing-2017')
             """)
     out, err = capfd.readouterr()
     assert "Failed to load dynlib/dll" in err
+
+
+@skipif_notosx
+@xfail_py2
+def test_issue_2322(pyi_builder, capfd):
+    pyi_builder.test_source("""
+        from multiprocessing import set_start_method, Process
+        from multiprocessing import freeze_support
+        from multiprocessing.util import log_to_stderr
+
+        def test():
+            print('In subprocess')
+
+        if __name__ == '__main__':
+            log_to_stderr()
+            freeze_support()
+            set_start_method('spawn')
+
+            print('In main')
+            proc = Process(target=test)
+            proc.start()
+            proc.join()
+        """)
+
+    out, err = capfd.readouterr()
+
+    # Print the captured output and error so that it will show up in the test output.
+    sys.stderr.write(err)
+    sys.stdout.write(out)
+
+    expected = ["In main", "In subprocess"]
+
+    assert "\n".join(expected) in out
+    for substring in expected:
+        assert out.count(substring) == 1


### PR DESCRIPTION
A few notes: 

- the evidence that this works is [here](https://travis-ci.org/xoviat/mac_scratchpad/builds/210814888)
- this may break compatibility with the 'fork' method on mac; needs further investigation
- closes #2322.