### PR TITLE
hook-jsonschema: fix for jsonschema>=3

### DIFF
--- a/PyInstaller/hooks/hook-jsonschema.py
+++ b/PyInstaller/hooks/hook-jsonschema.py
@@ -10,5 +10,6 @@
 # This is needed to bundle draft3.json and draft4.json files that come
 # with jsonschema module
 
-from PyInstaller.utils.hooks import collect_data_files
+from PyInstaller.utils.hooks import collect_data_files, copy_metadata
 datas = collect_data_files('jsonschema')
+datas += copy_metadata('jsonschema')


### PR DESCRIPTION
Thanks to @kieranlea who came up with the solution.

Fixes: https://github.com/pyinstaller/pyinstaller/issues/4100

Signed-off-by: Antonio Gutierrez <chibby0ne@gmail.com>