### PR TITLE
Fix of the addition of resources for Windows executables

### DIFF
--- a/PyInstaller/utils/win32/winmanifest.py
+++ b/PyInstaller/utils/win32/winmanifest.py
@@ -935,8 +935,9 @@ class Manifest(object):
 
     def update_resources(self, dstpath, names=None, languages=None):
         """ Update or add manifest resource in dll/exe file dstpath """
-        UpdateManifestResourcesFromXML(dstpath, self.toprettyxml(), names,
-                                       languages)
+        UpdateManifestResourcesFromXML(dstpath,
+                                       self.toprettyxml().encode("UTF-8"),
+                                       names, languages)
 
     def writeprettyxml(self, filename_or_file=None, indent="  ", newl=os.linesep,
                        encoding="UTF-8"):

--- a/PyInstaller/utils/win32/winresource.py
+++ b/PyInstaller/utils/win32/winresource.py
@@ -199,8 +199,7 @@ def UpdateResources(dstpath, data, type_, names=None, languages=None):
             for language in res[type_][name]:
                 logger.info("Updating resource type %s name %s language %s",
                             type_, name, language)
-                win32api.UpdateResource(hdst, type_, name,
-                                        data.encode('UTF-8'), language)
+                win32api.UpdateResource(hdst, type_, name, data, language)
     win32api.EndUpdateResource(hdst, 0)
 
 
@@ -242,7 +241,7 @@ def UpdateResourcesFromDict(dstpath, res, types=None, names=None,
                         if not languages or language in languages:
                             UpdateResources(dstpath,
                                             res[type_][name][language],
-                                            [type_], [name], [language])
+                                            type_, [name], [language])
 
 
 def UpdateResourcesFromResFile(dstpath, srcpath, types=None, names=None,


### PR DESCRIPTION
I have faced issue that PyInstaller crashes when trying to add resources to Windows executable using `--resource` option. This pull request contains minimal fix tested on Python 2.7.14 and 3.6.3.

There is also an issue proposing the same fix: https://github.com/pyinstaller/pyinstaller/issues/2675