### PR TITLE
Add hook for imageio

### DIFF
--- a/PyInstaller/hooks/hook-imageio.py
+++ b/PyInstaller/hooks/hook-imageio.py
@@ -1,0 +1,14 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2017, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+# Hook for imageio: http://imageio.github.io/
+
+from PyInstaller.utils.hooks import collect_data_files
+
+datas = collect_data_files('imageio', subdir="resources")


### PR DESCRIPTION
Imageio is a Python library that provides an easy interface to read and write a wide range of image data, including animated images, video, volumetric data, and scientific formats.
http://imageio.github.io/

This hook script will make it possible to include binaries for ffmpeg, avbin, and freeimage.
References:
- https://github.com/imageio/imageio/pull/270
- https://github.com/imageio/imageio/issues/32

[skip ci] no test case for this