### PR TITLE
Hint users to install development package for missing `pyconfig.h`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ __pycache__/
 # PyCharm settings
 .idea
 
+# Spyder settings
+.spyproject
+
 # /tests/
 /tests/build*
 /tests/dist*

--- a/PyInstaller/building/utils.py
+++ b/PyInstaller/building/utils.py
@@ -492,9 +492,21 @@ def format_binaries_and_datas(binaries_or_datas, workingdir=None):
             src_root_paths = glob.glob(src_root_path_or_glob)
 
         if not src_root_paths:
-            raise SystemExit(
-                'Unable to find "%s" when adding binary and data files.' % (
-                src_root_path_or_glob))
+            msg = 'Unable to find "%s" when adding binary and data files.' % (
+                    src_root_path_or_glob)
+            # on Debian/Ubuntu, missing pyconfig.h files can be fixed with
+            # installing python-dev
+            if src_root_path_or_glob.endswith("pyconfig.h"):
+                msg += """This would mean your Python installation doesn't
+come with proper library files. This usually happens by missing development
+package, or unsuitable build parameters of Python installation.
+* On Debian/Ubuntu, you would need to install Python development packages
+  * apt-get install python3-dev
+  * apt-get install python-dev
+* If you're building Python by yourself, please rebuild your Python with 
+`--enable-shared` (or, `--enable-framework` on Darwin)
+"""
+            raise SystemExit(msg)
 
         for src_root_path in src_root_paths:
             if os.path.isfile(src_root_path):

--- a/PyInstaller/building/utils.py
+++ b/PyInstaller/building/utils.py
@@ -493,7 +493,7 @@ def format_binaries_and_datas(binaries_or_datas, workingdir=None):
 
         if not src_root_paths:
             msg = 'Unable to find "%s" when adding binary and data files.' % (
-                    src_root_path_or_glob)
+                src_root_path_or_glob)
             # on Debian/Ubuntu, missing pyconfig.h files can be fixed with
             # installing python-dev
             if src_root_path_or_glob.endswith("pyconfig.h"):
@@ -503,7 +503,7 @@ package, or unsuitable build parameters of Python installation.
 * On Debian/Ubuntu, you would need to install Python development packages
   * apt-get install python3-dev
   * apt-get install python-dev
-* If you're building Python by yourself, please rebuild your Python with 
+* If you're building Python by yourself, please rebuild your Python with
 `--enable-shared` (or, `--enable-framework` on Darwin)
 """
             raise SystemExit(msg)


### PR DESCRIPTION
* On missing `pyconfig.h` file, prompt to install `python-dev`
* Add `.spyproject`to `.gitignore`

See https://github.com/pyinstaller/pyinstaller/issues/1539 for discussion that prompted this pull request.