### PR TITLE
add pyfilterbank hook

### DIFF
--- a/PyInstaller/hooks/hook-pyfilterbank.py
+++ b/PyInstaller/hooks/hook-pyfilterbank.py
@@ -1,0 +1,3 @@
+from PyInstaller.utils.hooks import collect_dynamic_libs
+
+binaries = collect_dynamic_libs("pyfilterbank")

--- a/PyInstaller/utils/hooks/__init__.py
+++ b/PyInstaller/utils/hooks/__init__.py
@@ -651,7 +651,7 @@ def is_module_or_submodule(name, mod_or_submod):
 PY_DYLIB_PATTERNS = [
     '*.dll',
     '*.dylib',
-    'lib*.so',
+    '*.so',
 ]
 
 


### PR DESCRIPTION
I work with pyfilterbank using shared library using library not matched with lib*.so. So I add pyfilterbank hook file and modify utils.hooks.__init__.py.