### PR TITLE
Doc: Revise section on info_plist for plistlib functionality.

### DIFF
--- a/doc/_common_definitions.txt
+++ b/doc/_common_definitions.txt
@@ -43,6 +43,7 @@
 .. _PIL: http://www.pythonware.com/products/pil/
 .. _pip: http://www.pip-installer.org/
 .. _pip-Win: https://sites.google.com/site/pydatalog/python/pip-for-windows
+.. _plistlib: https://docs.python.org/3/library/plistlib.html
 .. _png2icns: http://icns.sourceforge.net/
 .. _PyCrypto: https://pypi.python.org/pypi/pycrypto/
 .. _PyInstaller.org: https://github.com/pyinstaller/pyinstaller/wiki/Community

--- a/doc/spec-files.rst
+++ b/doc/spec-files.rst
@@ -375,8 +375,8 @@ Python dict with keys and values to be included in the :file:`Info.plist`
 file.
 |PyInstaller| creates :file:`Info.plist` from the info_plist dict
 using the Python Standard Library module plistlib_.
-plistlib can handle nested python objects (which are translated to nested
-XML.)  Python data types are translated to the proper :file:`Info.plist`
+plistlib can handle nested Python objects (which are translated to nested
+XML,) and translates Python data types to the proper :file:`Info.plist`
 XML types.  Here's an example::
 
     app = BUNDLE(exe,
@@ -402,12 +402,11 @@ also work in retina screen.
 
 Also in the above example is the key ``CFBundleDocumentTypes``.
 This entry in :file:`Info.plist` tells Mac OS X
-what filetypes your app supports.  (see `Apple document types`_).
+what filetypes your app supports (see `Apple document types`_).
 The value of that key in :file:`Info.plist` is a list of dicts,
 each containing up to five key:value pairs.  This is represented in the
 info_plist argument by assigning to the key ``CFBundleDocumentTypes`` a value
 that is a python list containing python dicts.
-
 
 Multipackage Bundles
 ~~~~~~~~~~~~~~~~~~~~~

--- a/doc/spec-files.rst
+++ b/doc/spec-files.rst
@@ -376,7 +376,7 @@ file.
 |PyInstaller| creates :file:`Info.plist` from the info_plist dict
 using the Python Standard Library module plistlib_.
 plistlib can handle nested Python objects (which are translated to nested
-XML,) and translates Python data types to the proper :file:`Info.plist`
+XML), and translates Python data types to the proper :file:`Info.plist`
 XML types.  Here's an example::
 
     app = BUNDLE(exe,

--- a/doc/spec-files.rst
+++ b/doc/spec-files.rst
@@ -384,7 +384,8 @@ XML types.  Here's an example::
              icon=None,
              bundle_identifier=None,
              info_plist={
-             	'NSHighResolutionCapable': True,
+             	'NSPrincipleClass': 'NSApplication',
+                'NSAppleScriptEnabled': False,
                 'CFBundleDocumentTypes': [
                     {
                         'CFBundleTypeName': 'My File Format',
@@ -396,13 +397,12 @@ XML types.  Here's an example::
              	},
              )
 
-For example, when you use PyQt5,
-you can set ``NSHighResolutionCapable`` to ``True`` to let your app
-also work in retina screen.
-
-Also in the above example is the key ``CFBundleDocumentTypes``.
-This entry in :file:`Info.plist` tells Mac OS X
-what filetypes your app supports (see `Apple document types`_).
+In the above example, the key/value ``'NSPrincipleClass': 'NSApplication'`` is
+necessary to allow Mac OS X to render applications using retina resolution.
+The key ``'NSAppleScriptEnabled'`` is assigned the Python boolean
+``False``, which will be output to :file:`Info.plist` properly as ``<false/>``.
+Finally the key ``CFBundleDocumentTypes`` tells Mac OS X what filetypes your
+application supports (see `Apple document types`_).
 
 Multipackage Bundles
 ~~~~~~~~~~~~~~~~~~~~~

--- a/doc/spec-files.rst
+++ b/doc/spec-files.rst
@@ -370,60 +370,44 @@ of ``Info.plist``.)
 
 |PyInstaller| creates a minimal :file:`Info.plist`.
 You can add or overwrite entries in the plist by passing an
-``info_plist=`` parameter to the BUNDLE call.
-The value of this argument is a Python dict.
-Each key and value in the dict becomes a key and value in the
-:file:`Info.plist` file.
-For example, when you use PyQt5,
-you can set ``NSHighResolutionCapable`` to ``True`` to let your app
-also work in retina screen::
-
-    app = BUNDLE(exe,
-             name='myscript.app',
-             icon=None,
-             bundle_identifier=None
-             info_plist={
-             	'NSHighResolutionCapable': True
-             	},
-             )
-
+``info_plist=`` parameter to the BUNDLE call.  Its argument should be a
+Python dict with keys and values to be included in the :file:`Info.plist`
+file.
 |PyInstaller| creates :file:`Info.plist` from the info_plist dict
 using the Python Standard Library module plistlib_.
 plistlib can handle nested python objects (which are translated to nested
-XML.)  The following python data types are translated to the proper
-:file:`Info.plist` types: strings, integers, floats, booleans, tuples, lists,
-dictionaries (but only with string keys), Data, bytes, bytesarray, and
-datetime.datetime objects.
-
-An example of a useful nested :file:`Info.plist` object is the
-``CFBundleDocumentTypes`` entry.  To modify :file:`Info.plist` to tell Mac OS X
-what filetypes your app supports, you would add a 
-``CFBundleDocumentTypes`` entry to :file:`Info.plist`
-(see `Apple document types`_).
-The value of that keyword is a list of dicts,
-each containing up to five key:value pairs.  This is represented in the
-info_plist argument by assigning to the key ``CFBundleDocumentTypes`` a value
-that is a python list containing python dicts.  A simple example with
-one file type::
+XML.)  Python data types are translated to the proper :file:`Info.plist`
+XML types.  Here's an example::
 
     app = BUNDLE(exe,
              name='myscript.app',
              icon=None,
-             bundle_identifier=None
+             bundle_identifier=None,
              info_plist={
-             	'NSHighResolutionCapable': True
+             	'NSHighResolutionCapable': True,
                 'CFBundleDocumentTypes': [
                     {
-                        'CFBundleTypeName': 'My File Format'
-                        'CFBundleTypeIconFile': 'MyFileIcon.icns'
-                        'LSItemContentTypes': [
-                            'com.example.myformat'
-                            ]
+                        'CFBundleTypeName': 'My File Format',
+                        'CFBundleTypeIconFile': 'MyFileIcon.icns',
+                        'LSItemContentTypes': ['com.example.myformat'],
                         'LSHandlerRank': 'Owner'
                         }
                     ]
              	},
              )
