### PR TITLE
Support using pypiwin32 or pywin32-ctypes

### DIFF
--- a/PyInstaller/__main__.py
+++ b/PyInstaller/__main__.py
@@ -17,14 +17,12 @@ import argparse
 import platform
 import sys
 
-import PyInstaller.building.makespec
-import PyInstaller.building.build_main
-import PyInstaller.log
-
 
 from . import __version__
-from .compat import check_requirements
 from . import log as logging
+
+# note: don't import anything else until this function is run!
+from .compat import check_requirements
 
 logger = logging.getLogger(__name__)
 
@@ -36,12 +34,15 @@ def run_makespec(filenames, **opts):
     for p in temppaths:
         pathex.extend(p.split(os.pathsep))
 
+    import PyInstaller.building.makespec
+
     spec_file = PyInstaller.building.makespec.main(filenames, **opts)
     logger.info('wrote %s' % spec_file)
     return spec_file
 
 
 def run_build(pyi_config, spec_file, **kwargs):
+    import PyInstaller.building.build_main
     PyInstaller.building.build_main.main(pyi_config, spec_file, **kwargs)
 
 
@@ -56,6 +57,10 @@ def run(pyi_args=None, pyi_config=None):
     pyi_config   allows checking configuration once when running multiple tests
     """
     check_requirements()
+    
+    import PyInstaller.building.makespec
+    import PyInstaller.building.build_main
+    import PyInstaller.log
 
     try:
         parser = argparse.ArgumentParser()

--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -846,8 +846,17 @@ def check_requirements():
     if is_win:
         try:
             from PyInstaller.utils.win32 import winutils
-            pywintypes = winutils.import_pywin32_module('pywintypes')
+            try:
+                pywintypes = winutils.import_pywin32_module('pywintypes')
+            except ImportError:
+                from win32ctypes.pywin32 import pywintypes
+                from win32ctypes.pywin32 import win32api
+                
+                # if this succeeded, then install pywin32-ctypes into sys.modules
+                sys.modules['win32api'] = win32api
+                sys.modules['pywintypes'] = pywintypes
+                
         except ImportError:
             raise SystemExit('PyInstaller cannot check for assembly dependencies.\n'
-                             'Please install PyWin32.\n\n'
+                             'Please install PyWin32 or pywin32-ctypes.\n\n'
                              'pip install pypiwin32\n')

--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -844,6 +844,11 @@ def check_requirements():
         raise SystemExit('PyInstaller requires at least Python 2.7 or 3.3+.')
 
     if is_win:
+        if 'win32api' in sys.modules or 'pywintypes' in sys.modules:
+            # Users should never see this error; if it occurs, it means someone
+            # wasn't careful and added an import where it shouldn't be
+            raise SystemExit("Internal error: early pywin32 import was introduced")
+        
         try:
             from PyInstaller.utils.win32 import winutils
             try:

--- a/PyInstaller/depend/dylib.py
+++ b/PyInstaller/depend/dylib.py
@@ -217,7 +217,8 @@ elif is_win:
     class WinExcludeList(object):
         def __init__(self, global_exclude_list):
             self._exclude_list = global_exclude_list
-            self._windows_dir = winutils.get_windows_dir().lower()
+            # use normpath because msys2 uses / instead of \
+            self._windows_dir = os.path.normpath(winutils.get_windows_dir().lower())
 
         def search(self, libname):
             libname = libname.lower()
@@ -227,7 +228,8 @@ elif is_win:
             else:
                 # Exclude everything from the Windows directory by default.
                 # .. sometimes realpath changes the case of libname, lower it
-                fn = os.path.realpath(libname).lower()
+                # .. use normpath because msys2 uses / instead of \
+                fn = os.path.normpath(os.path.realpath(libname).lower())
                 return fn.startswith(self._windows_dir)
 
     exclude_list = WinExcludeList(exclude_list)

--- a/PyInstaller/lib/modulegraph/find_modules.py
+++ b/PyInstaller/lib/modulegraph/find_modules.py
@@ -187,6 +187,7 @@ def plat_prepare(includes, packages, excludes):
             'nturl2path',
             'win32api',
             'win32con',
+            'win32ctypes',
             'win32event',
             'win32evtlogutil',
             'win32evtlog',

--- a/setup.py
+++ b/setup.py
@@ -29,9 +29,13 @@ if sys.platform.startswith('win'):
     try:
         import pywintypes
     except ImportError:
-        # 'pypiwin32' is PyWin32 package made installable by 'pip install'
-        # command.
-        REQUIREMENTS.append('pypiwin32')
+        # try using pywin32-ctypes, as pypiwin32 doesn't compile for msys2
+        try:
+            import win32ctypes.pywin32.pywintypes
+        except ImportError:
+            # 'pypiwin32' is PyWin32 package made installable by 'pip install'
+            # command. Prefer it by default.
+            REQUIREMENTS.append('pypiwin32')
 
 
 # Create long description from README.rst and doc/CHANGES.rst.

--- a/tests/functional/scripts/pyi_win_py3_no_shortpathname.py
+++ b/tests/functional/scripts/pyi_win_py3_no_shortpathname.py
@@ -10,7 +10,12 @@
 # This script is used by multiple tests. It checks that various paths set by the
 # bootloader are usable filenames.
 
-import sys, os, win32api
+import sys, os
+
+try:
+    import win32api
+except ImportError:
+    from win32ctypes.pywin32 import win32api
 
 if sys.version_info[0] == 2:
     safe_repr = repr


### PR DESCRIPTION
pypiwin32 doesn't work on msys2 for a variety of reasons, but pywin32-ctypes (once https://github.com/enthought/pywin32-ctypes/pull/53 is merged and a 0.1.0 release is made)
supports the minimum API that pyinstaller needs to work (except win32com, but that doesn't seem to be used anymore?).

There are ~40 test failures without msys2, and even more failures with msys2. If you're willing to accept this patch eventually, I can look into the tests some more. However, if that's not the case, then I'll probably just make a shim package that emulates pywin32 instead and has the correct pacakge names.

See also: https://github.com/Alexpux/MINGW-packages/issues/751