### PR TITLE
Bootloader: Ensure that symlinks to binaries do not get resolved.

### DIFF
--- a/bootloader/src/pyi_path.c
+++ b/bootloader/src/pyi_path.c
@@ -331,7 +331,7 @@ pyi_path_executable(char *execfile, const char *appname)
                 return -1;
             }
         }
-        if (pyi_path_fullpath(execfile, PATH_MAX, buffer) == false) {
+        if (pyi_path_fullpath_keep_basename(execfile, buffer) == false) {
             VS("LOADER: Cannot get fullpath for %s\n", execfile);
             return -1;
         }

--- a/bootloader/src/pyi_path.c
+++ b/bootloader/src/pyi_path.c
@@ -169,6 +169,27 @@ pyi_path_normalize(char *result, const char *path)
 {
 }
 
+
+#if !defined(_WIN32) && !defined(__APPLE__)
+/*
+ * Return full path to a file's directory, but keeps the basename.
+ * This is required to pass the correct basename to execvp().
+ */
+int
+pyi_path_fullpath_keep_basename(char *abs, const char *rel)
+{
+    char dirname[PATH_MAX];
+    char full_dirname[PATH_MAX];
+    char basename[PATH_MAX];
+    pyi_path_basename(basename, rel);
+    pyi_path_dirname(dirname, rel);
+    if (realpath(dirname, full_dirname) == NULL) {
+        return false;
+    }
+    return (pyi_path_join(abs, full_dirname, basename) == NULL);
+}
+#endif
+
 /*
  * Return full path to a file. Wraps platform specific function.
  */
@@ -288,52 +309,31 @@ pyi_path_executable(char *execfile, const char *appname)
     }
 
 #else /* ifdef _WIN32 */
