### PR TITLE
Update certificate for mock HTTPS server

### DIFF
--- a/tests/functional/data/requests/server.pem
+++ b/tests/functional/data/requests/server.pem
@@ -1,47 +1,99 @@
 -----BEGIN PRIVATE KEY-----
-MIIBVAIBADANBgkqhkiG9w0BAQEFAASCAT4wggE6AgEAAkEA1ZloHnJ3UASdHMwf
-MgUNx/6nMYJNTLMmvzOEsj5/7YIkkElj6Hx6MykPu96ov1a9valI9xe1prX1ZDL1
-gxBqGQIDAQABAkB7hw101kP0DccC2XWNCukuaTIt6qpjmhPlbZjnMEfxhUwRKPD0
-Ni3iCcR6imyOkincFoW/dtqK2sAzNU47QVEBAiEA+yG1zo/VNukkMYdn9Lz1lnnF
-d4vnYmj1lQaNyIhftmECIQDZvW88qo6KfHhkdfnEAPu0ntKFYlKobh/x0qtRu65e
-uQIgfNIOiXLYKQjMYonI084vyvEPgxHYmgNNPRsa0bdmy0ECIQC04naCg34e9gBe
-FNQFTHvONRLW1DOu0K2hC05fe/cDoQIgB74nib5vB88ExUINRaLCVA8dtU4fmExJ
-UbqpePPAQrM=
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDWa9w08ag/g2+N
+MoR5MzWWTbI7kdWifFZjumGYcUVzkn928IX1iYnPgBLmS/VxZMDO8NtkhCQWr0oh
+JaKuvmZJQAse3AF4iBRfg7nejWb/ck9VFNnm4c3BljbsaLqkBJj3G7GJG/seGcaI
+W52ws/scGKa2cBN9wN40YPeV27f4KMu7XyGHf2hwWUap2akhrKR5cYi+Mh9oc+ES
+aOMA0H5GWyBFQjXtbE9U4qVosbfc6HxqOS09fmpoyTeUDA4yLL0B7myQIMII0+Ap
+kHeNNr4RcEke08jQ/eoybuQ38hyRvbBBxEQB9WVZDZIXxNJv1vr4FClHZSLV2pYl
+ozz8L0ejAgMBAAECggEAZ6VloVX6zRC8mFUGAgwF6CyQbgkVamCN5dEPIgAG4VG8
+OYMUTdb4/YtcF2Q6NWDNbnqwokrZovmCbLljhPJWQSwq8/TG5TtqFa136CMT2YCo
+5miY1+joa54v2GDbbzMlubTyQWN8JFWzSPB4LhUh2bf0xhUw5sWW41zH8PFvYQ18
+tW7NEoKtd9GN7zj6bK0vQxkgaCXqFGaTdQiL45McA2ogymNSKLrtkn1T9KwpkX1T
+WBxVBaXUSas2Qi7ZvdRtrqtpiSNPAtD7TJbeDcIBOBA04FzGJGfrtnmRmqOkPkq/
+JIu/KZEQLWSuWBLzZDcAChJTTqzzkWWVQR+6PyjMsQKBgQDvtGfLFnT4XBburbEZ
+arZzoPFOwYbPAvGubrWg03MVVzLE+rSIOSrN5SKMLn6lab0s64m5ceTUakbRtVHD
+0ZIGM1IXAg8enKUbrTIiNAap6yYFHxDRPVELCmK0A08VsigTfkJlhJCUBFIXHAkd
+33quVuvcTby6O2r3cHZLyEM+iQKBgQDk/3JX8S8oiJHY4TeFtH32E/M7bFa8XXRd
+OtUN3ANI/l10oylQvTmj6kCE6mPUzWECsm5XlaCyoSMAZqiLjcB7GGXqJzbh/kWv
+Ol59ZKFPjYvmh2WgcgRjfy714gWqTipwErPedooMmhXN+EGINKMm7DYdwe/TuynA
+/39LFuLpywKBgA/WUY0/fJb0LqeyXiMZw9g75/WWH7wJq8Ikmmd30QC19CrDja36
+aPOVkgTFBaUUKWWQYlcYSVAnfWpZmn9fl1BFj8TpY+pX2yjK9qb/3PjZCngIJ2pL
+rNEX7JGMLmt2i+NN0kE20v6Ukn/oYEnS/B4MrCSwFioPxu92RLqZDqhRAoGBAK7e
+mvSpCvgLAkT6ByolIKNPrMhN/RYuz3N6P8QrpJ6TD87H4f7z4RZZBhf53W5dv50N
+oNFlQ6flAROHUWHwR3I4uWrLs090msYq7okW1VAoqRLLhkG1j8BjGPtPNEBPHH0k
+6xIQt27UI557258lgwlwDAtBU+D95e6prQ0sVu9tAoGAKQLW27WAjpRlhfpfrFFR
+IPBcwhRkpZ3ACa2HbNnBzjGW6LTmMUIgl6SpmbWyci/WGCuf1I54lEYzSEIf1PTy
+wtIHGToS0Pv4xyogWLe4reo2LferXy9/pfbVFlmkgsboFT3tXEorDI/ij+SizMlW
+1iXgN4XoagAzWnJ7v0U7MnA=
 -----END PRIVATE KEY-----
 Certificate:
     Data:
         Version: 3 (0x2)
