### PR TITLE
fix issue #2826: "datas" is "binaries"?

### DIFF
--- a/PyInstaller/building/build_main.py
+++ b/PyInstaller/building/build_main.py
@@ -250,7 +250,7 @@ class Analysis(Target):
         if datas:
             logger.info("Appending 'datas' from .spec")
             for name, pth in format_binaries_and_datas(datas, workingdir=spec_dir):
-                self.binaries.append((name, pth, 'DATA'))
+                self.datas.append((name, pth, 'DATA'))
 
     _GUTS = (# input parameters
             ('inputs', _check_guts_eq),  # parameter `scripts`

--- a/news/2326.bugfix.rst
+++ b/news/2326.bugfix.rst
@@ -1,0 +1,2 @@
+Fix appending the content of ``datas`` in a `spec` files to ``binaries``
+instead of the internal ``datas``.

--- a/news/3694.bugfix.rst
+++ b/news/3694.bugfix.rst
@@ -1,0 +1,2 @@
+Fix appending the content of ``datas`` in a `spec` files to ``binaries``
+instead of the internal ``datas``.


### PR DESCRIPTION
This commit fixes issue #2826, '"datas" is "binaries"?'.