### PR TITLE
fix versioninfo.py breakage on Python 3.x

### DIFF
--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -199,6 +199,27 @@ else:
     modname_tkinter = 'tkinter'
 
 
+if is_win:
+    try:
+        import pywintypes
+        if is_py3:
+            # pywintypes.Unicode() breaks under Python 3, just stub it out if we're running
+            # under such a Python version.
+            pywintypes.Unicode = str
+    except ImportError:
+        # Do nothing here. User should be warned when check_requirements() is
+        # called.
+        pass
+
+def encode(text):
+    """
+    Encodes a string as bytes.
+    """
+    if is_py3:
+        return str.encode(text)
+    else:
+        return str(text)
+
 def architecture():
     """
     Returns the bit depth of the python interpreter's architecture as


### PR DESCRIPTION
Ran into these kinds of exceptions on Python 3.5 and 3.6:

```
Traceback (most recent call last):
  File "setup.py", line 67, in <module>
    'Topic :: Utilities'
  File "C:\dev\authenticator\yubioath-desktop\yubioath\yubicommon\setup\__init__.py", line 124, in setup
    return _setup(**kwargs)
  File "c:\python35-x86\Lib\distutils\core.py", line 148, in setup
    dist.run_commands()
  File "c:\python35-x86\Lib\distutils\dist.py", line 955, in run_commands
    self.run_command(cmd)
  File "c:\python35-x86\Lib\distutils\dist.py", line 974, in run_command
    cmd_obj.run()
  File "C:\dev\authenticator\yubioath-desktop\yubioath\yubicommon\setup\exe.py", line 76, in run
    pyinst_run([spec_name])
  File "c:\python35-x86\lib\site-packages\PyInstaller\__main__.py", line 87, in run
    run_build(pyi_config, spec_file, **vars(args))
  File "c:\python35-x86\lib\site-packages\PyInstaller\__main__.py", line 45, in run_build
    PyInstaller.building.build_main.main(pyi_config, spec_file, **kwargs)
  File "c:\python35-x86\lib\site-packages\PyInstaller\building\build_main.py", line 788, in main
    build(specfile, kw.get('distpath'), kw.get('workpath'), kw.get('clean_build'))
  File "c:\python35-x86\lib\site-packages\PyInstaller\building\build_main.py", line 734, in build
    exec(text, spec_namespace)
  File "<string>", line 151, in <module>
  File "c:\python35-x86\lib\site-packages\PyInstaller\building\api.py", line 415, in __init__
    self.__postinit__()
  File "c:\python35-x86\lib\site-packages\PyInstaller\building\datastruct.py", line 161, in __postinit__
    self.assemble()
  File "c:\python35-x86\lib\site-packages\PyInstaller\building\api.py", line 504, in assemble
    versioninfo.SetVersion(tmpnm, self.versrsrc)
  File "c:\python35-x86\lib\site-packages\PyInstaller\utils\win32\versioninfo.py", line 558, in SetVersion
    win32api.UpdateResource(hdst, pefile.RESOURCE_TYPE['RT_VERSION'], 1, vs.toRaw())
  File "c:\python35-x86\lib\site-packages\PyInstaller\utils\win32\versioninfo.py", line 161, in toRaw
    nm = pywintypes.Unicode(u'VS_VERSION_INFO')
TypeError: argument 1 (impossible<bad format char>)
```

I've tested the proposed changeset on Python 2.7.13, 3.5.3, and 3.6.1.