### PR TITLE
Use single process on Mac for --onedir mode

### DIFF
--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -102,13 +102,17 @@ pyi_main(int argc, char * argv[])
     archive_status->argc = argc;
     archive_status->argv = argv;
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__APPLE__)
 
-    /* On Windows use single-process for --onedir mode. */
+    /* On Windows and Mac use single-process for --onedir mode. */
     if (!extractionpath && !pyi_launch_need_to_extract_binaries(archive_status)) {
         VS("LOADER: No need to extract files to run; setting extractionpath to homepath\n");
         extractionpath = homepath;
     }
+
+#endif
+
+#ifdef _WIN32
 
     if (extractionpath) {
         /* Add extraction folder to DLL search path */


### PR DESCRIPTION
On Mac, launching an application that's already open puts it in the
foreground. This didn't work for apps built with PyInstaller because
of the parent -> subprocess structure at runtime. The present commit
fixes the problem for --onedir mode by using a single process.

Closes #2616.