### PR TITLE
depend: improve Windows pylib detection

### DIFF
--- a/PyInstaller/depend/bindepend.py
+++ b/PyInstaller/depend/bindepend.py
@@ -893,6 +893,12 @@ def get_python_library_path():
                 return filename
 
     # Python library NOT found. Resume searching using alternative methods.
+
+    # Work around for python venv having VERSION.dll rather than pythonXY.dll
+    if is_win and 'VERSION.dll' in dlls:
+        pydll = 'python%d%d.dll' % sys.version_info[:2]
+        return getfullnameof(pydll)
+
     # Applies only to non Windows platforms and conda.
 
     if is_conda:

--- a/news/3942.bugfix.rst
+++ b/news/3942.bugfix.rst
@@ -1,0 +1,1 @@
+(Windows\\Py3.7) Now able to locate pylib when VERSION.dll is listed in python.exe PE Header rather than pythonXY.dll

--- a/news/3956.bugfix.rst
+++ b/news/3956.bugfix.rst
@@ -1,0 +1,1 @@
+(Windows\\Py3.7) Now able to locate pylib when VERSION.dll is listed in python.exe PE Header rather than pythonXY.dll


### PR DESCRIPTION
Allow pylib detection when VERSION.dll is a dependency of python.exe
rather than pythonXY.dll

If libpython is not detected uses the dependency checker to look for a
dll matching the pattern pythonXY.dll using the same method as
automated detection.

Checks after automated detection and only on windows systems.

Fixes #3942
Refers #3956