### PR TITLE
fix: py2 non-unicode sys.path been tempted by os.path.abspath

### DIFF
--- a/PyInstaller/loader/pyiboot01_bootstrap.py
+++ b/PyInstaller/loader/pyiboot01_bootstrap.py
@@ -60,7 +60,11 @@ if VIRTENV in os.environ:
 # application.
 python_path = []
 for pth in sys.path:
-    python_path.append(os.path.abspath(pth))
+    if not os.path.isabs(pth):
+        # careful about using abspath with non-unicode path,
+        # it breaks multibyte character that contain slash under win32/Python 2
+        pth = os.path.abspath(pth)
+    python_path.append(pth)
     sys.path = python_path
 
 

--- a/PyInstaller/loader/pyiboot01_bootstrap.py
+++ b/PyInstaller/loader/pyiboot01_bootstrap.py
@@ -63,6 +63,7 @@ for pth in sys.path:
     if not os.path.isabs(pth):
         # careful about using abspath with non-unicode path,
         # it breaks multibyte character that contain slash under win32/Python 2
+        # TODO: Revert when dropping suport for is_py2.
         pth = os.path.abspath(pth)
     python_path.append(pth)
     sys.path = python_path


### PR DESCRIPTION
this fix #2585,

after some simple exam shows that os.path.abspath incorrect handle multibyte path,
so only apply it when necessary.