### PR TITLE
Hooks: Added empty string check for version in is_module_satisfies()

### DIFF
--- a/PyInstaller/utils/hooks/__init__.py
+++ b/PyInstaller/utils/hooks/__init__.py
@@ -492,7 +492,10 @@ def is_module_satisfies(requirements, version=None, version_attr='__version__'):
         version = get_module_attribute(module_name, version_attr)
 
     # Compare this version against the version parsed from these requirements.
-    return version in requirements_parsed
+    if version is '':
+        return False
+    else:
+        return version in requirements_parsed
 
 
 def is_package(module_name):


### PR DESCRIPTION
'' in string returns True in Python.
Previously return version in requirements_parsed returned True.
Now added an if statement to check for an empty string check for version,
before returning the value of the function.
Fixes #3428