### PR TITLE
ci: Fix CI with pip>=19 ensuring local PyInstaller package can be imported

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,8 @@ from setuptools import setup
 
 # Hack required to allow compat to not fail when pypiwin32 isn't found
 os.environ["PYINSTALLER_NO_PYWIN32_FAILURE"] = "1"
+
+sys.path.insert(0, os.path.dirname(__file__))
 from PyInstaller import __version__ as version, HOMEPATH, PLATFORM
 from PyInstaller.compat import is_win, is_cygwin, is_py2
 


### PR DESCRIPTION
Co-authored-by: Francois Budin <francois.budin@kitware.com>