### PR TITLE
Test/CI: Update Appveyor to run Windows Server 2016

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,15 @@ branches:
   except:
     - /pyup\/.*/
 
+# Selecting this `image <https://www.appveyor.com/docs/build-environment/#choosing-image-for-your-builds>`_
+# causes Appveyor to run on `Windows Server 2016 <https://www.appveyor.com/docs/build-environment/#operating-system>`_
+# instead of Windows Server 2012. This allows ``test_PyQt5_Qt`` to succeed on
+# PyQt 5.10 and higher, since the updated Qt Bluetooth API (which any import to
+# ``PyQt5.Qt`` implicitly imports) isn't compatible with Windows Server 2012.
+# Specifically, running on Server 2012 causes the test to display an error in
+# `a dialog box <https://github.com/mindfulness-at-the-computer/mindfulness-at-the-computer/issues/234>`_.
+image: Visual Studio 2017
+
 environment:
   PYTEST: py.test -n3 --maxfail 5 --durations=10 --junitxml=junit-results.xml
   APPVEYOR_SAVE_CACHE_ON_ERROR: true

--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -400,8 +400,10 @@ def configure(ctx):
     # searched.
     if ctx.options.target_arch == '32bit':
         ctx.env['MSVC_TARGETS'] = ['x86']
+        ctx.env['MSVC_VERSIONS'] = ['msvc 15.0']
     elif ctx.options.target_arch == '64bit':
         ctx.env['MSVC_TARGETS'] = ['x64']
+        ctx.env['MSVC_VERSIONS'] = ['msvc 15.0']
 
     ### C compiler
     # Allow to use Clang if preferred.

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -61,7 +61,7 @@ pyenchant==2.0.0; sys_platform == 'darwin' or (sys_platform == 'win32' and pytho
 
 # While PyQt5 itself is provided as wheels for Python 3.4, it requires
 # SIP>=4.19 which is not available for Python 3.4.
-pyqt5==5.9.2; python_version >= '3.5'
+pyqt5==5.10.1; python_version >= '3.5'
 
 # No wheel for python 3.5.
 PySide==1.2.4; sys_platform == 'win32' and python_version <= '3.4'


### PR DESCRIPTION
The purpose of this PR is to allow PyQt 5.10 tests to pass, since the underlying Qt libraries aren't compatible with the standard Appveyor Windows Server 2012 R2 environment. Comments in the text of the PR provide more information on this incompatibility.

However, the tests [fail](https://ci.appveyor.com/project/bjones1/pyinstaller/build/1.0.692):
- Python 3.6 64-bit tests are cut off after 30 minutes of execution, before they complete.
- Python 3.6 and 3.5 32-bit tests run for 1 hour but don't complete before they're cut off. They complete less than 25% of the tests.
- Python 3.4 and 2.7 32-bit tests complete successfully.

I don't know how to fix these longer run times, so I'm keeping this PR only for archival and documentation purposes.