### PR TITLE
Change "early pywin32 import" warning back into an error

### DIFF
--- a/PyInstaller/__init__.py
+++ b/PyInstaller/__init__.py
@@ -38,8 +38,7 @@ if is_win and is_py2:
         # Do conversion to ShortPathName really only in case HOMEPATH is not
         # ascii only - conversion to unicode type cause this unicode error.
         try:
-            import win32api
-            HOMEPATH = win32api.GetShortPathName(HOMEPATH)
+            HOMEPATH = compat.win32api.GetShortPathName(HOMEPATH)
         except ImportError:
             pass
 

--- a/PyInstaller/utils/win32/icon.py
+++ b/PyInstaller/utils/win32/icon.py
@@ -21,6 +21,8 @@ try:
 except AttributeError:
     StringTypes = [ type("") ]
 
+from ...compat import win32api
+
 import PyInstaller.log as logging
 logger = logging.getLogger(__name__)
 
@@ -112,7 +114,6 @@ class IconFile:
 
 
 def CopyIcons_FromIco(dstpath, srcpath, id=1):
-    import win32api #, win32con
     icons = map(IconFile, srcpath)
     logger.info("Updating icons from %s to %s", srcpath, dstpath)
 
@@ -167,7 +168,7 @@ def CopyIcons(dstpath, srcpath):
         logger.info("Updating icons from %s, %d to %s", srcpath, index, dstpath)
     else:
         logger.info("Updating icons from %s to %s", srcpath, dstpath)
-    import win32api #, win32con
+
     hdst = win32api.BeginUpdateResource(dstpath, 0)
     hsrc = win32api.LoadLibraryEx(srcpath, 0, LOAD_LIBRARY_AS_DATAFILE)
     if index is None:

--- a/PyInstaller/utils/win32/versioninfo.py
+++ b/PyInstaller/utils/win32/versioninfo.py
@@ -12,9 +12,8 @@
 import codecs
 import struct
 
-from ...compat import is_py3
+from ...compat import is_py3, win32api
 
-import win32api
 # ::TODO:: #1920 revert to using pypi version
 import pefile
 

--- a/PyInstaller/utils/win32/winresource.py
+++ b/PyInstaller/utils/win32/winresource.py
@@ -16,10 +16,7 @@ winresource.py <dstpath> <srcpath>
 Updates or adds resources from file <srcpath> in file <dstpath>.
 """
 
-
-import pywintypes
-import win32api
-
+from ...compat import pywintypes, win32api
 
 import PyInstaller.log as logging
 logger = logging.getLogger(__name__)

--- a/PyInstaller/utils/win32/winutils.py
+++ b/PyInstaller/utils/win32/winutils.py
@@ -17,7 +17,8 @@ __all__ = ['get_windows_dir']
 import os
 import sys
 
-# Do not import this globally, import_pywin32_module is used by compat
+# Do not import 'compat' globally to avoid circual import:
+# import_pywin32_module() is used by compat
 #from ... import compat
 
 import PyInstaller.log as logging
@@ -28,7 +29,7 @@ def get_windows_dir():
     """
     Return the Windows directory e.g. C:\\Windows.
     """
-    # imported here because of circular import
+    # imported here to avoid circular import
     from ... import compat
     windir = compat.win32api.GetWindowsDirectory()
     if not windir:
@@ -40,7 +41,7 @@ def get_system_path():
     """
     Return the path that Windows will search for dlls.
     """
-    # imported here because of circular import
+    # imported here to avoid circular import
     from ... import compat
     _bpath = []
     sys_dir = compat.win32api.GetSystemDirectory()
@@ -60,7 +61,7 @@ def extend_system_path(paths):
 
     Some hooks might extend PATH where PyInstaller should look for dlls.
     """
-    # imported here because of circular import
+    # imported here to avoid circular import
     from ... import compat
     old_PATH = compat.getenv('PATH', '')
     paths.append(old_PATH)
@@ -85,8 +86,10 @@ def import_pywin32_module(module_name, _is_venv=None):
     module_name : str
         Fully-qualified name of this module.
     _is_venv: bool
-        Internal paramter used by compat.py, to prevent circular import. If not
-        None, should be the same as compat.is_venv, else compat.is_venv is used
+        Internal paramter used by compat.py, to prevent circular import. If None
+        (the default), compat is imported and comapt.is_venv ist used. If not
+        None, it is assumed to be called from compat and the value to be the same
+        as compat.is_venv.
 
     Returns
     ----------
@@ -112,13 +115,12 @@ def import_pywin32_module(module_name, _is_venv=None):
             # an ugly hack, but there is no other way.
             sys.frozen = '|_|GLYH@CK'
 
