### PR TITLE
Hooks: Add hook for ttkthemes

### DIFF
--- a/PyInstaller/hooks/hook-ttkthemes.py
+++ b/PyInstaller/hooks/hook-ttkthemes.py
@@ -1,0 +1,54 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013-2019, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+"""
+Hook for use with the ttkthemes package
+
+ttkthemes depends on a large set of image and Tcl-code files contained
+within its package directory. These are not imported, and thus this hook
+is required so they are copied.
+
+The file structure of the ttkthemes package folder is:
+ttkthemes
+├───advanced
+|   └───*.tcl
+├───themes
+|   ├───theme1
+|   |   ├───theme1
+|   |   |   └───*.gif
+|   |   └───theme1.tcl
+|   ├───theme2
+|   ├───...
+|   └───pkgIndex.tcl
+├───png
+└───gif
+
+The ``themes`` directory contains themes which only have a universal
+image version (either base64 encoded in the theme files or GIF), while
+``png`` and ``gif`` contain the PNG and GIF versions of the themes which
+support both respectively.
+
+All of this must be copied, as the package expects all the data to be
+present and only checks what themes to load at runtime.
+
+Tested hook on Linux (Ubuntu 18.04, Python 3.6 minimal venv) and on
+Windows 7 (Python 3.7, minimal system-wide installation).
+
+>>> from tkinter import ttk
+>>> from ttkthemes import ThemedTk
+>>>
+>>>
+>>> if __name__ == '__main__':
+>>>     window = ThemedTk(theme="plastik")
+>>>     ttk.Button(window, text="Quit", command=window.destroy).pack()
+>>>     window.mainloop()
+"""
+from PyInstaller.utils.hooks import collect_data_files
+
+
+datas = collect_data_files("ttkthemes")

--- a/news/4105.hooks.rst
+++ b/news/4105.hooks.rst
@@ -1,0 +1,1 @@
+Add hook for ttkthemes.


### PR DESCRIPTION
[ttkthemes](https://github.com/RedFantom/ttkthemes) is a package that provides a set of themes for Tkinter. In order to achieve this, it uses Tcl-code files and image files. These are not properly copied by PyInstaller by default on Windows. There are various work-arounds, including for users to adjust their `spec` file, writing custom release scripts and maybe even other ways, but given the amount of confusion this has caused so far, I would like for a hook to be included with PyInstaller.

It is my understanding that this is the best way to achieve this. I have tested the hook, and the files are now copied over correctly and the result of PyInstaller on Windows runs without the need of manually copying over files.

Issue references:
- PyInstaller Issue pyinstaller/pyinstaller#3517
- RedFantom/ttkthemes#56
- [StackOverflow Question 47380748](https://stackoverflow.com/questions/47380748)
- [Python Forum Thread](https://python-forum.io/Thread-Tkinter-How-to-make-pyinstaller-import-the-ttk-theme)
