### PR TITLE
Fix python library lookup for RHSCL python 3.6

### DIFF
--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -86,7 +86,8 @@ elif is_unix:
     # Python 3 .so library on Linux is: libpython3.2mu.so.1.0, libpython3.3m.so.1.0
     PYDYLIB_NAMES = {'libpython%d.%d.so.1.0' % _pyver,
                      'libpython%d.%dm.so.1.0' % _pyver,
-                     'libpython%d.%dmu.so.1.0' % _pyver}
+                     'libpython%d.%dmu.so.1.0' % _pyver,
+                     'libpython%d.%dm.so' % _pyver}
 else:
     raise SystemExit('Your platform is not yet supported. '
                      'Please define constant PYDYLIB_NAMES for your platform.')

--- a/news/3536.feature.rst
+++ b/news/3536.feature.rst
@@ -1,0 +1,1 @@
+Add support for the RedHat Software Collections (SCL) Python 3.x.

--- a/news/3881.feature.rst
+++ b/news/3881.feature.rst
@@ -1,0 +1,1 @@
+Add support for Software Collections (SCL) python 3.x

--- a/news/3881.feature.rst
+++ b/news/3881.feature.rst
@@ -1,1 +1,1 @@
-Add support for Software Collections (SCL) python 3.x
+Add support for the RedHat Software Collections (SCL) Python 3.x.


### PR DESCRIPTION
The current patterns does not match the way python is installed
with RedHat SCL python36 on RHEL7.

libpython3.6m.so (libpython%d.%dm.so) points to the right library