### PR TITLE
Revert "Fix for issue #2215: hook-lib.wx.pubsub is not working."

### DIFF
--- a/PyInstaller/hooks/hook-wx.lib.pubsub.py
+++ b/PyInstaller/hooks/hook-wx.lib.pubsub.py
@@ -15,8 +15,6 @@
 from PyInstaller.utils.hooks import collect_submodules, collect_data_files
 
 hiddenimports = collect_submodules('wx.lib.pubsub')
-hiddenimports += collect_submodules('wx.lib.pubsub.core.kwargs')
-hiddenimports += collect_submodules('wx.lib.pubsub.core.arg1')
 
 # collect_submodules does not find `pubsub1` or `pubsub2` because
 # they are not packages, just folders without an `__init__.py`

--- a/PyInstaller/utils/hooks/__init__.py
+++ b/PyInstaller/utils/hooks/__init__.py
@@ -612,15 +612,7 @@ def collect_submodules(package, filter=lambda name: True):
                         ## This is the original Py3 code.
                         #yield from walk_packages(path, name+'.', onerror)
 
-        def AllowRuntimeExceptions(exc):
-           # some modules, such as wx.lib.pubsub, are problematic in that they purposefully raise an exception
-           # if the user tries to import them directly.  In Pyinstaller, we are just querying, so we don't want
-           # to abort the search if the module doesn't want to play nice.  Partially addresses issue #2215.
-           typ, _, _ = sys.exc_info()
-           if typ == RuntimeError: return
-           else: raise
-
-        for module_loader, name, ispkg in walk_packages([{}], '{}.', onerror=AllowRuntimeExceptions):
+        for module_loader, name, ispkg in walk_packages([{}], '{}.'):
             print(name)
         """.format(
                   # Use repr to escape Windows backslashes.


### PR DESCRIPTION
Reverts pyinstaller/pyinstaller#2233

This pull request caused test failures related to pyzmq. We need to be stricter about only merging pull requests when the tests pass now.