### PR TITLE
Fix compiling bootloader with Python 3.7

### DIFF
--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -396,6 +396,7 @@ def set_arch_flags(ctx):
 
 
 def configure(ctx):
+    ctx.msg('Python Version', sys.version.replace(os.linesep, ''))
     # For MSVC the target arch must already been set when the compiler is
     # searched.
     if ctx.options.target_arch == '32bit':


### PR DESCRIPTION
Waf 2.0.7 or greater is needed to successfully compile the bootloader with Python 3.7. See waf [commit](https://gitlab.com/ita1024/waf/commit/facdc0b173d933073832c768ec1917c553cb369c)

Three commits - adding logging, reproducing the problem, and fixing the problem - pushed one at a time to allow Travis to build each.