### PR TITLE
Hooks: Fix exec_command usage in PySide2.QtQuick

### DIFF
--- a/PyInstaller/hooks/hook-PySide2.QtQuick.py
+++ b/PyInstaller/hooks/hook-PySide2.QtQuick.py
@@ -10,29 +10,14 @@
 import os
 
 from PyInstaller.utils import misc
-from PyInstaller.utils.hooks import get_qmake_path, exec_command
+from PyInstaller.utils.hooks import pyside2_library_info
 from PyInstaller import log as logging
 
 logger = logging.getLogger(__name__)
 
 
 def qt5_qml_dir():
-    qmake = get_qmake_path('5')
-    if qmake is None:
-        qmldir = ''
-        logger.warning('Could not find qmake version 5.x, make sure PATH is '
-                       'set correctly or try setting QT5DIR.')
-    else:
-        qmldir = exec_command(qmake, "-query", "QT_INSTALL_QML").strip()
-    if qmldir:
-        logger.error('Cannot find QT_INSTALL_QML directory, "qmake -query '
-                     'QT_INSTALL_QML" returned nothing')
-    elif not os.path.exists(qmldir):
-        logger.error("Directory QT_INSTALL_QML: %s doesn't exist", qmldir)
-
-    # 'qmake -query' uses / as the path separator, even on Windows
-    qmldir = os.path.normpath(qmldir)
-    return qmldir
+    return pyside2_library_info.location['Qml2ImportsPath']
 
 
 def qt5_qml_data(qmldir, directory):

--- a/PyInstaller/hooks/hook-PySide2.QtWebEngineWidgets.py
+++ b/PyInstaller/hooks/hook-PySide2.QtWebEngineWidgets.py
@@ -8,7 +8,7 @@
 #-----------------------------------------------------------------------------
 
 import os
