### PR TITLE
Fix to use UTF-8 while reading XML manifest file. 

### DIFF
--- a/PyInstaller/utils/win32/winmanifest.py
+++ b/PyInstaller/utils/win32/winmanifest.py
@@ -911,7 +911,7 @@ class Manifest(object):
             xmlstr = domtree.toprettyxml(indent, newl, encoding)
         else:
             xmlstr = domtree.toprettyxml(indent, newl)
-        xmlstr = xmlstr.decode().strip(os.linesep).replace(
+        xmlstr = xmlstr.decode(encoding).strip(os.linesep).replace(
                 '<?xml version="1.0" encoding="%s"?>' % encoding,
                 '<?xml version="1.0" encoding="%s" standalone="yes"?>' %
                 encoding)
@@ -1072,8 +1072,7 @@ def create_manifest(filename, manifest, console, uac_admin=False, uac_uiaccess=F
     # only write a new manifest if it is different from the old
     need_new = not os.path.exists(filename)
     if not need_new:
-        with open(filename) as f:
-            old_xml = f.read()
+        old_xml = ManifestFromXMLFile(filename).toprettyxml()
         new_xml = manifest.toprettyxml().replace('\r','')
 
         # this only works if PYTHONHASHSEED is set in environment

--- a/news/3478.bugfix.rst
+++ b/news/3478.bugfix.rst
@@ -1,0 +1,3 @@
+Fix encoding problem raised while reading XML manifest file which includes
+Non ASCII characters. Otherwise, Pyinstaller cannot build executable which
+runs ``<Named by non ASCII characters>.py`` at first.

--- a/tests/functional/test_updating_manifest.py
+++ b/tests/functional/test_updating_manifest.py
@@ -1,0 +1,64 @@
+# -*- encoding: utf-8 -*-
+
+__author__ = 'Suzumizaki-Kimitaka(鈴見咲 君高)'
+
+# -----------------------------------------------------------------------------
+# Copyright (c) 2005-2018, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+# -----------------------------------------------------------------------------
+
+from PyInstaller.utils.win32 import winmanifest
+from PyInstaller.utils.tests import skipif_notwin
+from PyInstaller import is_py2
+
+
+test_manifest_which_uses_non_ascii = \
+    r'''<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+      <assemblyIdentity name="日本語で書かれた名前"
+       processorArchitecture="amd64" type="win32" version="1.0.0.0"/>
+      <dependency>
+        <dependentAssembly>
+          <assemblyIdentity language="*"
+           name="Microsoft.Windows.Common-Controls" processorArchitecture="*"
+            publicKeyToken="6595b64144ccf1df" type="win32" version="6.0.0.0"/>
+          <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1"/>
+        </dependentAssembly>
+      </dependency>
+      <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+        <application>
+          <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
+          <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+          <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+          <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+          <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+        </application>
+      </compatibility>
+    </assembly>
+    '''
+
+
+@skipif_notwin
+def test_reading_manifest(tmpdir):
+    """Check not using invalid encoding when reading XML manifest files
+
+    Currently, Python 3.6.5, "open" built-in functions uses the
+    encoding which locale.getpreferredencoding() returns. But generally,
+    XML manifest files are written with UTF-8 even localized Windows.
+    We check here not to use local encoding against UTF-8 manifest file.
+    """
+    # We create the XML file written with UTF-8 as Microsoft tools do.
+    tmppath = tmpdir.join('manifest.xml')
+    with tmppath.open('wt', ensure=True, encoding='utf-8') as write_handle:
+        if is_py2:
+            write_handle.write(unicode(test_manifest_which_uses_non_ascii,
+                                       'utf-8'))
+        else:
+            write_handle.write(test_manifest_which_uses_non_ascii)
+    # ... and check the following method always uses UTF-8.
+    # It will read the file, reformat and overwrite it.
+    winmanifest.create_manifest(str(tmppath), None, None)


### PR DESCRIPTION
Otherwise, PyInstaller cannot make the package which starts &lt;Non-ASCII-named&gt;.py.
Of course, this is the issue under Windows.