### PR TITLE
Hooks: update Gst and GdkPixbuf to work on msys2

### DIFF
--- a/PyInstaller/hooks/hook-gi.repository.GdkPixbuf.py
+++ b/PyInstaller/hooks/hook-gi.repository.GdkPixbuf.py
@@ -52,9 +52,13 @@ else:
     if is_win:
         pattern = os.path.join(
             libdir, 'gdk-pixbuf-2.0', '2.10.0', 'loaders', '*.dll')
+        pattern2 = os.path.join(
+            libdir, '..', 'lib', 'gdk-pixbuf-2.0', '2.10.0', 'loaders', '*.dll')
     elif is_darwin or is_linux:
         pattern = os.path.join(
             libdir, 'gdk-pixbuf-2.0', '2.10.0', 'loaders', '*.so')
+        pattern2 = os.path.join(
+            libdir, '..', 'lib', 'gdk-pixbuf-2.0', '2.10.0', 'loaders', '*.so')
 
     # If loader detection is supported on this platform, bundle all detected
     # loaders and an updated loader cache.
@@ -63,8 +67,15 @@ else:
 
         # Bundle all found loaders with this user application.
         for f in glob.glob(pattern):
-            binaries.append((f, 'lib/gdk-pixbuf/loaders'))
+            binaries.append((f, 'lib/gdk-pixbuf-2.0/2.10.0/loaders'))
             loader_libs.append(f)
+
+        # Sometimes the loaders are stored in a different directory from
+        # the library (msys2)
+        if not loader_libs:
+            for f in glob.glob(pattern2):
+                binaries.append((f, 'lib/gdk-pixbuf-2.0/2.10.0/loaders'))
+                loader_libs.append(f)
 
         # Filename of the loader cache to be written below.
         cachefile = os.path.join(CONF['workpath'], 'loaders.cache')
@@ -104,7 +115,7 @@ else:
                 if line.startswith('#'):
                     continue
                 if line.startswith(prefix):
-                    line = '"@executable_path/lib/gdk-pixbuf' + line[plen:]
+                    line = '"@executable_path/lib/gdk-pixbuf-2.0/2.10.0' + line[plen:]
                 cd.append(line)
 
             # Rejoin these lines in a manner preserving this object's "unicode"
@@ -122,7 +133,7 @@ else:
                 fp.write(subprocess.check_output(gdk_pixbuf_query_loaders))
 
         # Bundle this loader cache with this frozen application.
-        datas.append((cachefile, 'lib/gdk-pixbuf'))
+        datas.append((cachefile, 'lib/gdk-pixbuf-2.0/2.10.0'))
     # Else, loader detection is unsupported on this platform.
     else:
         logger.warning('GdkPixbuf loader bundling unsupported on your platform.')

--- a/PyInstaller/hooks/hook-gi.repository.Gst.py
+++ b/PyInstaller/hooks/hook-gi.repository.Gst.py
@@ -53,8 +53,6 @@ plugin_path = exec_statement(statement)
 
 # Use a pattern of libgst* since all GStreamer plugins that conform to GStreamer standards start with libgst
 # and we may have mixed plugin extensions, e.g., .so and .dylib.
-pattern = os.path.join(plugin_path, 'libgst*')
-
-binaries += [(f, os.path.join('gst_plugins')) for f in glob.glob(pattern)]
-
-
+for pattern in ['libgst*.dll', 'libgst*.dylib', 'libgst*.so']:
+    pattern = os.path.join(plugin_path, pattern)
+    binaries += [(f, os.path.join('gst_plugins')) for f in glob.glob(pattern)]

--- a/PyInstaller/loader/rthooks/pyi_rth_gdkpixbuf.py
+++ b/PyInstaller/loader/rthooks/pyi_rth_gdkpixbuf.py
@@ -12,7 +12,8 @@ import os
 import tempfile
 import sys
 
-pixbuf_file = os.path.join(sys._MEIPASS, 'lib', 'gdk-pixbuf', 'loaders.cache')
+pixbuf_file = os.path.join(sys._MEIPASS, 'lib', 'gdk-pixbuf-2.0', '2.10.0',
+                           'loaders.cache')
 
 # If we're not on Windows we need to rewrite the cache
 # -> we rewrite on OSX to support --onefile mode
@@ -25,8 +26,8 @@ if os.path.exists(pixbuf_file) and sys.platform != 'win32':
     # we injected with the actual path
     fd, pixbuf_file = tempfile.mkstemp()
     with os.fdopen(fd, 'wb') as fp:
-        fp.write(contents.replace(b'@executable_path/lib',
-                                  os.path.join(sys._MEIPASS, 'lib').encode('utf-8')))
+        libpath = os.path.join(sys._MEIPASS, 'lib').encode('utf-8')
+        fp.write(contents.replace(b'@executable_path/lib', libpath))
 
     try:
         atexit.register(os.unlink, pixbuf_file)


### PR DESCRIPTION
Tested on msys2 and Fedora. Probably fixes #3257. 