### PR TITLE
utils/hooks: Fixes the behavior of get_module_attribute

### DIFF
--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -357,7 +357,7 @@ def exec_command(*cmdargs, **kwargs):
     """
 
     encoding = kwargs.pop('encoding', None)
-    out = subprocess.Popen(cmdargs, stdout=subprocess.PIPE, **kwargs).communicate()[0]
+    out = subprocess.Popen(cmdargs, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, **kwargs).communicate()[0]
     # Python 3 returns stdout/stderr as a byte array NOT as string.
     # Thus we need to convert that to proper encoding.
 

--- a/PyInstaller/utils/hooks/__init__.py
+++ b/PyInstaller/utils/hooks/__init__.py
@@ -287,8 +287,9 @@ def get_module_attribute(module_name, attr_name):
         import %s as m
         print(getattr(m, %r, %r))
     """ % (module_name, attr_name, attr_value_if_undefined))
-
-    if attr_value == attr_value_if_undefined:
+    if 'Error' in attr_value:
+        raise ImportError
+    elif attr_value == attr_value_if_undefined:
         raise AttributeError(
             'Module %r has no attribute %r' % (module_name, attr_name))
     else:
@@ -331,7 +332,7 @@ def get_module_file_attribute(package):
                 pass
         """
         attr = exec_statement(__file__statement % package)
-        if not attr.strip():
+        if 'Error' in attr.strip():
             raise ImportError
     return attr
 
@@ -488,8 +489,11 @@ def is_module_satisfies(requirements, version=None, version_attr='__version__'):
     # If no version was explicitly passed, query this module for it.
     if version is None:
         module_name = requirements_parsed.project_name
-        version = get_module_attribute(module_name, version_attr)
-
+        try:
+            version = get_module_attribute(module_name, version_attr)
+            print(version)
+        except ImportError:
+            raise
     if not version:
         # Module does not exist in the system.
         return False

--- a/tests/unit/test_hookutils.py
+++ b/tests/unit/test_hookutils.py
@@ -16,7 +16,7 @@ from os.path import join
 from PyInstaller.utils.hooks import collect_data_files, collect_submodules, \
     get_module_file_attribute, remove_prefix, remove_suffix, \
     remove_file_extension, is_module_or_submodule, \
-    is_module_satisfies
+    is_module_satisfies, get_module_attribute
 from PyInstaller.compat import exec_python, ALL_SUFFIXES
 
 
@@ -191,7 +191,8 @@ def test_is_module_or_submodule():
 
 def test_is_module_satisfies_package_not_installed():
     assert is_module_satisfies('pytest')
-    assert not is_module_satisfies('magnumopus-no-package-test-case')
+    with pytest.raises(ImportError):
+        is_module_satisfies('magnumopus-no-package-test-case')
 
 
 _DATA_BASEPATH = join(TEST_MOD_PATH, TEST_MOD)
@@ -270,3 +271,10 @@ def test_collect_data_all_included(data_lists):
 def test_get_module_file_attribute_non_exist_module():
     with pytest.raises(ImportError):
         get_module_file_attribute('pyinst_nonexisting_module_name')
+
+# An Import error must be thrown if a module cannot be imported with get_module_attribute.
+def test_get_module_attribute_no_module_import_error():
+    with pytest.raises(ImportError):
+        get_module_attribute('magnum-opus-non-existant-module','')
+    with pytest.raises(AttributeError):
+        get_module_attribute('json','')


### PR DESCRIPTION
Fixes #3483 with the following tasks completed.
- [x] Intended behavior for get_module_attribute is that, an ImportError is issued when the module cannot be imported.  
- [x] Test Cases implemented in tests/unit/test_hookutils.py 
- [x] Updated String doc. Unsure about _attr_value_if_not_imported_, will need your suggestion on that front. 
- [x] get_module_file_attribute broke. Fixed to the best of my ability. 

 