### PR TITLE
hook-sklearn

### DIFF
--- a/PyInstaller/hooks/hook-sklearn.py
+++ b/PyInstaller/hooks/hook-sklearn.py
@@ -1,0 +1,4 @@
+from PyInstaller.utils.hooks import collect_data_files
+
+datas = collect_data_files('sklearn')
+hiddenimports = ['sklearn.neighbors.typedefs']


### PR DESCRIPTION
There is no sklearn hook for the latest version. This is only part of all the hidden imports, but it was enough for our project to get it to work. So I figured I'd contribute it.