### PR TITLE
Clarify differences when specifying a spec file vs a script file to P…

### DIFF
--- a/PyInstaller/__main__.py
+++ b/PyInstaller/__main__.py
@@ -70,8 +70,7 @@ def run(pyi_args=None, pyi_config=None):
         PyInstaller.log.__add_options(parser)
         parser.add_argument('filenames', metavar='scriptname', nargs='+',
                             help=("name of scriptfiles to be processed or "
-                                  "exactly one .spec-file. If a .spec-file is "
-                                  "specified, most options are unnecessary and ignored."))
+                                  "exactly one .spec-file"))
 
         args = parser.parse_args(pyi_args)
         PyInstaller.log.__process_options(parser, args)

--- a/PyInstaller/__main__.py
+++ b/PyInstaller/__main__.py
@@ -70,7 +70,8 @@ def run(pyi_args=None, pyi_config=None):
         PyInstaller.log.__add_options(parser)
         parser.add_argument('filenames', metavar='scriptname', nargs='+',
                             help=("name of scriptfiles to be processed or "
-                                  "exactly one .spec-file"))
+                                  "exactly one .spec-file. If a .spec-file is "
+                                  "specified, most options are unnecessary and ignored."))
 
         args = parser.parse_args(pyi_args)
         PyInstaller.log.__process_options(parser, args)

--- a/PyInstaller/__main__.py
+++ b/PyInstaller/__main__.py
@@ -70,7 +70,8 @@ def run(pyi_args=None, pyi_config=None):
         PyInstaller.log.__add_options(parser)
         parser.add_argument('filenames', metavar='scriptname', nargs='+',
                             help=("name of scriptfiles to be processed or "
-                                  "exactly one .spec-file"))
+                                   "exactly one .spec-file. If a .spec-file is "
+                                   "specified, most options are unnecessary and ignored."))
 
         args = parser.parse_args(pyi_args)
         PyInstaller.log.__process_options(parser, args)

--- a/doc/pyinstaller.1
+++ b/doc/pyinstaller.1
@@ -39,8 +39,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .sp
 Automatically calls pyi\-configure, pyi\-makespec and pyi\-build in one
 run. In most cases, running \fBpyinstaller\fP will be all you have to
-do. If an existing spec-file is provided instead of SCRIPT, most options
-are unnecessary and will be ignored.
+do.
 .sp
 Please see the PyInstaller Manual for more information.
 .SH OPTIONS

--- a/doc/pyinstaller.1
+++ b/doc/pyinstaller.1
@@ -39,7 +39,8 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .sp
 Automatically calls pyi\-configure, pyi\-makespec and pyi\-build in one
 run. In most cases, running \fBpyinstaller\fP will be all you have to
-do.
+do. If an existing spec-file is provided instead of SCRIPT, most options
+are unnecessary and will be ignored.
 .sp
 Please see the PyInstaller Manual for more information.
 .SH OPTIONS

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -37,6 +37,18 @@ After you do this, you name the spec file to |PyInstaller| instead of the script
 
     ``pyinstaller myscript.spec``
 
+The :file:`myscript.spec` file contains most of the information provided by the options that were specified
+when ``pyinstaller`` (or ``pyi-makespec``) was run with the script file as the argument.
+You typically do not need to specify any options when running ``pyinstaller`` with the spec file.
+Only the following command-line options (described below) have an effect when building from a spec file:
+
+* ``--upx-dir=``
+* ``--distpath=``
+* ``--workpath=``
+* ``--noconfirm``
+* ``--ascii``
+* ``--clean``
+
 You may give a path to the script or spec file, for example
 
     ``pyinstaller`` `options...` ``~/myproject/source/myscript.py``
@@ -75,7 +87,7 @@ For example, in Linux::
         --hidden-import=secret1 \
         --hidden-import=secret2 \
         --upx-dir=/usr/local/share/ \
-        myscript.spec
+        myscript.py
 
 Or in Windows, use the little-known BAT file line continuation::
 
@@ -87,7 +99,7 @@ Or in Windows, use the little-known BAT file line continuation::
         --hidden-import=secret1 ^
         --hidden-import=secret2 ^
         --icon=..\MLNMFLCN.ICO ^
-        myscript.spec
+        myscript.py
 
 
 Using UPX

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -37,18 +37,6 @@ After you do this, you name the spec file to |PyInstaller| instead of the script
 
     ``pyinstaller myscript.spec``
 
-The :file:`myscript.spec` file contains most of the information provided by the options that were specified
-when ``pyinstaller`` (or ``pyi-makespec``) was run with the script file as the argument.
-You typically do not need to specify any options when running ``pyinstaller`` with the spec file.
-Only the following command-line options (described below) have an effect when building from a spec file:
-
-* ``--upx-dir=``
-* ``--distpath=``
-* ``--workpath=``
-* ``--noconfirm``
-* ``--ascii``
-* ``--clean``
-
 You may give a path to the script or spec file, for example
 
     ``pyinstaller`` `options...` ``~/myproject/source/myscript.py``
@@ -87,7 +75,7 @@ For example, in Linux::
         --hidden-import=secret1 \
         --hidden-import=secret2 \
         --upx-dir=/usr/local/share/ \
-        myscript.py
+        myscript.spec
 
 Or in Windows, use the little-known BAT file line continuation::
 
@@ -99,7 +87,7 @@ Or in Windows, use the little-known BAT file line continuation::
         --hidden-import=secret1 ^
         --hidden-import=secret2 ^
         --icon=..\MLNMFLCN.ICO ^
-        myscript.py
+        myscript.spec
 
 
 Using UPX

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -37,6 +37,11 @@ After you do this, you name the spec file to |PyInstaller| instead of the script
 
     ``pyinstaller myscript.spec``
 
+The :file:`myscript.spec` file contains most of the information provided by the options that were specified
+when :command:`pyinstaller` (or :command:`pyi-makespec`) was run with the script file as the argument.
+You typically do not need to specify any options when running :command:`pyinstaller` with the spec file.
+Only :ref:`a few command-line options <Using Spec Files>` have an effect when building from a spec file.
+
 You may give a path to the script or spec file, for example
 
     ``pyinstaller`` `options...` ``~/myproject/source/myscript.py``

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -80,7 +80,7 @@ For example, in Linux::
         --hidden-import=secret1 \
         --hidden-import=secret2 \
         --upx-dir=/usr/local/share/ \
-        myscript.spec
+        myscript.py
 
 Or in Windows, use the little-known BAT file line continuation::
 
@@ -92,7 +92,7 @@ Or in Windows, use the little-known BAT file line continuation::
         --hidden-import=secret1 ^
         --hidden-import=secret2 ^
         --icon=..\MLNMFLCN.ICO ^
-        myscript.spec
+        myscript.py
 
 
 Using UPX


### PR DESCRIPTION
Although mentioned in the documentation, it is not readily apparent that most of the Pyinstaller options are not valid when a spec file is provided to the `pyinstaller` command instead of a script file. These changes attempt to make that fact harder to miss for users. Also, two example commands are modified to use a script file argument instead of a spec file (where most of the example options would be ignored).