### PR TITLE
(WIP) Exclude selected binaries from compression with UPX using `--exclude-upx`

### DIFF
--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -154,7 +154,7 @@ class PKG(Target):
                  'DEPENDENCY': 'd'}
 
     def __init__(self, toc, name=None, cdict=None, exclude_binaries=0,
-                 strip_binaries=False, upx_binaries=False, exclude_upx=[]):
+                 strip_binaries=False, upx_binaries=False, exclude_upx=None):
         """
         toc
                 A TOC (Table of Contents)
@@ -181,7 +181,7 @@ class PKG(Target):
         self.exclude_binaries = exclude_binaries
         self.strip_binaries = strip_binaries
         self.upx_binaries = upx_binaries
-        self.exclude_upx = exclude_upx
+        self.exclude_upx = exclude_upx or []
         # This dict tells PyInstaller what items embedded in the executable should
         # be compressed.
         if self.cdict is None:
@@ -255,9 +255,11 @@ class PKG(Target):
                     seenFnms[fnm] = inm
                     seenFnms_typ[fnm] = typ
 
-                    do_upx = os.path.basename(fnm) not in self.exclude_upx
+                    do_upx = (self.upx_binaries
+                              and (is_win or is_cygwin)
+                              and os.path.basename(fnm) not in self.exclude_upx)
                     fnm = checkCache(fnm, strip=self.strip_binaries,
-                                     upx=(self.upx_binaries and (is_win or is_cygwin) and do_upx),
+                                     upx=do_upx,
                                      dist_nm=inm)
 
                     mytoc.append((inm, fnm, self.cdict.get(typ, 0),
@@ -707,9 +709,11 @@ class COLLECT(Target):
             if not os.path.exists(todir):
                 os.makedirs(todir)
             if typ in ('EXTENSION', 'BINARY'):
-                do_upx = os.path.basename(fnm) not in self.exclude_upx
+                do_upx = (self.upx_binaries
+                          and (is_win or is_cygwin)
+                          and os.path.basename(fnm) not in self.exclude_upx)
                 fnm = checkCache(fnm, strip=self.strip_binaries,
-                                 upx=(self.upx_binaries and (is_win or is_cygwin) and do_upx),
+                                 upx=do_upx,
                                  dist_nm=inm)
             if typ != 'DEPENDENCY':
                 shutil.copy(fnm, tofnm)

--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -154,7 +154,7 @@ class PKG(Target):
                  'DEPENDENCY': 'd'}
 
     def __init__(self, toc, name=None, cdict=None, exclude_binaries=0,
-                 strip_binaries=False, upx_binaries=False, exclude_upx=None):
+                 strip_binaries=False, upx_binaries=False, upx_exclude=None):
         """
         toc
                 A TOC (Table of Contents)
@@ -181,7 +181,7 @@ class PKG(Target):
         self.exclude_binaries = exclude_binaries
         self.strip_binaries = strip_binaries
         self.upx_binaries = upx_binaries
-        self.exclude_upx = exclude_upx or []
+        self.upx_exclude = upx_exclude or []
         # This dict tells PyInstaller what items embedded in the executable should
         # be compressed.
         if self.cdict is None:
@@ -257,7 +257,7 @@ class PKG(Target):
 
                     do_upx = (self.upx_binaries
                               and (is_win or is_cygwin)
-                              and os.path.basename(fnm) not in self.exclude_upx)
+                              and os.path.basename(fnm) not in self.upx_exclude)
                     fnm = checkCache(fnm, strip=self.strip_binaries,
                                      upx=do_upx,
                                      dist_nm=inm)
@@ -353,7 +353,7 @@ class EXE(Target):
         self.manifest = kwargs.get('manifest', None)
         self.resources = kwargs.get('resources', [])
         self.strip = kwargs.get('strip', False)
-        self.exclude_upx = kwargs.get("exclude_upx", [])
+        self.upx_exclude = kwargs.get("upx_exclude", [])
         self.runtime_tmpdir = kwargs.get('runtime_tmpdir', None)
         # If ``append_pkg`` is false, the archive will not be appended
         # to the exe, but copied beside it.
@@ -427,7 +427,7 @@ class EXE(Target):
         self.pkg = PKG(self.toc, cdict=kwargs.get('cdict', None),
                        exclude_binaries=self.exclude_binaries,
                        strip_binaries=self.strip, upx_binaries=self.upx,
-                       exclude_upx=self.exclude_upx
+                       upx_exclude=self.upx_exclude
                        )
         self.dependencies = self.pkg.dependencies
 
