### PR TITLE
Hooks: override default hook if user provided custom hook

### DIFF
--- a/PyInstaller/building/build_main.py
+++ b/PyInstaller/building/build_main.py
@@ -414,11 +414,12 @@ class Analysis(Target):
         ### Hook cache.
         logger.info('Caching module hooks...')
 
-        # List of all directories containing hook scripts. Default hooks are
-        # listed before and hence take precedence over custom hooks.
-        module_hook_dirs = [get_importhooks_dir()]
+        # List of all directories containing hook scripts. Custom hooks are
+        # listed before and hence take precedence over default hooks.
+        module_hook_dirs = []
         if self.hookspath:
             module_hook_dirs.extend(self.hookspath)
+        module_hook_dirs.append(get_importhooks_dir())
 
         # Hook cache prepopulated with these lazy loadable hook scripts.
         module_hook_cache = ModuleHookCache(

--- a/PyInstaller/building/imphook.py
+++ b/PyInstaller/building/imphook.py
@@ -109,6 +109,10 @@ class ModuleHookCache(UserDict):
             hook scripts to be cached.
         """
 
+        # If a hook was already processed (e.g. user has provided custom hook),
+        # it is bypassed
+        parsed_modules_hooks = set()
+
         for hook_dir in hook_dirs:
             # Canonicalize this directory's path and validate its existence.
             hook_dir = os.path.abspath(expand_path(hook_dir))
@@ -122,6 +126,11 @@ class ModuleHookCache(UserDict):
                 # Fully-qualified name of this hook's corresponding module,
                 # constructed by removing the "hook-" prefix and ".py" suffix.
                 module_name = os.path.basename(hook_filename)[5:-3]
+
+                if module_name in parsed_modules_hooks:
+                    continue
+                else:
+                    parsed_modules_hooks.add(module_name)
 
                 # Lazily loadable hook object.
                 module_hook = ModuleHook(


### PR DESCRIPTION
When user provides custom hooks via `--additional-hooks-dir`, they are parsed first. If there is a duplicated hook for module in further processing, it is omitted.

refs #1835