### PR TITLE
Add hook for imageio_ffmpeg

### DIFF
--- a/PyInstaller/hooks/hook-imageio_ffmpeg.py
+++ b/PyInstaller/hooks/hook-imageio_ffmpeg.py
@@ -1,5 +1,5 @@
 #-----------------------------------------------------------------------------
-# Copyright (c) 2017-2019, PyInstaller Development Team.
+# Copyright (c) 2019, PyInstaller Development Team.
 #
 # Distributed under the terms of the GNU General Public License with exception
 # for distributing bootloader.

--- a/PyInstaller/hooks/hook-imageio_ffmpeg.py
+++ b/PyInstaller/hooks/hook-imageio_ffmpeg.py
@@ -1,0 +1,14 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2017-2019, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+# Hook for imageio: http://imageio.github.io/
+
+from PyInstaller.utils.hooks import collect_data_files
+
+datas = collect_data_files('imageio_ffmpeg', subdir="binaries")

--- a/news/4051.hooks.rst
+++ b/news/4051.hooks.rst
@@ -1,0 +1,1 @@
+Add hook for imageio_ffmpeg.


### PR DESCRIPTION
In imageio version 2.5, ffmpeg is installed via the imageio-ffmpeg package and not via downloading to the resources directory. The initial imageio hook (https://github.com/pyinstaller/pyinstaller/blob/develop/PyInstaller/hooks/hook-imageio.py) still applies and should remain in PyInstaller.

https://github.com/imageio/imageio-ffmpeg
https://github.com/imageio/imageio-ffmpeg/issues/5