@@ -647,7 +647,7 @@ class COLLECT(Target):
         from ..config import CONF
         Target.__init__(self)
         self.strip_binaries = kws.get('strip', False)
-        self.exclude_upx = kws.get("exclude_upx", [])
+        self.upx_exclude = kws.get("upx_exclude", [])
         self.console = True
 
         if CONF['hasUPX']:
@@ -711,7 +711,7 @@ class COLLECT(Target):
             if typ in ('EXTENSION', 'BINARY'):
                 do_upx = (self.upx_binaries
                           and (is_win or is_cygwin)
-                          and os.path.basename(fnm) not in self.exclude_upx)
+                          and os.path.basename(fnm) not in self.upx_exclude)
                 fnm = checkCache(fnm, strip=self.strip_binaries,
                                  upx=do_upx,
                                  dist_nm=inm)

--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -203,6 +203,7 @@ class PKG(Target):
             ('exclude_binaries', _check_guts_eq),
             ('strip_binaries', _check_guts_eq),
             ('upx_binaries', _check_guts_eq),
+            ('upx_exclude', _check_guts_eq)
             # no calculated/analysed values
             )
 
@@ -255,11 +256,9 @@ class PKG(Target):
                     seenFnms[fnm] = inm
                     seenFnms_typ[fnm] = typ
 
