### PR TITLE
hook-flexx

### DIFF
--- a/PyInstaller/hooks/hook-flexx.py
+++ b/PyInstaller/hooks/hook-flexx.py
@@ -1,13 +1,11 @@
 import os
 from PyInstaller.utils.hooks import collect_data_files, get_module_file_attribute
 
-datas = collect_data_files('flexx', include_py_files=True)
-
 # We must also collect flexx source code manually and add it to data to
 # allow transpilation of py->js.
 flexx_py_path = os.path.dirname(get_module_file_attribute('flexx'))
 
-datas = datas + [
+datas = collect_data_files('flexx', include_py_files=True) + [
     (flexx_py_path, 'flexx'),
     (flexx_py_path, 'site-packages/flexx'),
 ]

--- a/PyInstaller/hooks/hook-flexx.py
+++ b/PyInstaller/hooks/hook-flexx.py
@@ -1,0 +1,13 @@
+import os
+from PyInstaller.utils.hooks import collect_data_files, get_module_file_attribute
+
+datas = collect_data_files('flexx', include_py_files=True)
+
+# We must also collect flexx source code manually and add it to data to
+# allow transpilation of py->js.
+flexx_py_path = os.path.dirname(get_module_file_attribute('flexx'))
+
+datas = datas + [
+    (flexx_py_path, 'flexx'),
+    (flexx_py_path, 'site-packages/flexx'),
+]


### PR DESCRIPTION
Flexx is a special package that does python to JS transpilation, and it relies on `inspect.getsource` to do it's magic. Therefore it needs a hook to package its own sources.

@almarklein