### PR TITLE
Produce deterministic pyc files in base_library.zip

### DIFF
--- a/PyInstaller/depend/utils.py
+++ b/PyInstaller/depend/utils.py
@@ -35,7 +35,7 @@ from .. import log as logging
 try:
     # source_hash only exists in Python 3.7
     from importlib.util import source_hash as importlib_source_hash
-except:
+except ImportError:
     pass
 
 logger = logging.getLogger(__name__)

--- a/PyInstaller/depend/utils.py
+++ b/PyInstaller/depend/utils.py
@@ -32,6 +32,12 @@ from ..compat import (is_darwin, is_unix, is_freebsd, is_py2, is_py37,
 from .dylib import include_library
 from .. import log as logging
 
+try:
+    # source_hash only exists in Python 3.7
+    from importlib.util import source_hash as importlib_source_hash
+except:
+    pass
+
 logger = logging.getLogger(__name__)
 
 
@@ -80,9 +86,14 @@ def create_py3_base_library(libzip_filename, graph):
                             fc.write(BYTECODE_MAGIC)
                             if is_py37:
                                 # Additional bitfield according to PEP 552
-                                # zero means timestamp based
-                                fc.write(struct.pack('<I', 0))
-                            fc.write(struct.pack('<II', timestamp, size))
+                                # 0b01 means hash based but don't check the hash
+                                fc.write(struct.pack('<I', 0b01))
+                                with open(mod.filename, 'rb') as fs:
+                                    source_bytes = fs.read()
+                                source_hash = importlib_source_hash(source_bytes)
+                                fc.write(source_hash)
+                            else:
+                                fc.write(struct.pack('<II', timestamp, size))
                             marshal.dump(mod.code, fc)
                             # Use a ZipInfo to set timestamp for deterministic build
                             info = zipfile.ZipInfo(new_name)

--- a/news/4096.core.rst
+++ b/news/4096.core.rst
@@ -1,0 +1,1 @@
+Now uses hash based `.pyc` files as specified in :pep:`552` in `base_library.zip` when using Python 3.7


### PR DESCRIPTION
For the pyc files in base_library.zip, produce the deterministic pyc files as described in PEP-552.

The reason for this is that I found when using pyenv and trying to do deterministic builds with multiple machines, builds were not deterministic due to the pyc file in base_library.zip having different timestamps that corresponded to the time that pyenv installed python.

I was unable to figure out how to get this to work when the hashes are checked so this uses the unchecked mode.