### PR TITLE
Add support for the jsonpath_rw_ext library

### DIFF
--- a/PyInstaller/hooks/hook-jsonpath_rw_ext.py
+++ b/PyInstaller/hooks/hook-jsonpath_rw_ext.py
@@ -1,0 +1,12 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2018-2018, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import copy_metadata
+
+datas = copy_metadata('jsonpath_rw_ext')

--- a/news/3841.hooks.rst
+++ b/news/3841.hooks.rst
@@ -1,0 +1,1 @@
+Add hook for jsonpath_rw_ext.


### PR DESCRIPTION
This is a simple hook that adds a hook to support the following python library: https://pypi.org/project/jsonpath-rw-ext/.

