### PR TITLE
Detection of python library failing when using python from RedHat Software Collections

### DIFF
--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -85,7 +85,7 @@ elif is_unix:
     PYDYLIB_NAMES = {'libpython%d.%d.so.1.0' % _pyver,
                      'libpython%d.%dm.so.1.0' % _pyver,
                      'libpython%d.%dmu.so.1.0' % _pyver,
-                     'libpython%d.%dm.so.rh-python%d%d-1.0' % (_pyver[0], _pyver[1], _pyver[0], _pyver[1])}
+                     'libpython%d.%dm.so.rh-python%d%d-1.0' % (_pyver * 2)}
 else:
     raise SystemExit('Your platform is not yet supported. '
                      'Please define constant PYDYLIB_NAMES for your platform.')

--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -84,7 +84,8 @@ elif is_unix:
     # Python 3 .so library on Linux is: libpython3.2mu.so.1.0, libpython3.3m.so.1.0
     PYDYLIB_NAMES = {'libpython%d.%d.so.1.0' % _pyver,
                      'libpython%d.%dm.so.1.0' % _pyver,
-                     'libpython%d.%dmu.so.1.0' % _pyver}
+                     'libpython%d.%dmu.so.1.0' % _pyver,
+                     'libpython%d.%dm.so.rh-python%d%d-1.0' % (_pyver[0], _pyver[1], _pyver[0], _pyver[1])}
 else:
     raise SystemExit('Your platform is not yet supported. '
                      'Please define constant PYDYLIB_NAMES for your platform.')


### PR DESCRIPTION
Issue with Pyinstaller 3.3.1
Easily reproducible with a docker [centos](https://hub.docker.com/_/centos/)
Python version 3.6, package **rh-python36-2.0-1** available in RHSCL repo.
`pyinstaller --onefile myapp.py`

I was using python 3.6 from RedHat Software Collections and got an issue while trying to generate a bundle for my application with the option `--onefile`
Python is installed in an unusual path and libraries have non-standard names: 
* /opt/rh/rh-python36/root/usr/bin/python
* /opt/rh/rh-python36/root/usr/lib64
* /opt/rh/rh-python36/root/usr/lib64/libpython3.6m.so
* /opt/rh/rh-python36/root/usr/lib64/libpython3.6m.so.rh-python36-1.0
* /opt/rh/rh-python36/root/usr/lib64/libpython3.so.rh-python36

I managed to make the packaging to work with the `--onefile` option. I tried to make the fix as general as possible so that all python versions from RHSCL will now be detected correctly. However I think it needs to be reworked.
What would you advise to fix the detection at [PyInstaller/depend/bindepend.py#L757](https://github.com/pyinstaller/pyinstaller/blob/v3.3.1/PyInstaller/depend/bindepend.py#L757) and  [PyInstaller/building/build_main.py#L606](https://github.com/pyinstaller/pyinstaller/blob/v3.3.1/PyInstaller/building/build_main.py#L606) ? 