### PR TITLE
Make versioninfo.py round trip the version info correctly

### DIFF
--- a/PyInstaller/utils/win32/versioninfo.py
+++ b/PyInstaller/utils/win32/versioninfo.py
@@ -347,8 +347,6 @@ class StringFileInfo(object):
             pad = '\000\000'
         tmp = ''.join([kid.toRaw() for kid in self.kids])
         sublen = sublen + len(pad) + len(tmp)
-        if tmp[-2:] == '\000\000':
-            sublen = sublen - 2
         return (struct.pack('hhh', sublen, vallen, typ)
                 + getRaw(self.name) + '\000\000' + pad + tmp)
 
@@ -398,8 +396,6 @@ class StringTable:
             tmp.append(raw)
         tmp = ''.join(tmp)
         sublen += len(tmp)
-        if tmp[-2:] == '\000\000':
-            sublen -= 2
         return (struct.pack('hhh', sublen, vallen, typ)
                 + getRaw(self.name) + '\000\000' + tmp)
 
@@ -446,13 +442,13 @@ class StringStruct:
         if sublen % 4:
             pad = '\000\000'
         sublen = sublen + len(pad) + vallen
-        abcd = (struct.pack('hhh', sublen, vallen, typ)
+        abcd = (struct.pack('hhh', sublen, vallen / 2, typ)
                 + raw_name + '\000\000' + pad
                 + raw_val + '\000\000')
         return abcd
 
     def __unicode__(self, indent=''):
-        return u"StringStruct(u'%s', u'%s')" % (self.name, self.val) 
+        return u"StringStruct(u'%s', u'%s')" % (self.name, self.val)
 
 
 def parseCodePage(data, i, limit):


### PR DESCRIPTION
I noticed that the "Product version" string in the file details tab doesn't display correctly for PyInstaller built executables. It's just empty...

This is caused by differences/errors in the way we serialize the `VS_VERSIONINFO` structure and substructures, so I tried to fix those differences/errors, so that the version info structure round trips correctly.

I essentially fixed this two issues:
* The String structure `wValueLength` is in *words*, not bytes.
* We used to somehow remove two bytes from the size of
`{String,Var}FileInfo` which seems wrong and causes Windows to skip an
entry.

I figured this out by binary diffing and not by some magical intimate knowledge of those structures so I hope this is correct.

I think Windows also pads the entire structure to some boundary (I don't know what that boundary is) but that doesn't seem important, I think/hope...

Before:
![capture](https://cloud.githubusercontent.com/assets/24731903/25973466/e0969716-36ac-11e7-96e0-dfeb3555acb4.PNG)

After:
![capture](https://cloud.githubusercontent.com/assets/24731903/25973503/0b68791e-36ad-11e7-8b8a-644dc13c4ba4.PNG)

I used this "file_version_info.txt" to test:
```python
# UTF-8
#
# For more details about fixed file info 'ffi' see:
# http://msdn.microsoft.com/en-us/library/ms646997.aspx
VSVersionInfo(
  ffi=FixedFileInfo(
    # filevers and prodvers should be always a tuple with four items: (1, 2, 3, 4)
    # Set not needed items to zero 0.
    filevers=(10, 0, 14393, 1198),
    prodvers=(10, 0, 14393, 1198),
    # Contains a bitmask that specifies the valid bits 'flags'r
    mask=0x3f,
    # Contains a bitmask that specifies the Boolean attributes of the file.
    flags=0x0,
    # The operating system for which this file was designed.
    # 0x4 - NT and there is no need to change it.
    OS=0x40004,
    # The general type of file.
    # 0x1 - the file is an application.
    fileType=0x2,
    # The function of the file.
    # 0x0 - the function is not defined for this fileType
    subtype=0x0,
    # Creation date and time stamp.
    date=(0, 0)
    ),
  kids=[
    StringFileInfo(
      [
      StringTable(
        u'040904B0',
        [StringStruct(u'CompanyName', u'Microsoft Corporation'),
        StringStruct(u'FileDescription', u'Windows NT BASE API Client DLL'),
        StringStruct(u'FileVersion', u'10.0.14393.1198 (rs1_release_sec.170427-1353)'),
        StringStruct(u'InternalName', u'kernel32'),
        StringStruct(u'LegalCopyright', u'© Microsoft Corporation. All rights reserved.'),
        StringStruct(u'OriginalFilename', u'kernel32'),
        StringStruct(u'ProductName', u'Microsoft® Windows® Operating System'),
        StringStruct(u'ProductVersion', u'10.0.14393.1198')])
      ]), 
    VarFileInfo([VarStruct(u'Translation', [1033, 1200])])
  ]
)
```