### PR TITLE
Make it compatible with applications using Pythonnet package

### DIFF
--- a/PyInstaller/utils/win32/winutils.py
+++ b/PyInstaller/utils/win32/winutils.py
@@ -100,7 +100,7 @@ def import_pywin32_module(module_name, _is_venv=None):
 
     try:
         module = __import__(
-            name=module_name, globals={}, locals={}, fromlist=[''])
+            module_name, globals={}, locals={}, fromlist=[''])
     except ImportError as exc:
         if str(exc).startswith('No system module'):
             # True if "sys.frozen" is currently set.


### PR DESCRIPTION
Python.net override built-in __import__ function and is too strict on its signature. This change allow import to work with all Python (and python.net) versions.