### PR TITLE
added a hook for pysoundfile

### DIFF
--- a/PyInstaller/hooks/hook-soundfile.py
+++ b/PyInstaller/hooks/hook-soundfile.py
@@ -8,11 +8,12 @@
 #-----------------------------------------------------------------------------
 
 """
-pysoundfile: https://github.com/bastibe/SoundFile
+pysoundfile:
+https://github.com/bastibe/SoundFile
 """
 
 import os
-from PyInstaller.utils.hooks import *
+from PyInstaller.utils.hooks import get_package_paths
 
 # get path of soundfile
 sfp = get_package_paths('soundfile')

--- a/PyInstaller/hooks/hook-soundfile.py
+++ b/PyInstaller/hooks/hook-soundfile.py
@@ -1,0 +1,22 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2016-2018, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+"""
+pysoundfile: https://github.com/bastibe/SoundFile
+"""
+
+import os
+from PyInstaller.utils.hooks import *
+
+# get path of soundfile
+sfp = get_package_paths('soundfile')
+
+# add the binaries
+bins = os.path.join(sfp[0], "_soundfile_data")
+binaries = [(bins, "_soundfile_data")]

--- a/news/3844.hooks.rst
+++ b/news/3844.hooks.rst
@@ -1,1 +1,1 @@
-added a hook for pysoundfile
+Add hook for pysoundfile.

--- a/news/3844.hooks.rst
+++ b/news/3844.hooks.rst
@@ -1,0 +1,1 @@
+added a hook for pysoundfile


### PR DESCRIPTION
hi,
this module can be installed by using pip install pysoundfile
it depends on libsndfile, which is located at _soundfile_data, which this hook loads it and put's it in its directory for loading.