### PR TITLE
Fix to show utf-8 debug messages correctly(noconsole mode)/convert to…

### DIFF
--- a/bootloader/src/pyi_global.c
+++ b/bootloader/src/pyi_global.c
@@ -201,14 +201,21 @@ void vprintf_to_stderr(const char *fmt, va_list v) {
     if (pyi_win32_utf8_to_mbs(mbcs_buffer,
                               utf8_buffer,
                               VPRINTF_TO_STDERR_BUFSIZE)) {
-        fprintf(stderr, mbcs_buffer);
+        fprintf(stderr, "%s", mbcs_buffer);
     }
     else {
-        fprintf(stderr, utf8_buffer);
+        fprintf(stderr, "%s", utf8_buffer);
     }
 #else
     vfprintf(stderr, fmt, v);
 #endif /* if defined(_WIN32) */
+}
+
+void printf_to_stderr(const char* fmt, ...) {
+    va_list v;
+    va_start(v, fmt);
+    vprintf_to_stderr(fmt, v);
+    va_end(v);
 }
 
 /*
@@ -267,6 +274,6 @@ void pyi_global_winerror(const char *funcname, const char *fmt, ...) {
     va_start(v, fmt);
     vprintf_to_stderr(fmt, v);
     va_end(v);
-    vprintf_to_stderr("%s: %s", funcname, GetWinErrorString(GetLastError()));
+    printf_to_stderr("%s: %s", funcname, GetWinErrorString(GetLastError()));
 }
 #endif

--- a/bootloader/src/pyi_global.c
+++ b/bootloader/src/pyi_global.c
@@ -190,7 +190,6 @@ mbvs(const char *fmt, ...)
     #endif /* if defined(_WIN32) && defined(WINDOWED) */
 #endif /* ifdef LAUNCH_DEBUG */
 
