### PR TITLE
Added hook for Pendulum and its dependency pytzdata

### DIFF
--- a/PyInstaller/hooks/hook-pendulum.py
+++ b/PyInstaller/hooks/hook-pendulum.py
@@ -1,0 +1,17 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2018, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_data_files, collect_submodules
+
+
+# Pendulum checks for locale modules via os.path.exists before import.
+# If the include_py_files option is turned off, this check fails, pendulum
+# will raise a ValueError.
+datas = collect_data_files("pendulum.locales", include_py_files=True)
+hiddenimports = collect_submodules("pendulum.locales")

--- a/PyInstaller/hooks/hook-pytzdata.py
+++ b/PyInstaller/hooks/hook-pytzdata.py
@@ -1,0 +1,13 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2018, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_data_files
+
+
+datas = collect_data_files("pytzdata")

--- a/news/3906.hooks.rst
+++ b/news/3906.hooks.rst
@@ -1,0 +1,1 @@
+Add hooks for Pendulum and Pytzdata.

--- a/tests/functional/test_libraries.py
+++ b/tests/functional/test_libraries.py
@@ -852,3 +852,12 @@ def test_phonenumbers(pyi_builder):
         assert(parsed_number.country_code == 1)
         assert(parsed_number.national_number == 7034820623)
         """)
+
+
+@importorskip('pendulum')
+def test_pendulum(pyi_builder):
+    pyi_builder.test_source("""
+        import pendulum
+
+        print(pendulum.now().isoformat())
+        """)

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -53,6 +53,7 @@ h5py==2.8.0
 python-dateutil==2.7.5
 phonenumbers==8.10.1
 requests==2.20.1
+pendulum==2.0.4
 
 
 # Special cases


### PR DESCRIPTION
This PR addresses the issues with Pendulum, as discussed in #3528.
The hooks were tested on the following setup:

- OSX 10.13.6
- Python 2.7.15
- Python 3.7.0
- Pendulum 2.0.4
- Pytzdata 2018.7