### PR TITLE
Tests/CI: Use services for xvfb on xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -109,6 +109,8 @@ jobs:
       python: 3.7
       dist: xenial
       sudo: true
+      services:
+        - xvfb
 
     - <<: *test-pyinstaller
       python: nightly
@@ -118,6 +120,8 @@ jobs:
       python: nightly
       dist: xenial
       sudo: true
+      services:
+        - xvfb
 
   allow_failures:
       # Just tests how PyInstaller performs with upcoming Python


### PR DESCRIPTION
Work around not being able to open /etc/init.d/xvfb.