### PR TITLE
Hooks: Add Hook for Google Big Query

### DIFF
--- a/PyInstaller/hooks/hook-google.cloud.bigquery.py
+++ b/PyInstaller/hooks/hook-google.cloud.bigquery.py
@@ -1,0 +1,13 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2017-2019, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import copy_metadata
+datas = (copy_metadata('google-cloud-bigquery') +
+         # the pakcage queries meta-data about ``request``
+         copy_metadata('requests'))

--- a/news/4083.hooks.rst
+++ b/news/4083.hooks.rst
@@ -1,0 +1,1 @@
+Add Hook for google.cloud.bigquery.

--- a/news/4084.hooks.rst
+++ b/news/4084.hooks.rst
@@ -1,0 +1,1 @@
+Add Hook for google.cloud.bigquery.


### PR DESCRIPTION
Add hooks for google.cloud.bigquery and requests library as big query depends on requests.

Fixes issue #4083