### PR TITLE
Hooks: fix QtWebEngine hooks

### DIFF
--- a/PyInstaller/hooks/hook-PyQt5.QtWebEngineWidgets.py
+++ b/PyInstaller/hooks/hook-PyQt5.QtWebEngineWidgets.py
@@ -8,6 +8,7 @@
 #-----------------------------------------------------------------------------
 
 import os
+import glob
 from PyInstaller.utils.hooks import add_qt5_dependencies, \
     remove_prefix, get_module_file_attribute, pyqt5_library_info, \
     collect_system_data_files
@@ -21,17 +22,16 @@ rel_data_path = ['PyQt5', 'Qt']
 if compat.is_darwin:
     # This is based on the layout of the Mac wheel from PyPi.
     data_path = pyqt5_library_info.location['DataPath']
-    resources = ['lib', 'QtWebEngineCore.framework', 'Resources']
-    web_engine_process = ['lib', 'QtWebEngineCore.framework', 'Helpers']
-    # When Python 3.4 goes EOL (see
-    # `PEP 448 <https://www.python.org/dev/peps/pep-0448/>`_, this is
-    # better written as ``os.path.join(*rel_data_path, *resources[:-1])``.
-    datas += collect_system_data_files(
-        os.path.join(data_path, *resources),
-        os.path.join(*(rel_data_path + resources[:-1])), True)
-    datas += collect_system_data_files(
-        os.path.join(data_path, *web_engine_process),
-        os.path.join(*(rel_data_path + web_engine_process[:-1])), True)
+    libraries = ['QtCore', 'QtWebEngineCore', 'QtQuick', 'QtQml', 'QtNetwork',
+                 'QtGui', 'QtWebChannel', 'QtPositioning']
+    for i in libraries:
+        datas += collect_system_data_files(
+            os.path.join(data_path, 'lib', i + '.framework'),
+            os.path.join(*(rel_data_path, ['lib'])), True)
+    datas += [(f, (os.path.basename(os.path.normpath(f))
+                   if os.path.isdir(f) else os.curdir)) for f
+                    in glob.glob(os.path.join(data_path, 'lib',
+                             'QtWebengineCore.framework', 'Resources', '*'))]
 else:
     locales = 'qtwebengine_locales'
     resources = 'resources'

--- a/PyInstaller/hooks/hook-PyQt5.QtWebEngineWidgets.py
+++ b/PyInstaller/hooks/hook-PyQt5.QtWebEngineWidgets.py
@@ -27,11 +27,12 @@ if compat.is_darwin:
     for i in libraries:
         datas += collect_system_data_files(
             os.path.join(data_path, 'lib', i + '.framework'),
-            os.path.join(*(rel_data_path, ['lib'])), True)
+            os.path.join(*(rel_data_path + ['lib'])), True)
     datas += [(f, (os.path.basename(os.path.normpath(f))
                    if os.path.isdir(f) else os.curdir)) for f
-                    in glob.glob(os.path.join(data_path, 'lib',
-                             'QtWebengineCore.framework', 'Resources', '*'))]
+              in glob.glob(os.path.join(data_path, 'lib',
+                                        'QtWebengineCore.framework',
+                                        'Resources', '*'))]
 else:
     locales = 'qtwebengine_locales'
     resources = 'resources'

--- a/PyInstaller/loader/rthooks/pyi_rth_qt5webengine.py
+++ b/PyInstaller/loader/rthooks/pyi_rth_qt5webengine.py
@@ -14,5 +14,6 @@ import sys
 if sys.platform == 'darwin':
     os.environ['QTWEBENGINEPROCESS_PATH'] = os.path.normpath(os.path.join(
         sys._MEIPASS, '..', 'Resources', 'PyQt5', 'Qt', 'lib',
-        'QtWebEngineCore.framework', 'Helpers'
+        'QtWebEngineCore.framework', 'Helpers', 'QtWebEngineProcess.app',
+        'Contents', 'MacOS', 'QtWebEngineProcess'
     ))

--- a/news/pr3661.hooks.rst
+++ b/news/pr3661.hooks.rst
@@ -1,0 +1,1 @@
+Fixed QtWebEngine hook

--- a/tests/functional/test_libraries.py
+++ b/tests/functional/test_libraries.py
@@ -276,12 +276,14 @@ def test_PyQt5_QWebEngine(pyi_builder, data_dir):
         #
         # 1. Run only a onedir build -- onefile builds don't work.
         if pyi_builder._mode != 'onedir':
-            pytest.skip('The QWebEngine .app bundle only supports onedir mode.')
+            pytest.skip('The QWebEngine .app bundle ' +
+                        'only supports onedir mode.')
 
-        # 2. Only test the Mac .app bundle, by modifying the executes this fixture
-        #    runs.
+        # 2. Only test the Mac .app bundle, by modifying the executes this
+        #    fixture runs.
         _old_find_executables = pyi_builder._find_executables
         # Create a replacement method that selects just the .app bundle.
+
         def _replacement_find_executables(self, name):
             path_to_onedir, path_to_app_bundle = _old_find_executables(name)
             return [path_to_app_bundle]
@@ -292,9 +294,7 @@ def test_PyQt5_QWebEngine(pyi_builder, data_dir):
 
         # 3. Run the test with specific command-line arguments.
         pyi_builder.test_source(source_to_test,
-            pyi_args=[
-                '--windowed',
-                '--osx-bundle-identifier', 'org.qt-project.Qt.QtWebEngineCore'])
+                                pyi_args=['--windowed'])
     else:
         # The Linux and Windows QWebEngine test needs no special handling.
         pyi_builder.test_source(source_to_test)


### PR DESCRIPTION
This fixes issue #3652 so that the QtWebEngine can be used on macOS.