### PR TITLE
Fix several ResourceWarnings and DeprecationWarnings

### DIFF
--- a/PyInstaller/archive/writers.py
+++ b/PyInstaller/archive/writers.py
@@ -112,9 +112,9 @@ class ArchiveWriter(object):
         ispkg = pynm == '__init__'
         assert ext in ('.pyc', '.pyo')
         self.toc.append((nm, (ispkg, self.lib.tell())))
-        f = open(entry[1], 'rb')
-        f.seek(8)  # skip magic and timestamp
-        self.lib.write(f.read())
+        with open(entry[1], 'rb') as f:
+            f.seek(8)  # skip magic and timestamp
+            self.lib.write(f.read())
 
     def save_trailer(self, tocpos):
         """

--- a/PyInstaller/archive/writers.py
+++ b/PyInstaller/archive/writers.py
@@ -423,6 +423,9 @@ class CArchiveWriter(ArchiveWriter):
             if pathnm.find('.__init__.py') > -1:
                 typcd = 'M'
 
+        if fh:
+            fh.close()
+
         # Record the entry in the CTOC
         self.toc.add(where, dlen, ulen, flag, typcd, nm)
 

--- a/PyInstaller/building/makespec.py
+++ b/PyInstaller/building/makespec.py
@@ -437,17 +437,16 @@ def main(scripts, name=None, onefile=None,
 
     # Write down .spec file to filesystem.
     specfnm = os.path.join(specpath, name + '.spec')
-    specfile = open(specfnm, 'w')
-    if onefile:
-        specfile.write(onefiletmplt % d)
-        # For OSX create .app bundle.
-        if is_darwin and not console:
-            specfile.write(bundleexetmplt % d)
-    else:
-        specfile.write(onedirtmplt % d)
-        # For OSX create .app bundle.
-        if is_darwin and not console:
-            specfile.write(bundletmplt % d)
-    specfile.close()
+    with open(specfnm, 'w') as specfile:
+        if onefile:
+            specfile.write(onefiletmplt % d)
+            # For OSX create .app bundle.
+            if is_darwin and not console:
+                specfile.write(bundleexetmplt % d)
+        else:
+            specfile.write(onedirtmplt % d)
+            # For OSX create .app bundle.
+            if is_darwin and not console:
+                specfile.write(bundletmplt % d)
 
     return specfnm

--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -95,6 +95,7 @@ else:
 # module as io.open(). The Python 2 open() built-in is commonly regarded as
 # unsafe in regards to character encodings and hence inferior to io.open().
 open_file = open if is_py3 else io.open
+text_read_mode = 'r' if is_py3 else 'rU'
 
 # In Python 3 there is exception FileExistsError. But it is not available
 # in Python 2. For Python 2 fall back to OSError exception.

--- a/PyInstaller/depend/bindepend.py
+++ b/PyInstaller/depend/bindepend.py
@@ -319,9 +319,8 @@ def check_extract_from_egg(pth, todir=None):
                         dirname = os.path.dirname(pth)
                         if not os.path.isdir(dirname):
                             os.makedirs(dirname)
-                        f = open(pth, "wb")
-                        f.write(egg.read(member))
-                        f.close()
+                        with open(pth, "wb") as f:
+                            f.write(egg.read(member))
                     rv.append((pth, eggpth, member))
                 return rv
     return [(pth, None, None)]
@@ -343,9 +342,8 @@ def getAssemblies(pth):
     # check for manifest file
     manifestnm = pth + ".manifest"
     if os.path.isfile(manifestnm):
-        fd = open(manifestnm, "rb")
-        res = {RT_MANIFEST: {1: {0: fd.read()}}}
-        fd.close()
+        with open(manifestnm, "rb") as fd:
+            res = {RT_MANIFEST: {1: {0: fd.read()}}}
     else:
         # check the binary for embedded manifest
         try:

--- a/PyInstaller/depend/dylib.py
+++ b/PyInstaller/depend/dylib.py
@@ -311,12 +311,11 @@ def mac_set_relative_dylib_deps(libname, distname):
     # Write changes into file.
     # Write code is based on macholib example.
     try:
-        f = open(dll.filename, 'rb+')
-        for header in dll.headers:
-            f.seek(0)
-            dll.write(f)
-        f.seek(0, 2)
-        f.flush()
-        f.close()
+        with open(dll.filename, 'rb+') as f:
+            for header in dll.headers:
+                f.seek(0)
+                dll.write(f)
+            f.seek(0, 2)
+            f.flush()
     except Exception:
         pass

--- a/PyInstaller/lib/modulegraph/modulegraph.py
+++ b/PyInstaller/lib/modulegraph/modulegraph.py
@@ -189,7 +189,7 @@ def _eval_str_tuple(value):
 def _path_from_importerror(exc, default):
     # This is a hack, but sadly enough the necessary information
     # isn't available otherwise.
-    m = re.match('^No module named (\S+)$', str(exc))
+    m = re.match(r'^No module named (\S+)$', str(exc))
     if m is not None:
         return m.group(1)
 

--- a/PyInstaller/lib/modulegraph/modulegraph.py
+++ b/PyInstaller/lib/modulegraph/modulegraph.py
@@ -1081,8 +1081,7 @@ class ModuleGraph(ObjectGraph):
 
                 for fn in ldir:
                     if fn.endswith('-nspkg.pth'):
-                        fp = open(os.path.join(entry, fn), _READ_MODE)
-                        try:
+                        with open(os.path.join(entry, fn), _READ_MODE) as fp:
                             for ln in fp:
                                 for pfx in _SETUPTOOLS_NAMESPACEPKG_PTHs:
                                     if ln.startswith(pfx):
@@ -1104,8 +1103,6 @@ class ModuleGraph(ObjectGraph):
                                         else:
                                             pkgmap[identifier] = [subdir]
                                         break
-                        finally:
-                            fp.close()
 
         return pkgmap
 

--- a/PyInstaller/lib/modulegraph/modulegraph.py
+++ b/PyInstaller/lib/modulegraph/modulegraph.py
@@ -1081,7 +1081,7 @@ class ModuleGraph(ObjectGraph):
 
                 for fn in ldir:
                     if fn.endswith('-nspkg.pth'):
-                        fp = open(os.path.join(entry, fn), 'rU')
+                        fp = open(os.path.join(entry, fn), _READ_MODE)
                         try:
                             for ln in fp:
                                 for pfx in _SETUPTOOLS_NAMESPACEPKG_PTHs:

--- a/PyInstaller/lib/modulegraph/util.py
+++ b/PyInstaller/lib/modulegraph/util.py
@@ -13,7 +13,7 @@ try:
 except NameError:
     unicode = str
 
-from ._compat import StringIO, BytesIO, get_instructions
+from ._compat import StringIO, BytesIO, get_instructions, _READ_MODE
 
 
 def imp_find_module(name, path=None):
@@ -72,7 +72,7 @@ def imp_walk(name):
             if hasattr(res, 'load_module'):
                 if res.path.endswith('.py') or res.path.endswith('.pyw'):
                     fp = StringIO(res.get_source(namepart))
-                    res = (fp, res.path, ('.py', 'rU', imp.PY_SOURCE))
+                    res = (fp, res.path, ('.py', _READ_MODE, imp.PY_SOURCE))
                 elif res.path.endswith('.pyc') or res.path.endswith('.pyo'):
                     co  = res.get_code(namepart)
                     fp = BytesIO(imp.get_magic() + b'\0\0\0\0' + marshal.dumps(co))

--- a/PyInstaller/lib/modulegraph/util.py
+++ b/PyInstaller/lib/modulegraph/util.py
@@ -95,7 +95,7 @@ def imp_walk(name):
     raise ImportError('No module named %s' % (name,))
 
 
-cookie_re = re.compile(b"coding[:=]\s*([-\w.]+)")
+cookie_re = re.compile(br"coding[:=]\s*([-\w.]+)")
 if sys.version_info[0] == 2:
     default_encoding = 'ascii'
 else:

--- a/PyInstaller/loader/pyimod03_importers.py
+++ b/PyInstaller/loader/pyimod03_importers.py
@@ -680,8 +680,8 @@ class CExtensionImporter(object):
                         if filename in self._file_cache:
                             break
                     filename = pyi_os_path.os_path_join(SYS_PREFIX, filename)
-                    fp = open(filename, 'rb')
-                    module = imp.load_module(fullname, fp, filename, ext_tuple)
+                    with open(filename, 'rb') as fp:
+                        module = imp.load_module(fullname, fp, filename, ext_tuple)
                     # Set __file__ attribute.
                     if hasattr(module, '__setattr__'):
                         module.__file__ = filename

--- a/PyInstaller/loader/pyimod03_importers.py
+++ b/PyInstaller/loader/pyimod03_importers.py
@@ -760,10 +760,8 @@ class CExtensionImporter(object):
         module.__file__ (or pkg.__path__ items)
         """
         # Since __file__ attribute works properly just try to open and read it.
