### PR TITLE
3374 - added styles to PySide2 hook to fix style mismatch

### DIFF
--- a/PyInstaller/hooks/hook-PySide2.QtGui.py
+++ b/PyInstaller/hooks/hook-PySide2.QtGui.py
@@ -19,6 +19,7 @@ binaries.extend(qt_plugins_binaries('imageformats', namespace='PySide2'))
 binaries.extend(qt_plugins_binaries('inputmethods', namespace='PySide2'))
 binaries.extend(qt_plugins_binaries('graphicssystems', namespace='PySide2'))
 binaries.extend(qt_plugins_binaries('platforms', namespace='PySide2'))
+binaries.extend(qt_plugins_binaries('styles', namespace='PySide2'))
 
 if is_linux:
     binaries.extend(qt_plugins_binaries('platformthemes', namespace='PySide2'))


### PR DESCRIPTION
This adds the styles directory to binaries and should fix #3374 . I was having the same problem on MacOS. This resolved it for me.