### PR TITLE
Depend: Make platform-specific dependencies conditional

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,8 @@
 # also tests/requirements-libraries.txt.
 
 setuptools
-pefile
-macholib
+pefile; sys_platform == 'win32'
+macholib; sys_platform == 'darwin'
 altgraph
 
 dis3; python_version < '3.0'

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,6 @@ from PyInstaller.compat import is_win, is_cygwin, is_py2
 
 REQUIREMENTS = [
     'setuptools',
-    'pefile >= 2017.8.1',
-    'macholib >= 1.8',
     'altgraph',
 ]
 
@@ -33,7 +31,11 @@ if sys.version_info < (3,):
 
 # For Windows install PyWin32 if not already installed.
 if sys.platform.startswith('win'):
-    REQUIREMENTS.append('pywin32-ctypes >= 0.2.0')
+    REQUIREMENTS += ['pywin32-ctypes >= 0.2.0',
+                     'pefile >= 2017.8.1']
+
+if sys.platform == 'darwin':
+    REQUIREMENTS.append('macholib >= 1.8')
 
 
 # Create long description from README.rst and doc/CHANGES.rst.


### PR DESCRIPTION
The pefile and macholib libraries are only used on Windows and macOS,
respectively. All uses of these imports are conditional for the
platform, but setup.py contains a non-conditinal requirement for them.
This causes the libraries to be installed even on platforms where they
are not needed.

Resolves: #4166 