### PR TITLE
add hook-skimage.io.py

### DIFF
--- a/PyInstaller/hooks/hook-skimage.io.py
+++ b/PyInstaller/hooks/hook-skimage.io.py
@@ -1,0 +1,17 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2018, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+
+# This hook was tested with scikit-image (skimage) 0.14.1:
+# https://scikit-image.org
+
+from PyInstaller.utils.hooks import collect_data_files, collect_submodules
+
+datas = collect_data_files("skimage.io._plugins")
+hiddenimports = collect_submodules('skimage.io._plugins')

--- a/news/3934.hooks.rst
+++ b/news/3934.hooks.rst
@@ -1,0 +1,1 @@
+Add hook for skimage.io


### PR DESCRIPTION
Hooks: Add hook for skimage.io
 
The skimage.io package (of Scikit-Image) uses the additional package skimage.io._plugins as hidden import and its data. When skimage.io is being used, the added hook makes sure that pyinstaller imports the skimage.io._plugins package and its data too.
This solves issue #3313 