-        Serial Number: 10311955402435042588 (0x8f1b6ccdadcf9d1c)
-    Signature Algorithm: sha256WithRSAEncryption
-        Issuer: CN=localhost
+        Serial Number:
+            3e:92:1c:fc:f2:9c:66:10:b0:a7:b2:47:84:4c:5e:d4:73:49:9f:82
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = localhost
         Validity
-            Not Before: Mar  2 19:14:47 2016 GMT
-            Not After : Feb  7 19:14:47 2116 GMT
-        Subject: CN=localhost
+            Not Before: Mar  6 09:08:35 2019 GMT
+            Not After : Feb 10 09:08:35 2119 GMT
+        Subject: CN = localhost
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-                Public-Key: (512 bit)
+                RSA Public-Key: (2048 bit)
                 Modulus:
-                    00:d5:99:68:1e:72:77:50:04:9d:1c:cc:1f:32:05:
-                    0d:c7:fe:a7:31:82:4d:4c:b3:26:bf:33:84:b2:3e:
-                    7f:ed:82:24:90:49:63:e8:7c:7a:33:29:0f:bb:de:
-                    a8:bf:56:bd:bd:a9:48:f7:17:b5:a6:b5:f5:64:32:
-                    f5:83:10:6a:19
+                    00:d6:6b:dc:34:f1:a8:3f:83:6f:8d:32:84:79:33:
+                    35:96:4d:b2:3b:91:d5:a2:7c:56:63:ba:61:98:71:
+                    45:73:92:7f:76:f0:85:f5:89:89:cf:80:12:e6:4b:
+                    f5:71:64:c0:ce:f0:db:64:84:24:16:af:4a:21:25:
+                    a2:ae:be:66:49:40:0b:1e:dc:01:78:88:14:5f:83:
+                    b9:de:8d:66:ff:72:4f:55:14:d9:e6:e1:cd:c1:96:
+                    36:ec:68:ba:a4:04:98:f7:1b:b1:89:1b:fb:1e:19:
+                    c6:88:5b:9d:b0:b3:fb:1c:18:a6:b6:70:13:7d:c0:
+                    de:34:60:f7:95:db:b7:f8:28:cb:bb:5f:21:87:7f:
+                    68:70:59:46:a9:d9:a9:21:ac:a4:79:71:88:be:32:
+                    1f:68:73:e1:12:68:e3:00:d0:7e:46:5b:20:45:42:
+                    35:ed:6c:4f:54:e2:a5:68:b1:b7:dc:e8:7c:6a:39:
+                    2d:3d:7e:6a:68:c9:37:94:0c:0e:32:2c:bd:01:ee:
+                    6c:90:20:c2:08:d3:e0:29:90:77:8d:36:be:11:70:
+                    49:1e:d3:c8:d0:fd:ea:32:6e:e4:37:f2:1c:91:bd:
+                    b0:41:c4:44:01:f5:65:59:0d:92:17:c4:d2:6f:d6:
+                    fa:f8:14:29:47:65:22:d5:da:96:25:a3:3c:fc:2f:
+                    47:a3
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
             X509v3 Subject Alternative Name: 
                 DNS:localhost
     Signature Algorithm: sha256WithRSAEncryption
