### PR TITLE
Fix: Subclass PyInstallerImportError from OSError.

### DIFF
--- a/PyInstaller/loader/pyiboot01_bootstrap.py
+++ b/PyInstaller/loader/pyiboot01_bootstrap.py
@@ -130,7 +130,7 @@ try:
                 name = frozen_name
         return name
 
-    class PyInstallerImportError(Exception):
+    class PyInstallerImportError(OSError):
         def __init__(self, name):
             self.msg = ("Failed to load dynlib/dll %r. "
                         "Most probably this dynlib/dll was not found "


### PR DESCRIPTION
Commit b66f244 in the development version introduced the new exception type `PyInstallerImportError` that gets thrown if a library cannot be loaded with ctypes. However, this changes the behavior of previously working applications. 

For example, my application uses a library ([scikit-cuda](https://github.com/lebedov/scikit-cuda)) that tries to load multiple versions of DLLs of which only one has to be present. To handle missing libraries, it catches `OSError` and continues with the next one.

But when run with PyInstaller, `ctypes.CDLL` etc. do not throw `OSError` anymore, but instead `PyInstallerImportError`, which scikit-cuda does not catch, so it aborts.
Right now, I have to manually patch either PyInstaller or scikit-cuda to make it work (again).

The proper solution would be to subclass `PyInstallerImportError` from `OSError` so that existing code, that already handles missing libraries, continues to work.

The test for the exception in `tests/functional/test_runtime.py` still works after this change.
Tested on Win 10 with Python 3.6.1.
