### PR TITLE
Hooks: Add hooks for PySide.phonon and PySide.QtSql

### DIFF
--- a/PyInstaller/hooks/hook-PySide.QtSql.py
+++ b/PyInstaller/hooks/hook-PySide.QtSql.py
@@ -1,0 +1,14 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2017, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import qt_plugins_binaries
+
+hiddenimports = ['PySide.QtCore']
+
+binaries = qt_plugins_binaries('sqldrivers', namespace='PySide')

--- a/PyInstaller/hooks/hook-PySide.phonon.py
+++ b/PyInstaller/hooks/hook-PySide.phonon.py
@@ -1,0 +1,14 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2017, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import qt_plugins_binaries
+
+hiddenimports = ['PySide.QtGui']
+
+binaries = qt_plugins_binaries('phonon_backend', namespace='PySide')


### PR DESCRIPTION
Current PySide hooks properly include both QtSql and Phonon dll and pyd files, but plugins for sql drivers and phonon backends are missing. These additonal hooks fix the problem.