### PR TITLE
Fix #2633: Resolve library name reported by usb.backend in hook-usb

### DIFF
--- a/PyInstaller/hooks/hook-usb.py
+++ b/PyInstaller/hooks/hook-usb.py
@@ -47,6 +47,7 @@ try:
 except (ValueError, usb.core.USBError) as exc:
     logger.warning("%s", exc)
 
+
 # if nothing found, try to use our custom mechanism
 if not binaries:
     # Try to resolve your libusb libraries in the following order:

--- a/PyInstaller/hooks/hook-usb.py
+++ b/PyInstaller/hooks/hook-usb.py
@@ -40,11 +40,12 @@ try:
     binaries = []
     for usblib in [getattr(usb.backend, be)._lib for be in backends]:
         if usblib is not None:
-            binaries = [(usblib._name, '')]
+            binaries = _resolveCtypesImports([os.path.basename(usblib._name)])
+            assert len(binaries[0]) == 3
+            binaries = [(binaries[0][1], '')]
 
 except (ValueError, usb.core.USBError) as exc:
     logger.warning("%s", exc)
-
 
 # if nothing found, try to use our custom mechanism
 if not binaries:


### PR DESCRIPTION
`hook-usb.py` "asks" pyusb which library to pack by inspecting `usb.backend`. This only result in a library name (e.g `libusb-1.0.so.0`), which is sufficient for `ctypes` to load the library, but not enough for pyinstaller to find the file and pack it.
This fix solves this problem by using `_resolveCtypesImports` to figure out the full path to the file pyusb loads.