-        fp = open(path, 'rb')
-        content = fp.read()
-        fp.close()
-        return content
+        with open(path, 'rb') as fp:
+            return fp.read()
 
     def get_filename(self, fullname):
         """

--- a/PyInstaller/utils/cliutils/archive_viewer.py
+++ b/PyInstaller/utils/cliutils/archive_viewer.py
@@ -94,7 +94,8 @@ def main(name, brief, debug, rec_debug, **unused_options):
             if not filename:
                 print(repr(data))
             else:
-                open(filename, 'wb').write(data)
+                with open(filename, 'wb') as fp:
+                    fp.write(data)
         elif cmd == 'Q':
             break
         else:
@@ -138,7 +139,8 @@ def get_archive(name):
         x, data = parent.extract(ndx)
         tempfilename = tempfile.mktemp()
         cleanup.append(tempfilename)
-        open(tempfilename, 'wb').write(data)
+        with open(tempfilename, 'wb') as fp:
+            fp.write(data)
         if typcd == 'z':
             return ZlibArchive(tempfilename)
         else:

--- a/PyInstaller/utils/cliutils/grab_version.py
+++ b/PyInstaller/utils/cliutils/grab_version.py
@@ -31,9 +31,8 @@ def run():
         vs = PyInstaller.utils.win32.versioninfo.decode(args.exe_file)
         if not vs:
             raise SystemExit("Error: VersionInfo resource not found in exe")
-        fp = codecs.open(args.out_filename, 'w', 'utf-8')
-        fp.write(u"%s" % (vs,))
-        fp.close()
+        with codecs.open(args.out_filename, 'w', 'utf-8') as fp:
+            fp.write(u"%s" % (vs,))
         print(('Version info written to: %s' % args.out_filename))
     except KeyboardInterrupt:
         raise SystemExit("Aborted by user request.")

--- a/PyInstaller/utils/misc.py
+++ b/PyInstaller/utils/misc.py
@@ -145,10 +145,10 @@ def compile_py_files(toc, workpath):
         # instead of just read(4)? Yes for many a .pyc file, it is all
         # in one sector so there's no difference in I/O but still it
         # seems inelegant to copy it all then subscript 4 bytes.
-        needs_compile = ( (mtime(src_fnm) > mtime(obj_fnm) )
-                          or
-                          (open(obj_fnm, 'rb').read()[:4] != BYTECODE_MAGIC)
-                        )
+        needs_compile = mtime(src_fnm) > mtime(obj_fnm)
+        if not needs_compile:
+            with open(obj_fnm, 'rb') as fh:
+                needs_compile = fh.read()[:4] != BYTECODE_MAGIC
         if needs_compile:
             try:
                 # TODO: there should be no need to repeat the compile,
@@ -179,9 +179,10 @@ def compile_py_files(toc, workpath):
 
                 obj_fnm = os.path.join(leading, mod_name + ext)
                 # TODO see above regarding read()[:4] versus read(4)
-                needs_compile = (mtime(src_fnm) > mtime(obj_fnm)
-                                 or
-                                 open(obj_fnm, 'rb').read()[:4] != BYTECODE_MAGIC)
+                needs_compile = mtime(src_fnm) > mtime(obj_fnm)
+                if not needs_compile:
+                    with open(obj_fnm, 'rb') as fh:
+                        needs_compile = fh.read()[:4] != BYTECODE_MAGIC
                 if needs_compile:
                     # TODO see above todo regarding using node.code
                     py_compile.compile(src_fnm, obj_fnm)

--- a/PyInstaller/utils/misc.py
+++ b/PyInstaller/utils/misc.py
@@ -19,7 +19,7 @@ import py_compile
 import sys
 
 from PyInstaller import log as logging
-from PyInstaller.compat import BYTECODE_MAGIC, is_py2
+from PyInstaller.compat import BYTECODE_MAGIC, is_py2, text_read_mode
 
 logger = logging.getLogger(__name__)
 
@@ -219,9 +219,9 @@ def load_py_data_struct(filename):
     """
     if is_py2:
         import codecs
