### PR TITLE
Tests: functional: Fix idlelib test for python 3.6+

### DIFF
--- a/tests/functional/test_libraries.py
+++ b/tests/functional/test_libraries.py
@@ -306,14 +306,15 @@ def test_zope_interface(pyi_builder):
         """)
 
 
-@xfail(is_darwin, reason='Issue #1895.')
-@xfail(is_py36, reason='Fails on python 3.6')
 @importorskip('idlelib')
 def test_idlelib(pyi_builder):
     pyi_builder.test_source(
         """
         # This file depends on loading some icons, located based on __file__.
-        import idlelib.TreeWidget
+        try:
+            import idlelib.TreeWidget
+        except:
+            import idlelib.tree
         """)
 
 


### PR DESCRIPTION
Fixes #2361. The module `idlelib.TreeWidget` name was changed to `idlelib.tree`.