### PR TITLE
doc: update runtime information

### DIFF
--- a/doc/runtime-information.rst
+++ b/doc/runtime-information.rst
@@ -5,8 +5,8 @@ Run-time Information
 
 Your app should run in a bundle exactly as it does when run from source.
 However, you may want to learn at run-time whether the app is running from
-source or whether it is bundled. You can use the following code to check "are
-we bundled?"::
+source or whether it is bundled ("frozen"). You can use the following code to
+check "are we bundled?"::
 
     import sys
     if getattr(sys, 'frozen') and hasattr(sys, '_MEIPASS'):

--- a/doc/runtime-information.rst
+++ b/doc/runtime-information.rst
@@ -101,18 +101,18 @@ symbolic link::
 	#!/usr/bin/python3
 	import sys, os
 	frozen = 'not'
-	if getattr(sys, 'frozen'):
+	if getattr(sys, 'frozen', False):
 		# we are running in a bundle
 		frozen = 'ever so'
 		bundle_dir = sys._MEIPASS
 	else:
 		# we are running in a normal Python environment
 		bundle_dir = os.path.dirname(os.path.abspath(__file__))
-	print('we are', frozen, 'frozen')
-	print('bundle dir is', bundle_dir)
-	print('sys.argv[0] is', sys.argv[0])
-	print('sys.executable is', sys.executable)
-	print('os.getcwd is', os.getcwd())
+	print( 'we are',frozen,'frozen')
+	print( 'bundle dir is', bundle_dir )
+	print( 'sys.argv[0] is', sys.argv[0] )
+	print( 'sys.executable is', sys.executable )
+	print( 'os.getcwd is', os.getcwd() )
 
 
 

--- a/doc/runtime-information.rst
+++ b/doc/runtime-information.rst
@@ -4,46 +4,60 @@ Run-time Information
 =====================
 
 Your app should run in a bundle exactly as it does when run from source.
-However, you may need to learn at run-time
-whether the app is running from source, or is "frozen" (bundled).
-For example, you might have
-data files that are normally found based on a module's ``__file__`` attribute.
-That will not work when the code is bundled.
+However, you may want to learn at run-time whether the app is running from
+source or whether it is bundled. You can use the following code to check "are
+we bundled?"::
 
-The |PyInstaller| |bootloader| adds the name ``frozen`` to the ``sys`` module.
-So the test for "are we bundled?" is::
+    import sys
+    if getattr(sys, 'frozen') and hasattr(sys, '_MEIPASS'):
+        print('running in a PyInstaller bundle')
+    else:
+        print('running in a normal Python process')
 
-	import sys
-	if getattr( sys, 'frozen', False ) :
-		# running in a bundle
-	else :
-		# running live
+When a bundled app starts up, the |bootloader| sets the ``sys.frozen``
+attribute and stores the absolute path to the bundle folder in
+``sys._MEIPASS``. For a one-folder bundle, this is the path to that folder. For
+a one-file bundle, this is the path to the temporary folder created by the
+|bootloader| (see :ref:`How the One-File Program Works`).
 
-When your app is running, it may need to access data files in any of
-three general locations:
+When your app is running, it may need to access data files in one of the
+following locations:
 
 * Files that were bundled with it (see :ref:`Adding Data Files`).
-
 * Files the user has placed with the app bundle, say in the same folder.
-
 * Files in the user's current working directory.
 
-The program has access to several path variables for these uses.
+The program has access to several variables for these uses.
 
 
-Using ``__file__`` and ``sys._MEIPASS``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Using ``__file__``
+~~~~~~~~~~~~~~~~~~
 
-When your program is not frozen, the standard Python
-variable ``__file__`` is the full path to the script now executing.
-When a bundled app starts up,
-the |bootloader| sets the ``sys.frozen`` attribute
-and stores the absolute path to the bundle folder in ``sys._MEIPASS``.
-For a one-folder bundle, this is the path to that folder, 
-wherever the user may have put it.
-For a one-file bundle, this is the path to the :file:`_MEI{xxxxxx}`
-temporary folder
-created by the |bootloader| (see :ref:`How the One-File Program Works`).
+When your program is not bundled, the Python variable ``__file__`` refers to
+the current path of the module it is contained in. When importing a module
+from a bundled script, the |PyInstaller| |bootloader| will set the module's
+``__file__`` attribute to the correct path relative to the bundle folder.
+
+For example, if you import ``mypackage.mymodule`` from a bundled script, then
+the ``__file__`` attribute of that module will be ``sys._MEIPASS +
+'mypackage/mymodule.pyc'``.  So if you have a data file at
+``mypackage/file.dat`` that you added to the bundle at ``mypackage/file.dat``,
+the following code will get its path (in both the non-bundled and the bundled
+case)::
+
+    from os import path
+    path_to_dat = path.join(path.dirname(__file__), 'file.dat')
+
+In the bundled main script itself the above might not work, as it is unclear
+where it resides in the package hierarchy. So in when trying to find data files
+relative to the main script, ``sys._MEIPASS`` can be used. The following will
+get the path to a file ``other-file.dat`` next to the main script if not
+bundled and in the bundle folder if it is bundled::
+
+    from os import path
+    import sys
+    bundle_dir = getattr(sys, '_MEIPASS', path.abspath(path.dirname(__file__)))
+    path_to_dat = path.join(bundle_dir, 'other-file.dat')
 
 
 Using ``sys.executable`` and ``sys.argv[0]``
@@ -87,18 +101,18 @@ symbolic link::
 	#!/usr/bin/python3
 	import sys, os
 	frozen = 'not'
-	if getattr(sys, 'frozen', False):
+	if getattr(sys, 'frozen'):
 		# we are running in a bundle
 		frozen = 'ever so'
 		bundle_dir = sys._MEIPASS
 	else:
 		# we are running in a normal Python environment
 		bundle_dir = os.path.dirname(os.path.abspath(__file__))
-	print( 'we are',frozen,'frozen')
-	print( 'bundle dir is', bundle_dir )
-	print( 'sys.argv[0] is', sys.argv[0] )
-	print( 'sys.executable is', sys.executable )
-	print( 'os.getcwd is', os.getcwd() )
+	print('we are', frozen, 'frozen')
+	print('bundle dir is', bundle_dir)
+	print('sys.argv[0] is', sys.argv[0])
+	print('sys.executable is', sys.executable)
+	print('os.getcwd is', os.getcwd())
 
 
 


### PR DESCRIPTION
Just checking `sys.frozen` is not enough to check if a program is
running from PyInstaller - some other Python packages also seem to set
this.

Mention that in most cases `__file__` can be used from a bundled app as
one usually does. Also mention that this does not work from the main
script as it doesn't know where it lives in the module hierarchy.

Fix #2882