### PR TITLE
Runtime hooks: Fixes #2759: Fix multiprocess forking on macOS

### DIFF
--- a/PyInstaller/loader/rthooks/pyi_rth_multiprocessing.py
+++ b/PyInstaller/loader/rthooks/pyi_rth_multiprocessing.py
@@ -1,8 +1,7 @@
-from sys import platform as _platform
+import sys
 
 # 'spawn' multiprocessing needs some adjustments on osx
-if _platform == 'darwin':
-    import sys
+if (sys.platform == 'darwin' or sys.platform == 'linux') and sys.version_info >= (3, 4):
     import os
     import re
     import multiprocessing
@@ -32,16 +31,17 @@ if _platform == 'darwin':
 
     multiprocessing.freeze_support = spawn.freeze_support = _freeze_support
 
-    # Module multiprocessing is organized differently in Python 3.4+
-    try:
-        # Python 3.4+
-        if sys.platform.startswith('win'):
-            import multiprocessing.popen_spawn_win32 as forking
-        else:
-            import multiprocessing.popen_fork as forking
-    except ImportError:
-        import multiprocessing.forking as forking
+# Module multiprocessing is organized differently in Python 3.4+
+try:
+    # Python 3.4+
+    if sys.platform.startswith('win'):
+        import multiprocessing.popen_spawn_win32 as forking
+    else:
+        import multiprocessing.popen_fork as forking
+except ImportError:
+    import multiprocessing.forking as forking
 
+if sys.platform.startswith('win'):
     # First define a modified version of Popen.
     class _Popen(forking.Popen):
         def __init__(self, *args, **kw):

--- a/PyInstaller/loader/rthooks/pyi_rth_multiprocessing.py
+++ b/PyInstaller/loader/rthooks/pyi_rth_multiprocessing.py
@@ -31,6 +31,11 @@ if (sys.platform == 'darwin' or sys.platform == 'linux') and sys.version_info >=
 
     multiprocessing.freeze_support = spawn.freeze_support = _freeze_support
 
+# Bootloader unsets _MEIPASS2 for child processes to allow running
+# PyInstaller binaries inside pyinstaller binaries.
+# This is ok for mac or unix with fork() system call.
+# But on Windows we need to overcome missing fork() function.
+
 # Module multiprocessing is organized differently in Python 3.4+
 try:
     # Python 3.4+

--- a/tests/functional/scripts/pyi_multiprocess.py
+++ b/tests/functional/scripts/pyi_multiprocess.py
@@ -7,16 +7,6 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-
-# Bootloader unsets _MEIPASS2 for child processes to allow running
-# PyInstaller binaries inside pyinstaller binaries.
-# This is ok for mac or unix with fork() system call.
-# But on Windows we need to overcome missing fork() fuction for onefile
-# mode.
-#
-# See http://www.pyinstaller.org/wiki/Recipe/Multiprocessing
-
-
 import multiprocessing
 import sys
 

--- a/tests/functional/scripts/pyi_multiprocess_forking.py
+++ b/tests/functional/scripts/pyi_multiprocess_forking.py
@@ -7,58 +7,11 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-
-# Bootloader unsets _MEIPASS2 for child processes to allow running
-# PyInstaller binaries inside pyinstaller binaries.
-# This is ok for mac or unix with fork() system call.
-# But on Windows we need to overcome missing fork() fuction.
-#
-# See http://www.pyinstaller.org/wiki/Recipe/Multiprocessing
-
-
-import os
-
 import sys
 import multiprocessing
 
-# Module multiprocessing is organized differently in Python 3.4+
-try:
-    # Python 3.4+
-    if sys.platform.startswith('win'):
-        import multiprocessing.popen_spawn_win32 as forking
-    else:
-        import multiprocessing.popen_fork as forking
-except ImportError:
-    import multiprocessing.forking as forking
 
-
-class _Popen(forking.Popen):
-    def __init__(self, *args, **kw):
-        if hasattr(sys, 'frozen'):
-            # We have to set original _MEIPASS2 value from sys._MEIPASS
-            # to get --onefile mode working.
-            # Last character is stripped in C-loader. We have to add
-            # '/' or '\\' at the end.
-            os.putenv('_MEIPASS2', sys._MEIPASS + os.sep)
-        try:
-            super(_Popen, self).__init__(*args, **kw)
-        finally:
-            if hasattr(sys, 'frozen'):
-                # On some platforms (e.g. AIX) 'os.unsetenv()' is not
-                # available. In those cases we cannot delete the variable
-                # but only set it to the empty string. The bootloader
-                # can handle this case.
-                if hasattr(os, 'unsetenv'):
-                    os.unsetenv('_MEIPASS2')
-                else:
-                    os.putenv('_MEIPASS2', '')
-
-
-class Process(multiprocessing.Process):
-    _Popen = _Popen
-
-
-class SendeventProcess(Process):
+class SendeventProcess(multiprocessing.Process):
     def __init__(self, resultQueue):
         self.resultQueue = resultQueue
 

