### PR TITLE
building: Handle unicode content in source files

### DIFF
--- a/PyInstaller/building/build_main.py
+++ b/PyInstaller/building/build_main.py
@@ -29,7 +29,7 @@ from .. import HOMEPATH, DEFAULT_DISTPATH, DEFAULT_WORKPATH
 from .. import compat
 from .. import log as logging
 from ..utils.misc import absnormpath, compile_py_files
-from ..compat import is_py2, is_win, PYDYLIB_NAMES, VALID_MODULE_TYPES
+from ..compat import is_py2, is_win, open_file, PYDYLIB_NAMES, VALID_MODULE_TYPES
 from ..depend import bindepend
 from ..depend.analysis import initialize_modgraph
 from .api import PYZ, EXE, COLLECT, MERGE
@@ -618,7 +618,7 @@ class Analysis(Target):
 
         from ..config import CONF
         miss_toc = self.graph.make_missing_toc()
-        with open(CONF['warnfile'], 'w') as wf:
+        with open_file(CONF['warnfile'], 'w', encoding='utf-8') as wf:
             wf.write(WARNFILE_HEADER)
             for (n, p, status) in miss_toc:
                 importers = self.graph.get_importers(n)
@@ -779,7 +779,7 @@ def build(spec, distpath, workpath, clean_build):
     CONF['workpath'] = workpath
 
     # Executing the specfile.
-    with open(spec, 'r') as f:
+    with open_file(spec, encoding='utf-8') as f:
         text = f.read()
     exec(text, spec_namespace)
 

--- a/PyInstaller/building/makespec.py
+++ b/PyInstaller/building/makespec.py
@@ -19,7 +19,7 @@ from distutils.version import LooseVersion
 
 from .. import HOMEPATH, DEFAULT_SPECPATH
 from .. import log as logging
-from ..compat import expand_path, is_darwin
+from ..compat import expand_path, is_darwin, open_file
 from .templates import onefiletmplt, onedirtmplt, cipher_absent_template, \
     cipher_init_template, bundleexetmplt, bundletmplt
 
