### PR TITLE
tests: libraries: add hp5y

### DIFF
--- a/tests/functional/test_libraries.py
+++ b/tests/functional/test_libraries.py
@@ -806,3 +806,9 @@ def test_pandas_extension(pyi_builder):
         from pandas.lib import is_float
         assert is_float(1) == 0
         """)
+
+@importorskip('h5py')
+def test_h5py(pyi_builder):
+    pyi_builder.test_source("""
+        import h5py
+        """)

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -88,3 +88,5 @@ pypiwin32==219; python_version <= '3.5' and sys_platform == 'win32' # pyup: igno
 # For parsing PE headers and get list of dependent DLLs.
 # ::TODO:: #1920 revert to using pypi version
 #pefile; sys_platform == 'win32'
+
+h5py==2.7.0

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -89,4 +89,4 @@ pypiwin32==219; python_version <= '3.5' and sys_platform == 'win32' # pyup: igno
 # ::TODO:: #1920 revert to using pypi version
 #pefile; sys_platform == 'win32'
 
-h5py==2.7.0
+h5py==2.7.0; python_version != '3.3'


### PR DESCRIPTION
#2686 was a better fix, but failed to add the test proposed in #2549. Closes #2540.