### PR TITLE
correction in gi-hooks for binary paths

### DIFF
--- a/PyInstaller/utils/hooks/gi.py
+++ b/PyInstaller/utils/hooks/gi.py
@@ -86,7 +86,7 @@ def get_gi_typelibs(module, version):
                 path = findSystemLibrary(lib.strip())
                 if path:
                     logger.debug('Found shared library %s at %s', lib, path)
-                    binaries.append((path, ''))
+                    binaries.append((path, '.'))
 
         d = gir_library_path_fix(typelibs_data['typelib'])
         if d:


### PR DESCRIPTION
It was giving error:
    31529 INFO: Loading module hook "hook-gi.repository.GObject.py"...
    Empty DEST not allowed when adding binary and data files. Maybe you want to used '.'.
    Caused by '/usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0'.