-from PyInstaller.utils.hooks import collect_data_files, get_qmake_path
+from PyInstaller.utils.hooks import collect_data_files, pyside2_library_info
 import PyInstaller.compat as compat
 
 hiddenimports = ['PySide2.QtCore',
@@ -19,33 +19,34 @@ hiddenimports = ['PySide2.QtCore',
                  ]
 
 # Find the additional files necessary for QtWebEngine.
-datas = (collect_data_files('PySide2', True, os.path.join('Qt', 'resources')) +
-         collect_data_files('PySide2', True, os.path.join('Qt', 'translations')) +
-         [x for x in collect_data_files('PySide2', False, os.path.join('Qt', 'bin'))
+datas = (collect_data_files('PySide2', True, 'resources') +
+         collect_data_files('PySide2', True, 'translations') +
+         [x for x in collect_data_files('PySide2', False)
           if x[0].endswith('QtWebEngineProcess.exe')])
 
 # Note that for QtWebEngineProcess to be able to find icudtl.dat the bundle_identifier
 # must be set to 'org.qt-project.Qt.QtWebEngineCore'. This can be done by passing
 # bundle_identifier='org.qt-project.Qt.QtWebEngineCore' to the BUNDLE command in
 # the .spec file. FIXME: This is not ideal and a better solution is required.
-qmake = get_qmake_path('5')
-if qmake:
-    libdir = compat.exec_command(qmake, "-query", "QT_INSTALL_LIBS").strip()
+libdir = pyside2_library_info.location["LibrariesPath"]
 
-    if compat.is_darwin:
-        binaries = [
-            (os.path.join(libdir, 'QtWebEngineCore.framework', 'Versions', '5',
-                          'Helpers', 'QtWebEngineProcess.app', 'Contents', 'MacOS', 'QtWebEngineProcess'),
-             os.path.join('QtWebEngineProcess.app', 'Contents', 'MacOS'))
-        ]
+if compat.is_darwin:
+    binaries = [
+        (os.path.join(libdir, 'QtWebEngineCore.framework', 'Versions', '5',
+                      'Helpers', 'QtWebEngineProcess.app', 'Contents', 'MacOS',
+                      'QtWebEngineProcess'),
+         os.path.join('QtWebEngineProcess.app', 'Contents', 'MacOS'))
+    ]
 
-        resources_dir = os.path.join(libdir, 'QtWebEngineCore.framework', 'Versions', '5', 'Resources')
-        datas += [
-            (os.path.join(resources_dir, 'icudtl.dat'), '.'),
-            (os.path.join(resources_dir, 'qtwebengine_resources.pak'), '.'),
-            # The distributed Info.plist has LSUIElement set to true, which prevents the
-            # icon from appearing in the dock.
-            (os.path.join(libdir, 'QtWebEngineCore.framework', 'Versions', '5',
-                          'Helpers', 'QtWebEngineProcess.app', 'Contents', 'Info.plist'),
-             os.path.join('QtWebEngineProcess.app', 'Contents'))
-        ]
+    resources_dir = os.path.join(libdir, 'QtWebEngineCore.framework', 'Versions',
+                                 '5', 'Resources')
+    datas += [
+        (os.path.join(resources_dir, 'icudtl.dat'), '.'),
+        (os.path.join(resources_dir, 'qtwebengine_resources.pak'), '.'),
+        # The distributed Info.plist has LSUIElement set to true, which prevents the
+        # icon from appearing in the dock.
+        (os.path.join(libdir, 'QtWebEngineCore.framework', 'Versions', '5',
+                      'Helpers', 'QtWebEngineProcess.app', 'Contents',
+                      'Info.plist'),
+         os.path.join('QtWebEngineProcess.app', 'Contents'))
+    ]

--- a/PyInstaller/hooks/hook-PySide2.py
+++ b/PyInstaller/hooks/hook-PySide2.py
@@ -19,15 +19,11 @@ from PyInstaller.compat import getsitepackages, is_darwin, is_win
 # version of Qt libraries when there is installed another application (e.g. QtCreator)
 if is_win:
     from PyInstaller.utils.win32.winutils import extend_system_path
-
-    extend_system_path([os.path.join(x, 'PySide2') for x in getsitepackages()])
-    extend_system_path([os.path.join(os.path.dirname(get_module_file_attribute('PySide2')),
-                                     'Qt', 'bin')])
+    extend_system_path([os.path.dirname(get_module_file_attribute('PySide2'))])
 
 # FIXME: this should not be needed
 hiddenimports = ['numpy.core.multiarray']
 
-# TODO: check if this is needed
 # Collect just the qt.conf file.
-datas = [x for x in collect_data_files('PySide2', False, os.path.join('Qt', 'bin')) if
-         x[0].endswith('qt.conf')]
+datas = [x for x in collect_data_files('PySide2', False) if
+         os.path.basename(x[0]) == 'qt.conf']

--- a/PyInstaller/utils/hooks/qt.py
+++ b/PyInstaller/utils/hooks/qt.py
@@ -79,6 +79,7 @@ class Qt5LibraryInfo:
 
 # Provide an instance of this class, to avoid each hook constructing its own.
 pyqt5_library_info = Qt5LibraryInfo('PyQt5')
+pyside2_library_info = Qt5LibraryInfo('PySide2')
 
 
 def qt_plugins_dir(namespace):
@@ -539,4 +540,5 @@ def add_qt5_dependencies(hook_file):
 
 
 __all__ = ('qt_plugins_dir', 'qt_plugins_binaries', 'qt_menu_nib_dir',
-           'get_qmake_path', 'add_qt5_dependencies', 'pyqt5_library_info')
+           'get_qmake_path', 'add_qt5_dependencies', 'pyqt5_library_info',
+           'pyside2_library_info')

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -93,3 +93,6 @@ web3==4.5.0; python_version >= '3.5'
 
 # Django supports Python 3.5 and up.
 Django==2.1; python_version >= '3.5'
+
+# No wheel for python 3.4
+PySide2==5.11.1; python_version != '3.4'


### PR DESCRIPTION
As requested, this pull request fixes #3689.

Now imports `exec_command_stdout`.

The qmldir is also now checked correctly (the logic was backwards).