### PR TITLE
Fake timestamp in pyc-header

### DIFF
--- a/PyInstaller/archive/writers.py
+++ b/PyInstaller/archive/writers.py
@@ -28,7 +28,8 @@ from types import CodeType
 import marshal
 import zlib
 
-from PyInstaller.building.utils import get_code_object, strip_paths_in_code
+from PyInstaller.building.utils import get_code_object, strip_paths_in_code,\
+    fake_pyc_timestamp
 from .readers import PYZ_TYPE_MODULE, PYZ_TYPE_PKG, PYZ_TYPE_DATA
 from ..compat import BYTECODE_MAGIC, is_py2
 
@@ -393,10 +394,15 @@ class CArchiveWriter(ArchiveWriter):
                 self.lib.write(comprobj.compress(code_data))
             else:
                 assert fh
+                # We only want to change it for pyc files
+                modify_header = typcd in ('M', 'm', 's')
                 while 1:
                     buf = fh.read(16*1024)
                     if not buf:
                         break
+                    if modify_header:
+                        modify_header = False
+                        buf = fake_pyc_timestamp(buf)
                     self.lib.write(comprobj.compress(buf))
             self.lib.write(comprobj.flush())
 

--- a/PyInstaller/building/utils.py
+++ b/PyInstaller/building/utils.py
@@ -26,7 +26,7 @@ import struct
 from PyInstaller.config import CONF
 from .. import compat
 from ..compat import is_darwin, is_win, EXTENSION_SUFFIXES, \
-    FileNotFoundError, open_file, is_py3, py37
+    FileNotFoundError, open_file, is_py3, is_py37
 from ..depend import dylib
 from ..depend.bindepend import match_binding_redirect
 from ..utils import misc

--- a/PyInstaller/building/utils.py
+++ b/PyInstaller/building/utils.py
@@ -26,7 +26,7 @@ import struct
 from PyInstaller.config import CONF
 from .. import compat
 from ..compat import is_darwin, is_win, EXTENSION_SUFFIXES, \
-    FileNotFoundError, open_file, is_py3
+    FileNotFoundError, open_file, is_py3, py37
 from ..depend import dylib
 from ..depend.bindepend import match_binding_redirect
 from ..utils import misc
@@ -656,7 +656,7 @@ def fake_pyc_timestamp(buf):
     assert buf[:4] == compat.BYTECODE_MAGIC, \
         "Expected pyc magic {}, got {}".format(compat.BYTECODE_MAGIC, buf[:4])
     start, end = 4, 8
-    if False and compat.py_37:  # TODO py_37 Python 3.7
+    if compat.py_37:
         # see https://www.python.org/dev/peps/pep-0552/
         (flags,) = struct.unpack_from(">I", buf, 4)
         if flags & 1:

--- a/PyInstaller/building/utils.py
+++ b/PyInstaller/building/utils.py
@@ -21,6 +21,8 @@ import platform
 import shutil
 import sys
 
+import struct
+
 from PyInstaller.config import CONF
 from .. import compat
 from ..compat import is_darwin, is_win, EXTENSION_SUFFIXES, \
@@ -640,3 +642,31 @@ def strip_paths_in_code(co, new_filename=None):
                      co.co_varnames, new_filename, co.co_name,
                      co.co_firstlineno, co.co_lnotab,
                      co.co_freevars, co.co_cellvars)
+
+
+def fake_pyc_timestamp(buf):
+    """
+    Reset the timestamp from a .pyc-file header to a fixed value.
+
+    This enables deterministic builds without having to set pyinstaller
+    source metadata (mtime) since that changes the pyc-file contents.
+
+    _buf_ must at least contain the full pyc-file header.
+    """
+    assert buf[:4] == compat.BYTECODE_MAGIC, \
+        "Expected pyc magic {}, got {}".format(compat.BYTECODE_MAGIC, buf[:4])
+    start, end = 4, 8
+    if False and compat.py_37:  # TODO py_37 Python 3.7
+        # see https://www.python.org/dev/peps/pep-0552/
+        (flags,) = struct.unpack_from(">I", buf, 4)
+        if flags & 1:
+            # We are in the future and hash-based pyc-files are used, so
+            # clear "check_source" flag, since there is no source
+            buf[4:8] = struct.pack(">I", flags ^ 2)
+            return buf
+        else:
+            # no hash-based pyc-file, timestamp is the next field
+            start, end = 8, 12
+
+    ts = b'pyi0'  # So people know where this comes from
+    return buf[:start] + ts + buf[end:]

--- a/PyInstaller/building/utils.py
+++ b/PyInstaller/building/utils.py
@@ -656,7 +656,7 @@ def fake_pyc_timestamp(buf):
     assert buf[:4] == compat.BYTECODE_MAGIC, \
         "Expected pyc magic {}, got {}".format(compat.BYTECODE_MAGIC, buf[:4])
     start, end = 4, 8
-    if compat.py_37:
+    if is_py37:
         # see https://www.python.org/dev/peps/pep-0552/
         (flags,) = struct.unpack_from(">I", buf, 4)
         if flags & 1:


### PR DESCRIPTION
Directly bundling pyc-files makes the build output dependent on the modification time of pyinstaller source files. This change removes that relation and re-enables deterministic builds.

I didn't find a better place to add this than here. We need low-level access to the file to change the header so it can't be done after compressing it.

PEP552 actually made this a bit harder as it changed the pyc-header format. Since we don't know the magic number for the outstanding release that adds PEP552 support, I checked for the presence of the bit-field instead:

> The pyc header currently consists of 3 32-bit words. We will expand it to 4. The first word will continue to be the magic number, versioning the bytecode and pyc format. The second word, conceptually the new word, will be a bit field. The interpretation of the rest of the header and invalidation behavior of the pyc depends on the contents of the bit field.

Basically, there are three possible pyc file headers:

    magic | timestamp                        | size               (old style)
    magic | 00000000000000000000000000000000 | timestamp | size   (new style)
    magic | 00000000000000000000000000000001 | hash      | size   (new style)

Since the bit-field is either 0 or 1 we can just check if that's the content of the second word to find out if this a new-style header. Of course this misses an edge-case where the pyinstaller files were last changed on 01/01/1970 around midnight but I guess we can ignore that.

-----

Closes: #3000 