### PR TITLE
Hooks: Get qmldir from Qml2ImportsPath for PySide2

### DIFF
--- a/PyInstaller/hooks/hook-PySide2.QtQuick.py
+++ b/PyInstaller/hooks/hook-PySide2.QtQuick.py
@@ -10,27 +10,19 @@
 import os
 
 from PyInstaller.utils import misc
-from PyInstaller.utils.hooks import get_qmake_path, exec_command
 from PyInstaller import log as logging
+from PyInstaller.utils.hooks.qt import pyside2_library_info
 
 logger = logging.getLogger(__name__)
 
 
 def qt5_qml_dir():
-    qmake = get_qmake_path('5')
-    if qmake is None:
-        qmldir = ''
-        logger.warning('Could not find qmake version 5.x, make sure PATH is '
-                       'set correctly or try setting QT5DIR.')
-    else:
-        qmldir = exec_command(qmake, "-query", "QT_INSTALL_QML").strip()
-    if qmldir:
-        logger.error('Cannot find QT_INSTALL_QML directory, "qmake -query '
-                     'QT_INSTALL_QML" returned nothing')
+    qmldir = pyside2_library_info.location['Qml2ImportsPath']
+    if not qmldir:
+        logger.error('Cannot find QT_INSTALL_QML directory')
     elif not os.path.exists(qmldir):
         logger.error("Directory QT_INSTALL_QML: %s doesn't exist", qmldir)
 
-    # 'qmake -query' uses / as the path separator, even on Windows
     qmldir = os.path.normpath(qmldir)
     return qmldir
 

--- a/PyInstaller/utils/hooks/qt.py
+++ b/PyInstaller/utils/hooks/qt.py
@@ -82,6 +82,7 @@ class Qt5LibraryInfo:
 
 # Provide an instance of this class, to avoid each hook constructing its own.
 pyqt5_library_info = Qt5LibraryInfo('PyQt5')
+pyside2_library_info = Qt5LibraryInfo('PySide2')
 
 
 def qt_plugins_dir(namespace):
@@ -542,4 +543,4 @@ def add_qt5_dependencies(hook_file):
 
 
 __all__ = ('qt_plugins_dir', 'qt_plugins_binaries', 'qt_menu_nib_dir',
-           'get_qmake_path', 'add_qt5_dependencies', 'pyqt5_library_info')
+           'get_qmake_path', 'add_qt5_dependencies', 'pyqt5_library_info', 'pyside2_library_info')

--- a/news/4206.bugfix.rst
+++ b/news/4206.bugfix.rst
@@ -1,0 +1,1 @@
+Fix broken hook support for QML / QtQuick libraries within PySide2.


### PR DESCRIPTION
Fixes #3689

This is a duplicate of #4136, rebased to `develop` and with a news entry added.  All credit for the bugfix goes to @cbenhagen.