### PR TITLE
adding hooks for google cloud & google api modules

### DIFF
--- a/PyInstaller/hooks/hook-google.api.py
+++ b/PyInstaller/hooks/hook-google.api.py
@@ -1,0 +1,11 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2017, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import copy_metadata
+datas = copy_metadata('google-api-core')

--- a/news/3251.hooks.rst
+++ b/news/3251.hooks.rst
@@ -1,0 +1,1 @@
+Add hook for google.api (resp. google.api.core).


### PR DESCRIPTION
In my build, I found a runtime error unless I included these hook files before build.