### PR TITLE
WIP: Fix runtime hook for PyQt5 plugins

### DIFF
--- a/PyInstaller/loader/rthooks.dat
+++ b/PyInstaller/loader/rthooks.dat
@@ -14,7 +14,7 @@
     'osgeo':      ['pyi_rth_osgeo.py'],
     'pkg_resources':  ['pyi_rth_pkgres.py'],
     'PyQt4':      ['pyi_rth_qt4plugins.py'],
-    'PyQt5':      ['pyi_rth_qt5.py'],
+    'PyQt5':      ['pyi_rth_qt5.py', 'pyi_rth_qt5plugins.py'],
     'PyQt5.QtQuick':  ['pyi_rth_qml.py'],
     'PyQt5.QtWebEngineWidgets': ['pyi_rth_qt5webengine.py'],
     'PySide':      ['pyi_rth_qt4plugins.py'],

--- a/PyInstaller/loader/rthooks/pyi_rth_qt5plugins.py
+++ b/PyInstaller/loader/rthooks/pyi_rth_qt5plugins.py
@@ -15,8 +15,11 @@
 import os
 import sys
 
-d = "qt5_plugins"
-d = os.path.join(sys._MEIPASS, d)
+
+sub_dir = os.path.join('PyQt5', 'Qt', 'plugins')
+d = os.path.join(sys._MEIPASS, sub_dir)
+if not os.path.isfile(d):
+    d = os.path.join(os.path.dirname(sys.executable), 'PyQt5', 'Qt', 'plugins')
 
 
 # We remove QT_PLUGIN_PATH variable, because we want Qt5 to load

--- a/tests/functional/test_libraries.py
+++ b/tests/functional/test_libraries.py
@@ -277,6 +277,24 @@ def test_PyQt4_uic(tmpdir, pyi_builder, data_dir):
     pyi_builder.test_script('pyi_lib_PyQt4-uic.py')
 
 
+@importorskip('PyQt5')
+def test_PyQt5_QtWidgets(pyi_builder):
+    pyi_builder.test_source(
+        """
+        from PyQt5 import Qt
+        from PyQt5 import QtCore
+        from PyQt5 import QtGui
+        from PyQt5 import QtWidgets
+
+        app = QtWidgets.QApplication([])        
+        label = QtWidgets.QLabel("Hello World from PyQt5", None)
+        label.setWindowTitle("Hello World from PyQt5")
+        label.resize(300, 300)
+        label.show()
+        """
+    )
+
+
 @pytest.mark.skipif(is_module_satisfies('Qt >= 5.6', get_module_attribute('PyQt5.QtCore', 'QT_VERSION_STR')),
                     reason='QtWebKit is depreciated in Qt 5.6+')
 @importorskip('PyQt5')


### PR DESCRIPTION
Hi,

PyQt5 seems to no longer work in `pyinstaller` 3.3.0, failing with this message:

```
could not find or load the Qt platform plugin "windows"
```

The location configured by the runtime hook is incorrect, Qt puts the plugins directory in `PyQt5/Qt/plugins`, not `qt5_plugins` as stated in the comment of the runtime hook.

This PR is still a WIP because while the test passes for `onedir` mode, it fails for `onefile` mode. I'm not sure if I should be using `sys._MEIPASS` like I did, any pointers are appreciated.

The commit is marked as WIP because it still needs to fix the `onefile` mode and update the comments/docstrings.

Fix #2857

Inspired by #2991