### PR TITLE
versioninfo: Fixes PE file corruption during version update.

### DIFF
--- a/PyInstaller/utils/win32/versioninfo.py
+++ b/PyInstaller/utils/win32/versioninfo.py
@@ -581,6 +581,23 @@ def SetVersion(exenm, versionfile):
         txt = fp.read()
         fp.close()
         vs = eval(txt)
+
+    # Remember overlay
+    pe = pefile.PE(exenm, fast_load=True)
+    overlay_before = pe.get_overlay()
+    pe.close()
+
     hdst = win32api.BeginUpdateResource(exenm, 0)
     win32api.UpdateResource(hdst, pefile.RESOURCE_TYPE['RT_VERSION'], 1, vs.toRaw())
     win32api.EndUpdateResource (hdst, 0)
+
+    if overlay_before:
+        # Check if the overlay is still present
+        pe = pefile.PE(exenm, fast_load=True)
+        overlay_after = pe.get_overlay()
+        pe.close()
+
+        # If the update removed the overlay data, re-append it
+        if not overlay_after:
+            with open(exenm, 'ab') as exef:
+                exef.write(overlay_before)

--- a/news/3142.bugfix.rst
+++ b/news/3142.bugfix.rst
@@ -1,0 +1,1 @@
+Fixes PE-file corruption during version update.

--- a/news/3572.bugfix.rst
+++ b/news/3572.bugfix.rst
@@ -1,0 +1,1 @@
+Fixes PE-file corruption during version update.


### PR DESCRIPTION
When updating the PE file version resource on some platforms, the Windows API calls
exclude the overlay region when writing back the executable. PyInstaller stores its
archive in the overlay region and the executable unusable without it.

This change restores the overlay region if it is eliminated during version update.

Commit resolves #3142.