### PR TITLE
Write additional bitfield for Python 3.7 and later.

### DIFF
--- a/PyInstaller/depend/utils.py
+++ b/PyInstaller/depend/utils.py
@@ -21,13 +21,12 @@ import marshal
 import os
 import re
 import struct
-import sys
 import zipfile
 
 from ..lib.modulegraph import util, modulegraph
 
 from .. import compat
-from ..compat import (is_darwin, is_unix, is_freebsd, is_py2,
+from ..compat import (is_darwin, is_unix, is_freebsd, is_py2, is_py37,
                       BYTECODE_MAGIC, PY3_BASE_MODULES,
                       exec_python_rc)
 from .dylib import include_library
@@ -79,8 +78,9 @@ def create_py3_base_library(libzip_filename, graph):
                         with io.BytesIO() as fc:
                             # Prepare all data in byte stream file-like object.
                             fc.write(BYTECODE_MAGIC)
-                            # Additional bitfield according to PEP552 - still timestamp based
-                            if sys.version_info[:2] >= (3, 7):
+                            if is_py37:
+                                # Additional bitfield according to PEP 552
+                                # zero means timestamp based
                                 fc.write(struct.pack('<I', 0))
                             fc.write(struct.pack('<II', timestamp, size))
                             marshal.dump(mod.code, fc)


### PR DESCRIPTION
Current implementation of PEP552 was only valid for Python 3.7.
By the way I've replaced the helper function _write_long with standard Python lib calls.