### PR TITLE
Add hooks for google-cloud-translate and google-api-core

### DIFF
--- a/PyInstaller/hooks/hook-google.api_core.py
+++ b/PyInstaller/hooks/hook-google.api_core.py
@@ -1,0 +1,11 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2017-2018, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import copy_metadata
+datas = copy_metadata('google-api-core')

--- a/PyInstaller/hooks/hook-google.cloud.translate.py
+++ b/PyInstaller/hooks/hook-google.cloud.translate.py
@@ -1,0 +1,11 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2017-2018, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import copy_metadata
+datas = copy_metadata('google-cloud-translate')


### PR DESCRIPTION
Add hooks to allow building of scripts using google.cloud.translate and google.api_core imports e.g:
```
from google.cloud import translate
from google.api_core.exceptions import ...
```
This should also resolve pr: #3251 
