### PR TITLE
building: warn users if bincache gets corrupted

### DIFF
--- a/PyInstaller/building/utils.py
+++ b/PyInstaller/building/utils.py
@@ -170,7 +170,15 @@ def checkCache(fnm, strip=False, upx=False, dist_nm=None):
         os.makedirs(cachedir)
     cacheindexfn = os.path.join(cachedir, "index.dat")
     if os.path.exists(cacheindexfn):
-        cache_index = load_py_data_struct(cacheindexfn)
+        try:
+            cache_index = load_py_data_struct(cacheindexfn)
+        except Exception as e:
+            # tell the user they may want to fix their cache
+            # .. however, don't delete it for them; if it keeps getting
+            #    corrupted, we'll never find out
+            logger.warn("pyinstaller bincache may be corrupted; "
+                        "use pyinstaller --clean to fix")
+            raise
     else:
         cache_index = {}
 


### PR DESCRIPTION
I ran into this and it took me awhile to figure out what had happened. Add an error message so that users can more easily figure it out and recover.