### PR TITLE
Fix #1522: Fix modulegraph to reimport failed SWIG C modules (_gdal)

### DIFF
--- a/PyInstaller/lib/modulegraph/modulegraph.py
+++ b/PyInstaller/lib/modulegraph/modulegraph.py
@@ -2219,6 +2219,16 @@ class ModuleGraph(ObjectGraph):
         """
         self.msg(3, "_safe_import_hook", target_module_partname, source_module, target_attr_names, level)
 
+        def is_swig_candidate():
+            return (source_module is not None and
+                    target_attr_names is None and
+                    level == ABSOLUTE_IMPORT_LEVEL and
+                    type(source_module) is SourceModule and
+                    target_module_partname ==
+                      '_' + source_module.identifier.rpartition('.')[2] and
+                    sys.version_info[0] == 3)
+            
+
         # List of the graph nodes created for all target modules both
         # imported by and returned from this call, whose:
         #
@@ -2272,14 +2282,7 @@ class ModuleGraph(ObjectGraph):
             #
             # Only source modules (e.g., ".py"-suffixed files) are SWIG import
             # candidates. All other node types are safely ignorable.
-            if (
-                source_module is not None and
-                target_attr_names is None and
-                level == ABSOLUTE_IMPORT_LEVEL and
-                type(source_module) is SourceModule and
-                target_module_partname ==
-                    '_' + source_module.identifier.rpartition('.')[2] and
-                sys.version_info[0] == 3):
+            if is_swig_candidate():
                 self.msg(4, 'SWIG import candidate (name=%r, caller=%r, level=%r)' % (target_module_partname, source_module, level))
 
                 # TODO Define a new function util.open_text_file() performing
@@ -2339,22 +2342,25 @@ class ModuleGraph(ObjectGraph):
         # Target module imported above.
         target_module = target_modules[0]
 
-        if (isinstance(target_module, MissingModule) and
-                source_module is not None and
-                target_attr_names is None and
-                level == ABSOLUTE_IMPORT_LEVEL and
-                type(source_module) is SourceModule and
-                target_module_partname ==
-                    '_' + source_module.identifier.rpartition('.')[2] and
-                sys.version_info[0] == 3):
+        if isinstance(target_module, MissingModule) and is_swig_candidate():
             # if this possible swig C module was previously imported from
             # a python module other than its corresponding swig python
-            # module, then it may have been considering a MissingModule.
-            # Try to reimport it now
+            # module, then it may have been considered a MissingModule.
+            # Try to reimport it now. For details see pull-request #2578
+            # and issue #1522.
+            # Remove the MissingModule node from the graph so that we can
+            # attempt a reimport and avoid collisions. This node should be
+            # fine to remove because the proper module will be imported and
+            # added to the graph in the next line (call to _safe_import_hook).
             self.removeNode(target_module)
+            # Reimport the SWIG C module
             target_modules = self._safe_import_hook(
                 target_module_partname, source_module,
                 target_attr_names=None, level=level, edge_attr=edge_attr)
+            # Ensure that the above logic imported exactly one target module.
+            assert len(target_modules) == 1, (
+                'Expected _safe_import_hook() to'
+                'return only one module but received: {}'.format(target_modules))
             target_module = target_modules[0]
 
         if isinstance(edge_attr, DependencyInfo):

--- a/PyInstaller/lib/modulegraph/modulegraph.py
+++ b/PyInstaller/lib/modulegraph/modulegraph.py
@@ -2357,11 +2357,9 @@ class ModuleGraph(ObjectGraph):
             target_modules = self._safe_import_hook(
                 target_module_partname, source_module,
                 target_attr_names=None, level=level, edge_attr=edge_attr)
-            # Ensure that the above logic imported exactly one target module.
-            assert len(target_modules) == 1, (
-                'Expected _safe_import_hook() to'
-                'return only one module but received: {}'.format(target_modules))
-            target_module = target_modules[0]
+            # return the output regardless because it would just be
+            # duplicating the processing below
+            return target_modules
 
         if isinstance(edge_attr, DependencyInfo):
             edge_attr = edge_attr._replace(fromlist=True)

--- a/PyInstaller/lib/modulegraph/modulegraph.py
+++ b/PyInstaller/lib/modulegraph/modulegraph.py
@@ -2339,6 +2339,24 @@ class ModuleGraph(ObjectGraph):
         # Target module imported above.
         target_module = target_modules[0]
 
+        if (isinstance(target_module, MissingModule) and
+                source_module is not None and
+                target_attr_names is None and
+                level == ABSOLUTE_IMPORT_LEVEL and
+                type(source_module) is SourceModule and
+                target_module_partname ==
+                    '_' + source_module.identifier.rpartition('.')[2] and
+                sys.version_info[0] == 3):
+            # if this possible swig C module was previously imported from
+            # a python module other than its corresponding swig python
+            # module, then it may have been considering a MissingModule.
+            # Try to reimport it now
+            self.removeNode(target_module)
+            target_modules = self._safe_import_hook(
+                target_module_partname, source_module,
+                target_attr_names=None, level=level, edge_attr=edge_attr)
+            target_module = target_modules[0]
+
         if isinstance(edge_attr, DependencyInfo):
             edge_attr = edge_attr._replace(fromlist=True)
 


### PR DESCRIPTION
Main culprit is `osgeo._gdal`. This module is first imported by
`osgeo/__init__.py` via `import _gdal`. It is also imported "properly"
from `osgeo/gdal.py` which is the corresponding SWIG python module. By the time `osgeo/gdal.py` is imported the `_gdal` module has already been defined as missing and never gets imported.
This solution was chosen as the least obstructive while still being
generic enough to help other modules in the future.

An argument could be made (see related issue) that the osgeo hook should just handle this, but since osgeo/gdal may not be the only one breaking the mold on how to use SWIG modules this may be useful again. I leave it up to the maintainers on what the best option is. I've copied the important part of my last comment in the related issue below:

Test file `test.py`:

    from osgeo import gdal

Run with `pyinstaller -y -d --clean test.py` will perform the following operations:

1. Find the `from osgeo import gdal`
2. Try to import `osgeo` which is actually `osgeo/__init__.py`
3. Find the `import _gdal` import and try to import it.
4. Fail (ImportError) and get to this line: https://github.com/pyinstaller/pyinstaller/blob/develop/PyInstaller/lib/modulegraph/modulegraph.py#L2275
5. Due to the import being from `osgeo/__init__.py` and not `osgeo/gdal.py` the above mentioned line of code doesn't resolve to `True` so the `_gdal` module not seen as a SWIG generated module. This results in a `MissingModule` node being added to the import graph here: https://github.com/pyinstaller/pyinstaller/blob/develop/PyInstaller/lib/modulegraph/modulegraph.py#L2321
6. As import analysis continues we get to `osgeo/gdal.py`.
7. Find `import _gdal` import and try to import it.
8. See that we've already tried to import `_gdal` and failed so we don't raise an ImportError, we just have the `MissingModule` node. No ImportError means never falling in to the "check if this is SWIG" check so the module never gets included.

My fix solves the issue at step 8 above where a SWIG module was marked as missing, but only because it was incorrectly marked as not-SWIG.