--- a/tests/functional/scripts/pyi_multiprocess_pool.py
+++ b/tests/functional/scripts/pyi_multiprocess_pool.py
@@ -7,57 +7,10 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-
-# Bootloader unsets _MEIPASS2 for child processes to allow running
-# PyInstaller binaries inside pyinstaller binaries.
-# This is ok for mac or unix with fork() system call.
-# But on Windows we need to overcome missing fork() fuction.
-#
-# See http://www.pyinstaller.org/wiki/Recipe/Multiprocessing
-
-import os
-import sys
-
-# Module multiprocessing is organized differently in Python 3.4+
-try:
-    # Python 3.4+
-    if sys.platform.startswith('win'):
-        import multiprocessing.popen_spawn_win32 as forking
-    else:
-        import multiprocessing.popen_fork as forking
-except ImportError:
-    import multiprocessing.forking as forking
-
-
-if sys.platform.startswith('win'):
-    # First define a modified version of Popen.
-    class _Popen(forking.Popen):
-        def __init__(self, *args, **kw):
-            if hasattr(sys, 'frozen'):
-                # We have to set original _MEIPASS2 value from sys._MEIPASS
-                # to get --onefile mode working.
-                os.putenv('_MEIPASS2', sys._MEIPASS)
-            try:
-                super(_Popen, self).__init__(*args, **kw)
-            finally:
-                if hasattr(sys, 'frozen'):
-                    # On some platforms (e.g. AIX) 'os.unsetenv()' is not
-                    # available. In those cases we cannot delete the variable
-                    # but only set it to the empty string. The bootloader
-                    # can handle this case.
-                    if hasattr(os, 'unsetenv'):
-                        os.unsetenv('_MEIPASS2')
-                    else:
-                        os.putenv('_MEIPASS2', '')
-
-    # Second override 'Popen' class with our modified version.
-    forking.Popen = _Popen
-
-
 import multiprocessing
 
 
-def  f(x):
+def f(x):
     return x*x
 
 

--- a/tests/functional/test_basic.py
+++ b/tests/functional/test_basic.py
@@ -205,7 +205,6 @@ def test_multiprocess(pyi_builder):
     pyi_builder.test_script('pyi_multiprocess.py')
 
 
-@xfail(is_darwin, reason="Pull Request #2505")
 @importorskip('multiprocessing')
 def test_multiprocess_forking(pyi_builder):
     pyi_builder.test_script('pyi_multiprocess_forking.py')

--- a/tests/functional/test_basic.py
+++ b/tests/functional/test_basic.py
@@ -196,25 +196,6 @@ def test_module_reload(pyi_builder):
     pyi_builder.test_script('pyi_module_reload.py')
 
 
-# TODO move 'multiprocessig' tests into 'test_multiprocess.py.
-
-
-@skipif_win(reason="Issue #2116")
-@importorskip('multiprocessing')
-def test_multiprocess(pyi_builder):
-    pyi_builder.test_script('pyi_multiprocess.py')
-
-
-@importorskip('multiprocessing')
-def test_multiprocess_forking(pyi_builder):
-    pyi_builder.test_script('pyi_multiprocess_forking.py')
-
-
-@importorskip('multiprocessing')
-def test_multiprocess_pool(pyi_builder):
-    pyi_builder.test_script('pyi_multiprocess_pool.py')
-
-
 # TODO test it on OS X.
 @skipif_no_compiler
 def test_load_dll_using_ctypes(monkeypatch, pyi_builder, compiled_dylib):

--- a/tests/functional/test_multiprocess.py
+++ b/tests/functional/test_multiprocess.py
@@ -10,6 +10,7 @@
 
 # Library imports
 # ---------------
+import os
 import sys
 
 # Local imports
@@ -63,7 +64,7 @@ def test_multiprocess_spawn(pyi_builder, capfd):
 
     expected = ["In main", "In subprocess"]
 
-    assert "\n".join(expected) in out
+    assert os.linesep.join(expected) in out
     for substring in expected:
         assert out.count(substring) == 1
 

