### PR TITLE
More descriptive error when a missing tool

### DIFF
--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -360,7 +360,13 @@ def exec_command(*cmdargs, **kwargs):
     """
 
     encoding = kwargs.pop('encoding', None)
-    out = subprocess.Popen(cmdargs, stdout=subprocess.PIPE, **kwargs).communicate()[0]
+    try:
+        out = subprocess.Popen(cmdargs, stdout=subprocess.PIPE, **kwargs).communicate()[0]
+    except OSError as e:
+        print('--' * 20, file=sys.stderr)
+        print("Error running '%s': (%s) " % (" ".join(cmdargs), str(e)), file=sys.stderr)
+        print('--' * 20, file=sys.stderr)
+        raise
     # Python 3 returns stdout/stderr as a byte array NOT as string.
     # Thus we need to convert that to proper encoding.
 


### PR DESCRIPTION
- I was missing the "binutils" package containing the "objdump". The error raised was very very confusing so I needed to debug the pyinstaller code. I think just printing the command invocation can help a lot for similar issues.

```
...
17207 INFO: Looking for eggs
17208 INFO: Python library not in binary dependencies. Doing additional searching...
Traceback (most recent call last):
  File "/usr/local/bin/pyinstaller", line 11, in <module>
    sys.exit(run())
  File "/usr/local/lib/python2.7/dist-packages/PyInstaller/__main__.py", line 111, in run
    run_build(pyi_config, spec_file, **vars(args))
  File "/usr/local/lib/python2.7/dist-packages/PyInstaller/__main__.py", line 63, in run_build
    PyInstaller.building.build_main.main(pyi_config, spec_file, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/PyInstaller/building/build_main.py", line 838, in main
    build(specfile, kw.get('distpath'), kw.get('workpath'), kw.get('clean_build'))
  File "/usr/local/lib/python2.7/dist-packages/PyInstaller/building/build_main.py", line 784, in build
    exec(text, spec_namespace)
  File "<string>", line 17, in <module>
  File "/usr/local/lib/python2.7/dist-packages/PyInstaller/building/build_main.py", line 241, in __init__
    self.__postinit__()
  File "/usr/local/lib/python2.7/dist-packages/PyInstaller/building/datastruct.py", line 158, in __postinit__
    self.assemble()
  File "/usr/local/lib/python2.7/dist-packages/PyInstaller/building/build_main.py", line 573, in assemble
    self._check_python_library(self.binaries)
  File "/usr/local/lib/python2.7/dist-packages/PyInstaller/building/build_main.py", line 661, in _check_python_library
    python_lib = bindepend.get_python_library_path()
  File "/usr/local/lib/python2.7/dist-packages/PyInstaller/depend/bindepend.py", line 879, in get_python_library_path
    python_libname = findLibrary(name)
  File "/usr/local/lib/python2.7/dist-packages/PyInstaller/depend/bindepend.py", line 825, in findLibrary
    return os.path.join(dir, _get_so_name(lib))
  File "/usr/local/lib/python2.7/dist-packages/PyInstaller/depend/bindepend.py", line 836, in _get_so_name
    m = re.search(r'\s+SONAME\s+([^\s]+)', compat.exec_command(*cmd))
  File "/usr/local/lib/python2.7/dist-packages/PyInstaller/compat.py", line 364, in exec_command
    out = subprocess.Popen(cmdargs, stdout=subprocess.PIPE, **kwargs).communicate()[0]
  File "/usr/lib/python2.7/subprocess.py", line 711, in __init__
    errread, errwrite)
  File "/usr/lib/python2.7/subprocess.py", line 1343, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory
```

With this PR it is printed this before the error trace:

```
----------------------------------------
Error running 'objdump -p /usr/lib/x86_64-linux-gnu/libpython2.7.so.1.0': ([Errno 2] No such file or directory)
----------------------------------------
```