### PR TITLE
Mac OSX: Added code signing capability with --osx-codesign-identity arg.

### DIFF
--- a/PyInstaller/building/build_main.py
+++ b/PyInstaller/building/build_main.py
@@ -840,5 +840,6 @@ def main(pyi_config, specfile, noconfirm, ascii=False, **kw):
 
     CONF['ui_admin'] = kw.get('ui_admin', False)
     CONF['ui_access'] = kw.get('ui_uiaccess', False)
+    CONF['codesign_identity'] = kw.get('codesign_identity', None)
 
     build(specfile, kw.get('distpath'), kw.get('workpath'), kw.get('clean_build'))

--- a/PyInstaller/building/makespec.py
+++ b/PyInstaller/building/makespec.py
@@ -280,6 +280,14 @@ def __add_options(parser):
                         'name for code signing purposes. The usual form is a hierarchical name '
                         'in reverse DNS notation. For example: com.mycompany.department.appname '
                         "(default: first script's basename)")
+    g.add_argument('--osx-codesign-identity', dest='codesign_identity',
+                   help='If this option is given, all binaries packaged in the'
+                        ' app, including the app bundle itself, will be code '
+                        'signed using the ``codesign`` utility provided by '
+                        'Xcode Developer Tools. Make sure the utility is in '
+                        'your PATH and that the identity specified is valid '
+                        'for code signing, '
+                        'e.g. \'Developer ID Application: Your Name\'')
 
     g = parser.add_argument_group('Rarely used special options')
     g.add_argument("--runtime-tmpdir", dest="runtime_tmpdir", metavar="PATH",

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -418,6 +418,24 @@ and for more detail, the `Apple code signing overview`_ technical note).
 You can add other items to the :file:`Info.plist` by editing the spec file;
 see :ref:`Spec File Options for a Mac OS X Bundle` below.
 
+Code Signing Embedded Binaries
+-------------------
+
+You may also optionally specify that |PyInstaller| code sign all binaries which
+get embedded into your built application (such as the Python interpreter, its
+.so files, .dylib files for packages such as PyQt, etc). To enable code signing
+of embedded binaries, use the ``--osx-codesign-identity`` command-line option
+(or ``codesign_identity=`` kw arg). This facility requires the ``codesign``
+utility (which comes installed with a full install of Xcode) be present in your
+PATH.
+
+The identity argument must be a valid code signing identity installed on the
+system obtained via Apple's Developer program. Code signing identities are
+usually of the form: "Developer ID Application: YOUR NAME".
+
+Using this option will also cause |PyInstaller| to sign any generated ``.app``
+bundle with the same identity.
+
 
 Platform-specific Notes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/news/3991.feature.rst
+++ b/news/3991.feature.rst
@@ -1,0 +1,2 @@
+Addition of embedded binary code signing capability for MacOS using the
+``--osx-codesign-identity`` command-line option.


### PR DESCRIPTION
OSX only: if `--osx-codesign-identity` is specified on the command-line, then we will use the Xcode Developer Tools `codesign` utility to sign **all embedded binaries** (as well as the .app bundle itself). Note that this option may also be given to PKG and BUNDLE for finer-grained control as well, but it is recommended to just use the option on the command-line to ensure everything is signed with the same identity.

Let me know if this PR passes review properly and/or if anything needs to be modified.  Note that it outputs verbose output form the codesign utility which looks like this:

```
19541 INFO: Building PKG (CArchive) PKG-00.pkg
_struct.cpython-36m-darwin.so: replacing existing signature
_struct.cpython-36m-darwin.so: signed Mach-O thin (x86_64) [_struct.cpython-36m-darwin]
zlib.cpython-36m-darwin.so: replacing existing signature
zlib.cpython-36m-darwin.so: signed Mach-O thin (x86_64) [zlib.cpython-36m-darwin]
Python: replacing existing signature
Python: signed Mach-O thin (x86_64) [Python]

... etc ...
157934 INFO: Code signing BUNDLE with identity "Developer ID Application: My Test Identity"
MyTestApp.app: signed app bundle with Mach-O thin (x86_64) [org.mydomain.MyTestApp]
```
--

**Note:** It was always possible to code sign apps after building, but the embedded/collected binaries were unsigned.  

This facility adds the capability to code sign *deeply* so that the embedded binaries are signed as well (stuff like the Python interpreter, .so files that Python libs come with, embedded libs such as Qt, etc).

Apple has threatened/announced that in the future unsigned apps (and by extension unsigned embedded binaries) may not have as much access to OS facilities (the camera, microphone, etc) as signed apps have.

So, aside from that -- It's useful to be able to code sign apps as well as all the binaries embedded within the app. This is guaranteed to keep Mac's GateKeeper happy.

Also, this will be compatible with 'notarized apps' that is a feature Apple may require developers to comply with in the future. The Hardened Runtime introduced in macOS Mojave kills apps whose code signature gets invalidated (as far as I understand).

- Notarized apps must use the Hardened Runtime.
- In the future, all Developer ID signed apps must be notarized.

In short: There will be a point in the future where PyInstall either must implement this or be only usable for developers who do not sign their code at all.
