### PR TITLE
fix unable to find "C:\Users\user\nltk_data" #3799

### DIFF
--- a/PyInstaller/hooks/hook-nltk.py
+++ b/PyInstaller/hooks/hook-nltk.py
@@ -10,6 +10,7 @@
 
 # hook for nltk
 import nltk
+import os
 from PyInstaller.utils.hooks import collect_data_files
 
 # add datas for nltk
@@ -17,7 +18,8 @@ datas = collect_data_files('nltk', False)
 
 # loop through the data directories and add them
 for p in nltk.data.path:
-    datas.append((p, "nltk_data"))
+    if os.path.exists(p):
+        datas.append((p, "nltk_data"))
 
 # nltk.chunk.named_entity should be included
 hiddenimports = ["nltk.chunk.named_entity"]

--- a/news/3900.hooks.rst
+++ b/news/3900.hooks.rst
@@ -1,0 +1,1 @@
+Prevent hook-nltk from adding non-existing directories.


### PR DESCRIPTION
Had the same issue as here:
https://github.com/pyinstaller/pyinstaller/issues/3799

proposed change is what htgoebel suggested