### PR TITLE
Display a friendly error message when grab_version.py utility fails (#859)

### DIFF
--- a/PyInstaller/utils/cliutils/grab_version.py
+++ b/PyInstaller/utils/cliutils/grab_version.py
@@ -32,6 +32,8 @@ def run():
     try:
         import PyInstaller.utils.win32.versioninfo
         vs = PyInstaller.utils.win32.versioninfo.decode(args.exe_file)
+        if not vs:
+            raise SystemExit("Error: VersionInfo resource not found in exe")
         fp = codecs.open(args.out_filename, 'w', 'utf-8')
         fp.write(u"%s" % (vs,))
         fp.close()

--- a/PyInstaller/utils/win32/versioninfo.py
+++ b/PyInstaller/utils/win32/versioninfo.py
@@ -121,8 +121,11 @@ else:
 
 def decode(pathnm):
     h = win32api.LoadLibraryEx(pathnm, 0, LOAD_LIBRARY_AS_DATAFILE)
-    nm = win32api.EnumResourceNames(h, pefile.RESOURCE_TYPE['RT_VERSION'])[0]
-    data = win32api.LoadResource(h, pefile.RESOURCE_TYPE['RT_VERSION'], nm)
+    res = win32api.EnumResourceNames(h, pefile.RESOURCE_TYPE['RT_VERSION'])
+    if not len(res):
+        return None
+    data = win32api.LoadResource(h, pefile.RESOURCE_TYPE['RT_VERSION'],
+                                 res[0])
     vs = VSVersionInfo()
     j = vs.fromRaw(data)
     win32api.FreeLibrary(h)


### PR DESCRIPTION
As in the title. Fixes Issue #859.