### PR TITLE
Fixed hook for psycopg2 >= 2.7

### DIFF
--- a/PyInstaller/hooks/hook-psycopg2.py
+++ b/PyInstaller/hooks/hook-psycopg2.py
@@ -9,3 +9,4 @@
 
 
 hiddenimports = ['mx.DateTime']
+excludedimports = ['psycopg2.tests']


### PR DESCRIPTION
Pyinstaller crashes with error on simple warnings after analyzing 'psycopg2.tests' of psycopg2 >= 2.7