### PR TITLE
 Travis CI: Do not hard-code Trusty, it EOLs this month

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ branches:
   except:
     - /pyup\/.*/
 
-# Make sure we are on Ubuntu 14.04
-dist: trusty
-
 # Cache pip packages. Explicitly name the pip-cache directory since we
 # use a custom `install` step which annuls `cache: pip`.
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: python
 
-# Use the new container-based Travis infrastructure.
-sudo: false
-
 branches:
   except:
     - /pyup\/.*/
@@ -95,28 +92,23 @@ jobs:
       python: 3.6
 
     # Building Python > 3.7 requires OpenSSL 1.0.2 (or 1.1), which is
-    # available in xenial (16.04 LTS) only. As of 2018-07-08 xenial is only
-    # available as VM (sudo: true)
+    # available in xenial (16.04 LTS) only.
 
     - <<: *test-pyinstaller
       python: 3.7
       dist: xenial
-      sudo: true
     - <<: *test-libraries
       python: 3.7
       dist: xenial
-      sudo: true
       services:
         - xvfb
 
     - <<: *test-pyinstaller
       python: nightly
       dist: xenial
-      sudo: true
     - <<: *test-libraries
       python: nightly
       dist: xenial
-      sudo: true
       services:
         - xvfb
 


### PR DESCRIPTION
Do not hard-code __Trusty__ because it reaches its end-of-life next month.
https://wiki.ubuntu.com/Releases

Also, [Travis are now recommending removing the __sudo__ tag](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).