### PR TITLE
Use Travis stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -110,8 +110,6 @@ jobs:
   allow_failures:
       # Just tests how PyInstaller performs with upcoming Python 3.6
       - python: "nightly"
-      # Ignore failures from OS X.
-      - os: osx
 
 addons:
   # Ubuntu 12.04 (LTS) packages installed into this Travis-CI container. Since

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,36 +8,110 @@ sudo: false
 cache:
   directories:
     - $HOME/.cache/pip
-    - $HOME/Library/Caches/pip
 
-# Try OS X.
 os:
   - linux
 
-env:
-#  - PYCRYPTO_VERSION=2.4.1
-#  - PYCRYPTO_VERSION=2.6.1
+jobs:
+  fast_finish: true
+  include:
+    # macOS is first to account for the delay in starting the build on macOS. This prevents the build from hanging on
+    # macOS as the last job to finish in a stage.
+    - stage: Cache
+      os: osx
+      language: generic
+      python: 3.6
+      cache:
+        directories:
+          - $HOME/Library/Caches/pip
+    - stage: Test - PyInstaller
+      os: osx
+      language: generic
+      python: 3.6
+      cache:
+        directories:
+          - $HOME/Library/Caches/pip
+      install:
+        # Update pip.
+        - python -m pip install -U pip setuptools wheel | cat
 
-python:
-  - "2.7"
-  - "3.3"
-  - "3.4"
-  - "3.5"
-  - "3.6"
-  - "nightly"
+        # Install dependencies for PyInstaller tests.
+        - pip install -U -r tests/requirements-tools.txt | cat
 
-matrix:
+        # Install PyInstaller.
+        - pip install -e . | cat
+      script: py.test -n 3 --maxfail 3 tests/unit tests/functional --ignore=tests/functional/test_libraries.py --ignore=tests/functional/test_hooks
+    - stage: Test - Libraries
+      os: osx
+      language: generic
+      python: 3.6
+      cache:
+        directories:
+          - $HOME/Library/Caches/pip
+      script: py.test -n 3 --maxfail 3 tests/functional/test_libraries.py tests/functional/test_hooks
+
+    - &cache
+      stage: Cache
+      python: 2.7
+    - &test-pyinstaller
+      stage: Test - PyInstaller
+      python: 2.7
+      install:
+        # Update pip.
+        - python -m pip install -U pip setuptools wheel | cat
+
+        # Install dependencies for PyInstaller tests.
+        - pip install -U -r tests/requirements-tools.txt | cat
+
+        # Install PyInstaller.
+        - pip install -e . | cat
+      # Run tests and speed them up by sending them to multiple CPUs.
+      script: py.test -n 3 --maxfail 3 tests/unit tests/functional --ignore=tests/functional/test_libraries.py --ignore=tests/functional/test_hooks
+    - &test-libraries
+      stage: Test - Libraries
+      python: 2.7
+      # Run tests and speed them up by sending them to multiple CPUs.
+      script: py.test -n 3 --maxfail 3 tests/functional/test_libraries.py tests/functional/test_hooks
+
+    - <<: *cache
+      python: 3.3
+    - <<: *test-pyinstaller
+      python: 3.3
+    - <<: *test-libraries
+      python: 3.3
+
+    - <<: *cache
+      python: 3.4
+    - <<: *test-pyinstaller
+      python: 3.4
+    - <<: *test-libraries
+      python: 3.4
+
+    - <<: *cache
+      python: 3.5
+    - <<: *test-pyinstaller
+      python: 3.5
+    - <<: *test-libraries
+      python: 3.5
+
+    - <<: *cache
+      python: 3.6
+    - <<: *test-pyinstaller
+      python: 3.6
+    - <<: *test-libraries
+      python: 3.6
+
+    - <<: *cache
+      python: nightly
+    - <<: *test-pyinstaller
+      python: nightly
+    - <<: *test-libraries
+      python: nightly
   allow_failures:
       # Just tests how PyInstaller performs with upcoming Python 3.6
       - python: "nightly"
       # Ignore failures from OS X.
       - os: osx