-    result = -1;
-    /* On Linux, FreeBSD, and Solaris, we try these /proc paths first
-     */
-    #if defined(__linux__)
-    result = readlink("/proc/self/exe", execfile, PATH_MAX);  /* Linux */
-    #elif defined(__FreeBSD__)
-    result = readlink("/proc/curproc/file", execfile, PATH_MAX);  /* FreeBSD */
-    #elif defined(__sun)
-    result = readlink("/proc/self/path/a.out", execfile, PATH_MAX);  /* Solaris */
-    #endif
-
-    if (-1 != result) {
-        /* execfile is not yet zero-terminated. result is the byte count. */
-        *(execfile + result) = '\0';
+    if (appname[0] == PYI_SEP || strchr(appname, PYI_SEP)) {
+        /* Absolute or relative path: Canonicalize directory path,
+         * but keep original basename.
+         */
+        if (pyi_path_fullpath_keep_basename(execfile, appname) == false) {
+            VS("LOADER: Cannot get fullpath for %s\n", execfile);
+            return -1;
+        }
     }
     else {
-        /* No /proc path found or provided
+        /* No absolute or relative path, just program name: search $PATH.
          */
-        if (appname[0] == PYI_SEP || strchr(appname, PYI_SEP)) {
-            /* Absolute or relative path.
-             * Convert to absolute and resolve symlinks.
-             */
-            if (pyi_path_fullpath(execfile, PATH_MAX, appname) == false) {
-                VS("LOADER: Cannot get fullpath for %s\n", execfile);
+        result = pyi_search_path(buffer, appname);
+        if (-1 == result) {
+            /* Searching $PATH failed, user is crazy. */
+            VS("LOADER: Searching $PATH failed for %s", appname);
+            strncpy(buffer, appname, PATH_MAX);
+            if (buffer[PATH_MAX-1] != '\0') {
+                VS("LOADER: Appname too large %s\n", appname);
                 return -1;
             }
         }
-        else {
-            /* Not absolute or relative path, just program name. Search $PATH
-             */
-            result = pyi_search_path(buffer, appname);
-
-            if (-1 == result) {
-                /* Searching $PATH failed, user is crazy. */
-                VS("LOADER: Searching $PATH failed for %s", appname);
-                strncpy(buffer, appname, PATH_MAX);
-                if (buffer[PATH_MAX-1] != '\0') {
-                    VS("LOADER: Appname too large %s\n", appname);
-                    return -1;
-                }
-            }
-
-            if (pyi_path_fullpath(execfile, PATH_MAX, buffer) == false) {
-                VS("LOADER: Cannot get fullpath for %s\n", execfile);
-                return -1;
-            }
+        if (pyi_path_fullpath(execfile, PATH_MAX, buffer) == false) {
+            VS("LOADER: Cannot get fullpath for %s\n", execfile);
+            return -1;
         }
     }
 #endif /* ifdef _WIN32 */

--- a/news/3823.bootloader.rst
+++ b/news/3823.bootloader.rst
@@ -1,0 +1,2 @@
+(POSIX) For one-file binaries, if the program is started via a symlink, the
+second process now keeps the basename of the symlink.

--- a/news/3829.bootloader.rst
+++ b/news/3829.bootloader.rst
@@ -1,0 +1,2 @@
+(POSIX) For one-file binaries, if the program is started via a symlink, the
+second process now keeps the basename of the symlink.

--- a/tests/functional/scripts/pyi_symlink_basename_is_kept.py
+++ b/tests/functional/scripts/pyi_symlink_basename_is_kept.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 ; mode: python -*-
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2019, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+import os
+import sys
+
+with open('/proc/self/status', 'r') as fh:
+    for line in fh.readlines():
+        if line.startswith('Name:'):
+            name_from_proc = line.split(":")[1].strip()
+            break
+
+# PyInstaller bootloader assumes the `Name:` entry in '/proc/self/status' to
+# be truncated to 15 characters. Fail if this assumption is no longer true.
+
+name_from_argv = os.path.basename(sys.argv[0])
+# linux will truncate the name to 15 chars
+truncated_name_from_argv = name_from_argv[:15]
+
+print('ARGV:', repr(truncated_name_from_argv))
+print('PROC:', repr(name_from_proc))
+assert truncated_name_from_argv == name_from_proc

--- a/tests/functional/scripts/pyi_symlink_basename_is_kept.py
+++ b/tests/functional/scripts/pyi_symlink_basename_is_kept.py
@@ -11,19 +11,24 @@
 import os
 import sys
 
+# To verify that the bootloader actually uses the unresolved symlink basename
+# when executing the second process, check what `Name:` entry in
+# '/proc/self/status' says. This value is truncated to 15 characters.
+#
+# This test is run twice: once with a short basename and once with a long
+# basename to detect if this 15 character limit is no longer true.
+
 with open('/proc/self/status', 'r') as fh:
     for line in fh.readlines():
         if line.startswith('Name:'):
             name_from_proc = line.split(":")[1].strip()
             break
 
-# PyInstaller bootloader assumes the `Name:` entry in '/proc/self/status' to
-# be truncated to 15 characters. Fail if this assumption is no longer true.
-
 name_from_argv = os.path.basename(sys.argv[0])
 # linux will truncate the name to 15 chars
 truncated_name_from_argv = name_from_argv[:15]
 
-print('ARGV:', repr(truncated_name_from_argv))
+print('ARGV:', repr(name_from_argv), "(complete)")
+print('ARGV:', repr(truncated_name_from_argv), "(truncated")
 print('PROC:', repr(name_from_proc))
 assert truncated_name_from_argv == name_from_proc

--- a/tests/functional/specs/symlink_basename_is_kept.spec
+++ b/tests/functional/specs/symlink_basename_is_kept.spec
@@ -9,19 +9,18 @@
 #-----------------------------------------------------------------------------
 
 import os
-import sys
 
 # substituted by test-case
-app_name = "@APPNAME@"
 script_name = '@SCRIPTDIR@/pyi_symlink_basename_is_kept.py'
+symlink_name =  "@SYMLINKNAME@_1"
 
 # ensure substitutes are done
-assert app_name != ("@APP" + "NAME@"), \
-    "APPNAME was not substituted in spec-file"
+assert not symlink_name.startswith("@SYMLINK" + "NAME@_"), \
+    "SYMLINKNAME was not substituted in spec-file"
 assert not script_name.startswith("@SCRIPT" + "DIR@/"), \
     "SCRIPTDIR was not substituted in spec-file"
 
-symlink_name =  app_name + "_1"
+app_name = "keep_symlink_basename"
 
 a = Analysis([script_name])
 
@@ -29,16 +28,12 @@ pyz = PYZ(a.pure, a.zipped_data)
 
 exe = EXE(pyz,
           a.scripts,
-          exclude_binaries=True,
+          a.binaries,
+          a.zipfiles,
+          a.datas,
           name=app_name,
+          strip=False,
           debug=False, # the test is this .spec-file
           console=True)
 
-coll = COLLECT(exe,
-               a.binaries,
-               a.zipfiles,
-               a.datas,
-               name=app_name)
-
-os.symlink(app_name,
-           os.path.join(DISTPATH, app_name, symlink_name))
+os.symlink(app_name, os.path.join(DISTPATH, symlink_name))

--- a/tests/functional/specs/symlink_basename_is_kept.spec
+++ b/tests/functional/specs/symlink_basename_is_kept.spec
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 ; mode: python -*-
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2019, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+import os
+import sys
+
+# substituted by test-case
+app_name = "@APPNAME@"
+script_name = '@SCRIPTDIR@/pyi_symlink_basename_is_kept.py'
+
+# ensure substitutes are done
+assert app_name != ("@APP" + "NAME@"), \
+    "APPNAME was not substituted in spec-file"
+assert not script_name.startswith("@SCRIPT" + "DIR@/"), \
+    "SCRIPTDIR was not substituted in spec-file"
+
+symlink_name =  app_name + "_1"
+
+a = Analysis([script_name])
+
+pyz = PYZ(a.pure, a.zipped_data)
+
+exe = EXE(pyz,
+          a.scripts,
+          exclude_binaries=True,
+          name=app_name,
+          debug=False, # the test is this .spec-file
+          console=True)
+
+coll = COLLECT(exe,
+               a.binaries,
+               a.zipfiles,
+               a.datas,
+               name=app_name)
+
+os.symlink(app_name,
+           os.path.join(DISTPATH, app_name, symlink_name))

--- a/tests/functional/specs/symlink_basename_is_kept.spec
+++ b/tests/functional/specs/symlink_basename_is_kept.spec
@@ -36,4 +36,12 @@ exe = EXE(pyz,
           debug=False, # the test is this .spec-file
           console=True)
 
-os.symlink(app_name, os.path.join(DISTPATH, symlink_name))
+dst = os.path.join(DISTPATH, symlink_name)
+src = app_name
+dirname = os.path.dirname(dst)
+if not os.path.exists(dirname):
+    os.makedirs(dirname)
+    # need to adjust the link src relative to the dst directory
+    src = os.path.relpath(src, os.path.dirname(symlink_name))
+print("creating symlink", src, dst)
+os.symlink(src, dst)

--- a/tests/functional/test_basic.py
+++ b/tests/functional/test_basic.py
@@ -43,20 +43,21 @@ def test_absolute_python_path(pyi_builder):
 @skipif_notlinux
 @skipif(not os.path.exists('/proc/self/status'),
         reason='/proc/self/status does not exist')
-@pytest.mark.parametrize("app_name", ["symlink", "very_long_name_in_symlink"])
-def test_symlink_basename_is_kept(pyi_builder_spec, app_name,
+@pytest.mark.parametrize("symlink_name",
+                         ["symlink", "very_long_name_in_symlink"])
+def test_symlink_basename_is_kept(pyi_builder_spec, symlink_name,
                                   tmpdir, SPEC_DIR, SCRIPT_DIR):
 
-    def patch(spec_name, app_name):
+    def patch(spec_name, symlink_name):
         content = SPEC_DIR.join(spec_name).read_text(encoding="utf-8")
-        content = content.replace("@APPNAME@", app_name)
+        content = content.replace("@SYMLINKNAME@", symlink_name)
         content = content.replace("@SCRIPTDIR@", str(SCRIPT_DIR))
         outspec = tmpdir.join(spec_name)
         outspec.write_text(content, encoding="utf-8", ensure=True)
         return outspec
 
-    specfile = patch("symlink_basename_is_kept.spec", app_name)
-    pyi_builder_spec.test_spec(str(specfile), app_name=app_name)
+    specfile = patch("symlink_basename_is_kept.spec", symlink_name)
+    pyi_builder_spec.test_spec(str(specfile), app_name=symlink_name)
 
 
 def test_pyz_as_external_file(pyi_builder, monkeypatch):

--- a/tests/functional/test_basic.py
+++ b/tests/functional/test_basic.py
@@ -44,7 +44,9 @@ def test_absolute_python_path(pyi_builder):
 @skipif(not os.path.exists('/proc/self/status'),
         reason='/proc/self/status does not exist')
 @pytest.mark.parametrize("symlink_name",
-                         ["symlink", "very_long_name_in_symlink"])
+                         ["symlink",
+                          "very_long_name_in_symlink",
+                          "sub/dir/progam"])
 def test_symlink_basename_is_kept(pyi_builder_spec, symlink_name,
                                   tmpdir, SPEC_DIR, SCRIPT_DIR):
 


### PR DESCRIPTION
This fixes #3823 

As far as I understand; the current behavior is wrong: when doing `execvp()` we are passing the **resolved** `argv[0]`. This means that the name under `/proc/self/status` will be incorrect.

If the new behavior is desired (it is for me at least; telegraf is reporting parent and child as different processes and that confuses my monitoring system) then the whole reading from `/proc/` to get our full path is not needed anymore (as that will resolve all symlinks).

Let me know if you want me to change anything