### PR TITLE
tests: functional: disable usb

### DIFF
--- a/tests/functional/test_libraries.py
+++ b/tests/functional/test_libraries.py
@@ -593,6 +593,7 @@ def test_pyexcelerate(pyi_builder):
 
 
 @importorskip('usb')
+@pytest.mark.skipif(not is_win, reason='Crashes Python on travis')
 def test_usb(pyi_builder):
     # See if the usb package is supported on this platform.
     try:


### PR DESCRIPTION
Test crashes the runner which significantly slows the test suite and exhausts disk space.