### PR TITLE
Revert "setup: Remove hack required to not fail when pypiwin32 isn't found."

### DIFF
--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -206,15 +206,18 @@ else:
 
 # On Windows we require pywin32-ctypes
 # -> all pyinstaller modules should use win32api from PyInstaller.compat to
-#    ensure that it can work on MSYS2
+#    ensure that it can work on MSYS2 (which requires pywin32-ctypes)
 if is_win:
     try:
         from win32ctypes.pywin32 import pywintypes  # noqa: F401
         from win32ctypes.pywin32 import win32api
     except ImportError:
-        raise SystemExit('PyInstaller cannot check for assembly dependencies.\n'
-                         'Please install pywin32-ctypes.\n\n'
-                         'pip install pywin32-ctypes\n')
+        # This environment variable is set by seutp.py
+        # - It's not an error for pywin32 to not be installed at that point
+        if not os.environ.get('PYINSTALLER_NO_PYWIN32_FAILURE'):
+            raise SystemExit('PyInstaller cannot check for assembly dependencies.\n'
+                             'Please install pywin32-ctypes.\n\n'
+                             'pip install pywin32-ctypes\n')
 
 
 def architecture():

--- a/PyInstaller/news/3513.core.rst
+++ b/PyInstaller/news/3513.core.rst
@@ -1,3 +1,0 @@
-Completely remove `pywin32` dependency, which has erratic releases and
-the version on pypi may no longer have future releases.
-Require `pywin32-ctypes` instead which is pure python.

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,8 @@ import sys
 import os
 from setuptools import setup
 
+# Hack required to allow compat to not fail when pypiwin32 isn't found
+os.environ["PYINSTALLER_NO_PYWIN32_FAILURE"] = "1"
 from PyInstaller import __version__ as version, HOMEPATH, PLATFORM
 from PyInstaller.compat import is_win, is_cygwin, is_py2
 


### PR DESCRIPTION
This reverts commit 250d72b4f884912b2c1ef4605c1de31c8d5cb55a, which causes PyInstaller to be uninstallable on Windows without pywin32-ctypes.

See https://github.com/pyinstaller/pyinstaller/pull/3513#discussion_r222240942 - cc @rth