### PR TITLE
compat: Support 64-bit ARM Linux (aarch64)

### DIFF
--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -265,6 +265,8 @@ def machine():
     mach = platform.machine()
     if mach.startswith('arm'):
         return 'arm'
+    elif mach.startswith('aarch'):
+        return 'aarch'
     else:
         # Assume x86/x86_64 machine.
         return None


### PR DESCRIPTION
Make use of the aarch64 bootloader enabled by the following patch:

    commit 2d5898c41efed11272790e96f478451ea36d64d6
    Author: Bharath Upadhya <1992bharath@gmail.com>
    Date:   Wed Sep 6 18:57:44 2017 +0530

    Build bootloader: wscript: for 64-bit arm/aarch linux ignore -m64 flag

Signed-off-by: Aaron Sierra <asierra@xes-inc.com>