-                    do_upx = (self.upx_binaries
-                              and (is_win or is_cygwin)
-                              and os.path.basename(fnm) not in self.upx_exclude)
                     fnm = checkCache(fnm, strip=self.strip_binaries,
-                                     upx=do_upx,
+                                     upx=(self.upx_binaries and (is_win or is_cygwin)),
+                                     upx_exclude=self.upx_exclude,
                                      dist_nm=inm)
 
                     mytoc.append((inm, fnm, self.cdict.get(typ, 0),
@@ -709,11 +708,9 @@ class COLLECT(Target):
             if not os.path.exists(todir):
                 os.makedirs(todir)
             if typ in ('EXTENSION', 'BINARY'):
-                do_upx = (self.upx_binaries
-                          and (is_win or is_cygwin)
-                          and os.path.basename(fnm) not in self.upx_exclude)
                 fnm = checkCache(fnm, strip=self.strip_binaries,
-                                 upx=do_upx,
+                                 upx=(self.upx_binaries and (is_win or is_cygwin)),
+                                 upx_exclude=self.upx_exclude,
                                  dist_nm=inm)
             if typ != 'DEPENDENCY':
                 shutil.copy(fnm, tofnm)

--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -257,7 +257,7 @@ class PKG(Target):
                     seenFnms_typ[fnm] = typ
 
                     fnm = checkCache(fnm, strip=self.strip_binaries,
-                                     upx=(self.upx_binaries and (is_win or is_cygwin)),
+                                     upx=self.upx_binaries,
                                      upx_exclude=self.upx_exclude,
                                      dist_nm=inm)
 
@@ -709,7 +709,7 @@ class COLLECT(Target):
                 os.makedirs(todir)
             if typ in ('EXTENSION', 'BINARY'):
                 fnm = checkCache(fnm, strip=self.strip_binaries,
-                                 upx=(self.upx_binaries and (is_win or is_cygwin)),
+                                 upx=self.upx_binaries,
                                  upx_exclude=self.upx_exclude,
                                  dist_nm=inm)
             if typ != 'DEPENDENCY':

--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -351,6 +351,7 @@ class EXE(Target):
         self.manifest = kwargs.get('manifest', None)
         self.resources = kwargs.get('resources', [])
         self.strip = kwargs.get('strip', False)
+        self.exclude_upx = kwargs.get("exclude_upx", [])
         self.runtime_tmpdir = kwargs.get('runtime_tmpdir', None)
         # If ``append_pkg`` is false, the archive will not be appended
         # to the exe, but copied beside it.
@@ -362,7 +363,6 @@ class EXE(Target):
 
         if CONF['hasUPX']:
             self.upx = kwargs.get('upx', False)
-            self.exclude_upx = kwargs.get("exclude_upx", [])
         else:
             self.upx = False
 
@@ -645,11 +645,11 @@ class COLLECT(Target):
         from ..config import CONF
         Target.__init__(self)
         self.strip_binaries = kws.get('strip', False)
+        self.exclude_upx = kws.get("exclude_upx", [])
         self.console = True
 
         if CONF['hasUPX']:
             self.upx_binaries = kws.get('upx', False)
-            self.exclude_upx = kws.get("exclude_upx", [])
         else:
             self.upx_binaries = False
 

--- a/PyInstaller/building/makespec.py
+++ b/PyInstaller/building/makespec.py
@@ -217,6 +217,7 @@ def __add_options(parser):
                    help="Prevent a binary from being compressed when using "
                         "upx. This is typically used if upx corrupts certain "
                         "binaries during compression. "
+                        "FILE is the filename of the binary without path. "
                         "This option can be used multiple times.")
 
     g = parser.add_argument_group('Windows and Mac OS X specific options')

--- a/PyInstaller/building/makespec.py
+++ b/PyInstaller/building/makespec.py
@@ -212,6 +212,10 @@ def __add_options(parser):
     g.add_argument("--noupx", action="store_true", default=False,
                    help="Do not use UPX even if it is available "
                         "(works differently between Windows and *nix)")
+    g.add_argument("--exclude-upx", dest="exclude_upx", metavar="<FILE>", action="append", default=[],
+                   help="Prevent a binary from being compressed using upx."
+                        "This is typically used if upx corrupts certain binaries during compression."
+                        "This option can be used multiple times.")
 
     g = parser.add_argument_group('Windows and Mac OS X specific options')
     g.add_argument("-c", "--console", "--nowindowed", dest="console",
@@ -301,7 +305,7 @@ def __add_options(parser):
 
 
 def main(scripts, name=None, onefile=None,
-         console=True, debug=None, strip=False, noupx=False,
+         console=True, debug=None, strip=False, noupx=False, exclude_upx=None,
          runtime_tmpdir=None, pathex=None, version_file=None, specpath=None,
          bootloader_ignore_signals=False,
          datas=None, binaries=None, icon_file=None, manifest=None, resources=None, bundle_identifier=None,
@@ -369,6 +373,8 @@ def main(scripts, name=None, onefile=None,
 
     hiddenimports = hiddenimports or []
 
+    exclude_upx = exclude_upx or []
+
     # If script paths are relative, make them relative to the directory containing .spec file.
     scripts = [make_path_spec_relative(x, specpath) for x in scripts]
     # With absolute paths replace prefix with variable HOMEPATH.
@@ -412,6 +418,7 @@ def main(scripts, name=None, onefile=None,
         'bootloader_ignore_signals': bootloader_ignore_signals,
         'strip': strip,
         'upx': not noupx,
+        'exclude_upx': exclude_upx,
         'runtime_tmpdir': runtime_tmpdir,
         'exe_options': exe_options,
         'cipher_init': cipher_init,

--- a/PyInstaller/building/makespec.py
+++ b/PyInstaller/building/makespec.py
@@ -212,7 +212,7 @@ def __add_options(parser):
     g.add_argument("--noupx", action="store_true", default=False,
                    help="Do not use UPX even if it is available "
                         "(works differently between Windows and *nix)")
-    g.add_argument("--exclude-upx", dest="exclude_upx", metavar="FILE",
+    g.add_argument("--upx-exclude", dest="upx_exclude", metavar="FILE",
                    action="append",
                    help="Prevent a binary from being compressed when using "
                         "upx. This is typically used if upx corrupts certain "
@@ -307,7 +307,7 @@ def __add_options(parser):
 
 
 def main(scripts, name=None, onefile=None,
-         console=True, debug=None, strip=False, noupx=False, exclude_upx=None,
+         console=True, debug=None, strip=False, noupx=False, upx_exclude=None,
          runtime_tmpdir=None, pathex=None, version_file=None, specpath=None,
          bootloader_ignore_signals=False,
          datas=None, binaries=None, icon_file=None, manifest=None, resources=None, bundle_identifier=None,
@@ -374,7 +374,7 @@ def main(scripts, name=None, onefile=None,
         exe_options = "%s, resources=%s" % (exe_options, repr(resources))
 
     hiddenimports = hiddenimports or []
-    exclude_upx = exclude_upx or []
+    upx_exclude = upx_exclude or []
 
     # If script paths are relative, make them relative to the directory containing .spec file.
     scripts = [make_path_spec_relative(x, specpath) for x in scripts]
@@ -419,7 +419,7 @@ def main(scripts, name=None, onefile=None,
         'bootloader_ignore_signals': bootloader_ignore_signals,
         'strip': strip,
         'upx': not noupx,
-        'exclude_upx': exclude_upx,
+        'upx_exclude': upx_exclude,
         'runtime_tmpdir': runtime_tmpdir,
         'exe_options': exe_options,
         'cipher_init': cipher_init,

--- a/PyInstaller/building/makespec.py
+++ b/PyInstaller/building/makespec.py
@@ -212,9 +212,11 @@ def __add_options(parser):
     g.add_argument("--noupx", action="store_true", default=False,
                    help="Do not use UPX even if it is available "
                         "(works differently between Windows and *nix)")
-    g.add_argument("--exclude-upx", dest="exclude_upx", metavar="<FILE>", action="append", default=[],
-                   help="Prevent a binary from being compressed using upx."
-                        "This is typically used if upx corrupts certain binaries during compression."
+    g.add_argument("--exclude-upx", dest="exclude_upx", metavar="FILE",
+                   action="append",
+                   help="Prevent a binary from being compressed when using "
+                        "upx. This is typically used if upx corrupts certain "
+                        "binaries during compression. "
                         "This option can be used multiple times.")
 
     g = parser.add_argument_group('Windows and Mac OS X specific options')
@@ -372,7 +374,6 @@ def main(scripts, name=None, onefile=None,
         exe_options = "%s, resources=%s" % (exe_options, repr(resources))
 
     hiddenimports = hiddenimports or []
-
     exclude_upx = exclude_upx or []
 
     # If script paths are relative, make them relative to the directory containing .spec file.

--- a/PyInstaller/building/osx.py
+++ b/PyInstaller/building/osx.py
@@ -62,6 +62,7 @@ class BUNDLE(Target):
                 self.toc.extend(arg.dependencies)
                 self.strip = arg.strip
                 self.upx = arg.upx
+                self.upx_exclude = arg.upx_exclude
                 self.console = arg.console
             elif isinstance(arg, TOC):
                 self.toc.extend(arg)
@@ -71,6 +72,7 @@ class BUNDLE(Target):
                 self.toc.extend(arg.toc)
                 self.strip = arg.strip_binaries
                 self.upx = arg.upx_binaries
+                self.upx_exclude = arg.upx_exclude
                 self.console = arg.console
             else:
                 logger.info("unsupported entry %s", arg.__class__.__name__)
@@ -166,7 +168,8 @@ class BUNDLE(Target):
             # Copy files from cache. This ensures that are used files with relative
             # paths to dynamic library dependencies (@executable_path)
             if typ in ('EXTENSION', 'BINARY'):
-                fnm = checkCache(fnm, strip=self.strip, upx=self.upx, dist_nm=inm)
+                fnm = checkCache(fnm, strip=self.strip, upx=self.upx, 
+                                 upx_exclude=self.upx_exclude, dist_nm=inm)
             if typ == 'DATA':  # add all data files to a list for symlinking later
                 links.append((inm, fnm))
             else:

--- a/PyInstaller/building/osx.py
+++ b/PyInstaller/building/osx.py
@@ -168,7 +168,7 @@ class BUNDLE(Target):
             # Copy files from cache. This ensures that are used files with relative
             # paths to dynamic library dependencies (@executable_path)
             if typ in ('EXTENSION', 'BINARY'):
-                fnm = checkCache(fnm, strip=self.strip, upx=self.upx, 
+                fnm = checkCache(fnm, strip=self.strip, upx=self.upx,
                                  upx_exclude=self.upx_exclude, dist_nm=inm)
             if typ == 'DATA':  # add all data files to a list for symlinking later
                 links.append((inm, fnm))

--- a/PyInstaller/building/templates.py
+++ b/PyInstaller/building/templates.py
@@ -40,7 +40,7 @@ exe = EXE(pyz,
           bootloader_ignore_signals=%(bootloader_ignore_signals)s,
           strip=%(strip)s,
           upx=%(upx)s,
-          exclude_upx=%(exclude_upx)s,
+          upx_exclude=%(upx_exclude)s,
           runtime_tmpdir=%(runtime_tmpdir)r,
           console=%(console)s %(exe_options)s)
 """
@@ -78,7 +78,7 @@ coll = COLLECT(exe,
                a.datas,
                strip=%(strip)s,
                upx=%(upx)s,
-               exclude_upx=%(exclude_upx)s,
+               upx_exclude=%(upx_exclude)s,
                name='%(name)s')
 """
 

--- a/PyInstaller/building/templates.py
+++ b/PyInstaller/building/templates.py
@@ -40,6 +40,7 @@ exe = EXE(pyz,
           bootloader_ignore_signals=%(bootloader_ignore_signals)s,
           strip=%(strip)s,
           upx=%(upx)s,
+          exclude_upx=%(exclude_upx)s,
           runtime_tmpdir=%(runtime_tmpdir)r,
           console=%(console)s %(exe_options)s)
 """
@@ -77,6 +78,7 @@ coll = COLLECT(exe,
                a.datas,
                strip=%(strip)s,
                upx=%(upx)s,
+               exclude_upx=%(exclude_upx)s,
                name='%(name)s')
 """
 

--- a/PyInstaller/building/utils.py
+++ b/PyInstaller/building/utils.py
@@ -26,7 +26,7 @@ import struct
 from PyInstaller.config import CONF
 from .. import compat
 from ..compat import is_darwin, is_win, EXTENSION_SUFFIXES, \
-    open_file, is_py3, is_py37
+    open_file, is_py3, is_py37, is_cygwin
 from ..depend import dylib
 from ..depend.bindepend import match_binding_redirect
 from ..utils import misc
@@ -150,7 +150,7 @@ def applyRedirects(manifest, redirects):
                 redirecting = True
     return redirecting
 
-def checkCache(fnm, strip=False, upx=False, dist_nm=None):
+def checkCache(fnm, strip=False, upx=False, upx_exclude=None, dist_nm=None):
     """
     Cache prevents preprocessing binary files again and again.
 
@@ -175,10 +175,8 @@ def checkCache(fnm, strip=False, upx=False, dist_nm=None):
         strip = True
     else:
         strip = False
-    if upx:
-        upx = True
-    else:
-        upx = False
+    upx = (upx and (is_win or is_cygwin)
+           and os.path.normcase(os.path.basename(fnm)) not in upx_exclude)
 
     # Load cache index
     # Make cachedir per Python major/minor version.

--- a/PyInstaller/building/utils.py
+++ b/PyInstaller/building/utils.py
@@ -175,6 +175,7 @@ def checkCache(fnm, strip=False, upx=False, upx_exclude=None, dist_nm=None):
         strip = True
     else:
         strip = False
+    upx_exclude = upx_exclude or []
     upx = (upx and (is_win or is_cygwin)
            and os.path.normcase(os.path.basename(fnm)) not in upx_exclude)
 

--- a/PyInstaller/building/utils.py
+++ b/PyInstaller/building/utils.py
@@ -150,6 +150,7 @@ def applyRedirects(manifest, redirects):
                 redirecting = True
     return redirecting
 
+
 def checkCache(fnm, strip=False, upx=False, upx_exclude=None, dist_nm=None):
     """
     Cache prevents preprocessing binary files again and again.
@@ -176,8 +177,8 @@ def checkCache(fnm, strip=False, upx=False, upx_exclude=None, dist_nm=None):
     else:
         strip = False
     upx_exclude = upx_exclude or []
-    upx = (upx and (is_win or is_cygwin)
-           and os.path.normcase(os.path.basename(fnm)) not in upx_exclude)
+    upx = (upx and (is_win or is_cygwin) and
+           os.path.normcase(os.path.basename(fnm)) not in upx_exclude)
 
     # Load cache index
     # Make cachedir per Python major/minor version.

--- a/news/3821.feature.rst
+++ b/news/3821.feature.rst
@@ -1,0 +1,1 @@
+Allow the user to prevent binaries from being compressed with UPX, using `--exclude-upx`

--- a/news/3821.feature.rst
+++ b/news/3821.feature.rst
@@ -1,1 +1,1 @@
-New command-line option ``--exclude-upx``, which allows the user to prevent binaries from being compressed with UPX.
+New command-line option ``--upx-exclude``, which allows the user to prevent binaries from being compressed with UPX.

--- a/news/3821.feature.rst
+++ b/news/3821.feature.rst
@@ -1,1 +1,1 @@
-Allow the user to prevent binaries from being compressed with UPX, using `--exclude-upx`
+New command-line option ``--exclude-upx``, which allows the user to prevent binaries from being compressed with UPX.


### PR DESCRIPTION
closes #2659.

With this PR, one can run PyInstaller with (for example) `--upx-exclude "vcruntime140.dll"`. This will exclude the "vcruntime140.dll" binary from being compressed with UPX.

I could only test with this specific dll (because i didn't stumble over any other that fails with UPX), but it appears to be working, both in onefile and onedir mode. In the specfile, this option looks like this:
```
[...]
upx=True,
upx_exclude=['vcruntime140.dll'],
runtime_tmpdir=None,
[...]
```

I'm marking this as WIP because there's still stuff to be done. According to the docs i should add some tests for this (a field i have no experience whatsoever in), ~~and the news fragment is missing as well~~. Also i would would be surprised if all tests passed *and* you approved this right away (it's my first time here, please be gentle).

Cheers!