@@ -437,7 +437,7 @@ def main(scripts, name=None, onefile=None,
 
     # Write down .spec file to filesystem.
     specfnm = os.path.join(specpath, name + '.spec')
-    with open(specfnm, 'w') as specfile:
+    with open_file(specfnm, 'w', encoding='utf-8') as specfile:
         if onefile:
             specfile.write(onefiletmplt % d)
             # For OSX create .app bundle.

--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -15,7 +15,7 @@ with previous versions of Python from 2.7 onward.
 
 from __future__ import print_function
 
-import io
+import codecs
 import os
 import platform
 import site
@@ -91,10 +91,10 @@ else:
 
 
 # Function with which to open files. In Python 3, this is the open() built-in;
-# in Python 2, this is the Python 3 open() built-in backported into the "io"
-# module as io.open(). The Python 2 open() built-in is commonly regarded as
-# unsafe in regards to character encodings and hence inferior to io.open().
-open_file = open if is_py3 else io.open
+# in Python 2, this is codecs.open(). The Python 2 open() built-in is commonly
+# regarded as unsafe in regards to character encodings and hence inferior to
+# codecs.open().
+open_file = open if is_py3 else codecs.open
 text_read_mode = 'r' if is_py3 else 'rU'
 
 # In Python 3 there is exception FileExistsError. But it is not available

--- a/PyInstaller/news/3734.building.rst
+++ b/PyInstaller/news/3734.building.rst
@@ -1,0 +1,1 @@
+Handle unicode content in source files

--- a/PyInstaller/news/3734.compat.rst
+++ b/PyInstaller/news/3734.compat.rst
@@ -1,0 +1,1 @@
+Use codecs.open() instead of io.open() for open_file()

--- a/PyInstaller/news/3734.utils.rst
+++ b/PyInstaller/news/3734.utils.rst
@@ -1,0 +1,1 @@
+Use compat.open_file() instead of conditional codecs.open()

--- a/PyInstaller/utils/misc.py
+++ b/PyInstaller/utils/misc.py
@@ -19,7 +19,7 @@ import py_compile
 import sys
 
 from PyInstaller import log as logging
-from PyInstaller.compat import BYTECODE_MAGIC, is_py2, text_read_mode
+from PyInstaller.compat import BYTECODE_MAGIC, is_py2, open_file, text_read_mode
 
 logger = logging.getLogger(__name__)
 
@@ -203,12 +203,7 @@ def save_py_data_struct(filename, data):
     dirname = os.path.dirname(filename)
     if not os.path.exists(dirname):
         os.makedirs(dirname)
-    if is_py2:
-        import codecs
-        f = codecs.open(filename, 'w', encoding='utf-8')
-    else:
-        f = open(filename, 'w', encoding='utf-8')
-    with f:
+    with open_file(filename, 'w', encoding='utf-8') as f:
         pprint.pprint(data, f)
 
 
@@ -218,12 +213,7 @@ def load_py_data_struct(filename):
     :param filename:
     :return:
     """
-    if is_py2:
-        import codecs
-        f = codecs.open(filename, text_read_mode, encoding='utf-8')
-    else:
-        f = open(filename, text_read_mode, encoding='utf-8')
-    with f:
+    with open_file(filename, text_read_mode, encoding='utf-8') as f:
         # Binding redirects are stored as a named tuple, so bring the namedtuple
         # class into scope for parsing the TOC.
         from ..depend.bindepend import BindingRedirect

--- a/tests/functional/specs/spec-with-utf8.spec
+++ b/tests/functional/specs/spec-with-utf8.spec
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 ; mode: python -*-
+# -*- mode: python -*-
 #-----------------------------------------------------------------------------
 # Copyright (c) 2005-2018, PyInstaller Development Team.
 #
@@ -10,7 +10,7 @@
 
 # spec-file containing some utf-8 umlauts
 # äöu Čapek
-"äöü Čapek"
+"äöü Čapek こん ツリー"
 
 app_name = "spec-with-utf8"
 


### PR DESCRIPTION
A little fix to allow building source files containing unicode characters. Without the fix, you will face these 2 exceptions:
```python
56 INFO: PyInstaller: 3.5.dev0
56 INFO: Python: 3.6.5
56 INFO: Platform: Windows-7-6.1.7601-SP1
Traceback (most recent call last):
  File "c:\deploy-dir\3.6.6\Scripts\pyinstaller-script.py", line 11, in <module>
    load_entry_point('PyInstaller==3.5.dev0', 'console_scripts', 'pyinstaller')()
  File "c:\deploy-dir\3.6.6\lib\site-packages\pyinstaller-3.5.dev0-py3.6.egg\PyInstaller\__main__.py", line 109, in run
    spec_file = run_makespec(**vars(args))
  File "c:\deploy-dir\3.6.6\lib\site-packages\pyinstaller-3.5.dev0-py3.6.egg\PyInstaller\__main__.py", line 56, in run_makespec
    spec_file = PyInstaller.building.makespec.main(filenames, **opts)
  File "c:\deploy-dir\3.6.6\lib\site-packages\pyinstaller-3.5.dev0-py3.6.egg\PyInstaller\building\makespec.py", line 447, in main
    specfile.write(onedirtmplt % d)
  File "C:\Python36-32\lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode characters in position 116-117: character maps to <undefined>
```
And:
```python
48 INFO: PyInstaller: 3.5.dev0
48 INFO: Python: 3.6.5
48 INFO: Platform: Windows-7-6.1.7601-SP1
48 INFO: wrote C:\Users\abc ?? ???\Desktop\a.spec
48 INFO: UPX is not available.
48 INFO: Removing temporary files and cleaning cache in C:\Users\abc ?? ???\AppData\Roaming\pyinstaller
Traceback (most recent call last):
  File "c:\deploy-dir\3.6.6\Scripts\pyinstaller-script.py", line 11, in <module>
    load_entry_point('PyInstaller==3.5.dev0', 'console_scripts', 'pyinstaller')()
  File "c:\deploy-dir\3.6.6\lib\site-packages\pyinstaller-3.5.dev0-py3.6.egg\PyInstaller\__main__.py", line 111, in run
    run_build(pyi_config, spec_file, **vars(args))
  File "c:\deploy-dir\3.6.6\lib\site-packages\pyinstaller-3.5.dev0-py3.6.egg\PyInstaller\__main__.py", line 63, in run_build
    PyInstaller.building.build_main.main(pyi_config, spec_file, **kwargs)
  File "c:\deploy-dir\3.6.6\lib\site-packages\pyinstaller-3.5.dev0-py3.6.egg\PyInstaller\building\build_main.py", line 839, in main
    build(specfile, kw.get('distpath'), kw.get('workpath'), kw.get('clean_build'))
  File "c:\deploy-dir\3.6.6\lib\site-packages\pyinstaller-3.5.dev0-py3.6.egg\PyInstaller\building\build_main.py", line 784, in build
    text = f.read()
  File "C:\Python36-32\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 117: character maps to <undefined>
```
In that case, the script is named `a.py` and contains:
```python
# coding: utf-8
import os
import os.path

folder = os.path.join(os.path.expanduser("~"), "Desktop", "abc こん ツリー", "logs")
os.makedirs(folder, exist_ok=True)
```