### PR TITLE
Hooks: GIR files are only required on OSX

### DIFF
--- a/PyInstaller/hooks/hook-gi.repository.GdkPixbuf.py
+++ b/PyInstaller/hooks/hook-gi.repository.GdkPixbuf.py
@@ -48,7 +48,7 @@ else:
     if pattern:
         # Bundle all found loaders with this user application.
         for f in glob.glob(pattern):
-            binaries.append((f, 'lib/gdk-pixbuf-2.0/2.10.0/loaders'))
+            binaries.append((f, 'lib/gdk-pixbuf/loaders'))
 
         # Filename of the loader cache to be written below.
         cachefile = os.path.join(CONF['workpath'], 'loaders.cache')
@@ -67,7 +67,7 @@ else:
             cachedata = exec_command_stdout('gdk-pixbuf-query-loaders')
 
             cd = []
-            prefix = '"' + libdir
+            prefix = '"' + os.path.join(libdir, 'gdk-pixbuf-2.0', '2.10.0')
             plen = len(prefix)
 
             # For each line in the updated loader cache...
@@ -75,7 +75,7 @@ else:
                 if line.startswith('#'):
                     continue
                 if line.startswith(prefix):
-                    line = '"@executable_path/lib' + line[plen:]
+                    line = '"@executable_path/lib/gdk-pixbuf' + line[plen:]
                 cd.append(line)
 
             # Rejoin these lines in a manner preserving this object's "unicode"
@@ -93,7 +93,7 @@ else:
                 fp.write(subprocess.check_output('gdk-pixbuf-query-loaders'))
 
         # Bundle this loader cache with this frozen application.
-        datas.append((cachefile, 'lib/gdk-pixbuf-2.0/2.10.0'))
+        datas.append((cachefile, 'lib/gdk-pixbuf'))
     # Else, loader detection is unsupported on this platform.
     else:
         logger.warning('GdkPixbuf loader bundling unsupported on your platform.')

--- a/PyInstaller/hooks/hook-gi.repository.Gio.py
+++ b/PyInstaller/hooks/hook-gi.repository.Gio.py
@@ -47,3 +47,20 @@ else:
     # To add a new platform add a new elif above with the proper is_<platform> and
     # proper pattern for finding the Gio modules on your platform.
     logger.warning('Bundling Gio modules is currently not supported on your platform.')
+
+
+# Bundle the mime cache -- might not be needed on Windows
+# -> this is used for content type detection (also used by GdkPixbuf)
+# -> gio/xdgmime/xdgmime.c looks for mime/mime.cache in the users home directory,
+#    followed by XDG_DATA_DIRS if specified in the environment, otherwise
+#    it searches /usr/local/share/ and /usr/share/
+if not is_win:
+    _mime_searchdirs = ['/usr/local/share', '/usr/share']
+    if 'XDG_DATA_DIRS' in os.environ:
+        _mime_searchdirs.insert(0, os.environ['XDG_DATA_DIRS'])
+
+    for sd in _mime_searchdirs:
+        spath = os.path.join(sd, 'mime', 'mime.cache')
+        if os.path.exists(spath):
+            datas.append((spath, 'share/mime'))
+            break

--- a/PyInstaller/loader/rthooks/pyi_rth_gdkpixbuf.py
+++ b/PyInstaller/loader/rthooks/pyi_rth_gdkpixbuf.py
@@ -10,4 +10,4 @@
 import os
 import sys
 
-os.environ['GDK_PIXBUF_MODULE_FILE'] = os.path.join(sys._MEIPASS, 'lib', 'gdk-pixbuf-2.0', '2.10.0', 'loaders.cache')
+os.environ['GDK_PIXBUF_MODULE_FILE'] = os.path.join(sys._MEIPASS, 'lib', 'gdk-pixbuf', 'loaders.cache')

--- a/PyInstaller/loader/rthooks/pyi_rth_gdkpixbuf.py
+++ b/PyInstaller/loader/rthooks/pyi_rth_gdkpixbuf.py
@@ -14,8 +14,9 @@ import sys
 
 pixbuf_file = os.path.join(sys._MEIPASS, 'lib', 'gdk-pixbuf', 'loaders.cache')
 
