### PR TITLE
Add hook for dclab

### DIFF
--- a/PyInstaller/hooks/hook-dclab.py
+++ b/PyInstaller/hooks/hook-dclab.py
@@ -1,0 +1,14 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013-2017, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+# Hook for dclab: https://pypi.python.org/pypi/dclab
+
+from PyInstaller.utils.hooks import collect_data_files
+
+datas = collect_data_files('dclab')


### PR DESCRIPTION
Please add this hook for dclab, a scientific library for deformability cytometry.
https://pypi.python.org/pypi/dclab