### PR TITLE
Hooks: Add hook-pandas.py to fix issue #2978.

### DIFF
--- a/PyInstaller/hooks/hook-pandas.py
+++ b/PyInstaller/hooks/hook-pandas.py
@@ -1,0 +1,17 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2017, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+
+"""
+Fixes issue #2978 with pandas version 0.21
+(Pandas missing `pandas._libs.tslibs.timedeltas.so`)
+"""
+
+
+hiddenimports = ['pandas._libs.tslibs.timedeltas']


### PR DESCRIPTION
pandas>=0.21 has a hidden import of "pandas._libs.tslibs.timedeltas.so".