### PR TITLE
tinycss2 1.0.2 hook

### DIFF
--- a/PyInstaller/hooks/hook-tinycss2
+++ b/PyInstaller/hooks/hook-tinycss2
@@ -1,0 +1,14 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2018, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+# The "VERSION" file is needed to bundle tinycss2 v1.0.2
+
+from PyInstaller.utils.hooks import get_package_paths
+
+datas = [(get_package_paths('tinycss2')[1]+'/VERSION',"tinycss2"),]


### PR DESCRIPTION
The latest version of tinycss2 (1.0.2 as of writing) requires it's VERSION file to be included.