### PR TITLE
depend/bindepend: Fix Linux Anaconda Python library search.

### DIFF
--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -204,8 +204,8 @@ is_venv = is_virtualenv = base_prefix != os.path.abspath(sys.prefix)
 # Conda environments sometimes have different paths or apply patches to
 # packages that can affect how a hook or package should access resources.
 # Method for determining conda taken from:
-# https://stackoverflow.com/a/21318941/433202
-is_conda = 'conda' in sys.version or 'Continuum' in sys.version
+# https://stackoverflow.com/questions/47610844#47610844
+is_conda = os.path.isdir(os.path.join(base_prefix, 'conda-meta'))
 
 # In Python 3.4 module 'imp' is deprecated and there is another way how
 # to obtain magic value.

--- a/PyInstaller/depend/bindepend.py
+++ b/PyInstaller/depend/bindepend.py
@@ -866,6 +866,14 @@ def get_python_library_path():
     Darwin custom builds could possibly also have non-framework style libraries,
     so this method also checks for that variant as well.
     """
+    def _find_lib_in_libdirs(*libdirs):
+        for libdir in libdirs:
+            for name in PYDYLIB_NAMES:
+                full_path = os.path.join(libdir, name)
+                if os.path.exists(full_path):
+                    return full_path
+        return None
+
     # Try to get Python library name from the Python executable. It assumes that Python
     # library is not statically linked.
     dlls = getImports(sys.executable)
@@ -902,12 +910,11 @@ def get_python_library_path():
         # We need special care for this case.
         # Anaconda places the python library in the lib directory, so
         # we search this one as well.
-        prefixes = [compat.base_prefix, os.path.join(compat.base_prefix, 'lib')]
-        for prefix in prefixes:
-            for name in PYDYLIB_NAMES:
-                full_path = os.path.join(prefix, name)
-                if os.path.exists(full_path):
-                    return full_path
+        python_libname = _find_lib_in_libdirs(
+            compat.base_prefix,
+            os.path.join(compat.base_prefix, 'lib'))
+        if python_libname:
+            return python_libname
 
     # Python library NOT found. Return just None.
     return None

--- a/news/3885.bugfix.rst
+++ b/news/3885.bugfix.rst
@@ -1,0 +1,1 @@
+(GNU/Linux) Fix Anaconda Python library search.

--- a/news/4015.bugfix.rst
+++ b/news/4015.bugfix.rst
@@ -1,0 +1,1 @@
+(GNU/Linux) Fix Anaconda Python library search.

--- a/news/is_conda.bugfix.rst
+++ b/news/is_conda.bugfix.rst
@@ -1,0 +1,1 @@
+(conda) Fix detection of conda/anaconda platform.


### PR DESCRIPTION
Fixes #3885

* PyInstaller/depend/bindepend.py: On Unix with Anaconda look
   in compat.base_prefix for Python dynamic library.

* PyInstaller/compat.py: Fix is_conda.