### PR TITLE
Hooks: Fix hook for numpy 1.16 (#3982)

### DIFF
--- a/PyInstaller/hooks/hook-numpy.core.py
+++ b/PyInstaller/hooks/hook-numpy.core.py
@@ -43,3 +43,7 @@ if os.path.isdir(lib_dir):
         logger = logging.getLogger(__name__)
         logger.info("MKL libraries found when importing numpy. Adding MKL to binaries")
         binaries += [(os.path.join(lib_dir, f), '.') for f in dlls_mkl]
+
+# https://github.com/pyinstaller/pyinstaller/issues/3982
+hiddenimports=['numpy.core._dtype_ctypes']
+

--- a/PyInstaller/hooks/hook-numpy.core.py
+++ b/PyInstaller/hooks/hook-numpy.core.py
@@ -20,6 +20,8 @@ import re
 from PyInstaller.utils.hooks import get_package_paths
 from PyInstaller import log as logging 
 from PyInstaller import compat
+from pkg_resources import parse_version
+import numpy.version
 
 binaries = []
 
@@ -44,6 +46,8 @@ if os.path.isdir(lib_dir):
         logger.info("MKL libraries found when importing numpy. Adding MKL to binaries")
         binaries += [(os.path.join(lib_dir, f), '.') for f in dlls_mkl]
 
+
 # https://github.com/pyinstaller/pyinstaller/issues/3982
-hiddenimports=['numpy.core._dtype_ctypes']
+if parse_version(numpy.version.version) >= parse_version('1.16'):
+        hiddenimports=['numpy.core._dtype_ctypes']
 


### PR DESCRIPTION
minimal testing executable:
```python
import numpy as np
print(np.array([1,2,3]))
```

before fix:
```sh
Traceback (most recent call last):
  File "test.py", line 1, in <module>
  File "/Users/lstolcman/projects/nptest/.venv/lib/python3.7/site-packages/PyInstaller/loader/pyimod03_importers.py", line 627, in exec_module
    exec(bytecode, module.__dict__)
  File "site-packages/numpy/__init__.py", line 151, in <module>
  File "/Users/lstolcman/projects/nptest/.venv/lib/python3.7/site-packages/PyInstaller/loader/pyimod03_importers.py", line 627, in exec_module
    exec(bytecode, module.__dict__)
  File "site-packages/numpy/ctypeslib.py", line 369, in <module>
  File "site-packages/numpy/ctypeslib.py", line 358, in _get_typecodes
  File "site-packages/numpy/ctypeslib.py", line 358, in <dictcomp>
ModuleNotFoundError: No module named 'numpy.core._dtype_ctypes'
[27719] Failed to execute script test
```

after fix:
`[1 2 3]`

fixes #3982 