-/* TODO improve following for windows. */
 #define VPRINTF_TO_STDERR_BUFSIZE (MBTXTLEN * 2)
 void vprintf_to_stderr(const char *fmt, va_list v) {
 #if defined(_WIN32)

--- a/bootloader/src/pyi_global.c
+++ b/bootloader/src/pyi_global.c
@@ -192,15 +192,12 @@ mbvs(const char *fmt, ...)
 
 /* TODO improve following for windows. */
 #define VPRINTF_TO_STDERR_BUFSIZE (MBTXTLEN * 2)
-void vprintf_to_stderr(const char *fmt, ...) {
-    va_list v;
+void vprintf_to_stderr(const char *fmt, va_list v) {
 #if defined(_WIN32)
     char utf8_buffer[VPRINTF_TO_STDERR_BUFSIZE];
     char mbcs_buffer[VPRINTF_TO_STDERR_BUFSIZE];
 
-    va_start(v, fmt);
     vsnprintf(utf8_buffer, VPRINTF_TO_STDERR_BUFSIZE, fmt, v);
-    va_end(v);
     if (pyi_win32_utf8_to_mbs(mbcs_buffer,
                               utf8_buffer,
                               VPRINTF_TO_STDERR_BUFSIZE)) {
@@ -210,9 +207,7 @@ void vprintf_to_stderr(const char *fmt, ...) {
         fprintf(stderr, utf8_buffer);
     }
 #else
-    va_start(v, fmt);
     vfprintf(stderr, fmt, v);
-    va_end(v);
 #endif /* if defined(_WIN32) */
 }
 

--- a/bootloader/src/pyi_global.c
+++ b/bootloader/src/pyi_global.c
@@ -195,7 +195,6 @@ mbvs(const char *fmt, ...)
 void vprintf_to_stderr(const char *fmt, ...) {
     va_list v;
 #if defined(_WIN32)
-    int count;
     char utf8_buffer[VPRINTF_TO_STDERR_BUFSIZE];
     char mbcs_buffer[VPRINTF_TO_STDERR_BUFSIZE];
 
@@ -249,7 +248,6 @@ void pyi_global_perror(const char *funcname, const char *fmt, ...) {
 
     va_start(v, fmt);
     vprintf_to_stderr(fmt, v);
-    vfprintf(stderr, fmt, v);
     va_end(v);
 
     perror(funcname);  // perror() writes to stderr
@@ -273,7 +271,7 @@ void pyi_global_winerror(const char *funcname, const char *fmt, ...) {
 
     va_start(v, fmt);
     vprintf_to_stderr(fmt, v);
-    va_end(v);    
+    va_end(v);
     vprintf_to_stderr("%s: %s", funcname, GetWinErrorString(GetLastError()));
 }
 #endif

--- a/bootloader/src/pyi_global.c
+++ b/bootloader/src/pyi_global.c
@@ -310,7 +310,7 @@ void pyi_global_winerror(const char *funcname, const char *fmt, ...) {
     va_end(v);
     pyi_print_encoded_if_possible(utf8_formatted);
     
-    vsprintf(utf8_formatted, "%s: %s", funcname, GetWinErrorString(error_code));
+    sprintf(utf8_formatted, "%s: %s", funcname, GetWinErrorString(error_code));
     pyi_print_encoded_if_possible(utf8_formatted);
 }
 

--- a/bootloader/src/pyi_win32_utils.c
+++ b/bootloader/src/pyi_win32_utils.c
@@ -63,20 +63,27 @@ char * GetWinErrorString(DWORD error_code) {
     if(error_code == 0) {
         error_code = GetLastError();
     }
-    FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM, // dwFlags
-                   NULL,                       // lpSource
-                   error_code,                 // dwMessageID
-                   0,                          // dwLanguageID
-                   errorString,                // lpBuffer
-                   ERROR_STRING_MAX,           // nSize
-                   NULL                        // Arguments
-                   );
+    wchar_t local_buffer[ERROR_STRING_MAX / 3];
+    DWORD result;
+    char * result2;
+    result = FormatMessageW(
+        FORMAT_MESSAGE_FROM_SYSTEM, // dwFlags
+        NULL,                       // lpSource
+        error_code,                 // dwMessageID
+        MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), // dwLanguageID
+        local_buffer,               // lpBuffer
+        ERROR_STRING_MAX / 3,       // nSize
+        NULL                        // Arguments
+        );
 
-    if (NULL == errorString) {
+    if (!result) {
         return "FormatMessage failed.";
     }
+    result2 = pyi_win32_utils_to_utf8(errorString, local_buffer, ERROR_STRING_MAX);
+    if (!result2) {
+        return "pyi_win32_utils_to_utf8 failed.";
+    }
     return errorString;
-
 }
 
 int

--- a/bootloader/src/pyi_win32_utils.c
+++ b/bootloader/src/pyi_win32_utils.c
@@ -62,8 +62,7 @@ static char errorString[ERROR_STRING_MAX];
 char * GetWinErrorString(DWORD error_code) {
     wchar_t local_buffer[ERROR_STRING_MAX];
     DWORD result;
-    char * result2;
-    
+
     if (error_code == 0) {
         error_code = GetLastError();
     }
@@ -73,16 +72,18 @@ char * GetWinErrorString(DWORD error_code) {
         error_code,                 // dwMessageID
         MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), // dwLanguageID
         local_buffer,               // lpBuffer
-        ERROR_STRING_MAX,       // nSize
+        ERROR_STRING_MAX,           // nSize
         NULL                        // Arguments
         );
 
     if (!result) {
-        return "FormatMessage failed.";
+        FATAL_WINERROR("FormatMessageW", "No error messages generated.\n");
+        return "PyInstaller: FormatMessageW failed.";
     }
-    result2 = pyi_win32_utils_to_utf8(errorString, local_buffer, ERROR_STRING_MAX);
-    if (!result2) {
-        return "pyi_win32_utils_to_utf8 failed.";
+    if (!pyi_win32_utils_to_utf8(errorString,
+                                 local_buffer,
+                                 ERROR_STRING_MAX)) {
+        return "PyInstaller: pyi_win32_utils_to_utf8 failed.";
     }
     return errorString;
 }

--- a/bootloader/src/pyi_win32_utils.c
+++ b/bootloader/src/pyi_win32_utils.c
@@ -66,6 +66,12 @@ char * GetWinErrorString(DWORD error_code) {
     if (error_code == 0) {
         error_code = GetLastError();
     }
+    /* Note: Giving 0 to dwLanguageID means MAKELANGID(LANG_NEUTRAL,
+     * SUBLANG_NEUTRAL), but we should use SUBLANG_DEFAULT instead of
+     * SUBLANG_NEUTRAL. Please see the note written in 
+     * "Language Identifier Constants and Strings" on MSDN.
+     * https://docs.microsoft.com/en-us/windows/desktop/intl/language-identifier-constants-and-strings
+     */
     result = FormatMessageW(
         FORMAT_MESSAGE_FROM_SYSTEM, // dwFlags
         NULL,                       // lpSource

--- a/bootloader/src/pyi_win32_utils.c
+++ b/bootloader/src/pyi_win32_utils.c
@@ -60,19 +60,20 @@ static char errorString[ERROR_STRING_MAX];
  */
 
 char * GetWinErrorString(DWORD error_code) {
-    if(error_code == 0) {
-        error_code = GetLastError();
-    }
-    wchar_t local_buffer[ERROR_STRING_MAX / 3];
+    wchar_t local_buffer[ERROR_STRING_MAX];
     DWORD result;
     char * result2;
+    
+    if (error_code == 0) {
+        error_code = GetLastError();
+    }
     result = FormatMessageW(
         FORMAT_MESSAGE_FROM_SYSTEM, // dwFlags
         NULL,                       // lpSource
         error_code,                 // dwMessageID
         MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), // dwLanguageID
         local_buffer,               // lpBuffer
-        ERROR_STRING_MAX / 3,       // nSize
+        ERROR_STRING_MAX,       // nSize
         NULL                        // Arguments
         );
 

--- a/bootloader/src/pyi_win32_utils.c
+++ b/bootloader/src/pyi_win32_utils.c
@@ -68,7 +68,7 @@ char * GetWinErrorString(DWORD error_code) {
     }
     /* Note: Giving 0 to dwLanguageID means MAKELANGID(LANG_NEUTRAL,
      * SUBLANG_NEUTRAL), but we should use SUBLANG_DEFAULT instead of
-     * SUBLANG_NEUTRAL. Please see the note written in 
+     * SUBLANG_NEUTRAL. Please see the note written in
      * "Language Identifier Constants and Strings" on MSDN.
      * https://docs.microsoft.com/en-us/windows/desktop/intl/language-identifier-constants-and-strings
      */


### PR DESCRIPTION
… mbcs strings before write to stderr(console mode) on Windows.

Until this patch applied, all non-ASCII messages are failed to show(mojibake).
For no-console(windowed) mode, uses MessageBoxW instead of MessageBoxA.
For console mode, strings encoded with user console encodings.

Note1: waf build system has a bug to detect MSVC with Japanese (or DBCS localized) version of Windows.
Note2: Because of C/C++ specification, we can only use one of printf or wprintf for each process. C/C++ stream can have 8bit mode or 16bit mode which is selected by first (w)printf, but cannot switch after first output. That's the reason I use MBCS for console mode.