### PR TITLE
UCRT warnings on win10

### DIFF
--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -38,6 +38,7 @@ is_py36 = sys.version_info >= (3, 6)
 is_py37 = sys.version_info >= (3, 7)
 
 is_win = sys.platform.startswith('win')
+is_win_10 = is_win and (platform.win32_ver()[0] == '10')
 is_cygwin = sys.platform == 'cygwin'
 is_darwin = sys.platform == 'darwin'  # Mac OS X
 

--- a/PyInstaller/depend/bindepend.py
+++ b/PyInstaller/depend/bindepend.py
@@ -21,7 +21,8 @@ import zipfile
 import collections
 
 from .. import compat
-from ..compat import (is_win, is_unix, is_aix, is_solar, is_cygwin, is_hpux,
+from ..compat import (is_win, is_win_10, is_unix,
+                      is_aix, is_solar, is_cygwin, is_hpux,
                       is_darwin, is_freebsd, is_venv, is_conda, base_prefix,
                       PYDYLIB_NAMES)
 from . import dylib, utils
@@ -536,7 +537,10 @@ def selectImports(pth, xtrapath=None):
                              lib, os.path.basename(pth), npth)
                 rv.append((lib, npth))
         else:
-            logger.warning("lib not found: %s dependency of %s", lib, pth)
+            # Don't spew out false warnings on win 10 and UCRT (see issue
+            # #1566).
+            if not (is_win_10 and lib.startswith("api-ms-win-crt")):
+                logger.warning("lib not found: %s dependency of %s", lib, pth)
 
     return rv
 

--- a/news/1566.core.rst
+++ b/news/1566.core.rst
@@ -1,0 +1,1 @@
+Suppress warnings about missing UCRT dependencies on Win 10.

--- a/news/3736.core.rst
+++ b/news/3736.core.rst
@@ -1,0 +1,1 @@
+Suppress warnings about missing UCRT dependencies on Win 10.


### PR DESCRIPTION
bindepend: don't generate warnings regarding missing UCRT dependencies on windows 10 as these files do not exist on purpose (see issue #1566)