### PR TITLE
Fix #2039 by properly handling missing or invalid icon file parameters

### DIFF
--- a/PyInstaller/utils/win32/icon.py
+++ b/PyInstaller/utils/win32/icon.py
@@ -82,10 +82,19 @@ class GRPICONDIRENTRY(Structure):
                "wBitCount", "dwBytesInRes", "nID")
     _format_ = "bbbbhhih"
 
+# An IconFile instance is created for each .ico file given.
 class IconFile:
     def __init__(self, path):
         self.path = path
-        file = open(path, "rb")
+        try:
+            # The path is from the user parameter, don't trust it.
+            file = open(path, "rb")
+        except OSError as OSexception :
+            # The icon file can't be opened for some reason. Stop the
+            # program with an informative message.
+            raise SystemExit(
+                'Unable to open icon file {}'.format(path)
+            )
         self.entries = []
         self.images = []
         header = self.header = ICONDIRHEADER()
@@ -120,6 +129,8 @@ def CopyIcons_FromIco(dstpath, srcpath, id=1):
     hdst = win32api.BeginUpdateResource(dstpath, 0)
 
     iconid = 1
+    # Each step in the following enumerate() will instantiate an IconFile
+    # object, as a result of deferred execution of the map() above.
     for i, f in enumerate(icons):
         data = f.grp_icon_dir()
         data = data + f.grp_icondir_entries(iconid)


### PR DESCRIPTION
When the user specifies an improper `--icon` file path the error is discovered at one of two different places in the `/utils/win32/icon.py` module. These commits trap both cases and terminate via raising SystemExit with a message.

If the path extension is *not* `.ico` then the attempt to open the file takes place in the course of calling the win32api function LoadLibraryEx. When the path does not exist, or does not lead to a file of type `.exe` (or something else that LoadLibraryEx can handle), win32api raises its own exception which is used as the source for the message. Note if the user has named a non-exe file such as a Mac OS .icns file, the message will be about "not a valid EXE" which may be confusing, but at least the specific path is given.

When the path extension is `.ico` then the attempt to open takes place in the `__init__` method of the IconFile class. The second commit traps any IOError, which includes FileNotFound and less-likely file system problems like a privilege error. It also adds a couple of comments to clarify the rather devious flow of execution.