### PR TITLE
Bootloader: OSX: Respect Info.plist options

### DIFF
--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -628,6 +628,7 @@ class COLLECT(Target):
         from ..config import CONF
         Target.__init__(self)
         self.strip_binaries = kws.get('strip', False)
+        self.console = True
 
         if CONF['hasUPX']:
             self.upx_binaries = kws.get('upx', False)
@@ -650,6 +651,7 @@ class COLLECT(Target):
             elif isinstance(arg, Target):
                 self.toc.append((os.path.basename(arg.name), arg.name, arg.typ))
                 if isinstance(arg, EXE):
+                    self.console = arg.console
                     for tocnm, fnm, typ in arg.toc:
                         if tocnm == os.path.basename(arg.name) + ".manifest":
                             self.toc.append((tocnm, fnm, typ))

--- a/PyInstaller/building/osx.py
+++ b/PyInstaller/building/osx.py
@@ -46,6 +46,7 @@ class BUNDLE(Target):
         self.toc = TOC()
         self.strip = False
         self.upx = False
+        self.console = True
 
         # .app bundle identifier for Code Signing
         self.bundle_identifier = kws.get('bundle_identifier')
@@ -61,6 +62,7 @@ class BUNDLE(Target):
                 self.toc.extend(arg.dependencies)
                 self.strip = arg.strip
                 self.upx = arg.upx
+                self.console = arg.console
             elif isinstance(arg, TOC):
                 self.toc.extend(arg)
                 # TOC doesn't have a strip or upx attribute, so there is no way for us to
@@ -69,6 +71,7 @@ class BUNDLE(Target):
                 self.toc.extend(arg.toc)
                 self.strip = arg.strip_binaries
                 self.upx = arg.upx_binaries
+                self.console = arg.console
             else:
                 logger.info("unsupported entry %s", arg.__class__.__name__)
         # Now, find values for app filepath (name), app name (appname), and name
@@ -137,15 +140,12 @@ class BUNDLE(Target):
                            "CFBundlePackageType": "APPL",
                            "CFBundleShortVersionString": self.version,
 
-                           # Setting this to 1 will cause Mac OS X *not* to show
-                           # a dock icon for the PyInstaller process which
-                           # decompresses the real executable's contents. As a
-                           # side effect, the main application doesn't get one
-                           # as well, but at startup time the loader will take
-                           # care of transforming the process type.
-                           "LSBackgroundOnly": False,
-
                            }
+
+        # Setting EXE console=True implies LSBackgroundOnly=True.
+        # But it still can be overwrite by the user.
+        if self.console:
+            info_plist_dict['LSBackgroundOnly'] = True
 
         # Merge info_plist settings from spec file
         if isinstance(self.info_plist, dict) and self.info_plist:

--- a/bootloader/src/pyi_launch.c
+++ b/bootloader/src/pyi_launch.c
@@ -503,15 +503,7 @@ done:
 void
 pyi_launch_initialize(ARCHIVE_STATUS * status)
 {
-#if defined(__APPLE__) && defined(WINDOWED)
-    /*
-     * On OS X this ensures that the application is handled as GUI app.
-     * Call TransformProcessType() in the child process.
-     */
-    ProcessSerialNumber psn = { 0, kCurrentProcess };
-    OSStatus returnCode = TransformProcessType(&psn,
-                                               kProcessTransformToForegroundApplication);
-#elif defined(_WIN32)
+#if defined(_WIN32)
     char * manifest;
     manifest = pyi_arch_get_option(status, "pyi-windows-manifest-filename");
 
@@ -520,7 +512,7 @@ pyi_launch_initialize(ARCHIVE_STATUS * status)
         CreateActContext(manifest);
         free(manifest);
     }