-        f = codecs.open(filename, 'rU', encoding='utf-8')
+        f = codecs.open(filename, text_read_mode, encoding='utf-8')
     else:
-        f = open(filename, 'rU', encoding='utf-8')
+        f = open(filename, text_read_mode, encoding='utf-8')
     with f:
         # Binding redirects are stored as a named tuple, so bring the namedtuple
         # class into scope for parsing the TOC.

--- a/PyInstaller/utils/osx.py
+++ b/PyInstaller/utils/osx.py
@@ -101,6 +101,5 @@ def fix_exe_for_code_signing(filename):
     linkedit.filesize = new_segsize
     linkedit.vmsize = new_segsize
     ## Write changes back.
-    fp = open(exe_data.filename, 'rb+')
-    exe_data.write(fp)
-    fp.close()
+    with open(exe_data.filename, 'rb+') as fp:
+        exe_data.write(fp)

--- a/PyInstaller/utils/win32/versioninfo.py
+++ b/PyInstaller/utils/win32/versioninfo.py
@@ -12,7 +12,7 @@
 import codecs
 import struct
 
-from ...compat import is_py3, win32api
+from ...compat import is_py3, text_read_mode, win32api
 
 # ::TODO:: #1920 revert to using pypi version
 import pefile
@@ -577,7 +577,7 @@ def SetVersion(exenm, versionfile):
     if isinstance(versionfile, VSVersionInfo):
         vs = versionfile
     else:
