### PR TITLE
Add missing gi.repository.xlib hook

### DIFF
--- a/PyInstaller/hooks/hook-gi.repository.xlib.py
+++ b/PyInstaller/hooks/hook-gi.repository.xlib.py
@@ -1,0 +1,15 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2017, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+"""
+Import hook for PyGObject https://wiki.gnome.org/PyGObject
+"""
+
+from PyInstaller.utils.hooks import get_gi_typelibs
+
+binaries, datas, hiddenimports = get_gi_typelibs('xlib', '2.0')

--- a/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.xlib.py
+++ b/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.xlib.py
@@ -1,0 +1,15 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2017, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+
+def pre_safe_import_module(api):
+    # PyGObject modules loaded through the gi repository are marked as
+    # MissingModules by modulegraph so we convert them to
+    # RuntimeModules so their hooks are loaded and run.
+    api.add_runtime_module(api.module_name)


### PR DESCRIPTION
PyInstaller need a hook to correctly import `gi.repository.xlib` module
and the associated files.

Fixes #2634