### PR TITLE
utils/win32: trap invalid --icon arguments and terminate with a message

### DIFF
--- a/PyInstaller/utils/win32/icon.py
+++ b/PyInstaller/utils/win32/icon.py
@@ -89,7 +89,7 @@ class IconFile:
         try:
             # The path is from the user parameter, don't trust it.
             file = open(path, "rb")
-        except OSError as OSexception:
+        except OSError:
             # The icon file can't be opened for some reason. Stop the
             # program with an informative message.
             raise SystemExit(

--- a/PyInstaller/utils/win32/icon.py
+++ b/PyInstaller/utils/win32/icon.py
@@ -82,10 +82,19 @@ class GRPICONDIRENTRY(Structure):
                "wBitCount", "dwBytesInRes", "nID")
     _format_ = "bbbbhhih"
 
+# An IconFile instance is created for each .ico file given.
 class IconFile:
     def __init__(self, path):
         self.path = path
-        file = open(path, "rb")
+        try:
+            # The path is from the user parameter, don't trust it.
+            file = open(path, "rb")
+        except OSError as OSexception:
+            # The icon file can't be opened for some reason. Stop the
+            # program with an informative message.
+            raise SystemExit(
+                'Unable to open icon file {}'.format(path)
+            )
         self.entries = []
         self.images = []
         header = self.header = ICONDIRHEADER()
@@ -120,6 +129,8 @@ def CopyIcons_FromIco(dstpath, srcpath, id=1):
     hdst = win32api.BeginUpdateResource(dstpath, 0)
 
     iconid = 1
+    # Each step in the following enumerate() will instantiate an IconFile
+    # object, as a result of deferred execution of the map() above.
     for i, f in enumerate(icons):
         data = f.grp_icon_dir()
         data = data + f.grp_icondir_entries(iconid)
@@ -169,8 +180,21 @@ def CopyIcons(dstpath, srcpath):
     else:
         logger.info("Updating icons from %s to %s", srcpath, dstpath)
 
+    try:
+        # Attempt to load the .ico or .exe containing the icon into memory
+        # using the same mechanism as if it were a DLL. If this fails for
+        # any reason (for example if the file does not exist or is not a
+        # .ico/.exe) then LoadLibraryEx returns a null handle and win32api
+        # raises a unique exception with a win error code and a string.
+        hsrc = win32api.LoadLibraryEx(srcpath, 0, LOAD_LIBRARY_AS_DATAFILE)
+    except win32api.error as W32E:
+        # We could continue with no icon (i.e. just return) however it seems
+        # best to terminate the build with a message.
+        raise SystemExit(
+            "Unable to load icon file {}\n    {} (Error code {})".format(
+                srcpath, W32E.strerror, W32E.winerror)
+        )
     hdst = win32api.BeginUpdateResource(dstpath, 0)
-    hsrc = win32api.LoadLibraryEx(srcpath, 0, LOAD_LIBRARY_AS_DATAFILE)
     if index is None:
         grpname = win32api.EnumResourceNames(hsrc, RT_GROUP_ICON)[0]
     elif index >= 0:


### PR DESCRIPTION
An invalid file path argument to --icon is detected in one of two places. If it ends in `.ico` an attempt to open the file is in the `__init__()` method of the `IconFile` class. Here trap any IOError subclass, which would include nonexistent file, unreadable file, etc, and raise SystemExit with a simple "could not open" message.

Other file extensions are opened using win32api.LoadLibraryEx which expects to get an EXE (or a DLL?). If it fails, win32api raises its unique exception which includes the windows error string and error code. These are formatted into a message string for SystemExit.