### PR TITLE
Updated link to the pyinstaller manual

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -159,5 +159,5 @@ or simply use it directly from the source (pyinstaller.py).
 
 
 .. _PyCrypto: https://www.dlitz.net/software/pycrypto/
-.. _`manual`: https://pyinstaller.rtfd.io/en/latest/
+.. _`manual`: https://pyinstaller.readthedocs.io/en/latest/
 


### PR DESCRIPTION
The old link gave a warning because the certificate is not valid for the old domain.