### PR TITLE
Specify the utf-8 encoding when opening a text file

### DIFF
--- a/PyInstaller/building/makespec.py
+++ b/PyInstaller/building/makespec.py
@@ -19,7 +19,7 @@ from distutils.version import LooseVersion
 
 from .. import HOMEPATH, DEFAULT_SPECPATH
 from .. import log as logging
-from ..compat import expand_path, is_darwin
+from ..compat import expand_path, is_darwin, open_file, text_type
 from .templates import onefiletmplt, onedirtmplt, cipher_absent_template, \
     cipher_init_template, bundleexetmplt, bundletmplt
 
@@ -434,16 +434,16 @@ def main(scripts, name=None, onefile=None,
 
     # Write down .spec file to filesystem.
     specfnm = os.path.join(specpath, name + '.spec')
-    with open(specfnm, 'w') as specfile:
+    with open_file(specfnm, 'w', encoding='utf-8') as specfile:
         if onefile:
-            specfile.write(onefiletmplt % d)
+            specfile.write(text_type(onefiletmplt % d))
             # For OSX create .app bundle.
             if is_darwin and not console:
-                specfile.write(bundleexetmplt % d)
+                specfile.write(text_type(bundleexetmplt % d))
         else:
-            specfile.write(onedirtmplt % d)
+            specfile.write(text_type(onedirtmplt % d))
             # For OSX create .app bundle.
             if is_darwin and not console:
-                specfile.write(bundletmplt % d)
+                specfile.write(text_type(bundletmplt % d))
 
     return specfnm

--- a/PyInstaller/building/templates.py
+++ b/PyInstaller/building/templates.py
@@ -12,7 +12,7 @@
 Templates to generate .spec files.
 """
 
-onefiletmplt = """# -*- mode: python -*-
+onefiletmplt = """# -*- mode: python ; coding: utf-8 -*-
 %(cipher_init)s
 
 a = Analysis(%(scripts)s,
@@ -44,7 +44,7 @@ exe = EXE(pyz,
           console=%(console)s %(exe_options)s)
 """
 
-onedirtmplt = """# -*- mode: python -*-
+onedirtmplt = """# -*- mode: python ; coding: utf-8 -*-
 %(cipher_init)s
 
 a = Analysis(%(scripts)s,

--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -100,6 +100,37 @@ else:
 open_file = open if is_py3 else io.open
 text_read_mode = 'r' if is_py3 else 'rU'
 
+
+# These are copied from ``six``.
+#
+# Type for representing (Unicode) textual data.
+text_type = unicode if is_py2 else str
+# Type for representing binary data.
+binary_type = str if is_py2 else bytes
+
+
+# Create a class which converts all writes to unicode first. For use with
+# ``print(*args, file=f)``, since in Python 2 this ``print`` will write str, not
+# unicode.
+class unicode_writer:
+
+    # Store the object to proxy.
+    def __init__(self, f):
+        self.f = f
+
+    # Insist that writes use the ``text_type``.
+    def write(self, _str):
+        self.f.write(text_type(_str))
+
+    def writelines(self, lines):
+        self.f.writelines([text_type(_str) for _str in lines])
+
+    # Proxy all other methods.
+    def __getattr__(self, name):
+        return getattr(self.f, name)
+
+
+
 # In Python 3 there is exception FileExistsError. But it is not available
 # in Python 2. For Python 2 fall back to OSError exception.
 if is_py2:

--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -109,7 +109,7 @@ text_type = unicode if is_py2 else str
 binary_type = str if is_py2 else bytes
 
 
-# Create a class which converts all writes to unicode first. For use with
+# This class converts all writes to unicode first. For use with
 # ``print(*args, file=f)``, since in Python 2 this ``print`` will write str, not
 # unicode.
 class unicode_writer:

--- a/PyInstaller/hooks/hook-_tkinter.py
+++ b/PyInstaller/hooks/hook-_tkinter.py
@@ -11,7 +11,8 @@
 import os
 import sys
 
-from PyInstaller.compat import is_win, is_darwin, is_unix, is_venv, base_prefix
+from PyInstaller.compat import is_win, is_darwin, is_unix, is_venv, \
+    base_prefix, open_file, text_read_mode
 from PyInstaller.compat import modname_tkinter
 from PyInstaller.depend.bindepend import selectImports, getImports
 from PyInstaller.building.datastruct import Tree
@@ -77,7 +78,7 @@ def _warn_if_activetcl_or_teapot_installed(tcl_root, tcltree):
 
     mentions_activetcl = False
     mentions_teapot = False
-    with open(init_resource, 'r') as init_file:
+    with open_file(init_resource, text_read_mode, encoding='utf-8') as init_file:
         for line in init_file.readlines():
             line = line.strip().lower()
             if line.startswith('#'):

--- a/PyInstaller/hooks/hook-_tkinter.py
+++ b/PyInstaller/hooks/hook-_tkinter.py
@@ -10,6 +10,7 @@
 
 import os
 import sys
+import locale
 
 from PyInstaller.compat import is_win, is_darwin, is_unix, is_venv, \
     base_prefix, open_file, text_read_mode
@@ -78,7 +79,9 @@ def _warn_if_activetcl_or_teapot_installed(tcl_root, tcltree):
 
     mentions_activetcl = False
     mentions_teapot = False
-    with open_file(init_resource, text_read_mode, encoding='utf-8') as init_file:
+    # TCL/TK reads files using the `system encoding <https://www.tcl.tk/doc/howto/i18n.html#system_encoding>`_.
+    with open_file(init_resource, text_read_mode,
+                   encoding=locale.getpreferredencoding()) as init_file:
         for line in init_file.readlines():
             line = line.strip().lower()
             if line.startswith('#'):

--- a/PyInstaller/hooks/hook-sqlalchemy.py
+++ b/PyInstaller/hooks/hook-sqlalchemy.py
@@ -10,6 +10,7 @@
 import re
 from PyInstaller.utils.hooks import (
     exec_statement, is_module_satisfies, logger)
+from PyInstaller.compat import open_file, text_read_mode
 from PyInstaller.lib.modulegraph.modulegraph import SourceModule
 
 # 'sqlalchemy.testing' causes bundling a lot of unnecessary modules.
@@ -59,7 +60,7 @@ def hook(hook_api):
         if isinstance(node, SourceModule) and \
                 node.identifier.startswith('sqlalchemy.'):
             known_imports.add(node.identifier)
-            with open(node.filename) as f:
+            with open_file(node.filename, text_read_mode, encoding='utf-8') as f:
                 for match in depend_regex.findall(f.read()):
                     hidden_imports_set.add(match)
 

--- a/PyInstaller/hooks/hook-sqlalchemy.py
+++ b/PyInstaller/hooks/hook-sqlalchemy.py
@@ -12,6 +12,7 @@ from PyInstaller.utils.hooks import (
     exec_statement, is_module_satisfies, logger)
 from PyInstaller.compat import open_file, text_read_mode
 from PyInstaller.lib.modulegraph.modulegraph import SourceModule
+from PyInstaller.lib.modulegraph.util import guess_encoding
 
 # 'sqlalchemy.testing' causes bundling a lot of unnecessary modules.
 excludedimports = ['sqlalchemy.testing']
@@ -60,7 +61,12 @@ def hook(hook_api):
         if isinstance(node, SourceModule) and \
                 node.identifier.startswith('sqlalchemy.'):
             known_imports.add(node.identifier)
-            with open_file(node.filename, text_read_mode, encoding='utf-8') as f:
+            # Determine the encoding of the source file.
+            with open_file(node.filename, 'rb') as f:
+                encoding = guess_encoding(f)
+            # Use that to open the file.
+            with open_file(node.filename, text_read_mode,
+                           encoding=encoding) as f:
                 for match in depend_regex.findall(f.read()):
                     hidden_imports_set.add(match)
 

--- a/PyInstaller/lib/modulegraph/modulegraph.py
+++ b/PyInstaller/lib/modulegraph/modulegraph.py
@@ -905,8 +905,10 @@ class ArchiveModule(BaseModule):
 
 # HTML templates for ModuleGraph generator
 header = """\
+<!DOCTYPE html>
 <html>
   <head>
+    <meta charset="UTF-8">
     <title>%(TITLE)s</title>
     <style>
       .node { padding: 0.5em 0 0.5em; border-top: thin grey dotted; }
@@ -3255,7 +3257,7 @@ class ModuleGraph(ObjectGraph):
                 return {'style': 'dotted'}
             return {}
 
-        yield 'digraph %s {\n' % (name,)
+        yield 'digraph %s {\ncharset="UTF-8";\n' % (name,)
         attr = dict(rankdir='LR', concentrate='true')
         cpatt = '%s="%s"'
         for item in attr.items():

--- a/PyInstaller/utils/hooks/gi.py
+++ b/PyInstaller/utils/hooks/gi.py
@@ -143,8 +143,10 @@ def gir_library_path_fix(path):
 
         with open_file(gir_file, text_read_mode, encoding='utf-8') as f:
             lines = f.readlines()
+        # GIR files are `XML encoded <https://developer.gnome.org/gi/stable/gi-gir-reference.html>`_,
+        # which means they are by definition encoded using UTF-8.
         with open_file(os.path.join(CONF['workpath'], gir_name), 'w',
-                  encoding='utf-8') as f:
+                       encoding='utf-8') as f:
             for line in lines:
                 if 'shared-library' in line:
                     split = re.split('(=)', line)

--- a/PyInstaller/utils/hooks/gi.py
+++ b/PyInstaller/utils/hooks/gi.py
@@ -11,7 +11,8 @@ import re
 
 from ..hooks import collect_submodules, collect_system_data_files, eval_statement, exec_statement
 from ... import log as logging
-from ...compat import base_prefix, is_darwin, is_win
+from ...compat import base_prefix, is_darwin, is_win, open_file, \
+    text_read_mode, text_type
 from ...depend.bindepend import findSystemLibrary
 
 logger = logging.getLogger(__name__)
@@ -140,9 +141,10 @@ def gir_library_path_fix(path):
                          'package.', gir_file)
             return None
 
-        with open(gir_file, 'r') as f:
+        with open_file(gir_file, text_read_mode, encoding='utf-8') as f:
             lines = f.readlines()
-        with open(os.path.join(CONF['workpath'], gir_name), 'w') as f:
+        with open_file(os.path.join(CONF['workpath'], gir_name), 'w',
+                  encoding='utf-8') as f:
             for line in lines:
                 if 'shared-library' in line:
                     split = re.split('(=)', line)
@@ -151,7 +153,7 @@ def gir_library_path_fix(path):
                         if 'lib' in item:
                             files[count] = '@loader_path/' + os.path.basename(item)
                     line = ''.join(split[0:2]) + ''.join(files)
-                f.write(line)
+                f.write(text_type(line))
 
         # g-ir-compiler expects a file so we cannot just pipe the fixed file to it.
         command = subprocess.Popen(('g-ir-compiler', os.path.join(CONF['workpath'], gir_name),

--- a/news/3605.bugfix.rst
+++ b/news/3605.bugfix.rst
@@ -1,1 +1,1 @@
-Specify an encoding of UTF-8 when opening text files.
+Explicitly specify an encoding of UTF-8 when opening *all* text files.

--- a/news/3605.bugfix.rst
+++ b/news/3605.bugfix.rst
@@ -1,0 +1,1 @@
+Specify an encoding of UTF-8 when opening text files.

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -34,7 +34,6 @@ pyzmq==17.1.2
 zope.interface==4.6.0
 numpy==1.15.4
 scipy==1.1.0
-lxml==4.2.5
 keyring==17.0.0
 openpyxl==2.5.12
 pycparser==2.19

--- a/tests/requirements-tools.txt
+++ b/tests/requirements-tools.txt
@@ -37,3 +37,5 @@ subprocess32; python_version == '2.7'
 # Python 3.4 wheel.
 pywin32; python_version != '3.4' and sys_platform == 'win32'
 pypiwin32==219; python_version == '3.4' and sys_platform == 'win32'
+
+lxml

--- a/tests/unit/test_modulegraph/test_modulegraph.py
+++ b/tests/unit/test_modulegraph/test_modulegraph.py
@@ -9,7 +9,7 @@ import warnings
 from altgraph import Graph
 from PyInstaller.compat import is_win
 import textwrap
-import xml.etree.ElementTree as ET
+from lxml import etree
 import pickle
 
 try:
@@ -1079,7 +1079,12 @@ class TestModuleGraph (unittest.TestCase):
         graph.create_xref(out=fp)
 
         data = fp.getvalue()
-        r = ET.fromstring(data)
+        # Don't tolerate any HTML `parsing errors <https://lxml.de/parsing.html#parser-options>`_.
+        parser = etree.HTMLParser(recover=False)
+        tree = etree.parse(StringIO(data), parser)
+        assert tree is not None
+        # Verify no `errors <https://lxml.de/parsing.html#error-log>`_ occurred.
+        assert len(parser.error_log) == 0
 
     def test_itergraphreport(self):
         # XXX: This test is far from optimal, it just ensures


### PR DESCRIPTION
This is a fix for #3605, and generally for a number of places in the code where the encoding wasn't specified when opening a file. Since getting this working required more complexity than I expected, I'd appreciate @htgoebel's feedback before merging.