### PR TITLE
Add runtime hook for certifi.

### DIFF
--- a/PyInstaller/loader/rthooks.dat
+++ b/PyInstaller/loader/rthooks.dat
@@ -1,4 +1,5 @@
 {
+    'certifi':    ['pyi_rth_certifi.py'],
     'django':     ['pyi_rth_django.py'],
     'enchant':    ['pyi_rth_enchant.py'],
     'gi':         ['pyi_rth_gi.py'],

--- a/PyInstaller/loader/rthooks/pyi_rth_certifi.py
+++ b/PyInstaller/loader/rthooks/pyi_rth_certifi.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2015-2018, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+import os
+import ssl
+import sys
+
+# Use certificate from certifi only if cafile could not find by ssl.
+if ssl.get_default_verify_paths().cafile is None:
+    os.environ['SSL_CERT_FILE'] = os.path.join(sys._MEIPASS, 'certifi', 'cacert.pem')

--- a/PyInstaller/loader/rthooks/pyi_rth_certifi.py
+++ b/PyInstaller/loader/rthooks/pyi_rth_certifi.py
@@ -1,5 +1,5 @@
 #-----------------------------------------------------------------------------
-# Copyright (c) 2015-2018, PyInstaller Development Team.
+# Copyright (c) 2018-2019, PyInstaller Development Team.
 #
 # Distributed under the terms of the GNU General Public License with exception
 # for distributing bootloader.

--- a/news/3952.hooks.rst
+++ b/news/3952.hooks.rst
@@ -1,0 +1,1 @@
+Add runtime hook for certifi.


### PR DESCRIPTION
Use certificate from certifi only if cafile could not find by ssl.