### PR TITLE
Fix code block formatting in Documentation

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -33,17 +33,17 @@ such as |PyInstaller| in each of them.
 (For more on the uses of virtualenv, see :ref:`Supporting Multiple Platforms` below.)
 
 When pip-Win is working, enter this command in its Command field
-and click Run:
+and click Run::
 
-  ``venv -c -i  pyi-env-name``
+    venv -c -i pyi-env-name
 
 This creates a new virtual environment rooted at ``C:\Python\pyi-env-name``
 and makes it the current environment.
 A new command shell
 window opens in which you can run commands within this environment.
-Enter the command
+Enter the command::
 
-  ``pip install PyInstaller``
+    pip install PyInstaller
 
 Once it is installed, to use |PyInstaller|,
 
@@ -92,9 +92,9 @@ Verifying the installation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 On all platforms, the command ``pyinstaller`` should now exist on the
-execution path. To verify this, enter the command
+execution path. To verify this, enter the command::
 
-  ``pyinstaller --version``
+    pyinstaller --version
 
 The result should resemble ``3.n`` for a released version,
 and ``3.n.dev0-xxxxxx`` for a development branch.

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -41,7 +41,7 @@ This creates a new virtual environment rooted at ``C:\Python\pyi-env-name``
 and makes it the current environment.
 A new command shell
 window opens in which you can run commands within this environment.
-Enter the command::
+Enter the command ::
 
     pip install PyInstaller
 

--- a/doc/operating-mode.rst
+++ b/doc/operating-mode.rst
@@ -18,7 +18,7 @@ For the great majority of programs, this can be done with one short command, ::
     pyinstaller myscript.py
 
 or with a few added options, for example a windowed application
-as a single-file executable::
+as a single-file executable, ::
 
     pyinstaller --onefile --windowed myscript.py
 

--- a/doc/operating-mode.rst
+++ b/doc/operating-mode.rst
@@ -13,12 +13,12 @@ the active Python interpreter! -- and puts them with
 your script in a single folder,
 or optionally in a single executable file.
 
-For the great majority of programs, this can be done with one short command,
+For the great majority of programs, this can be done with one short command::
 
-	pyinstaller myscript.py
+    pyinstaller myscript.py
 
 or with a few added options, for example a windowed application
-as a single-file executable,
+as a single-file executable::
 
     pyinstaller --onefile --windowed myscript.py
 

--- a/doc/operating-mode.rst
+++ b/doc/operating-mode.rst
@@ -13,7 +13,7 @@ the active Python interpreter! -- and puts them with
 your script in a single folder,
 or optionally in a single executable file.
 
-For the great majority of programs, this can be done with one short command::
+For the great majority of programs, this can be done with one short command, ::
 
     pyinstaller myscript.py
 


### PR DESCRIPTION
Several pages in the documentation have code-blocks improperly formatted as quote blocks. This leads to commands being displayed improperly.

For example, in [`operating-mode.rst`](https://pyinstaller.readthedocs.io/en/stable/operating-mode.html#what-pyinstaller-does-and-how-it-does-it), the option for single-executable mode:

    pyinstaller --onefile --windowed myscript.py

Incorrectly renders with a single dash, causing the command to fail.

    pyinstaller -onefile -windowed myscript.py