-        fp = codecs.open(versionfile, 'rU', 'utf-8')
+        fp = codecs.open(versionfile, text_read_mode, 'utf-8')
         txt = fp.read()
         fp.close()
         vs = eval(txt)

--- a/PyInstaller/utils/win32/versioninfo.py
+++ b/PyInstaller/utils/win32/versioninfo.py
@@ -577,9 +577,8 @@ def SetVersion(exenm, versionfile):
     if isinstance(versionfile, VSVersionInfo):
         vs = versionfile
     else:
-        fp = codecs.open(versionfile, text_read_mode, 'utf-8')
-        txt = fp.read()
-        fp.close()
+        with codecs.open(versionfile, text_read_mode, 'utf-8') as fp:
+            txt = fp.read()
         vs = eval(txt)
     hdst = win32api.BeginUpdateResource(exenm, 0)
     win32api.UpdateResource(hdst, pefile.RESOURCE_TYPE['RT_VERSION'], 1, vs.toRaw())

--- a/PyInstaller/utils/win32/winmanifest.py
+++ b/PyInstaller/utils/win32/winmanifest.py
@@ -183,9 +183,8 @@ class File(_File):
         e.g. to update the hash if the file has changed.
 
         """
-        fd = open(self.filename, "rb")
-        buf = fd.read()
-        fd.close()
+        with open(self.filename, "rb") as fd:
+            buf = fd.read()
         if hashalg:
             self.hashalg = hashalg.upper()
         self.hash = getattr(hashlib, self.hashalg.lower())(buf).hexdigest()
@@ -947,8 +946,8 @@ class Manifest(object):
         if isinstance(filename_or_file, string_types):
             filename_or_file = open(filename_or_file, "wb")
         xmlstr = self.toprettyxml(indent, newl, encoding)
-        filename_or_file.write(xmlstr.encode())
-        filename_or_file.close()
+        with filename_or_file:
+            filename_or_file.write(xmlstr.encode())
 
     def writexml(self, filename_or_file=None, indent="  ", newl=os.linesep,
                  encoding="UTF-8"):
@@ -958,8 +957,8 @@ class Manifest(object):
         if isinstance(filename_or_file, string_types):
             filename_or_file = open(filename_or_file, "wb")
         xmlstr = self.toxml(encoding)
-        filename_or_file.write(xmlstr.encode())
-        filename_or_file.close()
+        with filename_or_file:
+            filename_or_file.write(xmlstr.encode())
 
 
 def ManifestFromResFile(filename, names=None, languages=None):

--- a/PyInstaller/utils/win32/winresource.py
+++ b/PyInstaller/utils/win32/winresource.py
@@ -212,9 +212,8 @@ def UpdateResourcesFromDataFile(dstpath, srcpath, type_, names=None,
     names = a list of resource names to update (None = all)
     languages = a list of resource languages to update (None = all)
     """
