### PR TITLE
Add hook for pyclipper.

### DIFF
--- a/PyInstaller/hooks/hook-pyclipper.py
+++ b/PyInstaller/hooks/hook-pyclipper.py
@@ -1,0 +1,11 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013-2018, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+
+hiddenimports = ['numbers'] 


### PR DESCRIPTION
pyclipper is a Cython module that has very little dependencies, but uses the numbers library from the standard library:
https://github.com/fonttools/pyclipper/blob/master/pyclipper/pyclipper.pyx#L30

pyinstaller does not include this library by default, and due to Cython it cannot auto detect this. So a small hook fixes this issue.