### PR TITLE
Add jedi hook

### DIFF
--- a/PyInstaller/hooks/hook-jedi.py
+++ b/PyInstaller/hooks/hook-jedi.py
@@ -7,11 +7,8 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-
-"""
-Hook for https://pypi.org/project/jedi/
-"""
-
+# Hook for Jedi, a static analysis tool https://pypi.org/project/jedi/
 
 from PyInstaller.utils.hooks import collect_data_files
+
 datas = collect_data_files('jedi')

--- a/PyInstaller/hooks/hook-jedi.py
+++ b/PyInstaller/hooks/hook-jedi.py
@@ -1,0 +1,17 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013-2018, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+
+"""
+Hook for https://pypi.org/project/jedi/
+"""
+
+
+from PyInstaller.utils.hooks import collect_data_files
+datas = collect_data_files('jedi')


### PR DESCRIPTION
#3535 jedi import fails because it doesn't find files from `site-packages\jedi\evaluate\compiled\fake\*.pym`
On `jedi\evaluate\compiled\fake.py", line 19, in _get_path_dict` there is not check if directory exists is `os.listdir` raises `FileNotFoundError`. 
This hook adds the required files.