--- a/tests/functional/test_multiprocess.py
+++ b/tests/functional/test_multiprocess.py
@@ -38,6 +38,8 @@ def test_multiprocess_pool(pyi_builder):
 @importorskip('multiprocessing')
 def test_multiprocess_spawn(pyi_builder, capfd):
     pyi_builder.test_source("""
+        import sys 
+
         from multiprocessing import set_start_method, Process
         from multiprocessing import freeze_support
         from multiprocessing.util import log_to_stderr
@@ -51,6 +53,7 @@ def test_multiprocess_spawn(pyi_builder, capfd):
             set_start_method('spawn')
 
             print('In main')
+            sys.stdout.flush()
             proc = Process(target=test)
             proc.start()
             proc.join()

--- a/tests/functional/test_multiprocess.py
+++ b/tests/functional/test_multiprocess.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+# ----------------------------------------------------------------------------
+# Copyright (c) 2005-2017, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+# ----------------------------------------------------------------------------
+
+# Library imports
+# ---------------
+import sys
+
+# Local imports
+# -------------
+from PyInstaller.compat import is_py34
+from PyInstaller.utils.tests import importorskip, skipif
+
+
+@importorskip('multiprocessing')
+def test_multiprocess(pyi_builder):
+    pyi_builder.test_script('pyi_multiprocess.py')
+
+
+@importorskip('multiprocessing')
+def test_multiprocess_forking(pyi_builder):
+    pyi_builder.test_script('pyi_multiprocess_forking.py')
+
+
+@importorskip('multiprocessing')
+def test_multiprocess_pool(pyi_builder):
+    pyi_builder.test_script('pyi_multiprocess_pool.py')
+
+
+@skipif(not is_py34, reason='Spawn was introduced in python 3.4+')
+@importorskip('multiprocessing')
+def test_multiprocess_spawn(pyi_builder, capfd):
+    pyi_builder.test_source("""
+        from multiprocessing import set_start_method, Process
+        from multiprocessing import freeze_support
+        from multiprocessing.util import log_to_stderr
+
+        def test():
+            print('In subprocess')
+
+        if __name__ == '__main__':
+            log_to_stderr()
+            freeze_support()
+            set_start_method('spawn')
+
+            print('In main')
+            proc = Process(target=test)
+            proc.start()
+            proc.join()
+        """)
+
+    out, err = capfd.readouterr()
+
+    # Print the captured output and error so that it will show up in the test output.
+    sys.stderr.write(err)
+    sys.stdout.write(out)
+
+    expected = ["In main", "In subprocess"]
+
+    assert "\n".join(expected) in out
+    for substring in expected:
+        assert out.count(substring) == 1
+

--- a/tests/functional/test_runtime.py
+++ b/tests/functional/test_runtime.py
@@ -22,38 +22,3 @@ def test_ctypes_cdll_unknown_dll(pyi_builder, capfd):
             """)
     out, err = capfd.readouterr()
     assert "Failed to load dynlib/dll" in err
-
-
-@skipif_notosx
-@xfail_py2
-def test_issue_2322(pyi_builder, capfd):
-    pyi_builder.test_source("""
-        from multiprocessing import set_start_method, Process
-        from multiprocessing import freeze_support
-        from multiprocessing.util import log_to_stderr
-
-        def test():
-            print('In subprocess')
-
-        if __name__ == '__main__':
-            log_to_stderr()
-            freeze_support()
-            set_start_method('spawn')
-
-            print('In main')
-            proc = Process(target=test)
-            proc.start()
-            proc.join()
-        """)
-
-    out, err = capfd.readouterr()
-
-    # Print the captured output and error so that it will show up in the test output.
-    sys.stderr.write(err)
-    sys.stdout.write(out)
-
-    expected = ["In main", "In subprocess"]
-
-    assert "\n".join(expected) in out
-    for substring in expected:
-        assert out.count(substring) == 1

--- a/tests/requirements-tools.txt
+++ b/tests/requirements-tools.txt
@@ -8,4 +8,5 @@ pytest-timeout   # Plugin to abort hanging tests.
 pytest-catchlog  # Capture log output separately from stdout/stderr
 pytest-drop-dup-tests # allows specifying order without duplicates
 
-psutil  # Better subprocess alternative with implemented timeout.
+# psutil 5.3.0 caused intermittent issues with the AppVeyor tests
+psutil < 5.3.0 # Better subprocess alternative with implemented timeout.


### PR DESCRIPTION
I have tested this as best I can with Travis and AppVeyor. All multiprocessing tests pass with these changes but I would appreciate real world testing. Pinging @mkassner, @bpteague, @simongus, @willpatera, @xoviat, and @htgoebel for testing.