### PR TITLE
Add missing warnings module in base_library.zip

### DIFF
--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -772,6 +772,7 @@ PY3_BASE_MODULES = {
     'traceback',  # for startup errors
     'types',
     'weakref',
+    'warnings',
 }
 
 if sys.version_info >= (3, 4):


### PR DESCRIPTION
When you use the -W option to python interpreter some of the modules
present in base_library.zip requires the warnings module, raising an
error. The issue is solved by adding it to the PY3_BASE_MODULES set.

Closes: #3397