### PR TITLE
compat: Fix DeprecationWarning: 'U' mode is deprecated in Python 3

### DIFF
--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -95,6 +95,7 @@ else:
 # module as io.open(). The Python 2 open() built-in is commonly regarded as
 # unsafe in regards to character encodings and hence inferior to io.open().
 open_file = open if is_py3 else io.open
+read_mode = 'r' if is_py3 else 'rU'
 
 # In Python 3 there is exception FileExistsError. But it is not available
 # in Python 2. For Python 2 fall back to OSError exception.

--- a/PyInstaller/lib/modulegraph/modulegraph.py
+++ b/PyInstaller/lib/modulegraph/modulegraph.py
@@ -1081,7 +1081,7 @@ class ModuleGraph(ObjectGraph):
 
                 for fn in ldir:
                     if fn.endswith('-nspkg.pth'):
-                        fp = open(os.path.join(entry, fn), 'rU')
+                        fp = open(os.path.join(entry, fn), _READ_MODE)
                         try:
                             for ln in fp:
                                 for pfx in _SETUPTOOLS_NAMESPACEPKG_PTHs:

--- a/PyInstaller/lib/modulegraph/util.py
+++ b/PyInstaller/lib/modulegraph/util.py
@@ -13,7 +13,7 @@ try:
 except NameError:
     unicode = str
 
-from ._compat import StringIO, BytesIO, get_instructions
+from ._compat import StringIO, BytesIO, get_instructions, _READ_MODE
 
 
 def imp_find_module(name, path=None):
@@ -72,7 +72,7 @@ def imp_walk(name):
             if hasattr(res, 'load_module'):
                 if res.path.endswith('.py') or res.path.endswith('.pyw'):
                     fp = StringIO(res.get_source(namepart))
-                    res = (fp, res.path, ('.py', 'rU', imp.PY_SOURCE))
+                    res = (fp, res.path, ('.py', _READ_MODE, imp.PY_SOURCE))
                 elif res.path.endswith('.pyc') or res.path.endswith('.pyo'):
                     co  = res.get_code(namepart)
                     fp = BytesIO(imp.get_magic() + b'\0\0\0\0' + marshal.dumps(co))

--- a/PyInstaller/utils/misc.py
+++ b/PyInstaller/utils/misc.py
@@ -19,7 +19,7 @@ import py_compile
 import sys
 
 from PyInstaller import log as logging
-from PyInstaller.compat import BYTECODE_MAGIC, is_py2
+from PyInstaller.compat import BYTECODE_MAGIC, is_py2, read_mode
 
 logger = logging.getLogger(__name__)
 
@@ -219,9 +219,9 @@ def load_py_data_struct(filename):
     """
     if is_py2:
         import codecs
-        f = codecs.open(filename, 'rU', encoding='utf-8')
+        f = codecs.open(filename, read_mode, encoding='utf-8')
     else:
-        f = open(filename, 'rU', encoding='utf-8')
+        f = open(filename, read_mode, encoding='utf-8')
     with f:
         # Binding redirects are stored as a named tuple, so bring the namedtuple
         # class into scope for parsing the TOC.

--- a/PyInstaller/utils/win32/versioninfo.py
+++ b/PyInstaller/utils/win32/versioninfo.py
@@ -12,7 +12,7 @@
 import codecs
 import struct
 
-from ...compat import is_py3, win32api
+from ...compat import is_py3, read_mode, win32api
 
 # ::TODO:: #1920 revert to using pypi version
 import pefile
@@ -577,7 +577,7 @@ def SetVersion(exenm, versionfile):
     if isinstance(versionfile, VSVersionInfo):
         vs = versionfile
     else:
-        fp = codecs.open(versionfile, 'rU', 'utf-8')
+        fp = codecs.open(versionfile, read_mode, 'utf-8')
         txt = fp.read()
         fp.close()
         vs = eval(txt)

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -51,7 +51,7 @@ from PyInstaller import configure, config
 from PyInstaller import __main__ as pyi_main
 from PyInstaller.utils.cliutils import archive_viewer
 from PyInstaller.compat import is_darwin, is_win, is_py2, safe_repr, \
-    architecture, is_linux, suppress
+    architecture, is_linux, read_mode, suppress
 from PyInstaller.depend.analysis import initialize_modgraph
 from PyInstaller.utils.win32 import winutils
 from PyInstaller.utils.hooks.qt import pyqt5_library_info
@@ -456,7 +456,7 @@ class AppBuilder(object):
         print('EXECUTING MATCHING:', toc_log)
         fname_list = archive_viewer.get_archive_content(exe)
         fname_list = [fn for fn in fname_list]
-        with open(toc_log, 'rU') as f:
+        with open(toc_log, read_mode) as f:
             pattern_list = eval(f.read())
         # Alphabetical order of patterns.
         pattern_list.sort()

--- a/tests/old_suite/runtests.py
+++ b/tests/old_suite/runtests.py
@@ -46,7 +46,7 @@ sys.path.insert(0, pyi_home)
 import PyInstaller
 from PyInstaller import compat, configure
 from PyInstaller import __main__ as pyi_main
-from PyInstaller.compat import is_py2, is_win, is_darwin, modname_tkinter
+from PyInstaller.compat import is_py2, is_win, is_darwin, modname_tkinter, read_mode
 from PyInstaller.utils import misc
 import PyInstaller.utils.hooks as hookutils
 from PyInstaller.utils.win32 import winutils
@@ -491,7 +491,7 @@ class BuildTestRunner(object):
                 return False, 'Executable for %s missing' % logfn
             fname_list = archive_viewer.get_archive_content(prog)
             fname_list = [fn for fn in fname_list]
-            pattern_list = eval(open(logfn, 'rU').read())
+            pattern_list = eval(open(logfn, read_mode).read())
             # Alphabetical order of patterns.
             pattern_list.sort()
             missing = []


### PR DESCRIPTION
Fixes Python 3 warnings:
```python
utils/misc.py:224: DeprecationWarning: 'U' mode is deprecated
  f = open(filename, 'rU', encoding='utf-8')
```
I fixed the whole module in several places to be consistent.