-  include:
-      # Use generic language for osx
-      - os: osx
-        sudo: required
-        language: generic
-        python: "3.6"
 
 addons:
   # Ubuntu 12.04 (LTS) packages installed into this Travis-CI container. Since
@@ -62,7 +136,6 @@ addons:
     - libatlas-base-dev
 
 before_install:
-  - SECONDS=0 && function timeout() { perl -e 'alarm shift; exec @ARGV' "$@"; }
   # Skip build if the commit message contains [skip travis] or [travis skip]
   - >
       echo "$TRAVIS_COMMIT_MESSAGE"
@@ -84,23 +157,18 @@ before_install:
   - python waf distclean all
   - cd ..
 
-
 install:
   # Update pip.
-  - python -m pip install -U pip setuptools wheel
+  - python -m pip install -U pip setuptools wheel | cat
 
   # Install dependencies for tests.
-  - pip install -U -r tests/requirements-tools.txt -r tests/requirements-libraries.txt
+  - pip install -U -r tests/requirements-tools.txt -r tests/requirements-libraries.txt | cat
 
   # Install PyInstaller.
-  - pip install -e .
-
+  - pip install -e . | cat
 
 script:
-  # Run tests and speed them up by sending them to multiple CPUs.
-  # Run unitttest first.
-  # Timeout before travis does so that the cache is always updated.
-  - timeout $((2760 - $SECONDS)) py.test -n 3 --maxfail 3 tests/unit tests/functional
+  - true
 
 notifications:
     irc:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -156,7 +156,7 @@ test_script:
           %CMD_IN_ENV% %PYTEST% %TESTS_UNITTESTS%
     ))'
 
-on_success:
+on_finish:
   # Remove old or huge cache files to hopefully not exceed the 1GB cache limit.
   #
   # If the cache limit is reached, the cache will not be updated (of not even
@@ -169,9 +169,6 @@ on_success:
   - C:\cygwin\bin\find "%LOCALAPPDATA%\pip" -empty -delete
   # Show size of cache
   - C:\cygwin\bin\du -hs "%LOCALAPPDATA%\pip\Cache"
-
-
-on_finish:
   - ps: |
       (new-object net.webclient).UploadFile(
         "https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)",

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,8 +19,8 @@ environment:
   # Break the tests into two runs, since together they exceed the 1 hour limit.
   # See https://github.com/pyinstaller/pyinstaller/issues/2024#issuecomment-224129520
   # for more discussion.
-  TESTS_UNITTESTS: tests/unit tests/functional -k "not tests/functional/test_libraries.py"
-  TESTS_LIBRARIES: tests/functional/test_libraries.py
+  TESTS_UNITTESTS: tests/unit tests/functional --ignore=tests/functional/test_libraries.py --ignore=tests/functional/test_hooks
+  TESTS_LIBRARIES: tests/functional/test_libraries.py tests/functional/test_hooks
   APPVEYOR_SAVE_CACHE_ON_ERROR: true
 
   matrix:

--- a/tests/functional/test_basic.py
+++ b/tests/functional/test_basic.py
@@ -205,6 +205,7 @@ def test_multiprocess(pyi_builder):
     pyi_builder.test_script('pyi_multiprocess.py')
 
 
+@xfail(is_darwin, reason="Pull Request #2505")
 @importorskip('multiprocessing')
 def test_multiprocess_forking(pyi_builder):
     pyi_builder.test_script('pyi_multiprocess_forking.py')


### PR DESCRIPTION
Unmark macOS as an allowed failure. Some failing tests may have recently been missed because of this.
Also fix a couple issues on AppVeyor, i.e., when the cache was being cleaned, and which tests were being run in which stage.