### PR TITLE
Regards architecture for aarch64 platform

### DIFF
--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -265,6 +265,8 @@ def machine():
     mach = platform.machine()
     if mach.startswith('arm'):
         return 'arm'
+    elif mach.startswith('aarch'):
+        return 'aarch'
     else:
         # Assume x86/x86_64 machine.
         return None


### PR DESCRIPTION
https://github.com/pyinstaller/pyinstaller/issues/2849

Currently the aarch64 machines use `Linux-64bit` to run Pyinstaller. It should regard the architecture as well to run Pyinstaller.