### PR TITLE
Only add NSS subdir path if it exists

### DIFF
--- a/PyInstaller/hooks/hook-PyQt5.QtWebEngineWidgets.py
+++ b/PyInstaller/hooks/hook-PyQt5.QtWebEngineWidgets.py
@@ -72,5 +72,6 @@ if compat.is_linux:
         if os.path.basename(imp).startswith('libnss3.so'):
             # Find the location of NSS: given a ``/path/to/libnss.so``,
             # add ``/path/to/nss/*.so`` to get the missing NSS libraries.
-            binaries.append((os.path.join(os.path.dirname(imp), 'nss', '*.so'),
-                             'nss'))
+            nss_subdir = os.path.join(os.path.dirname(imp), 'nss')
+            if os.path.exists(nss_subdir):
+                binaries.append((os.path.join(nss_subdir, '*.so'), 'nss'))

--- a/news/3758.hooks.rst
+++ b/news/3758.hooks.rst
@@ -1,0 +1,1 @@
+Fixed the QtWebEngine hook on distributions which don't have a NSS subdir (such as Archlinux)


### PR DESCRIPTION
On Archlinux, the NSS package ships with /usr/lib/libnss3.so.

The auto detection works fine with that, but the fix from #3439 breaks it again
since no /usr/lib/nss/libnss3.so exists:

    INFO: Loading module hook "hook-PyQt5.QtWebEngineWidgets.py"...
    Unable to find "/usr/lib/nss/*.so" when adding binary and data files.

Thus, it should only be added on distributions where it's really necessary.
With this change, test_PyQt5_QWebEngine works on Archlinux (it failed before).