### PR TITLE
Fix accessible_output, sound_lib hooks.

### DIFF
--- a/PyInstaller/hooks/hook-accessible_output2.py
+++ b/PyInstaller/hooks/hook-accessible_output2.py
@@ -11,6 +11,6 @@
 accessible_output2: http://hg.q-continuum.net/accessible_output2
 """
 
-from pyinstaller.utils.hooks import collect_dynamic_libs
+from PyInstaller.utils.hooks import collect_dynamic_libs
 
 binaries = collect_dynamic_libs('accessible_output2')

--- a/PyInstaller/hooks/hook-sound_lib.py
+++ b/PyInstaller/hooks/hook-sound_lib.py
@@ -11,6 +11,6 @@
 sound_lib: http://hg.q-continuum.net/sound_lib
 """
 
-from pyinstaller.utils.hooks import collect_dynamic_libs
+from PyInstaller.utils.hooks import collect_dynamic_libs
 
 binaries = collect_dynamic_libs('sound_lib')


### PR DESCRIPTION
This pull request fixes hooks for @CToth libraries (accessible_output and sound_lib) by importing from `PyInstaller` instead of `pyinstaller`.