### PR TITLE
Update scipy hook to support 1.0.0 revision

### DIFF
--- a/PyInstaller/hooks/hook-numpy.py
+++ b/PyInstaller/hooks/hook-numpy.py
@@ -1,0 +1,26 @@
+# -----------------------------------------------------------------------------
+# Copyright (c) 2013-2017, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+# -----------------------------------------------------------------------------
+import os
+import glob
+from PyInstaller.compat import is_win
+from PyInstaller.utils.hooks import get_module_file_attribute
+
+# if we bundle the testing module, this will cause
+# `scipy` to be pulled in unintentionally but numpy imports
+# numpy.testing at the top level for historical reasons.
+# excludedimports = collect_submodules('numpy.testing')
+
+binaries = []
+
+# package the DLL bundle that official numpy wheels for Windows ship
+if is_win:
+    dll_glob = os.path.join(os.path.dirname(
+        get_module_file_attribute('numpy')), 'extra-dll', "*.dll")
+    if glob.glob(dll_glob):
+        binaries.append((dll_glob, "."))

--- a/PyInstaller/hooks/hook-scipy.py
+++ b/PyInstaller/hooks/hook-scipy.py
@@ -1,0 +1,26 @@
+# -----------------------------------------------------------------------------
+# Copyright (c) 2013-2017, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+# -----------------------------------------------------------------------------
+
+import os
+import glob
+from PyInstaller.utils.hooks import get_module_file_attribute
+from PyInstaller.compat import is_win
+
+binaries = []
+
+# package the DLL bundle that official scipy wheels for Windows ship
+if is_win:
+    dll_glob = os.path.join(os.path.dirname(
+        get_module_file_attribute('scipy')), 'extra-dll', "*.dll")
+    if glob.glob(dll_glob):
+        binaries.append((dll_glob, "."))
+
+# collect library-wide utility extension modules
+hiddenimports = ['scipy._lib.%s' % m for m in [
+    'messagestream', "_ccallback_c", "_fpumode"]]


### PR DESCRIPTION
This hook will add the new private `scipy._lib` C-extension modules to the archive, and when building on Windows, include the DLL bundle used by the official wheel provider stored in `site-packages/scip/extra-dll`