### PR TITLE
Hooks: Fix GdkPixbuf loader cache stuff

### DIFF
--- a/PyInstaller/hooks/hook-gi.repository.GdkPixbuf.py
+++ b/PyInstaller/hooks/hook-gi.repository.GdkPixbuf.py
@@ -59,9 +59,12 @@ else:
     # If loader detection is supported on this platform, bundle all detected
     # loaders and an updated loader cache.
     if pattern:
+        loader_libs = []
+
         # Bundle all found loaders with this user application.
         for f in glob.glob(pattern):
             binaries.append((f, 'lib/gdk-pixbuf-2.0/2.10.0/loaders'))
+            loader_libs.append(f)
 
         # Filename of the loader cache to be written below.
         cachefile = os.path.join(CONF['workpath'], 'loaders.cache')
@@ -70,14 +73,27 @@ else:
         # output providing an updated loader cache; then write this output to
         # the loader cache bundled with this frozen application.
         #
-        # If the current platform is OS X...
-        if is_darwin:
+        # On OSX we use @executable_path to specify a path relative to the
+        # generated bundle. However, on non-Windows we need to rewrite the
+        # loader cache because it isn't relocatable by default. See
+        # https://bugzilla.gnome.org/show_bug.cgi?id=737523
+        #
+        # To make it easier to rewrite, we just always write @executable_path,
+        # since its significantly easier to find/replace at runtime. :)
+        #
+        # If we need to rewrite it...
+        if not is_win:
             # To permit string munging, decode the encoded bytes output by this
             # command (i.e., enable the "universal_newlines" option). Note that:
             #
             # * Under Python 2.7, "cachedata" will be a decoded "unicode" object.
             # * Under Python 3.x, "cachedata" will be a decoded "str" object.
-            cachedata = exec_command_stdout(gdk_pixbuf_query_loaders)
+            #
+            # On Fedora, the default loaders cache is /usr/lib64, but the libdir
+            # is actually /lib64. To get around this, we pass the path to the
+            # loader command, and it will create a cache with the right path.
+            cachedata = exec_command_stdout(gdk_pixbuf_query_loaders,
+                                            *loader_libs)
 
             cd = []
             prefix = '"' + libdir
@@ -98,7 +114,7 @@ else:
             # Write the updated loader cache to this file.
             with open_file(cachefile, 'w') as fp:
                 fp.write(cachedata)
-        # Else, the current platform is *NOT* OS X. In this case, no changes to
+        # Else, GdkPixbuf will do the right thing on Windows, so no changes to
         # the loader cache are required. For efficiency and reliability, this
         # command's encoded byte output is written as is without being decoded.
         else:

--- a/PyInstaller/hooks/hook-gi.repository.GdkPixbuf.py
+++ b/PyInstaller/hooks/hook-gi.repository.GdkPixbuf.py
@@ -16,13 +16,26 @@ import subprocess
 
 from PyInstaller.config import CONF
 from PyInstaller.compat import (
-    exec_command_stdout, is_darwin, is_win, is_linux, open_file, which)
+    architecture, exec_command_stdout, is_darwin, is_win, is_linux, open_file, which)
 from PyInstaller.utils.hooks import (
     collect_glib_translations, get_gi_typelibs, get_gi_libdir, logger)
 
 # If the "gdk-pixbuf-query-loaders" command is not in the current ${PATH}, GDK
 # and thus GdkPixbuf is unavailable. Return with a non-fatal warning.
-if which('gdk-pixbuf-query-loaders') is None:
+gdk_pixbuf_query_loaders = None
+
+if architecture() == '64bit':
+    # CentOS/Fedora package as -64
+    cmds = ['gdk-pixbuf-query-loaders-64', 'gdk-pixbuf-query-loaders']
+else:
+    cmds = ['gdk-pixbuf-query-loaders']
+
+for cmd in cmds:
+    gdk_pixbuf_query_loaders = which(cmd)
+    if gdk_pixbuf_query_loaders is not None:
+        break
+
+if gdk_pixbuf_query_loaders is None:
     logger.warning(
         '"hook-gi.repository.GdkPixbuf" ignored, since GDK not found '
         '(i.e., "gdk-pixbuf-query-loaders" not in $PATH).'
@@ -64,7 +77,7 @@ else:
             #
             # * Under Python 2.7, "cachedata" will be a decoded "unicode" object.
             # * Under Python 3.x, "cachedata" will be a decoded "str" object.
-            cachedata = exec_command_stdout('gdk-pixbuf-query-loaders')
+            cachedata = exec_command_stdout(gdk_pixbuf_query_loaders)
 
             cd = []
             prefix = '"' + libdir
@@ -90,7 +103,7 @@ else:
         # command's encoded byte output is written as is without being decoded.
         else:
             with open_file(cachefile, 'wb') as fp:
-                fp.write(subprocess.check_output('gdk-pixbuf-query-loaders'))
+                fp.write(subprocess.check_output(gdk_pixbuf_query_loaders))
 
         # Bundle this loader cache with this frozen application.
         datas.append((cachefile, 'lib/gdk-pixbuf-2.0/2.10.0'))

--- a/PyInstaller/loader/rthooks/pyi_rth_gdkpixbuf.py
+++ b/PyInstaller/loader/rthooks/pyi_rth_gdkpixbuf.py
@@ -7,7 +7,30 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
+import atexit
 import os
+import tempfile
 import sys
 
-os.environ['GDK_PIXBUF_MODULE_FILE'] = os.path.join(sys._MEIPASS, 'lib', 'gdk-pixbuf-2.0', '2.10.0', 'loaders.cache')
+pixbuf_file = os.path.join(sys._MEIPASS, 'lib', 'gdk-pixbuf-2.0', '2.10.0', 'loaders.cache')
+
+# If we're not on Windows or OSX we need to rewrite the cache
+if os.path.exists(pixbuf_file) and sys.platform not in ('win32', 'darwin'):
+
+    with open(pixbuf_file, 'rb') as fp:
+        contents = fp.read()
+
+    # create a temporary file with the cache and cleverly replace the prefix
+    # we injected with the actual path
+    fd, pixbuf_file = tempfile.mkstemp()
+    with os.fdopen(fd, 'wb') as fp:
+        fp.write(contents.replace(b'@executable_path/lib',
+                                  bytes(os.path.join(sys._MEIPASS, 'lib'))))
+
+    try:
+        atexit.register(os.unlink, pixbuf_file)
+    except OSError:
+        pass
+
+
+os.environ['GDK_PIXBUF_MODULE_FILE'] = pixbuf_file


### PR DESCRIPTION
Two fixes here for #1833:

* On Fedora/CentOS, the loaders cache program is sometimes named ending in '-64'
* On Linux, the loader cache isn't guaranteed to be relocatable, so we need to create a new one at runtime that points exactly at the pixbuf loader libraries

Tested on OSX, and packaged on Fedora 25 + ran on Ubuntu 16