### PR TITLE
3585 - Fix broken arguments including -h flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -154,6 +154,9 @@ install:
   # Install PyInstaller.
   - pip install -e . | cat
 
+  # Make sure the help options print.
+  - python -m pyinstaller -h
+
 
 script:
   - true

--- a/PyInstaller/__main__.py
+++ b/PyInstaller/__main__.py
@@ -36,10 +36,12 @@ class _SmartFormatter(argparse.HelpFormatter):
 
     def _split_lines(self, text, width):
         if text.startswith('R|'):
-            return argparse.RawTextHelpFormatter._split_lines(self, text[2:],
-                                                              width)
+            # The underlying implementation of ``RawTextHelpFormatter._split_lines``
+            # invokes this; mimic it.
+            return text[2:].splitlines()
         else:
-            return argparse.HelpFormatter._split_lines(self, text, width)
+            # Invoke the usual formatter.
+            return super(_SmartFormatter, self)._split_lines(text, width)
 
 
 def run_makespec(filenames, **opts):

--- a/PyInstaller/building/makespec.py
+++ b/PyInstaller/building/makespec.py
@@ -178,7 +178,7 @@ def __add_options(parser):
                    # then provide a default argument of all debug options enabled.
                    const=DEBUG_ALL_CHOICE,
                    # The options specified must come from this list.
-                   choices=[DEBUG_ALL_CHOICE] + DEBUG_ARGUMENT_CHOICES,
+                   choices=DEBUG_ALL_CHOICE + DEBUG_ARGUMENT_CHOICES,
                    # Append choice, rather than storing them (which would
                    # overwrite any previous selections).
                    action='append',

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -94,6 +94,9 @@ install:
   # Install PyInstaller
   - 'pip install -e .'
 
+  # Make sure the help options print.
+  - 'python -m pyinstaller -h'
+
 build: none
 
 test_script:


### PR DESCRIPTION
This is a fix for issue #3585 

The bug was introduced when DEBUG_ALL_CHOICE was placed inside a new list here: https://github.com/pyinstaller/pyinstaller/commit/bbede2ea3cb86c998bd21c3ccfa4a94633039e88#diff-98596315ae5d573e2ec661f6cd25f560R181

argparse was having trouble parsing the arguments.