-         c3:61:52:0c:b9:f1:3b:5d:8c:e4:a9:4e:a5:13:cf:5e:62:ff:
-         a3:69:26:2d:e2:5a:34:1a:32:bd:b0:80:74:16:28:58:50:7a:
-         8a:9c:83:06:35:dd:73:45:41:ae:38:e7:59:0b:31:43:fc:86:
-         ee:ef:6d:b6:0e:04:fa:13:f5:70
+         3b:01:28:88:4b:2d:28:99:78:7f:44:a5:76:5c:15:8a:77:bb:
+         61:4d:e0:37:c9:fe:6f:1e:65:c1:8d:7c:0a:74:b6:89:7a:79:
+         f2:c3:cd:51:53:43:e1:9a:c3:f5:46:da:84:34:64:60:af:25:
+         20:60:46:02:27:e3:d3:ba:45:95:18:4b:d9:c7:62:b7:eb:11:
+         1d:c9:bb:30:9a:8f:88:41:95:02:e5:04:dc:24:15:c8:43:61:
+         af:75:d5:e6:0d:51:53:1d:f2:bc:b1:68:59:19:30:93:4b:66:
+         01:49:13:3b:fb:a7:3c:de:6a:b1:e1:c4:60:c9:6d:6d:bf:0c:
+         59:99:ac:ba:47:0b:0b:1c:05:bc:a9:f2:7c:62:5f:18:9d:85:
+         48:e1:f1:1b:a6:3e:a1:1d:49:43:07:0c:10:dc:b3:c9:ad:5c:
+         ea:f3:ba:dd:65:41:8e:2f:18:a7:8e:67:5c:17:27:7c:68:6d:
+         83:cf:6d:bd:44:3f:ff:ea:00:0f:18:8c:df:3f:ab:74:73:dd:
+         06:51:04:19:07:7d:d4:d7:64:0e:4d:46:3c:a4:6a:5e:68:fb:
+         17:41:4f:b6:61:4d:07:61:1c:31:a8:e2:a0:0f:49:98:87:8b:
+         68:31:25:9b:3a:05:15:45:0a:85:c8:6d:68:fa:38:12:b9:49:
+         08:27:28:4f
 -----BEGIN CERTIFICATE-----
