### PR TITLE
Hooks: Fix missing SSL libraries on Windows with PyQt5.QtNetwork

### DIFF
--- a/PyInstaller/hooks/hook-PyQt5.QtNetwork.py
+++ b/PyInstaller/hooks/hook-PyQt5.QtNetwork.py
@@ -6,6 +6,20 @@
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
-from PyInstaller.utils.hooks import add_qt5_dependencies
+import os.path
+
+from PyInstaller.utils.hooks import pyqt5_library_info, add_qt5_dependencies
+from PyInstaller.compat import is_win
 
 hiddenimports, binaries, datas = add_qt5_dependencies(__file__)
+
+if is_win:
+    rel_data_path = ['PyQt5', 'Qt', 'bin']
+    binaries += [
+        (os.path.join(
+            pyqt5_library_info.location['BinariesPath'], 'libeay32.dll'),
+        os.path.join(*rel_data_path)),
+        (os.path.join(
+            pyqt5_library_info.location['BinariesPath'], 'ssleay32.dll'),
+         os.path.join(*rel_data_path))
+    ]

--- a/PyInstaller/hooks/hook-PyQt5.QtNetwork.py
+++ b/PyInstaller/hooks/hook-PyQt5.QtNetwork.py
@@ -13,13 +13,14 @@ from PyInstaller.compat import is_win
 
 hiddenimports, binaries, datas = add_qt5_dependencies(__file__)
 
+# Add libraries needed for SSL. See issue #3520.
 if is_win:
     rel_data_path = ['PyQt5', 'Qt', 'bin']
     binaries += [
-        (os.path.join(
-            pyqt5_library_info.location['BinariesPath'], 'libeay32.dll'),
-        os.path.join(*rel_data_path)),
-        (os.path.join(
-            pyqt5_library_info.location['BinariesPath'], 'ssleay32.dll'),
+        (os.path.join(pyqt5_library_info.location['BinariesPath'],
+                      'libeay32.dll'),
+         os.path.join(*rel_data_path)),
+        (os.path.join(pyqt5_library_info.location['BinariesPath'],
+                      'ssleay32.dll'),
          os.path.join(*rel_data_path))
     ]

--- a/tests/functional/test_libraries.py
+++ b/tests/functional/test_libraries.py
@@ -297,6 +297,15 @@ def test_PyQt5_QtQuick(pyi_builder):
         """)
 
 
+@importorskip('PyQt5')
+def test_PyQt5_SSL_support(pyi_builder):
+    pyi_builder.test_source(
+        """
+        from PyQt5.QtNetwork import QSslSocket
+        assert QSslSocket.supportsSsl()
+        """)
+
+
 # Test that the ``PyQt5.Qt`` module works by importing something from it.
 #
 # The Qt Bluetooth API (which any import to ``PyQt5.Qt`` implicitly imports)
@@ -799,7 +808,7 @@ def test_web3(pyi_builder):
 def test_phonenumbers(pyi_builder):
     pyi_builder.test_source("""
         import phonenumbers
-        
+
         number = '+17034820623'
         parsed_number = phonenumbers.parse(number)
 


### PR DESCRIPTION
Fixes #3511 . Tested to work on Windows.

I wish I could have added a functional test as well, but I can't seem to get the tests to run even after installing pypiwin32. I'm getting the following error:

```console
> py.test -n 8 tests\functional
PyInstaller cannot check for assembly dependencies.
Please install PyWin32 or pywin32-ctypes.

pip install pypiwin32
```