### PR TITLE
Hooks: Add hook for unidecode

### DIFF
--- a/PyInstaller/hooks/hook-unidecode.py
+++ b/PyInstaller/hooks/hook-unidecode.py
@@ -1,0 +1,18 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2017, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+
+# Hook for the unidecode package: https://pypi.python.org/pypi/unidecode
+# Tested with Unidecode 0.4.21 and Python 3.6.2, on Windows 10 x64.
+
+from PyInstaller.utils.hooks import collect_submodules
+
+# Unidecode dynamically imports modules with relevant character mappings.
+# Non-ASCII characters are ignored if the mapping files are not found.
+hiddenimports = collect_submodules('unidecode')

--- a/tests/functional/test_libraries.py
+++ b/tests/functional/test_libraries.py
@@ -812,3 +812,13 @@ def test_h5py(pyi_builder):
     pyi_builder.test_source("""
         import h5py
         """)
+
+
+@importorskip('unidecode')
+def test_unidecode(pyi_builder):
+    pyi_builder.test_source("""
+        from unidecode import unidecode
+
+        # Unidecode should not skip non-ASCII chars if mappings for them exist.
+        assert unidecode(u"kožušček") == "kozuscek"
+        """)

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -55,6 +55,7 @@ pycryptodomex==3.4.7
 future==0.16.0
 pyusb==1.0.0
 requests==2.15.1 # Newest version of requests that allows tests to pass
+Unidecode==0.4.21
 
 # Install wheels only on OS X and Win 32, no wheel for Py 3.6 yet.
 pyenchant==1.6.11; (sys_platform == 'darwin' or sys_platform == 'win32') and python_version <= '3.5'


### PR DESCRIPTION
This should fix `unidecode ` ignoring non-ASCII characters when frozen (see e,g. SO threads [here](https://stackoverflow.com/questions/30919966/unidecode-inconsistent-behavior-when-using-pyinstaller) and [here](https://stackoverflow.com/questions/25184178/using-pyinstaller-on-a-script-the-imports-unidecode)). 

Urgh, sorry - I see CI is not happy on 2.7. I'll check in the afternoon.