### PR TITLE
Fix replacement of runtime search path keywords

### DIFF
--- a/PyInstaller/depend/bindepend.py
+++ b/PyInstaller/depend/bindepend.py
@@ -645,8 +645,8 @@ def _getImports_macholib(pth):
                 # Replace the @executable_path and @loader_path keywords
                 # with the actual path to the binary.
                 executable_path = os.path.dirname(pth)
-                rpath = re.sub('^@(executable_path|loader_path|rpath)/',
-                               executable_path + '/', rpath)
+                rpath = re.sub('^@(executable_path|loader_path|rpath)(/|$)',
+                               executable_path + r'\2', rpath)
                 # Make rpath absolute. According to Apple doc LC_RPATH
                 # is always relative to the binary location.
                 rpath = os.path.normpath(os.path.join(executable_path, rpath))


### PR DESCRIPTION
Previously runtime search path keywords like @loader_path and @executable_path were only properly replaced if they were followed by a slash, for example for a value like "@executable_path/Frameworks".
If the LC_RPATH value is just "@executable_path" without slashes, it would not be replaced, resulting in an invalid path string computed from executable_path + "/" +  "@executable_path".
The fix is to match just the keyword which is not followed by a slash.