### PR TITLE
Linux usb hook fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ __pycache__/
 /*.egg
 /*.egg-info/
 /*.egg-link
+/.eggs/
+/.pytest_cache/
 
 # /
 /AES.pyd

--- a/PyInstaller/hooks/hook-usb.py
+++ b/PyInstaller/hooks/hook-usb.py
@@ -9,8 +9,6 @@
 
 import ctypes.util
 import os
-import usb.core
-import usb.backend
 
 from PyInstaller.depend.utils import _resolveCtypesImports
 from PyInstaller.compat import is_cygwin, getenv
@@ -23,69 +21,66 @@ hiddenimports = ['glob']
 # https://github.com/walac/pyusb/blob/master/docs/faq.rst
 # https://github.com/walac/pyusb/blob/master/docs/tutorial.rst
 
-binaries=[]
+binaries = []
 
-# loading usb.core.find in this script crashes Ubuntu 14.04LTS,
+
+# Running usb.core.find() in this script crashes Ubuntu 14.04LTS,
 # let users circumvent pyusb discovery with an environment variable.
 skip_pyusb_discovery = \
     bool(getenv('PYINSTALLER_USB_HOOK_SKIP_PYUSB_DISCOVERY'))
 
-# first try to use pyusb library locator
+
+# Try to use pyusb's library locator.
 if not skip_pyusb_discovery:
+    import usb.core
+    import usb.backend
     try:
         # get the backend symbols before find
-        pyusb_backend_dir = set(dir(usb.backend))
-
+        backend_contents_before_discovery = set(dir(usb.backend))
         # perform find, which will load a usb library if found
         usb.core.find()
-
         # get the backend symbols which have been added (loaded)
-        backends = set(dir(usb.backend)) - pyusb_backend_dir
-
-        # for each of the loaded backends, see if they have a library
-        binaries = []
+        backends = set(dir(usb.backend)) - backend_contents_before_discovery
+        # gather the libraries from the loaded backends
+        backend_lib_basenames = []
         for usblib in [getattr(usb.backend, be)._lib for be in backends]:
             if usblib is not None:
-                binaries = [(usblib._name, '')]
-
+                # OSX returns the full path, Linux only the filename.
+                # save the basename and reconstruct the path after gathering.
+                backend_lib_basenames.append(os.path.basename(usblib._name))
+        # try to resolve the library names to absolute paths.
+        binaries = _resolveCtypesImports(backend_lib_basenames)
     except (ValueError, usb.core.USBError) as exc:
         logger.warning("%s", exc)
 
 
-# if nothing found, try to use our custom mechanism
+# If pyusb didn't find a backend, manually search for usb libraries.
 if not binaries:
-    # Try to resolve your libusb libraries in the following order:
-    #
-    #   libusb-1.0, libusb-0.1, openusb
-    #
-    # NOTE: Mind updating run-time hook when adding further libs.
-    libusb_candidates = (
-        # libusb10
-        'usb-1.0', 'usb', 'libusb-1.0',
-        # libusb01
-        'usb-0.1', 'libusb0',
-        # openusb
-        'openusb',
-    )
+    # NOTE: Update these lists when adding further libs.
+    if is_cygwin:
+        libusb_candidates = ['cygusb-1.0-0.dll', 'cygusb0.dll']
+    else:
+        libusb_candidates = [
+            # libusb10
+            'usb-1.0', 'usb', 'libusb-1.0',
+            # libusb01
+            'usb-0.1', 'libusb0',
+            # openusb
+            'openusb',
+        ]
 
+    backend_library_basenames = []
     for candidate in libusb_candidates:
         libname = ctypes.util.find_library(candidate)
         if libname is not None:
-            break
+            backend_library_basenames.append(os.path.basename(libname))
+    if backend_library_basenames:
+        binaries = _resolveCtypesImports(backend_library_basenames)
 
-    if libname is not None:
-        # Use basename here because Python returns full library path
-        # on Mac OSX when using ctypes.util.find_library.
-        bins = [os.path.basename(libname)]
-        binaries = _resolveCtypesImports(bins)
-    elif is_cygwin:
-        bins = ['cygusb-1.0-0.dll', 'cygusb0.dll']
-        binaries = _resolveCtypesImports(bins)[:1] # use only the first one
-    else:
-        binaries = []
 
-    if binaries:
-        # `_resolveCtypesImports` returns a 3-tuple, but `binaries` are only
-        # 2-tuples, so remove the last element:
-        assert len(binaries[0]) == 3
-        binaries = [(binaries[0][1], '')]
+# Validate and normalize the first found usb library.
+if binaries:
+    # `_resolveCtypesImports` returns a 3-tuple, but `binaries` are only
+    # 2-tuples, so remove the last element:
+    assert len(binaries[0]) == 3
+    binaries = [(binaries[0][1], '')]

--- a/tests/functional/test_libraries.py
+++ b/tests/functional/test_libraries.py
@@ -700,24 +700,22 @@ def test_pyexcelerate(pyi_builder):
 
 
 @importorskip('usb')
-@pytest.mark.skipif(not is_win, reason='Crashes Python on travis')
+@pytest.mark.skipif(is_linux, reason='libusb_exit segfaults on some linuxes')
 def test_usb(pyi_builder):
     # See if the usb package is supported on this platform.
     try:
         import usb
         # This will verify that the backend is present; if not, it will
         # skip this test.
-        usb.core.find(find_all = True)
-    except (ImportError, ValueError):
+        usb.core.find()
+    except (ImportError, usb.core.NoBackendError):
         pytest.skip('USB backnd not found.')
 
     pyi_builder.test_source(
         """
         import usb.core
-        # Detect usb devices.
-        devices = usb.core.find(find_all = True)
-        if not devices:
-            raise SystemExit('No USB device found.')
+        # NoBackendError fails the test if no backends are found.
+        usb.core.find()
         """)
 
 


### PR DESCRIPTION
This PR addresses the issues raised in https://github.com/pyinstaller/pyinstaller/issues/2633:

~~1. Enable, always, `library_test::test_usb`. Make sure a backend exists on Travis by adding `libusb-1.0` to the package list. The code tests for the presence of a usb backend, which on some versions of Linux can crash Python when finalization happens (`libusb_exit` crashes), and seems related to whether libusb was loaded on a worker thread. Anyway, since asking if we have USB crashes, just ensure that a USB backend actually exists. This seems reasonable, since `requirements-library.txt` already installs `pyusb` and the expectation of pyusb is that you can do USB work.~~

1. Ugh, ok, it's really challenging to tiptoe around the linux pyusb issue. Currently the entire test_usb function is skipped for linux because pyusb causes crashes on the version of linux that Travis uses. We see this same crash at work on Ubuntu 14.04LTS machines. It has nothing to do with PyInstaller; I suspect it's a bug in pyusb around finalizing and libusb. I ended up just clarifying the existing `test_usb` function, and enabling the tests for mac, which doesn't exhibit this crash. There are a bunch of places this can crash: The generated functional test in `test_libraries.py` can crash and the hook can crash. Even with the environment variable trick described below in 3., the functional test still crashes because it imports pyusb and works with it. I don't think there's a way to work around this without fixing the core issue in pyusb. Bummer.

2. When using pyusb to enumerate libraries, normalize them by calling `os.path.basename` on them, and then get their absolute paths via `_resolveCtypesImports`. On Mac, pyusb returns absolute paths to so/dylib files. On Linux, pyusb returns just the filename, which causes PyInstaller to fail. This new approach works in both scenarios.

3. If the user sets the environment variable `PYINSTALLER_USB_HOOK_SKIP_PYUSB_DISCOVERY`, `hook-usb.py` will not use pyusb's backend mechanism to discover libraries. This lets users navigate around the pyusb crash if they choose. Note that the default behavior is still to use pyusb, so the existing behavior should remain unchanged.

4. (cleanup) Hoist the Cygwin dll path up to the top of the file, it seems less direct to use the pyusb discovery method here, since Cygwin is a much more controlled environment and there really aren't any other options. Why bother searching pyusb when you know exactly what dll's should be used? In any case, if those Cygwin dll's fail to load, pyusb interrogation still happens in case there's some other strange place Cygwin usb dll's can come from.

5. (cleanup) Remove the number of special cases: `binaries` is now always a list containing the results of `_resolveCtypesImports`, and only at the very end of the function is the first list element selected, validated, and normalized into the form that PyInstaller expects from its hooks. This doesn't change the behavior, but it reduces the number of code paths through the file and makes each path more similar.

6. Add `.eggs/` and `.pytest_cache/` to the `.gitignore` file; they showed up in my unstaged list after doing my first unit + functional test run, and it looks like they're not intended to be committed.
