### PR TITLE
Add hook for msl.loadlib.

### DIFF
--- a/PyInstaller/hooks/hook-msl.loadlib.py
+++ b/PyInstaller/hooks/hook-msl.loadlib.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013-2019, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+# msl-loadlib requires some binaries to work properly. Basically, it allows cross
+# loading DLLs by spawning a 32/64 bit python, and loading the dll there. This
+# means you can load a 32bit dll from 64bit python, and vice versa.
+# Calls to the DLL can then be proxied through the other python instance.
+
+from PyInstaller.utils.hooks import collect_data_files
+datas = collect_data_files('msl.loadlib')


### PR DESCRIPTION
This is a handy utility for loading 32 bit libraries from 64 bit python, and vice versa.
See: https://github.com/MSLNZ/msl-loadlib https://pypi.org/project/msl-loadlib/

This partially works. Right now, you specify a module name as a parameter on the `msl.loadlib.Client64()` constructor, and the launched python loads that file as the API definition. Everything works up to that point, but the specified module isn't automatically discovered during packaging.

If I manually add the `.py` file in my `.spec` file, everything operates fine. 

Is there a general consensus on how to handle this sort of thing? My knee-jerk reaction would be to walk the project for invocations to the `msl.loadlib.Client64()` constructor, and parse it's args manually, but that seems kind of brittle. 
