### PR TITLE
Doc: Reflect actual behavior in "Run-time Information"

### DIFF
--- a/doc/advanced-topics.rst
+++ b/doc/advanced-topics.rst
@@ -41,8 +41,8 @@ A. First process: bootloader starts.
 
     2. Modify various environment variables:
 
-       - Linux: save original value of LD_LIBRARY_PATH into LD_LIBRARY_PATH_ORIG,
-         prepend our path to LD_LIBRARY_PATH.
+       - Linux: save original value of LD_LIBRARY_PATH into LD_LIBRARY_PATH_ORIG
+         (if it exists). Prepend our path to LD_LIBRARY_PATH.
 
        - AIX: same thing, but using LIBPATH and LIBPATH_ORIG.
 

--- a/doc/advanced-topics.rst
+++ b/doc/advanced-topics.rst
@@ -41,8 +41,9 @@ A. First process: bootloader starts.
 
     2. Modify various environment variables:
 
-       - Linux: save original value of LD_LIBRARY_PATH into LD_LIBRARY_PATH_ORIG
-         (if it exists). Prepend our path to LD_LIBRARY_PATH.
+       - Linux: save original value of LD_LIBRARY_PATH (it set)
+         into LD_LIBRARY_PATH_ORIG,
+         prepend our path to LD_LIBRARY_PATH.
 
        - AIX: same thing, but using LIBPATH and LIBPATH_ORIG.
 

--- a/doc/advanced-topics.rst
+++ b/doc/advanced-topics.rst
@@ -41,9 +41,9 @@ A. First process: bootloader starts.
 
     2. Modify various environment variables:
 
-       - Linux: save original value of LD_LIBRARY_PATH (it set)
-         into LD_LIBRARY_PATH_ORIG,
-         prepend our path to LD_LIBRARY_PATH.
+       - Linux: If set, save the original value of LD_LIBRARY_PATH
+         into LD_LIBRARY_PATH_ORIG.
+         Prepend our path to LD_LIBRARY_PATH.
 
        - AIX: same thing, but using LIBPATH and LIBPATH_ORIG.
 

--- a/doc/runtime-information.rst
+++ b/doc/runtime-information.rst
@@ -109,9 +109,9 @@ This environment variable is used to discover libraries, it is the library
 search path - on Linux and \*BSD `LD_LIBRARY_PATH` is used, on AIX it is
 `LIBPATH`.
 
-If it exists, PyInstaller saves the original value to `*_ORIG`, then modifies
-the search path so that the bundled libraries are found first by the bundled
-code.
+If it exists,
+PyInstaller saves the original value to `*_ORIG`, then modifies the search
+path so that the bundled libraries are found first by the bundled code.
 
 But if your code executes a system program, you often do not want that this
 system program loads your bundled libraries (that are maybe not compatible
@@ -129,8 +129,7 @@ with the system program.
     if lp_orig is not None:
         env[lp_key] = lp_orig  # restore the original, unmodified value
     else:
-        # This happens when LD_LIBRARY_PATH was not set, or for old
-        # pyinstaller versions (< 20160820).
+        # This happens when LD_LIBRARY_PATH was not set.
         # Remove the env var as a last resort:
         env.pop(lp_key, None)
     p = Popen(system_cmd, ..., env=env)  # create the process

--- a/doc/runtime-information.rst
+++ b/doc/runtime-information.rst
@@ -109,8 +109,9 @@ This environment variable is used to discover libraries, it is the library
 search path - on Linux and \*BSD `LD_LIBRARY_PATH` is used, on AIX it is
 `LIBPATH`.
 
-PyInstaller saves the original value to `*_ORIG`, then modifies the search
-path so that the bundled libraries are found first by the bundled code.
+If it exists, PyInstaller saves the original value to `*_ORIG`, then modifies
+the search path so that the bundled libraries are found first by the bundled
+code.
 
 But if your code executes a system program, you often do not want that this
 system program loads your bundled libraries (that are maybe not compatible
@@ -124,11 +125,14 @@ with the system program.
 
     env = dict(os.environ)  # make a copy of the environment
     lp_key = 'LD_LIBRARY_PATH'  # for Linux and *BSD.
-    lp_orig = env.get(lp_key + '_ORIG')  # pyinstaller >= 20160820 has this
+    lp_orig = env.get(lp_key + '_ORIG')
     if lp_orig is not None:
         env[lp_key] = lp_orig  # restore the original, unmodified value
     else:
-        env.pop(lp_key, None)  # last resort: remove the env var
+        # This happens when LD_LIBRARY_PATH was not set, or for old
+        # pyinstaller versions (< 20160820).
+        # Remove the env var as a last resort:
+        env.pop(lp_key, None)
     p = Popen(system_cmd, ..., env=env)  # create the process
 
 


### PR DESCRIPTION
The docs make it seem like `LD_LIBRARY_PATH_ORIG` is always set on Linux. That's not the case. It's only set when `LD_LIBRARY_PATH` was set. Update the docs to reflect this.