### PR TITLE
Only update resources when necessary to keep signature valid

### DIFF
--- a/PyInstaller/building/utils.py
+++ b/PyInstaller/building/utils.py
@@ -122,12 +122,18 @@ def applyRedirects(manifest, redirects):
     :return:
     :rtype:
     """
+
+    redirecting = False
+
     for binding in redirects:
         for dep in manifest.dependentAssemblies:
             if match_binding_redirect(dep, binding):
                 logger.info("Redirecting %s version %s -> %s",
                             binding.name, dep.version, binding.newVersion)
                 dep.version = binding.newVersion
+                redirecting = True
+
+    return redirecting
 
 def checkCache(fnm, strip=False, upx=False, dist_nm=None):
     """
@@ -287,7 +293,8 @@ def checkCache(fnm, strip=False, upx=False, dist_nm=None):
                             logger.error("From file %s", cachedfile, exc_info=1)
                         else:
                             # optionally change manifest to private assembly
-                            if CONF.get('win_private_assemblies', False):
+                            private = CONF.get('win_private_assemblies', False)
+                            if private:
                                 if manifest.publicKeyToken:
                                     logger.info("Changing %s into a private assembly",
                                                 os.path.basename(fnm))
@@ -298,14 +305,15 @@ def checkCache(fnm, strip=False, upx=False, dist_nm=None):
                                     # Exclude common-controls which is not bundled
                                     if dep.name != "Microsoft.Windows.Common-Controls":
                                         dep.publicKeyToken = None
-                            applyRedirects(manifest, redirects)
-                            try:
-                                manifest.update_resources(os.path.abspath(cachedfile),
-                                                          [name],
-                                                          [language])
-                            except Exception as e:
-                                logger.error(os.path.abspath(cachedfile))
-                                raise
+                            redirecting = applyRedirects(manifest, redirects)
+                            if redirecting or private:
+                                try:
+                                    manifest.update_resources(os.path.abspath(cachedfile),
+                                                              [name],
+                                                              [language])
+                                except Exception as e:
+                                    logger.error(os.path.abspath(cachedfile))
+                                    raise
 
     if cmd:
         try:

--- a/PyInstaller/building/utils.py
+++ b/PyInstaller/building/utils.py
@@ -122,9 +122,7 @@ def applyRedirects(manifest, redirects):
     :return:
     :rtype:
     """
-
     redirecting = False
-
     for binding in redirects:
         for dep in manifest.dependentAssemblies:
             if match_binding_redirect(dep, binding):
@@ -132,7 +130,6 @@ def applyRedirects(manifest, redirects):
                             binding.name, dep.version, binding.newVersion)
                 dep.version = binding.newVersion
                 redirecting = True
-
     return redirecting
 
 def checkCache(fnm, strip=False, upx=False, dist_nm=None):


### PR DESCRIPTION
This fixes #2526. Pyinstaller is updating the resources for python35.dll and makes its signature invalid. This then prevents that dll from being signed with the 'signtool' utility (which then can have more consequences, like the inability to publish the app to a repository where signing is mandatory).

In this commit, the resource update is skipped if it is not necessary, i.e. it is only performed if there have been som redirections or if the dll has been made private.

Test scenario: run pyinstaller on a Python app (https://github.com/tlecomte/friture) without these changes and 'signtool' fails to sign python35.dll with the error code 0x800700C1, ERROR_BAD_EXE_FORMAT. With these changes, the packaged python35.dll still shows its "Python Software Foundation" signature, and 'signtool' can successfully re-sign it.