### PR TITLE
building: force --windowed option for .pyw

### DIFF
--- a/PyInstaller/building/makespec.py
+++ b/PyInstaller/building/makespec.py
@@ -19,7 +19,7 @@ from distutils.version import LooseVersion
 
 from .. import HOMEPATH, DEFAULT_SPECPATH
 from .. import log as logging
-from ..compat import expand_path, is_darwin, open_file, text_type
+from ..compat import expand_path, is_darwin, is_win, open_file, text_type
 from .templates import onefiletmplt, onedirtmplt, cipher_absent_template, \
     cipher_init_template, bundleexetmplt, bundletmplt
 
@@ -217,14 +217,16 @@ def __add_options(parser):
     g.add_argument("-c", "--console", "--nowindowed", dest="console",
                    action="store_true", default=True,
                    help="Open a console window for standard i/o (default). "
-                        "Caution: This option will have no effect if freezing a '.pyw' file.")
+                        "On Windows this option will have no effect if the "
+                        "first script is a '.pyw' file.")
     g.add_argument("-w", "--windowed", "--noconsole", dest="console",
                    action="store_false",
                    help="Windows and Mac OS X: do not provide a console window "
                         "for standard i/o. "
                         "On Mac OS X this also triggers building an OS X .app bundle. "
-                        "This option is ignored in *NIX systems. This option will be set "
-                        "automatically if freezing a '.pyw' file.")
+                        "On Windows this option will be set if the first "
+                        "script is a '.pyw' file. "
+                        "This option is ignored in *NIX systems.")
     g.add_argument("-i", "--icon", dest="icon_file",
                    metavar="<FILE.ico or FILE.exe,ID or FILE.icns>",
                    help="FILE.ico: apply that icon to a Windows executable. "
@@ -371,8 +373,8 @@ def main(scripts, name=None, onefile=None,
 
     hiddenimports = hiddenimports or []
 
-    # If file extension of main script is '.pyw', force --windowed option.
-    if os.path.splitext(scripts[0])[-1] == '.pyw':
+    # If file extension of the first script is '.pyw', force --windowed option.
+    if is_win and os.path.splitext(scripts[0])[-1] == '.pyw':
         console = False
 
     # If script paths are relative, make them relative to the directory containing .spec file.

--- a/PyInstaller/building/makespec.py
+++ b/PyInstaller/building/makespec.py
@@ -217,14 +217,14 @@ def __add_options(parser):
     g.add_argument("-c", "--console", "--nowindowed", dest="console",
                    action="store_true", default=True,
                    help="Open a console window for standard i/o (default). "
-                        "Caution: this option will be overwritten to use "
-                        "the --noconsole option if using a '*.pyw' file.")
+                        "Caution: This option will have no effect if freezing a '.pyw' file.")
     g.add_argument("-w", "--windowed", "--noconsole", dest="console",
                    action="store_false",
                    help="Windows and Mac OS X: do not provide a console window "
                         "for standard i/o. "
                         "On Mac OS X this also triggers building an OS X .app bundle. "
-                        "This option is ignored in *NIX systems.")
+                        "This option is ignored in *NIX systems. This option will be set "
+                        "automatically if freezing a '.pyw' file.")
     g.add_argument("-i", "--icon", dest="icon_file",
                    metavar="<FILE.ico or FILE.exe,ID or FILE.icns>",
                    help="FILE.ico: apply that icon to a Windows executable. "

--- a/PyInstaller/building/makespec.py
+++ b/PyInstaller/building/makespec.py
@@ -399,6 +399,10 @@ def main(scripts, name=None, onefile=None,
     if DEBUG_ALL_CHOICE[0] in debug:
         debug = DEBUG_ARGUMENT_CHOICES
 
+    # If file extension of main script is '.pyw', force --windowed option.
+    if str(scripts[0]).strip("'").split('.')[-1] == 'pyw':
+        console = False
+
     d = {
         'scripts': scripts,
         'pathex': pathex,

--- a/PyInstaller/building/makespec.py
+++ b/PyInstaller/building/makespec.py
@@ -216,7 +216,9 @@ def __add_options(parser):
     g = parser.add_argument_group('Windows and Mac OS X specific options')
     g.add_argument("-c", "--console", "--nowindowed", dest="console",
                    action="store_true", default=True,
-                   help="Open a console window for standard i/o (default)")
+                   help="Open a console window for standard i/o (default). "
+                        "Caution: this option will be overwritten to use "
+                        "the --noconsole option if using a '*.pyw' file.")
     g.add_argument("-w", "--windowed", "--noconsole", dest="console",
                    action="store_false",
                    help="Windows and Mac OS X: do not provide a console window "
@@ -400,7 +402,8 @@ def main(scripts, name=None, onefile=None,
         debug = DEBUG_ARGUMENT_CHOICES
 
     # If file extension of main script is '.pyw', force --windowed option.
-    if str(scripts[0]).strip("'").split('.')[-1] == 'pyw':
+    # scripts[0] is a Path object.
+    if os.path.splitext(scripts[0].path)[-1] == '.pyw':
         console = False
 
     d = {

--- a/PyInstaller/building/makespec.py
+++ b/PyInstaller/building/makespec.py
@@ -371,6 +371,10 @@ def main(scripts, name=None, onefile=None,
 
     hiddenimports = hiddenimports or []
 
+    # If file extension of main script is '.pyw', force --windowed option.
+    if os.path.splitext(scripts[0])[-1] == '.pyw':
+        console = False
+
     # If script paths are relative, make them relative to the directory containing .spec file.
     scripts = [make_path_spec_relative(x, specpath) for x in scripts]
     # With absolute paths replace prefix with variable HOMEPATH.
@@ -400,11 +404,6 @@ def main(scripts, name=None, onefile=None,
     # Translate the ``all`` option.
     if DEBUG_ALL_CHOICE[0] in debug:
         debug = DEBUG_ARGUMENT_CHOICES
-
-    # If file extension of main script is '.pyw', force --windowed option.
-    # scripts[0] is a Path object.
-    if os.path.splitext(scripts[0].path)[-1] == '.pyw':
-        console = False
 
     d = {
         'scripts': scripts,

--- a/doc/operating-mode.rst
+++ b/doc/operating-mode.rst
@@ -265,9 +265,12 @@ The |bootloader| starts Python with no target for standard output or input.
 Do this when your script has a graphical interface for user input and can properly
 report its own diagnostics.
 
-As noted in section 16.1.2 of the CPython manual Appendix, a file extention of `.pyw`
-suppresses the console window that normally appears.  Likewise, a console window
-will not be provided when using a :file:`myscript.pyw` script with |PyInstaller|.
+As noted in the `CPython tutorial Appendix
+<https://docs.python.org/3/tutorial/appendix.html#executable-python-scripts>`__,
+for Windows a file extention of `.pyw` suppresses the console window
+that normally appears.
+Likewise, a console window will not be provided when using
+a :file:`myscript.pyw` script with |PyInstaller|.
 
 
 Hiding the Source Code

--- a/doc/operating-mode.rst
+++ b/doc/operating-mode.rst
@@ -247,7 +247,7 @@ stored in the executable, and the bootloader will create the
     The temporary folder where the bundled app runs may not being readable
     after `setuid` is called. If your script needs to
     call `setuid`, it may be better to use one-folder mode
-    so as to have more control over the permissions on its files. 
+    so as to have more control over the permissions on its files.
 
 
 Using a Console Window
@@ -264,6 +264,10 @@ An option for Windows and Mac OS is to tell |PyInstaller| to not provide a conso
 The |bootloader| starts Python with no target for standard output or input.
 Do this when your script has a graphical interface for user input and can properly
 report its own diagnostics.
+
+As noted in section 16.1.2 of the CPython manual Appendix, a file extention of `.pyw`
+suppresses the console window that normally appears.  Likewise, a console window
+will not be provided when using a :file:`myscript.pyw` script with |PyInstaller|.
 
 
 Hiding the Source Code

--- a/news/4001.feature.rst
+++ b/news/4001.feature.rst
@@ -1,0 +1,1 @@
+Force --windowed option for ".pyw" files

--- a/news/4001.feature.rst
+++ b/news/4001.feature.rst
@@ -1,1 +1,2 @@
-Force --windowed option for ".pyw" files
+(win32) Force ``--windowed`` option if first script is a ``.pyw`` file.
+This might still be overwritten in the spec-file.


### PR DESCRIPTION
Force --windowed option for .pyw files as described in issue #3326.  This behavior is documented in appendix 16 of the Python manual as noted by @tallforasmurf .