### PR TITLE
Tests: Test data should get consistent line ending regardless of host

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -18,3 +18,5 @@ runw_d	-text
 *.dll	-text
 
 /PyInstaller/utils/_gitrevision.py ident export-subst
+# Tests relay on fixed \n line end
+/tests/unit/test_modulegraph/testdata/test.txt text eol=lf


### PR DESCRIPTION
Modified .gitattributes to get \n EOL regardless of host OS.