-            # If isolated to a venv, the preferred site.getsitepackages()
-            # function is unreliable. Fallback to searching "sys.path" instead.
-            if _is_venv is None:
-                # imported here because of circular import
+            if _is_venv is None:  # not called from within compat
+                # imported here to avoid circular import
                 from ... import compat
                 _is_venv = compat.is_venv
-
+            # If isolated to a venv, the preferred site.getsitepackages()
+            # function is unreliable. Fallback to searching "sys.path" instead.
             if _is_venv:
                 sys_paths = sys.path
             else:
@@ -159,7 +161,7 @@ def convert_dll_name_to_str(dll_name):
     :param dll_name:
     :return:
     """
-    # imported here because of circular import
+    # imported here to avoid circular import
     from ...compat import is_py3
     if is_py3 and isinstance(dll_name, bytes):
         return str(dll_name, encoding='UTF-8')

--- a/PyInstaller/utils/win32/winutils.py
+++ b/PyInstaller/utils/win32/winutils.py
@@ -17,8 +17,8 @@ __all__ = ['get_windows_dir']
 import os
 import sys
 
-from PyInstaller import compat
-from PyInstaller.compat import is_py3
+# Do not import this globally, import_pywin32_module is used by compat
+#from ... import compat
 
 import PyInstaller.log as logging
 logger = logging.getLogger(__name__)
@@ -28,12 +28,9 @@ def get_windows_dir():
     """
     Return the Windows directory e.g. C:\\Windows.
     """
-    try:
-        import win32api
-    except ImportError:
-        windir = compat.getenv('SystemRoot', compat.getenv('WINDIR'))
-    else:
-        windir = win32api.GetWindowsDirectory()
+    # imported here because of circular import
+    from ... import compat
+    windir = compat.win32api.GetWindowsDirectory()
     if not windir:
         raise SystemExit("Error: Can not determine your Windows directory")
     return windir
@@ -43,12 +40,10 @@ def get_system_path():
     """
     Return the path that Windows will search for dlls.
     """
+    # imported here because of circular import
+    from ... import compat
     _bpath = []
-    try:
-        import win32api
-        sys_dir = win32api.GetSystemDirectory()
-    except ImportError:
-        sys_dir = os.path.normpath(os.path.join(get_windows_dir(), 'system32'))
+    sys_dir = compat.win32api.GetSystemDirectory()
     # Ensure C:\Windows\system32  and C:\Windows directories are
     # always present in PATH variable.
     # C:\Windows\system32 is valid even for 64bit Windows. Access do DLLs are
@@ -65,13 +60,15 @@ def extend_system_path(paths):
 
     Some hooks might extend PATH where PyInstaller should look for dlls.
     """
+    # imported here because of circular import
+    from ... import compat
     old_PATH = compat.getenv('PATH', '')
     paths.append(old_PATH)
     new_PATH = os.pathsep.join(paths)
     compat.setenv('PATH', new_PATH)
 
 
-def import_pywin32_module(module_name):
+def import_pywin32_module(module_name, _is_venv=None):
     """
     Import and return the PyWin32 module with the passed name.
 
@@ -87,6 +84,9 @@ def import_pywin32_module(module_name):
     ----------
     module_name : str
         Fully-qualified name of this module.
+    _is_venv: bool
+        Internal paramter used by compat.py, to prevent circular import. If not
+        None, should be the same as compat.is_venv, else compat.is_venv is used
 
     Returns
     ----------
@@ -114,7 +114,12 @@ def import_pywin32_module(module_name):
 
             # If isolated to a venv, the preferred site.getsitepackages()
             # function is unreliable. Fallback to searching "sys.path" instead.
-            if compat.is_venv:
+            if _is_venv is None:
+                # imported here because of circular import
+                from ... import compat
+                _is_venv = compat.is_venv
+
+            if _is_venv:
                 sys_paths = sys.path
             else:
                 import site
@@ -154,6 +159,8 @@ def convert_dll_name_to_str(dll_name):
     :param dll_name:
     :return:
     """
+    # imported here because of circular import
+    from ...compat import is_py3
     if is_py3 and isinstance(dll_name, bytes):
         return str(dll_name, encoding='UTF-8')
     else:

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,9 @@ from __future__ import print_function
 import codecs
 import sys, os
 from setuptools import setup
+
+# Hack required to allow compat to not fail when pypiwin32 isn't found
+os.environ["PYINSTALLER_NO_PYWIN32_FAILURE"] = "1"
 from PyInstaller import (__version__ as version, is_linux, is_win, is_cygwin,
                          HOMEPATH, PLATFORM, compat)
 


### PR DESCRIPTION
Reverts c901c4265c1bd41332396e6e7ec7f5290bd79bb4 and fixes the problem instead*

... I'm not currently able to run the tests reliably on Windows, so I'm doing this so I can watch them on appveyor. I'll comment here if I think it got fixed.