-MIIBOjCB5aADAgECAgkAjxtsza3PnRwwDQYJKoZIhvcNAQELBQAwFDESMBAGA1UE
-AwwJbG9jYWxob3N0MCAXDTE2MDMwMjE5MTQ0N1oYDzIxMTYwMjA3MTkxNDQ3WjAU
-MRIwEAYDVQQDDAlsb2NhbGhvc3QwXDANBgkqhkiG9w0BAQEFAANLADBIAkEA1Zlo
-HnJ3UASdHMwfMgUNx/6nMYJNTLMmvzOEsj5/7YIkkElj6Hx6MykPu96ov1a9valI
-9xe1prX1ZDL1gxBqGQIDAQABoxgwFjAUBgNVHREEDTALgglsb2NhbGhvc3QwDQYJ
-KoZIhvcNAQELBQADQQDDYVIMufE7XYzkqU6lE89eYv+jaSYt4lo0GjK9sIB0FihY
-UHqKnIMGNd1zRUGuOOdZCzFD/Ibu7222DgT6E/Vw
+MIIC0DCCAbigAwIBAgIUPpIc/PKcZhCwp7JHhExe1HNJn4IwDQYJKoZIhvcNAQEL
+BQAwFDESMBAGA1UEAwwJbG9jYWxob3N0MCAXDTE5MDMwNjA5MDgzNVoYDzIxMTkw
+MjEwMDkwODM1WjAUMRIwEAYDVQQDDAlsb2NhbGhvc3QwggEiMA0GCSqGSIb3DQEB
+AQUAA4IBDwAwggEKAoIBAQDWa9w08ag/g2+NMoR5MzWWTbI7kdWifFZjumGYcUVz
+kn928IX1iYnPgBLmS/VxZMDO8NtkhCQWr0ohJaKuvmZJQAse3AF4iBRfg7nejWb/
+ck9VFNnm4c3BljbsaLqkBJj3G7GJG/seGcaIW52ws/scGKa2cBN9wN40YPeV27f4
+KMu7XyGHf2hwWUap2akhrKR5cYi+Mh9oc+ESaOMA0H5GWyBFQjXtbE9U4qVosbfc
+6HxqOS09fmpoyTeUDA4yLL0B7myQIMII0+ApkHeNNr4RcEke08jQ/eoybuQ38hyR
+vbBBxEQB9WVZDZIXxNJv1vr4FClHZSLV2pYlozz8L0ejAgMBAAGjGDAWMBQGA1Ud
+EQQNMAuCCWxvY2FsaG9zdDANBgkqhkiG9w0BAQsFAAOCAQEAOwEoiEstKJl4f0Sl
+dlwVine7YU3gN8n+bx5lwY18CnS2iXp58sPNUVND4ZrD9UbahDRkYK8lIGBGAifj
+07pFlRhL2cdit+sRHcm7MJqPiEGVAuUE3CQVyENhr3XV5g1RUx3yvLFoWRkwk0tm
+AUkTO/unPN5qseHEYMltbb8MWZmsukcLCxwFvKnyfGJfGJ2FSOHxG6Y+oR1JQwcM
+ENyzya1c6vO63WVBji8Yp45nXBcnfGhtg89tvUQ//+oADxiM3z+rdHPdBlEEGQd9
+1NdkDk1GPKRqXmj7F0FPtmFNB2EcMajioA9JmIeLaDElmzoFFUUKhchtaPo4ErlJ
+CCcoTw==
 -----END CERTIFICATE-----

--- a/tests/functional/scripts/pyi_lib_requests.py
+++ b/tests/functional/scripts/pyi_lib_requests.py
@@ -77,8 +77,7 @@ def main():
         assert False, "Could not bind server port: all ports in use."
 
     httpd.socket = ssl.wrap_socket(
-        httpd.socket, certfile=SERVER_CERT, server_side=True,
-        ssl_version=ssl.PROTOCOL_TLSv1,
+        httpd.socket, certfile=SERVER_CERT, server_side=True
     )
 
     def ssl_server():

--- a/tests/functional/test_libraries.py
+++ b/tests/functional/test_libraries.py
@@ -549,9 +549,6 @@ def test_cryptodome(pyi_builder):
         """)
 
 
-@skipif(is_win and is_py37, reason='The call to ssl.wrap_socket produces '
-        '"ssl.SSLError: [SSL: EE_KEY_TOO_SMALL] ee key too small '
-        '(_ssl.c:3717)" on Windows Python 3.7.')
 @importorskip('requests')
 def test_requests(tmpdir, pyi_builder, data_dir, monkeypatch):
     # Note that including the data_dir fixture copies files needed by this test.


### PR DESCRIPTION
This should fix the requests test case on all platforms.

I got the same error that is mentioned in the `@skipif` annotation on Linux, so I just generated a new key for the webserver.

I took the liberty to remove the restriction to TLSv1, so the test server can negotiate any TLS version the current Python supports.