### PR TITLE
Fix ImportError for sysconfig for 3.5.4 Conda

### DIFF
--- a/PyInstaller/hooks/hook-sysconfig.py
+++ b/PyInstaller/hooks/hook-sysconfig.py
@@ -37,6 +37,6 @@ if not is_win and hasattr(sysconfig, '_get_sysconfigdata_name'):
     # Python 3.6 uses additional modules like
     # `_sysconfigdata_m_linux_x86_64-linux-gnu`, see
     # https://github.com/python/cpython/blob/3.6/Lib/sysconfig.py#L417
-    # Note: Some versions of Anaconda backport this feature to before 3.6. 
+    # Note: Some versions of Anaconda backport this feature to before 3.6.
     # See issue #3105
     hiddenimports = [sysconfig._get_sysconfigdata_name()]

--- a/PyInstaller/hooks/hook-sysconfig.py
+++ b/PyInstaller/hooks/hook-sysconfig.py
@@ -17,7 +17,7 @@ import sysconfig
 import os
 
 from PyInstaller.utils.hooks import relpath_to_config_or_make
-from PyInstaller.compat import is_py36, is_win
+from PyInstaller.compat import is_win
 
 _CONFIG_H = sysconfig.get_config_h_filename()
 if hasattr(sysconfig, 'get_makefile_filename'):
@@ -33,8 +33,10 @@ datas = [(_CONFIG_H, relpath_to_config_or_make(_CONFIG_H))]
 if os.path.exists(_MAKEFILE):
     datas.append((_MAKEFILE, relpath_to_config_or_make(_MAKEFILE)))
 
-if is_py36 and not is_win:
+if not is_win and hasattr(sysconfig, '_get_sysconfigdata_name'):
     # Python 3.6 uses additional modules like
     # `_sysconfigdata_m_linux_x86_64-linux-gnu`, see
     # https://github.com/python/cpython/blob/3.6/Lib/sysconfig.py#L417
+    # Note: Some versions of Anaconda backport this feature to before 3.6. 
+    # See issue #3105
     hiddenimports = [sysconfig._get_sysconfigdata_name()]

--- a/PyInstaller/hooks/hook-sysconfig.py
+++ b/PyInstaller/hooks/hook-sysconfig.py
@@ -17,7 +17,7 @@ import sysconfig
 import os
 
 from PyInstaller.utils.hooks import relpath_to_config_or_make
-from PyInstaller.compat import is_win
+from PyInstaller.compat import is_py36, is_win
 
 _CONFIG_H = sysconfig.get_config_h_filename()
 if hasattr(sysconfig, 'get_makefile_filename'):
@@ -33,7 +33,7 @@ datas = [(_CONFIG_H, relpath_to_config_or_make(_CONFIG_H))]
 if os.path.exists(_MAKEFILE):
     datas.append((_MAKEFILE, relpath_to_config_or_make(_MAKEFILE)))
 
-if not is_win and hasattr(sysconfig, '_get_sysconfigdata_name'):
+if not is_win and (is_py36 or hasattr(sysconfig, '_get_sysconfigdata_name')):
     # Python 3.6 uses additional modules like
     # `_sysconfigdata_m_linux_x86_64-linux-gnu`, see
     # https://github.com/python/cpython/blob/3.6/Lib/sysconfig.py#L417

--- a/PyInstaller/hooks/hook-sysconfig.py
+++ b/PyInstaller/hooks/hook-sysconfig.py
@@ -17,7 +17,7 @@ import sysconfig
 import os
 
 from PyInstaller.utils.hooks import relpath_to_config_or_make
-from PyInstaller.compat import is_py36, is_win
+from PyInstaller.compat import is_win
 
 _CONFIG_H = sysconfig.get_config_h_filename()
 if hasattr(sysconfig, 'get_makefile_filename'):
@@ -33,7 +33,7 @@ datas = [(_CONFIG_H, relpath_to_config_or_make(_CONFIG_H))]
 if os.path.exists(_MAKEFILE):
     datas.append((_MAKEFILE, relpath_to_config_or_make(_MAKEFILE)))
 
-if not is_win and (is_py36 or hasattr(sysconfig, '_get_sysconfigdata_name')):
+if not is_win and hasattr(sysconfig, '_get_sysconfigdata_name'):
     # Python 3.6 uses additional modules like
     # `_sysconfigdata_m_linux_x86_64-linux-gnu`, see
     # https://github.com/python/cpython/blob/3.6/Lib/sysconfig.py#L417


### PR DESCRIPTION
The CPython implementation adds additional modules for importing in sysconfig for Python 3.6 and above.

Anaconda's Python 3.5.4 backports this feature for this version. This fixes the hook by removing the Python version check since there are cases where Python 3.5 may have the additional modules. Instead, sysconfig is checked for a function that was added for the additional module to get the name.

Fixes #3105