### PR TITLE
Fix `--debug` command-line argument

### DIFF
--- a/PyInstaller/building/makespec.py
+++ b/PyInstaller/building/makespec.py
@@ -172,11 +172,8 @@ def __add_options(parser):
                    # If this option is not specified, then its default value is
                    # an empty list (no debug options selected).
                    default=[],
-                   # Allow the user to specify any number of arguments.
-                   nargs='?',
-                   # If zero arguments are specified (``--debug`` by itself),
-                   # then provide a default argument of all debug options enabled.
-                   const=DEBUG_ALL_CHOICE,
+                   # Allow the user to specify one argument.
+                   nargs=1,
                    # The options specified must come from this list.
                    choices=DEBUG_ALL_CHOICE + DEBUG_ARGUMENT_CHOICES,
                    # Append choice, rather than storing them (which would
@@ -185,12 +182,10 @@ def __add_options(parser):
                    # Allow newlines in the help text; see the
                    # ``_SmartFormatter`` in ``__main__.py``.
                    help=("R|Provide assistance with debugging a frozen\n"
-                         "application, by specifying one or more of the\n"
-                         "following choices.\n"
+                         "application. This argument may be provided multiple\n"
+                         "times to select several of the following options.\n"
                          "\n"
-                         "- all: All three of the below options; this is the\n"
-                         "  default choice, unless one of the choices below is\n"
-                         "  specified.\n"
+                         "- all: All three of the following options.\n"
                          "\n"
                          "- imports: specify the -v option to the underlying\n"
                          "  Python interpreter, causing it to print a message\n"

--- a/doc/help2rst.py
+++ b/doc/help2rst.py
@@ -71,6 +71,10 @@ def process(program, generate_headings, headings_character):
     help = help.strip('\n')
     # escape stars prior to other processing
     help = help.replace('*', r'\*')
+    # Change troublesome argparse text that the optparse-like docutils parser
+    # doesn't understand.
+    help = help.replace('{all,imports,bootloader,noarchive}',
+                        '<all,imports,bootloader,noarchive>')
     if generate_headings:
         program = os.path.splitext(os.path.basename(program))[0].lower()
         help = textwrap.dedent(help)

--- a/news/3737.breaking.rst
+++ b/news/3737.breaking.rst
@@ -1,0 +1,1 @@
+Require an option for the ``--debug`` argument, rather than assuming a default of ``all``.

--- a/news/3737.doc.rst
+++ b/news/3737.doc.rst
@@ -1,0 +1,1 @@
+Update the text produced by ``--help`` to state that the ``--debug`` argument requires an option. Correctly format this argument in the Sphinx build process.


### PR DESCRIPTION
This fixes #3737 by making `--debug` require an option. Otherwise, `--debug` by itself only works when placed at the end of the command line, which is confusing. It also fixes the doc build for the `--debug` option.