### PR TITLE
Update utils.py

### DIFF
--- a/PyInstaller/building/utils.py
+++ b/PyInstaller/building/utils.py
@@ -337,16 +337,12 @@ def checkCache(fnm, strip=False, upx=False, dist_nm=None):
     return cachedfile
 
 
-def get_md5(fname):
-    hash_md5 = hashlib.md5()
-    with open(fname, "rb") as f:
-        for chunk in iter(lambda: f.read(4096), b""):
-            hash_md5.update(chunk)
-    return hash_md5
-
-
 def cacheDigest(fnm, redirects):
-    hasher = get_md5(fnm)
+    hasher = hashlib.md5()
+    with open(fnm, "rb") as f:
+        for chunk in iter(lambda: f.read(16*1024), b""):
+            hasher.update(chunk)
+
     if redirects:
         redirects = str(redirects)
         if is_py3:

--- a/PyInstaller/building/utils.py
+++ b/PyInstaller/building/utils.py
@@ -337,9 +337,19 @@ def checkCache(fnm, strip=False, upx=False, dist_nm=None):
     return cachedfile
 
 
+def get_md5(fnm):
+    hasher = hashlib.md5()
+    with open(fnm, 'rb') as fh:
+        while True:
+            data = fh.read(2048)    # 2048 each iteration
+            if not data:
+                break
+            hasher.update(data)
+    return hasher
+
+
 def cacheDigest(fnm, redirects):
-    data = open(fnm, "rb").read()
-    hasher = hashlib.md5(data)
+    hasher = get_md5(fnm)
     if redirects:
         redirects = str(redirects)
         if is_py3:

--- a/PyInstaller/building/utils.py
+++ b/PyInstaller/building/utils.py
@@ -337,15 +337,12 @@ def checkCache(fnm, strip=False, upx=False, dist_nm=None):
     return cachedfile
 
 
-def get_md5(fnm):
-    hasher = hashlib.md5()
-    with open(fnm, 'rb') as fh:
-        while True:
-            data = fh.read(2048)    # 2048 each iteration
-            if not data:
-                break
-            hasher.update(data)
-    return hasher
+def get_md5(fname):
+    hash_md5 = hashlib.md5()
+    with open(fname, "rb") as f:
+        for chunk in iter(lambda: f.read(4096), b""):
+            hash_md5.update(chunk)
+    return hash_md5
 
 
 def cacheDigest(fnm, redirects):

--- a/PyInstaller/building/utils.py
+++ b/PyInstaller/building/utils.py
@@ -340,9 +340,8 @@ def checkCache(fnm, strip=False, upx=False, dist_nm=None):
 def cacheDigest(fnm, redirects):
     hasher = hashlib.md5()
     with open(fnm, "rb") as f:
-        for chunk in iter(lambda: f.read(16*1024), b""):
+        for chunk in iter(lambda: f.read(16 * 1024), b""):
             hasher.update(chunk)
-
     if redirects:
         redirects = str(redirects)
         if is_py3:


### PR DESCRIPTION
To fix the MemoryError issue when pack a big file.
  File "c:\python27\lib\site-packages\PyInstaller\building\utils.py", line 333, in cacheDigest
    data = open(fnm, "rb").read()
MemoryError