### PR TITLE
Add a hook for Radicale

### DIFF
--- a/PyInstaller/hooks/hook-radicale.py
+++ b/PyInstaller/hooks/hook-radicale.py
@@ -1,0 +1,13 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2019, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import copy_metadata, collect_data_files
+
+datas = copy_metadata('radicale')
+datas += collect_data_files('radicale')

--- a/news/4109.hooks.rst
+++ b/news/4109.hooks.rst
@@ -1,0 +1,1 @@
+Add hook for radicale.


### PR DESCRIPTION
This hook fixes:
1. Failure to import due to get_distribution('radicale') failing
2. Missing data files needed for the web interface

Radicale - A Free and Open-Source CalDAV and CardDAV Server
https://radicale.org/