### PR TITLE
PyInstaller: add hooks for google.cloud and google.cloud.storage

### DIFF
--- a/PyInstaller/hooks/hook-google.cloud.py
+++ b/PyInstaller/hooks/hook-google.cloud.py
@@ -1,0 +1,11 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2017, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import copy_metadata
+datas = copy_metadata('google-cloud-core')

--- a/PyInstaller/hooks/hook-google.cloud.storage.py
+++ b/PyInstaller/hooks/hook-google.cloud.storage.py
@@ -1,0 +1,11 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2017, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import copy_metadata
+datas = copy_metadata('google-cloud-storage')


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/google-cloud-python/issues/1187