+
+For example, when you use PyQt5,
+you can set ``NSHighResolutionCapable`` to ``True`` to let your app
+also work in retina screen.
+
+Also in the above example is the key ``CFBundleDocumentTypes``.
+This entry in :file:`Info.plist` tells Mac OS X
+what filetypes your app supports.  (see `Apple document types`_).
+The value of that key in :file:`Info.plist` is a list of dicts,
+each containing up to five key:value pairs.  This is represented in the
+info_plist argument by assigning to the key ``CFBundleDocumentTypes`` a value
+that is a python list containing python dicts.
+
 
 Multipackage Bundles
 ~~~~~~~~~~~~~~~~~~~~~

--- a/doc/spec-files.rst
+++ b/doc/spec-files.rst
@@ -403,10 +403,6 @@ also work in retina screen.
 Also in the above example is the key ``CFBundleDocumentTypes``.
 This entry in :file:`Info.plist` tells Mac OS X
 what filetypes your app supports (see `Apple document types`_).
-The value of that key in :file:`Info.plist` is a list of dicts,
-each containing up to five key:value pairs.  This is represented in the
-info_plist argument by assigning to the key ``CFBundleDocumentTypes`` a value
-that is a python list containing python dicts.
 
 Multipackage Bundles
 ~~~~~~~~~~~~~~~~~~~~~

--- a/doc/spec-files.rst
+++ b/doc/spec-files.rst
@@ -383,36 +383,47 @@ also work in retina screen::
              icon=None,
              bundle_identifier=None
              info_plist={
-             	'NSHighResolutionCapable': 'True'
+             	'NSHighResolutionCapable': True
              	},
              )
 
-The ``info_plist=`` parameter only handles simple key:value pairs.
-It cannot handle nested XML arrays.
-For example, if you want to modify :file:`Info.plist` to tell Mac OS X
-what filetypes your app supports, you must add a 
+|PyInstaller| creates :file:`Info.plist` from the info_plist dict
+using the Python Standard Library module plistlib_.
+plistlib can handle nested python objects (which are translated to nested
+XML.)  The following python data types are translated to the proper
+:file:`Info.plist` types: strings, integers, floats, booleans, tuples, lists,
+dictionaries (but only with string keys), Data, bytes, bytesarray, and
+datetime.datetime objects.
+
+An example of a useful nested :file:`Info.plist` object is the
+``CFBundleDocumentTypes`` entry.  To modify :file:`Info.plist` to tell Mac OS X
+what filetypes your app supports, you would add a 
 ``CFBundleDocumentTypes`` entry to :file:`Info.plist`
 (see `Apple document types`_).
 The value of that keyword is a list of dicts,
-each containing up to five key:value pairs.
+each containing up to five key:value pairs.  This is represented in the
+info_plist argument by assigning to the key ``CFBundleDocumentTypes`` a value
+that is a python list containing python dicts.  A simple example with
+one file type::
 
-To add such a value to your app's :file:`Info.plist` you must edit the
-plist file separately after |PyInstaller| has created the app.
-However, when you re-run |PyInstaller|, your changes will be wiped out.
-One solution is to prepare a complete :file:`Info.plist` file and
-copy it into the app after creating it.
-
-Begin by building and testing the windowed app.
-When it works, copy the ``Info.plist`` prepared by |PyInstaller|.
-This includes the ``CFBundleExecutable`` value as well as the
-icon path and bundle identifier if you supplied them.
-Edit the ``Info.plist`` as necessary to add more items
-and save it separately.
-
-From that point on, to rebuild the app call |PyInstaller| in a shell script,
-and follow it with a statement such as::
-
-    cp -f Info.plist dist/myscript.app/Contents/Info.plist
+    app = BUNDLE(exe,
+             name='myscript.app',
+             icon=None,
+             bundle_identifier=None
+             info_plist={
+             	'NSHighResolutionCapable': True
+                'CFBundleDocumentTypes': [
+                    {
+                        'CFBundleTypeName': 'My File Format'
+                        'CFBundleTypeIconFile': 'MyFileIcon.icns'
+                        'LSItemContentTypes': [
+                            'com.example.myformat'
+                            ]
+                        'LSHandlerRank': 'Owner'
+                        }
+                    ]
+             	},
+             )
 
 Multipackage Bundles
 ~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
See Issue #3540 
As plistlib has been added to the code to process the info_plist build argument dict, info_plist can now accept nested python objects, and python datatypes other than strings.  This update to the documentation reflects these new capabilities and includes new examples, as well as removing descriptions of limitations that no longer exist.