### PR TITLE
Fix: Names of Tcl/Tk resources on Tkinter hooks. Mac OS X

### DIFF
--- a/PyInstaller/hooks/hook-_tkinter.py
+++ b/PyInstaller/hooks/hook-_tkinter.py
@@ -219,9 +219,9 @@ def _collect_tcl_tk_files(hook_api):
         return []
 
     tcltree = Tree(
-        tcl_root, prefix='tcl', excludes=['demos', '*.lib', 'tclConfig.sh'])
+        tcl_root, prefix='tclResources', excludes=['demos', '*.lib', 'tclConfig.sh'])
     tktree = Tree(
-        tk_root, prefix='tk', excludes=['demos', '*.lib', 'tkConfig.sh'])
+        tk_root, prefix='tkResources', excludes=['demos', '*.lib', 'tkConfig.sh'])
 
     # If the current Tcl installation is a Teapot-distributed version of
     # ActiveTcl and the current platform is OS X, warn that this is bad.

--- a/PyInstaller/loader/rthooks/pyi_rth__tkinter.py
+++ b/PyInstaller/loader/rthooks/pyi_rth__tkinter.py
@@ -21,8 +21,8 @@ except NameError:
     # terminates when this exception occurs.
     FileNotFoundError = IOError
 
-tcldir = os.path.join(sys._MEIPASS, 'tcl')
-tkdir = os.path.join(sys._MEIPASS, 'tk')
+tcldir = os.path.join(sys._MEIPASS, 'tclResources')
+tkdir = os.path.join(sys._MEIPASS, 'tkResources')
 
 if not os.path.isdir(tcldir):
     raise FileNotFoundError('Tcl data directory "%s" not found.' % (tcldir))


### PR DESCRIPTION
'The Pyinstaller Tkinter hook was trying to copy the Tcl binary from
"/Library/Frameworks/Tcl.framework/Versions/8.5" to the dist directory,
and then the "Resources/Scripts" folder as "tcl" in that same directory,
when building an OS X Tcl/Tk application. Mac OS X filesystems are
usually case insensitive, so the folder creation was failing. The same
was happening to the Tk binary and resource folder.

Renaming the Tcl/Tk resource folders on the build hook to "TclResources"
and "TkResources" appear to fix the problem. The environment variables
in the runtime hook were updated accordingly.'

Props to @viotti for figuring this out.