### PR TITLE
Tests: modulegraph: remove __slotnames__ from methods

### DIFF
--- a/tests/unit/test_modulegraph/test_modulegraph.py
+++ b/tests/unit/test_modulegraph/test_modulegraph.py
@@ -467,7 +467,7 @@ class TestNode (unittest.TestCase):
         if '__dict__' in d:
             # New in Python 3.4
             del d['__dict__']
-        if '__slotnames__ in d:
+        if '__slotnames__' in d:
             del d['__slotnames__']
         self.assertEqual(d, {})
 

--- a/tests/unit/test_modulegraph/test_modulegraph.py
+++ b/tests/unit/test_modulegraph/test_modulegraph.py
@@ -467,6 +467,8 @@ class TestNode (unittest.TestCase):
         if '__dict__' in d:
             # New in Python 3.4
             del d['__dict__']
+        if '__slotnames__ in d:
+            del d['__slotnames__']
         self.assertEqual(d, {})
 
     def assertHasExactMethods(self, klass, *methods):


### PR DESCRIPTION
`__slotnames__` can appear on objects that have slots, and needs
to be removed before comparing an object's dict.

This came up on #3107.