### PR TITLE
Look for libpython%.%.dll in Windows MSYS2

### DIFF
--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -55,7 +55,8 @@ is_unix = is_linux or is_solar or is_aix or is_freebsd or is_hpux
 # On different platforms is different file for dynamic python library.
 _pyver = sys.version_info[:2]
 if is_win:
-    PYDYLIB_NAMES = {'python%d%d.dll' % _pyver}
+    PYDYLIB_NAMES = {'python%d%d.dll' % _pyver,
+                     'libpython%d.%d.dll' % _pyver}  # For MSYS2 environment
 elif is_cygwin:
     PYDYLIB_NAMES = {'libpython%d%d.dll' % _pyver,
                      'libpython%d%dm.dll' % _pyver,


### PR DESCRIPTION
I'm using PyInstaller in MSYS2, and it's unable to find the python dynamic library during the build process, so this is a possible fix for that situation.

I've tried to detect MSYS2 using several methods (`sys.platform`, `os.uname`, etc.), but none really works consistently across different environments, so I'm just doing the simplest thing here and add the dynamic library name to `PYDYLIB_NAMES`