-#endif /* if defined(__APPLE__) && defined(WINDOWED) */
+#endif /* if defined(_WIN32) */
 }
 
 /*


### PR DESCRIPTION
A possible fix for #1917.

## What is the fix/workaround?

As proposed by @codewarrior0 in his [comment](https://github.com/pyinstaller/pyinstaller/pull/1206#issuecomment-165976396), I added a bootloader runtime option `pyi-osx-background` that triggers the right transform type in `pyi_launch_initialize()`.

This is the simplest option as it does not require to add new bootloaders nor a new argument to handle this specific case. The behavior is restored as it should have been: when the user sets `LSUIElement` in the Info.plist dict, PyInstaller handles it.

## Current status

The patch is good but does not work automatically because the TOC option is not yet forwarded to the bootloader.

In `$project/build/BUNDLE-00.toc`, I have the line `('pyi-osx-background', '', 'OPTION')` setted, which is what we need.
But as this kind of TOC line is traited before (when building the PKG), it is not possible to get it via `pyi_arch_get_option(status, "pyi-osx-background")`, steps are:
```
289 INFO: PyInstaller: 3.4.dev0+g8c071568.mod
290 INFO: Python: 3.6.2
297 INFO: Platform: Darwin-16.7.0-x86_64-i386-64bit
299 INFO: UPX is not available.
301 INFO: Extending PYTHONPATH with paths
['.../pyinstaller']
301 INFO: checking Analysis
301 INFO: Building Analysis because Analysis-00.toc is non existent
302 INFO: Initializing module dependency graph...
303 INFO: Initializing module graph hooks...
305 INFO: Analyzing base_library.zip ...
4519 INFO: running Analysis Analysis-00.toc
4533 INFO: Caching module hooks...
4538 INFO: Analyzing systray.py
4552 INFO: Loading module hooks...
4553 INFO: Loading module hook "hook-encodings.py"...
4627 INFO: Loading module hook "hook-pydoc.py"...
4627 INFO: Loading module hook "hook-PyQt5.py"...
4657 INFO: Loading module hook "hook-PyQt5.QtCore.py"...
4749 INFO: Loading module hook "hook-PyQt5.QtGui.py"...
4784 INFO: Loading module hook "hook-PyQt5.QtWidgets.py"...
4819 INFO: Loading module hook "hook-xml.py"...
5172 INFO: Looking for ctypes DLLs
5172 INFO: Analyzing run-time hooks ...
5177 INFO: Including run-time hook 'pyi_rth_qt5.py'
5189 INFO: Looking for dynamic libraries
5451 INFO: Looking for eggs
5451 INFO: Using Python library venv-pyinstaller/bin/../.Python
5457 INFO: Warnings written to systray/build/systray/warn-systray.txt
5495 INFO: Graph cross-reference written to systray/build/systray/xref-systray.html
5508 INFO: checking PYZ
5508 INFO: Building PYZ because PYZ-00.toc is non existent
5509 INFO: Building PYZ (ZlibArchive) systray/build/systray/PYZ-00.pyz
5887 INFO: Building PYZ (ZlibArchive) systray/build/systray/PYZ-00.pyz completed successfully.
5894 INFO: checking PKG
5894 INFO: Building PKG because PKG-00.toc is non existent
5894 INFO: Building PKG (CArchive) PKG-00.pkg
5904 INFO: Building PKG (CArchive) PKG-00.pkg completed successfully.
5905 INFO: Bootloader pyinstaller/PyInstaller/bootloader/Darwin-64bit/runw_d
5905 INFO: checking EXE
5905 INFO: Building EXE because EXE-00.toc is non existent
5905 INFO: Building EXE from EXE-00.toc
5905 INFO: Appending archive to EXE systray/build/systray/systray
5907 INFO: Fixing EXE for code signing systray/build/systray/systray
5915 INFO: Building EXE from EXE-00.toc completed successfully.
5917 INFO: checking COLLECT
5917 INFO: Building COLLECT because COLLECT-00.toc is non existent
5917 INFO: Building COLLECT COLLECT-00.toc
7202 INFO: Building COLLECT COLLECT-00.toc completed successfully.
7209 INFO: This is an agent app (LSUIElement is set to True)
7209 INFO: checking BUNDLE
7209 INFO: Building BUNDLE because BUNDLE-00.toc is non existent
7209 INFO: Building BUNDLE BUNDLE-00.toc
8430 INFO: moving BUNDLE data files to Resource directory
```
As we can see, the line `7209 INFO: This is an agent app (LSUIElement is set to True)` appears too late in the process.

Any clue to make it easy forwarded? Perhaps I misunderstand something?