### PR TITLE
Add hook for rdflib

### DIFF
--- a/PyInstaller/hooks/hook-rdflib.py
+++ b/PyInstaller/hooks/hook-rdflib.py
@@ -1,0 +1,13 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013-2018, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+
+from PyInstaller.utils.hooks import collect_submodules
+
+hiddenimports = collect_submodules('rdflib.plugins')

--- a/PyInstaller/news/3708.hooks.rst
+++ b/PyInstaller/news/3708.hooks.rst
@@ -1,0 +1,1 @@
+Add hook for rdflib


### PR DESCRIPTION
This hook adds the plugins included in `rdflib.plugins`, when `rdflib` is imported.
The RDFlib organizes the serializers and parsers in a plugin system, which is not loaded with import statements.

- https://github.com/RDFLib/rdflib
- https://rdflib.readthedocs.io/
- https://rdflib.readthedocs.io/en/stable/plugins.html