### PR TITLE
Hooks: Fix the nltk hook

### DIFF
--- a/PyInstaller/hooks/hook-nltk.py
+++ b/PyInstaller/hooks/hook-nltk.py
@@ -9,6 +9,7 @@
 
 
 # hook for nltk
+import os
 import nltk
 from PyInstaller.utils.hooks import collect_data_files
 
@@ -17,7 +18,8 @@ datas = collect_data_files('nltk', False)
 
 # loop through the data directories and add them
 for p in nltk.data.path:
-    datas.append((p, "nltk_data"))
+    if os.path.exists(p):
+        datas.append((p, "nltk_data"))
 
 # nltk.chunk.named_entity should be included
 hiddenimports = ["nltk.chunk.named_entity"]


### PR DESCRIPTION
Only add path to datas when it exists. Otherwise, it may have path not found error.