### PR TITLE
hooks: Fix QtWebEngine casing.

### DIFF
--- a/PyInstaller/hooks/hook-PyQt5.QtWebEngineWidgets.py
+++ b/PyInstaller/hooks/hook-PyQt5.QtWebEngineWidgets.py
@@ -28,7 +28,7 @@ if compat.is_darwin:
         datas += collect_system_data_files(
             os.path.join(data_path, 'lib', i + '.framework'),
             os.path.join(*(rel_data_path + ['lib'])), True)
-    datas += [(os.path.join(data_path, 'lib', 'QtWebengineCore.framework',
+    datas += [(os.path.join(data_path, 'lib', 'QtWebEngineCore.framework',
                             'Resources'), os.curdir)]
 else:
     locales = 'qtwebengine_locales'


### PR DESCRIPTION
On macOS with a case-sensitive filesystem, this failed because the folder name
is QtWebEngine and not QtWebengine.

cc @melvyn2 (introduced in 33e9adfb78c2cbec07bd06f01214581754c36cec)