### PR TITLE
freebsd: fix bootloader install, fixes #2861

### DIFF
--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -44,6 +44,7 @@ variants = {
 # map waf's DEST_OS to these values.
 DESTOS_TO_SYSTEM = {
     'linux': 'Linux',
+    'freebsd': 'FreeBSD',
     'win32': 'Windows',
     'darwin': 'Darwin',
     'sunos': platform.system(), ## FIXME: inhibits cross-compile
@@ -54,6 +55,7 @@ DESTOS_TO_SYSTEM = {
 # Map from platform.system() to waf's DEST_OS
 SYSTEM_TO_BUILDOS = {
     'Linux': 'linux',
+    'FreeBSD': 'freebsd',
     'Windows': 'win32',
     'Darwin': 'darwin',
     'Solaris': 'sunos',


### PR DESCRIPTION
"python setup.py install" failed due to missing translation map entries.

works, tested within the freebsd 64bit borgbackup build.

can we have a v3.3-maint branch (to later create 3.3.n from)?