### PR TITLE
Handle folders in COLLECT and BUNDLE

### DIFF
--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -706,7 +706,12 @@ class COLLECT(Target):
                                  upx=(self.upx_binaries and (is_win or is_cygwin)),
                                  dist_nm=inm)
             if typ != 'DEPENDENCY':
-                shutil.copy(fnm, tofnm)
+                if os.path.isdir(fnm):
+                    # beacuse shutil.copy2() is the default copy function
+                    # for shutil.copytree, this will also copy file metadata
+                    shutil.copytree(fnm, tofnm)
+                else:
+                    shutil.copy(fnm, tofnm)
                 try:
                     shutil.copystat(fnm, tofnm)
                 except OSError:

--- a/PyInstaller/building/osx.py
+++ b/PyInstaller/building/osx.py
@@ -174,7 +174,12 @@ class BUNDLE(Target):
                 todir = os.path.dirname(tofnm)
                 if not os.path.exists(todir):
                     os.makedirs(todir)
-                shutil.copy(fnm, tofnm)
+                if os.path.isdir(fnm):
+                    # beacuse shutil.copy2() is the default copy function
+                    # for shutil.copytree, this will also copy file metadata
+                    shutil.copytree(fnm, tofnm)
+                else:
+                    shutil.copy(fnm, tofnm)
 
         logger.info('moving BUNDLE data files to Resource directory')
 
@@ -190,7 +195,12 @@ class BUNDLE(Target):
                 todir = os.path.dirname(tofnm)
                 if not os.path.exists(todir):
                     os.makedirs(todir)
-                shutil.copy(fnm, tofnm)
+                if os.path.isdir(fnm):
+                    # beacuse shutil.copy2() is the default copy function
+                    # for shutil.copytree, this will also copy file metadata
+                    shutil.copytree(fnm, tofnm)
+                else:
+                    shutil.copy(fnm, tofnm)
                 base_path = os.path.split(inm)[0]
                 if base_path:
                     if not os.path.exists(os.path.join(bin_dir, inm)):

--- a/news/3653.core.rst
+++ b/news/3653.core.rst
@@ -1,1 +1,1 @@
-Added support for folders in `COLLECT` and `BUNDLE`
+Add support for folders in `COLLECT` and `BUNDLE`.

--- a/news/3653.core.rst
+++ b/news/3653.core.rst
@@ -1,0 +1,1 @@
+Added support for folders in `COLLECT` and `BUNDLE`


### PR DESCRIPTION
This will allow us to pass folders as data to BUNDLE and COLLECT and for them to be added like files instead of raising an exception.