### PR TITLE
websocket works within PyInstaller distributions

### DIFF
--- a/PyInstaller/hooks/hook-websocket.py
+++ b/PyInstaller/hooks/hook-websocket.py
@@ -1,0 +1,4 @@
+# This is needed to bundle cacert.pem that comes with websocket module, similar to what is done with python "requests"
+
+from PyInstaller.utils.hooks import collect_data_files
+datas = collect_data_files('websocket')


### PR DESCRIPTION
Added relevant hooks to support python `websocket-client` package (import name is websocket).

The package fails with SSL_ERRORS very similar to python "requests" package unless this hook is implemented