### PR TITLE
Fix Security-Alert: try to store file outside of dist-directory. Aborting. 'my..data.txt'

### DIFF
--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -678,7 +678,8 @@ class COLLECT(Target):
             if not os.path.exists(fnm) or not os.path.isfile(fnm) and is_path_to_egg(fnm):
                 # file is contained within python egg, it is added with the egg
                 continue
-            if os.pardir in os.path.normpath(inm).split(os.sep) or os.path.isabs(inm):
+            if os.pardir in os.path.normpath(inm).split(os.sep) \
+               or os.path.isabs(inm):
                 raise SystemExit('Security-Alert: try to store file outside '
                                  'of dist-directory. Aborting. %r' % inm)
             tofnm = os.path.join(self.name, inm)

--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -678,7 +678,7 @@ class COLLECT(Target):
             if not os.path.exists(fnm) or not os.path.isfile(fnm) and is_path_to_egg(fnm):
                 # file is contained within python egg, it is added with the egg
                 continue
-            if os.pardir in os.path.normpath(inm) or os.path.isabs(inm):
+            if os.pardir in os.path.normpath(inm).split(os.sep) or os.path.isabs(inm):
                 raise SystemExit('Security-Alert: try to store file outside '
                                  'of dist-directory. Aborting. %r' % inm)
             tofnm = os.path.join(self.name, inm)


### PR DESCRIPTION
resolves #2641

following up on an issue where the security alert is triggered when
building my code, and ran into this issue. PR seemed trivial, so putting
it up to help.

Not sure this will resolve my own issue with `inm` having a crazy path in my case