### PR TITLE
bootloader: use waitpid instead of wait

### DIFF
--- a/bootloader/src/pyi_utils.c
+++ b/bootloader/src/pyi_utils.c
@@ -907,7 +907,7 @@ pyi_utils_create_child(const char *thisfile, const int argc, char *const argv[])
         signal(SIGTERM, &_signal_handler);
     }
 
-    wait(&rc);
+    waitpid(child_pid, &rc, 0);
 
     /* Parent code. */
     if (child_pid != 0) {


### PR DESCRIPTION
On Linux, `wait` is used to wait for child process to exit. However, as stated in the manual:

```
The call wait(&status) is equivalent to:

           waitpid(-1, &status, 0);

```

Doing so works fine in most cases, but when the child process itself plays with `switch_root`, it seems to signal the parent process, consequently leaving the function before its child has exited.

It will then delete the previously extracted files, and so create a race condition (the child might not have loaded all its libraries yet).

Using `waitpid` ensures that the child process that we just created has finished.

