### PR TITLE
Added firebase_admin hook

### DIFF
--- a/PyInstaller/hooks/hook-firebase_admin.py
+++ b/PyInstaller/hooks/hook-firebase_admin.py
@@ -1,0 +1,2 @@
+from PyInstaller.utils.hooks import copy_metadata
+datas = copy_metadata('google-api-core')

--- a/PyInstaller/hooks/hook-firebase_admin.py
+++ b/PyInstaller/hooks/hook-firebase_admin.py
@@ -1,2 +1,11 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013-2018, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
 from PyInstaller.utils.hooks import copy_metadata
 datas = copy_metadata('google-api-core')


### PR DESCRIPTION
I'm using `firebase_admin` package, and this hook was required to avoid `DistributionNotFound` error when attempting to execute the built binary.