-# If we're not on Windows or OSX we need to rewrite the cache
-if os.path.exists(pixbuf_file) and sys.platform not in ('win32', 'darwin'):
+# If we're not on Windows we need to rewrite the cache
+# -> we rewrite on OSX to support --onefile mode
+if os.path.exists(pixbuf_file) and sys.platform != 'win32':
 
     with open(pixbuf_file, 'rb') as fp:
         contents = fp.read()

--- a/PyInstaller/utils/hooks/gi.py
+++ b/PyInstaller/utils/hooks/gi.py
@@ -114,7 +114,14 @@ def gir_library_path_fix(path):
     # On OSX we need to recompile the GIR files to reference the loader path,
     # but this is not necessary on other platforms
     if is_darwin:
+        
+        # If using a virtualenv, the base prefix and the path of the typelib
+        # have really nothing to do with each other, so try to detect that
         common_path = os.path.commonprefix([base_prefix, path])
+        if common_path == '/':
+            logger.debug("virtualenv detected? fixing the gir path...")
+            common_path = os.path.abspath(os.path.join(path, '..', '..', '..'))
+        
         gir_path = os.path.join(common_path, 'share', 'gir-1.0')
 
         typelib_name = os.path.basename(path)

--- a/PyInstaller/utils/hooks/gi.py
+++ b/PyInstaller/utils/hooks/gi.py
@@ -109,34 +109,30 @@ def gir_library_path_fix(path):
     # 'PyInstaller.config' cannot be imported as other top-level modules.
     from ...config import CONF
 
-    # if typelib file exist is not necessary to check gir file.
     path = os.path.abspath(path)
-    if os.path.exists(path):
-        return path, 'gi_typelibs'
-        
-    common_path = os.path.commonprefix([base_prefix, path])
-    # on windows the gir file is not in the same directory as linux.
-    if is_win:
-        common_path = os.path.join([common_path, "Lib", "site-packages", "gnome"])
-    gir_path = os.path.join(common_path, 'share', 'gir-1.0')
 
-    typelib_name = os.path.basename(path)
-    gir_name = os.path.splitext(typelib_name)[0] + '.gir'
-
-    gir_file = os.path.join(gir_path, gir_name)
-
-    if not os.path.exists(gir_path):
-        logger.error('Unable to find gir directory: %s.\n'
-                     'Try installing your platforms gobject-introspection '
-                     'package.', gir_path)
-        return None
-    if not os.path.exists(gir_file):
-        logger.error('Unable to find gir file: %s.\n'
-                     'Try installing your platforms gobject-introspection '
-                     'package.', gir_file)
-        return None
-
+    # On OSX we need to recompile the GIR files to reference the loader path,
+    # but this is not necessary on other platforms
     if is_darwin:
+        common_path = os.path.commonprefix([base_prefix, path])
+        gir_path = os.path.join(common_path, 'share', 'gir-1.0')
+
+        typelib_name = os.path.basename(path)
+        gir_name = os.path.splitext(typelib_name)[0] + '.gir'
+
+        gir_file = os.path.join(gir_path, gir_name)
+
+        if not os.path.exists(gir_path):
+            logger.error('Unable to find gir directory: %s.\n'
+                         'Try installing your platforms gobject-introspection '
+                         'package.', gir_path)
+            return None
+        if not os.path.exists(gir_file):
+            logger.error('Unable to find gir file: %s.\n'
+                         'Try installing your platforms gobject-introspection '
+                         'package.', gir_file)
+            return None
+
         with open(gir_file, 'r') as f:
             lines = f.readlines()
         with open(os.path.join(CONF['workpath'], gir_name), 'w') as f:


### PR DESCRIPTION
- This removes all of the GIR file detection logic, since the results are only used on OSX anyways
- Fixes bug introduced by #2306
- Fixes #2586 
- Fixes #2669
- Fixes #1833 
  * On Fedora/CentOS, the loaders cache program is sometimes named ending in '-64'
  * On Linux, the loader cache isn't guaranteed to be relocatable, so we need to create a new one at runtime that points exactly at the pixbuf loader libraries

Tested this on OSX and it works. Tested this on Linux... and it works, though I don't have a good isolated non-GTK environment to test it in. Logically, I think the change is sound, so it shouldn't break anything there.

@Readon please test this on Windows and see if it still works for you there.

Note: Contains commits from https://github.com/pyinstaller/pyinstaller/pull/2595, see that PR for additional discussion.