-    src = open(srcpath, "rb")
-    data = src.read()
-    src.close()
+    with open(srcpath, "rb") as src:
+        data = src.read()
     UpdateResources(dstpath, data, type_, names, languages)
 
 

--- a/news/3677.core.rst
+++ b/news/3677.core.rst
@@ -1,0 +1,1 @@
+Fix several ResourceWarnings and DeprecationWarnings

--- a/old/e2etests/win32/NextID.py
+++ b/old/e2etests/win32/NextID.py
@@ -54,7 +54,8 @@ class NextID:
     def getNextID(self):
         global d
         d['highID'] = d['highID'] + 1
-        open(self.fnm, 'w').write(repr(d))
+        with open(self.fnm, 'w') as fp:
+            fp.write(repr(d))
         return '%(systemID)-0.5x%(highID)-0.7x' % d
 
 def RegisterNextID():

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ from setuptools import setup
 # Hack required to allow compat to not fail when pypiwin32 isn't found
 os.environ["PYINSTALLER_NO_PYWIN32_FAILURE"] = "1"
 from PyInstaller import __version__ as version, HOMEPATH, PLATFORM
-from PyInstaller.compat import is_win, is_cygwin
+from PyInstaller.compat import is_win, is_cygwin, is_py2
 
 REQUIREMENTS = [
     'setuptools',
@@ -39,10 +39,12 @@ if sys.platform.startswith('win'):
 # Create long description from README.rst and doc/CHANGES.rst.
 # PYPI page will contain complete PyInstaller changelog.
 def read(filename):
-    try:
-        return unicode(codecs.open(filename, encoding='utf-8').read())
-    except NameError:
-        return open(filename, 'r', encoding='utf-8').read()
+    if is_py2:
+        with codecs.open(filename, encoding='utf-8') as fp:
+            return unicode(fp.read())
+    else:
+        with open(filename, 'r', encoding='utf-8') as fp:
+            return fp.read()
 long_description = u'\n\n'.join([read('README.rst'),
                                  read('doc/_dummy-roles.txt'),
                                  read('doc/CHANGES.rst')])

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -51,7 +51,7 @@ from PyInstaller import configure, config
 from PyInstaller import __main__ as pyi_main
 from PyInstaller.utils.cliutils import archive_viewer
 from PyInstaller.compat import is_darwin, is_win, is_py2, safe_repr, \
-    architecture, is_linux, suppress
+    architecture, is_linux, suppress, text_read_mode
 from PyInstaller.depend.analysis import initialize_modgraph
 from PyInstaller.utils.win32 import winutils
 from PyInstaller.utils.hooks.qt import pyqt5_library_info
@@ -457,7 +457,7 @@ class AppBuilder(object):
         print('EXECUTING MATCHING:', toc_log)
         fname_list = archive_viewer.get_archive_content(exe)
         fname_list = [fn for fn in fname_list]
-        with open(toc_log, 'rU') as f:
+        with open(toc_log, text_read_mode) as f:
             pattern_list = eval(f.read())
         # Alphabetical order of patterns.
         pattern_list.sort()

--- a/tests/functional/scripts/pyi_module_attributes.py
+++ b/tests/functional/scripts/pyi_module_attributes.py
@@ -22,9 +22,10 @@ from pyi_testmod_gettemp import gettemp
 
 _pyexe_file = gettemp("python_exe.build")
 
-_lines = open(_pyexe_file).readlines()
-_pyexe = _lines[0].strip()
-_env_path = _lines[2].strip()
+with open(_pyexe_file) as fp:
+    _lines = fp.readlines()
+    _pyexe = _lines[0].strip()
+    _env_path = _lines[2].strip()
 
 
 def exec_python(pycode):

--- a/tests/old_suite/runtests.py
+++ b/tests/old_suite/runtests.py
@@ -491,7 +491,8 @@ class BuildTestRunner(object):
                 return False, 'Executable for %s missing' % logfn
             fname_list = archive_viewer.get_archive_content(prog)
             fname_list = [fn for fn in fname_list]
-            pattern_list = eval(open(logfn, text_read_mode).read())
+            with open(logfn, text_read_mode) as fp:
+                pattern_list = eval(fp.read())
             # Alphabetical order of patterns.
             pattern_list.sort()
             missing = []

--- a/tests/old_suite/runtests.py
+++ b/tests/old_suite/runtests.py
@@ -46,7 +46,7 @@ sys.path.insert(0, pyi_home)
 import PyInstaller
 from PyInstaller import compat, configure
 from PyInstaller import __main__ as pyi_main
-from PyInstaller.compat import is_py2, is_win, is_darwin, modname_tkinter
+from PyInstaller.compat import is_py2, is_win, is_darwin, modname_tkinter, text_read_mode
 from PyInstaller.utils import misc
 import PyInstaller.utils.hooks as hookutils
 from PyInstaller.utils.win32 import winutils
@@ -491,7 +491,7 @@ class BuildTestRunner(object):
                 return False, 'Executable for %s missing' % logfn
             fname_list = archive_viewer.get_archive_content(prog)
             fname_list = [fn for fn in fname_list]
-            pattern_list = eval(open(logfn, 'rU').read())
+            pattern_list = eval(open(logfn, text_read_mode).read())
             # Alphabetical order of patterns.
             pattern_list.sort()
             missing = []

--- a/tests/old_suite/runtests.py
+++ b/tests/old_suite/runtests.py
@@ -197,10 +197,9 @@ class SkipChecker(object):
             for mod_name in self.MODULES[test_name]:
                 # STDOUT and STDERR are discarded (devnull) to hide
                 # import exceptions.
-                trash = open(os.devnull)
-                retcode = compat.exec_python_rc('-c', "import %s" % mod_name,
-                        stdout=trash, stderr=trash)
-                trash.close()
+                with open(os.devnull) as trash:
+                    retcode = compat.exec_python_rc('-c', "import %s" % mod_name,
+                                                    stdout=trash, stderr=trash)
                 if retcode != 0:
                     return mod_name
         return None

--- a/tests/unit/test_altgraph/test_dot.py
+++ b/tests/unit/test_altgraph/test_dot.py
@@ -271,10 +271,8 @@ class TestDot (unittest.TestCase):
         try:
             dot.save_dot(fn)
 
-            fp = open(fn, 'r')
-            data = fp.read()
-            fp.close()
-            self.assertEqual(data, ''.join(dot))
+            with open(fn, 'r') as fp:
+                self.assertEqual(fp.read(), ''.join(dot))
 
         finally:
             if os.path.exists(fn):

--- a/tests/unit/test_modulegraph/test_zipio.py
+++ b/tests/unit/test_modulegraph/test_zipio.py
@@ -36,27 +36,23 @@ class TestModuleGraph (unittest.TestCase):
 
     def test_open(self):
         # 1. Regular file
-        fp = zipio.open(os.path.join(TESTDATA, 'test.txt'), 'r')
-        data = fp.read()
-        fp.close()
+        with zipio.open(os.path.join(TESTDATA, 'test.txt'), 'r') as fp:
+            data = fp.read()
         self.assertEqual(data, 'This is test.txt\n')
 
         if sys.version_info[0] == 3:
-            fp = zipio.open(os.path.join(TESTDATA, 'test.txt'), 'rb')
-            data = fp.read()
-            fp.close()
+            with zipio.open(os.path.join(TESTDATA, 'test.txt'), 'rb') as fp:
+                data = fp.read()
             self.assertEqual(data, b'This is test.txt\n')
 
         # 2. File inside zipfile
-        fp = zipio.open(os.path.join(TESTDATA, 'zipped.egg', 'test.txt'), 'r')
-        data = fp.read()
-        fp.close()
+        with zipio.open(os.path.join(TESTDATA, 'zipped.egg', 'test.txt'), 'r') as fp:
+            data = fp.read()
         self.assertEqual(data, 'Zipped up test.txt\n')
 
         if sys.version_info[0] == 3:
-            fp = zipio.open(os.path.join(TESTDATA, 'zipped.egg', 'test.txt'), 'rb')
-            data = fp.read()
-            fp.close()
+            with zipio.open(os.path.join(TESTDATA, 'zipped.egg', 'test.txt'), 'rb') as fp:
+                data = fp.read()
             self.assertEqual(data, b'Zipped up test.txt\n')
 
         # 3. EXC: Directory inside zipfile


### PR DESCRIPTION
Fixes Python 3 warnings:
```python
utils/misc.py:224: DeprecationWarning: 'U' mode is deprecated
  f = open(filename, 'rU', encoding='utf-8')
```
I fixed the whole module in several places to be consistent.

---

Also fixes a lot of resource leaks:
```python
utils/misc.py:150: ResourceWarning: unclosed file <_io.BufferedReader name='/.../loader/pyimod03_importers.pyc'>
  (open(obj_fnm, 'rb').read()[:4] != BYTECODE_MAGIC)

archive/writers.py:86: ResourceWarning: unclosed file <_io.BufferedReader name='.../project/PYZ-00.pyz'>
  self.add(toc_entry)  # The guts of the archive.
```
Actually, there were numbers of those 2 specific warnings, more another one not really spotted:
```python
Exception ignored in: <_io.FileIO name='.../struct.pyo' mode='rb' closefd=True>
ResourceWarning: unclosed file <_io.BufferedReader name='.../struct.pyo'>
Exception ignored in: <_io.FileIO name='PyInstaller/loader/pyimod01_os_path.pyc' mode='rb' closefd=True>
ResourceWarning: unclosed file <_io.BufferedReader name='PyInstaller/loader/pyimod01_os_path.pyc'>
Exception ignored in: <_io.FileIO name='PyInstaller/loader/pyimod02_archive.pyc' mode='rb' closefd=True>
ResourceWarning: unclosed file <_io.BufferedReader name='PyInstaller/loader/pyimod02_archive.pyc'>
Exception ignored in: <_io.FileIO name='.../struct.pyo' mode='rb' closefd=True>
ResourceWarning: unclosed file <_io.BufferedReader name='.../struct.pyo'>
Exception ignored in: <_io.FileIO name='PyInstaller/loader/pyimod01_os_path.pyc' mode='rb' closefd=True>
ResourceWarning: unclosed file <_io.BufferedReader name='PyInstaller/loader/pyimod01_os_path.pyc'>
Exception ignored in: <_io.FileIO name='PyInstaller/loader/pyimod02_archive.pyc' mode='rb' closefd=True>
ResourceWarning: unclosed file <_io.BufferedReader name='PyInstaller/loader/pyimod02_archive.pyc'>
Exception ignored in: <_io.FileIO name='PyInstaller/loader/pyimod03_importers.pyc' mode='rb' closefd=True>
ResourceWarning: unclosed file <_io.BufferedReader name='PyInstaller/loader/pyimod03_importers.pyc'>
Exception ignored in: <_io.FileIO name='/tmp/pytest-15/test_egg_unzipped_onedir_0/build/test_egg_unzipped/PYZ-00.pyz' mode='rb' closefd=True>
ResourceWarning: unclosed file <_io.BufferedReader name='/tmp/pytest-15/test_egg_unzipped_onedir_0/build/test_egg_unzipped/PYZ-00.pyz'>
```

I changed almost every file handling to use the `with` context manager.