### PR TITLE
hooks/h5py: Correct hooks to have h5py. prefix

### DIFF
--- a/PyInstaller/hooks/hook-h5py.py
+++ b/PyInstaller/hooks/hook-h5py.py
@@ -13,4 +13,4 @@ Hook for http://pypi.python.org/pypi/h5py/
 """
 
 
-hiddenimports = ['_proxy', 'utils', 'defs', 'h5ac']
+hiddenimports = ['h5py._proxy', 'h5py.utils', 'h5py.defs', 'h5py.h5ac']

--- a/doc/hooks.rst
+++ b/doc/hooks.rst
@@ -108,7 +108,7 @@ applies them to the bundle being created.
     only when the hooked module is imported.
     Example::
 
-        hiddenimports = ['_proxy', 'utils', 'defs']
+        hiddenimports = ['h5py._proxy', 'h5py.utils', 'h5py.defs', 'h5py.h5ac']
 
 ``excludedimports``
     A list of absolute module names that should


### PR DESCRIPTION
I'm not sure how this worked before since my console always showed:
```
...
37855 INFO: Loading module hook "hook-h5py.py"...
37858 WARNING: Hidden import "_proxy" not found!
37859 WARNING: Hidden import "utils" not found!
37860 WARNING: Hidden import "defs" not found!
37861 WARNING: Hidden import "h5ac" not found!
...
```
without this change.

Maybe @htgoebel or @paulromano know if I did something wrong and how it worked before?
I just have `import h5py` in my file and I'm using h5py through Keras.