### PR TITLE
Enable PyInstaller to be run from the embedded Python

### DIFF
--- a/PyInstaller/lib/modulegraph/find_modules.py
+++ b/PyInstaller/lib/modulegraph/find_modules.py
@@ -99,7 +99,8 @@ def get_implies():
 
         import xml.etree
         for _, module_name, is_package in pkgutil.iter_modules(xml.etree.__path__):
-            result["_elementtree"].append("xml.etree.%s" % (module_name,))
+            if not is_package:
+                result["_elementtree"].append("xml.etree.%s" % (module_name,))
 
     if sys.version_info[:2] >= (2, 6):
         result['future_builtins'] = ['itertools']

--- a/PyInstaller/lib/modulegraph/find_modules.py
+++ b/PyInstaller/lib/modulegraph/find_modules.py
@@ -13,6 +13,7 @@ import sys
 import os
 import imp
 import warnings
+import pkgutil
 
 from . import modulegraph
 from .modulegraph import Alias, Script, Extension
@@ -97,10 +98,8 @@ def get_implies():
         result["_elementtree"] = ["pyexpat"]
 
         import xml.etree
-        files = os.listdir(xml.etree.__path__[0])
-        for fn in files:
-            if fn.endswith('.py') and fn != "__init__.py":
-                result["_elementtree"].append("xml.etree.%s" % (fn[:-3],))
+        for _, module_name, is_package in pkgutil.iter_modules(xml.etree.__path__):
+            result["_elementtree"].append("xml.etree.%s" % (module_name,))
 
     if sys.version_info[:2] >= (2, 6):
         result['future_builtins'] = ['itertools']


### PR DESCRIPTION
See #4181. Basically, we shouldn't be using filesystem operations for interacting with the modules, since we won't know what filesystem the modules will be housed in (the embedded version of Python has its standard library packages in a zip file, rather than a directory tree). 