### PR TITLE
Add hook file for shapely library to correctly copy DLL

### DIFF
--- a/PyInstaller/hooks/hook-shapely.py
+++ b/PyInstaller/hooks/hook-shapely.py
@@ -1,3 +1,12 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2017, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
 import os
 
 from PyInstaller.utils.hooks import get_package_paths

--- a/PyInstaller/hooks/hook-shapely.py
+++ b/PyInstaller/hooks/hook-shapely.py
@@ -10,6 +10,7 @@
 import os
 
 from PyInstaller.utils.hooks import get_package_paths
+from PyInstaller.utils.hooks import is_module_satisfies
 from PyInstaller import compat
 
 # Necessary when using the vectorized subpackage
@@ -34,4 +35,5 @@ elif compat.is_linux:
     # ./libs directory under its' package. There is a proposed fix for this in
     # shapely but it has not been accepted it:
     # https://github.com/Toblerity/Shapely/pull/485
-    binaries += [(os.path.join(lib_dir, f), dest_dir) for f in os.listdir(lib_dir)]
+    if is_module_satisfies('shapely <= 1.6'):
+        binaries += [(os.path.join(lib_dir, f), dest_dir) for f in os.listdir(lib_dir)]

--- a/PyInstaller/hooks/hook-shapely.py
+++ b/PyInstaller/hooks/hook-shapely.py
@@ -6,7 +6,7 @@ from PyInstaller import compat
 # Necessary when using the vectorized subpackage
 hiddenimports = ['shapely.prepared']
 
-pkb_base, pkg_dir = get_package_paths('shapely')
+pkg_base, pkg_dir = get_package_paths('shapely')
 
 if compat.is_win:
     binaries = []

--- a/PyInstaller/hooks/hook-shapely.py
+++ b/PyInstaller/hooks/hook-shapely.py
@@ -3,8 +3,23 @@ import os
 from PyInstaller.utils.hooks import get_package_paths
 from PyInstaller import compat
 
+pkb_base, pkg_dir = get_package_paths('shapely')
+
 if compat.is_win:
     binaries = []
-    pkb_base, pkg_dir = get_package_paths('shapely')
     lib_dir = os.path.join(pkg_dir, 'DLLs')
     binaries += [(os.path.join(lib_dir, f), '') for f in os.listdir(lib_dir)]
+elif compat.is_linux:
+    binaries = []
+    lib_dir = os.path.join(pkg_dir, '.libs')
+    dest_dir = os.path.join('shapely', '.libs')
+
+    # This duplicates the libgeos*.so* files in the build.  PyInstaller will
+    # copy them into the root of the build by default, but shapely cannot load
+    # them from there in linux IF shapely was installed via a whl file. The
+    # whl bundles its' own libgeos with a different name, something like
+    # libgeos_c-*.so.* but shapely tries to load libgeos_c.so if there isn't a
+    # ./libs directory under its' package. There is a proposed fix for this in
+    # shapely but it has not been accepted it:
+    # https://github.com/Toblerity/Shapely/pull/485
+    binaries += [(os.path.join(lib_dir, f), dest_dir) for f in os.listdir(lib_dir)]

--- a/PyInstaller/hooks/hook-shapely.py
+++ b/PyInstaller/hooks/hook-shapely.py
@@ -1,0 +1,10 @@
+import os
+
+from PyInstaller.utils.hooks import get_package_paths
+from PyInstaller import compat
+
+if compat.is_win:
+    binaries = []
+    pkb_base, pkg_dir = get_package_paths('shapely')
+    lib_dir = os.path.join(pkg_dir, 'DLLs')
+    binaries += [(os.path.join(lib_dir, f), '') for f in os.listdir(lib_dir)]

--- a/PyInstaller/hooks/hook-shapely.py
+++ b/PyInstaller/hooks/hook-shapely.py
@@ -3,6 +3,9 @@ import os
 from PyInstaller.utils.hooks import get_package_paths
 from PyInstaller import compat
 
+# Necessary when using the vectorized subpackage
+hiddenimports = ['shapely.prepared']
+
 pkb_base, pkg_dir = get_package_paths('shapely')
 
 if compat.is_win:


### PR DESCRIPTION
Tested this hook file with Shapely 1.5.17 on Windows 7 64-bit when Shapely was installed via whl file.  Also successfully tested a build in CentOS 6.4.  Oddly enough the `so` file is copied over correctly in Linux, but Shapely didn't know how to find it in a `frozen` state.  I've submitted a pull request to the shapely library for that fix as well.

https://github.com/Toblerity/Shapely/pull/485