### PR TITLE
Hooks: hook-Crypto: support for PyCryptodome

### DIFF
--- a/PyInstaller/hooks/hook-Crypto.py
+++ b/PyInstaller/hooks/hook-Crypto.py
@@ -14,6 +14,13 @@ PyCryptodome is an almost drop-in replacement for the now unmaintained
 PyCrypto library. The two are mutually exclusive as they live under
 the same package ("Crypto").
 
+PyCryptodome distributes dynamic libraries and builds them as if they were
+Python C extensions (even though they are not extensions - as they can't be
+imported by Python). It might sound a bit weird, but this decision is rooted
+in PyPy and its partial and slow support for C extensions. However, this also
+invalidates several of the existing methods used by PyInstaller to decide the
+right files to pull in.
+
 Even though this hook is meant to help with PyCryptodome only, it will be
 triggered also when PyCrypto is installed, so it must be tested with both.
 
@@ -24,7 +31,7 @@ import os
 import glob
 
 from PyInstaller.compat import EXTENSION_SUFFIXES
-from PyInstaller.utils.hooks import get_module_file_attribute, is_module_satisfies
+from PyInstaller.utils.hooks import get_module_file_attribute
 
 # Include the modules as binaries in a subfolder named like the package.
 # Cryptodome's loader expects to find them inside the package directory for
@@ -46,7 +53,7 @@ try:
         for ext in EXTENSION_SUFFIXES:
             module_bin = glob.glob(os.path.join(m_dir, '_*%s' % ext))
             for f in module_bin:
-                binaries.append((f, module_name.replace('.', '/')))
+                binaries.append((f, module_name.replace('.', os.sep)))
 except ImportError:
     # Do nothing for PyCrypto (Crypto.Math does not exist there)
     pass

--- a/PyInstaller/hooks/hook-Crypto.py
+++ b/PyInstaller/hooks/hook-Crypto.py
@@ -1,5 +1,5 @@
 #-----------------------------------------------------------------------------
-# Copyright (c) 2005-2016, PyInstaller Development Team.
+# Copyright (c) 2005-2018, PyInstaller Development Team.
 #
 # Distributed under the terms of the GNU General Public License with exception
 # for distributing bootloader.

--- a/PyInstaller/hooks/hook-Crypto.py
+++ b/PyInstaller/hooks/hook-Crypto.py
@@ -24,7 +24,7 @@ import os
 import glob
 
 from PyInstaller.compat import EXTENSION_SUFFIXES
-from PyInstaller.utils.hooks import get_module_file_attribute
+from PyInstaller.utils.hooks import get_module_file_attribute, is_module_satisfies
 
 # Include the modules as binaries in a subfolder named like the package.
 # Cryptodome's loader expects to find them inside the package directory for
@@ -33,19 +33,20 @@ from PyInstaller.utils.hooks import get_module_file_attribute
 
 binaries = []
 binary_module_names = [
+    'Crypto.Math',      # First in the list
     'Crypto.Cipher',
     'Crypto.Util',
     'Crypto.Hash',
     'Crypto.Protocol',
-    'Crypto.Math',
 ]
 
-for module_name in binary_module_names:
-    try:
+try:
+    for module_name in binary_module_names:
         m_dir = os.path.dirname(get_module_file_attribute(module_name))
-    except ImportError:
-        continue
-    for ext in EXTENSION_SUFFIXES:
-        module_bin = glob.glob(os.path.join(m_dir, '_*%s' % ext))
-        for f in module_bin:
-            binaries.append((f, module_name.replace('.', '/')))
+        for ext in EXTENSION_SUFFIXES:
+            module_bin = glob.glob(os.path.join(m_dir, '_*%s' % ext))
+            for f in module_bin:
+                binaries.append((f, module_name.replace('.', '/')))
+except ImportError:
+    # Do nothing for PyCrypto (Crypto.Math does not exist there)
+    pass

--- a/PyInstaller/hooks/hook-Crypto.py
+++ b/PyInstaller/hooks/hook-Crypto.py
@@ -1,0 +1,51 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2016, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+"""
+Hook for PyCryptodome library: https://pypi.python.org/pypi/pycryptodome
+
+PyCryptodome is an almost drop-in replacement for the now unmaintained
+PyCrypto library. The two are mutually exclusive as they live under
+the same package ("Crypto").
+
+Even though this hook is meant to help with PyCryptodome only, it will be
+triggered also when PyCrypto is installed, so it must be tested with both.
+
+Tested with PyCryptodome 3.5.1, PyCrypto 2.6.1, Python 2.7 & 3.6, Fedora & Windows
+"""
+
+import os
+import glob
+
+from PyInstaller.compat import EXTENSION_SUFFIXES
+from PyInstaller.utils.hooks import get_module_file_attribute
+
+# Include the modules as binaries in a subfolder named like the package.
+# Cryptodome's loader expects to find them inside the package directory for
+# the main module. We cannot use hiddenimports because that would add the
+# modules outside the package.
+
+binaries = []
+binary_module_names = [
+    'Crypto.Cipher',
+    'Crypto.Util',
+    'Crypto.Hash',
+    'Crypto.Protocol',
+    'Crypto.Math',
+]
+
+for module_name in binary_module_names:
+    try:
+        m_dir = os.path.dirname(get_module_file_attribute(module_name))
+    except ImportError:
+        continue
+    for ext in EXTENSION_SUFFIXES:
+        module_bin = glob.glob(os.path.join(m_dir, '_*%s' % ext))
+        for f in module_bin:
+            binaries.append((f, module_name.replace('.', '/')))


### PR DESCRIPTION
PyCryptodome is an almost drop-in support for the now unmaintained PyCrypto library (`Crypto` namespace).

**Important:** this PR adds support for applications that use PyCryptodome, but it does not allow encryption of the python script (``--key`` option). The reason is that PyInstaller assumes that either `Crypto.Cipher.AES` or `Crypto.Cipher._AES` are **native** Python extensions, but they are not in PyCryptodome.