### PR TITLE
Depend/util: Fix ctypes scanning on Python 3.7

### DIFF
--- a/PyInstaller/depend/utils.py
+++ b/PyInstaller/depend/utils.py
@@ -162,6 +162,7 @@ def __scan_code_instruction_for_ctypes(instructions):
         try:
             instruction = next(instructions)
             expected_ops = ('LOAD_GLOBAL', 'LOAD_NAME')
+            load_method = ('LOAD_ATTR', 'LOAD_METHOD')
 
             if not instruction or instruction.opname not in expected_ops:
                 continue
@@ -177,9 +178,8 @@ def __scan_code_instruction_for_ctypes(instructions):
                 #
                 # In this case "strip" the `ctypes` by advancing and expecting
                 # `LOAD_ATTR` next.
-                expected_ops = ('LOAD_ATTR',)
                 instruction = next(instructions)
-                if instruction.opname not in expected_ops:
+                if instruction.opname not in load_method:
                     continue
                 name = instruction.argval
 
@@ -205,7 +205,7 @@ def __scan_code_instruction_for_ctypes(instructions):
                 #     LOAD_ATTR     1 (LoadLibrary)
                 #     LOAD_CONST    1 ('library.so')
                 instruction = next(instructions)
-                if instruction.opname == 'LOAD_ATTR':
+                if instruction.opname in load_method:
                     if instruction.argval == "LoadLibrary":
                         # Second type, needs to fetch one more instruction
                         yield _libFromConst()
@@ -223,7 +223,7 @@ def __scan_code_instruction_for_ctypes(instructions):
                 #     LOAD_ATTR     1 (find_library)
                 #     LOAD_CONST    1 ('gs')
                 instruction = next(instructions)
-                if instruction.opname == 'LOAD_ATTR':
+                if instruction.opname in load_method:
                     if instruction.argval == "find_library":
                         libname = _libFromConst()
                         if libname:


### PR DESCRIPTION
LOAD_METHOD appears to have been added to the
bytecode as one possible option. See gh-2760 for
more details. Closes gh-2760.

The instruction abstraction really helped out in
tracking this down!