### PR TITLE
copy PyQt5 styles plugin binaries

### DIFF
--- a/PyInstaller/hooks/hook-PyQt5.QtGui.py
+++ b/PyInstaller/hooks/hook-PyQt5.QtGui.py
@@ -21,6 +21,7 @@ binaries.extend(qt_plugins_binaries('imageformats', namespace='PyQt5'))
 binaries.extend(qt_plugins_binaries('inputmethods', namespace='PyQt5'))
 binaries.extend(qt_plugins_binaries('graphicssystems', namespace='PyQt5'))
 binaries.extend(qt_plugins_binaries('platforms', namespace='PyQt5'))
+binaries.extend(qt_plugins_binaries('styles', namespace='PyQt5'))
 
 if is_linux:
     binaries.extend(qt_plugins_binaries('platformthemes', namespace='PyQt5'))


### PR DESCRIPTION
A PyQt5 app created with pyinstaller on the Mac is missing the "macintosh" theme which is needed to get native looks. This fix simply copies the "styles" plugins which results in the needed library "libqmacstyle.dylib" to be copied to the right location in the target.

