### PR TITLE
Pull in new ECC extension in PyCryptodome 3.8

### DIFF
--- a/PyInstaller/hooks/hook-Crypto.py
+++ b/PyInstaller/hooks/hook-Crypto.py
@@ -45,6 +45,7 @@ binary_module_names = [
     'Crypto.Util',
     'Crypto.Hash',
     'Crypto.Protocol',
+    'Crypto.PublicKey',
 ]
 
 try:

--- a/PyInstaller/hooks/hook-Cryptodome.py
+++ b/PyInstaller/hooks/hook-Cryptodome.py
@@ -31,6 +31,7 @@ binary_module_names = [
     'Cryptodome.Hash',
     'Cryptodome.Protocol',
     'Cryptodome.Math',
+    'Cryptodome.PublicKey',
 ]
 
 for module_name in binary_module_names:


### PR DESCRIPTION
PyCryptodome 3.8 added a new C extension for ECC in Crypto.PublicKey
(and Cryptodome.PublicKey), but such directory is not scanned like others,
so the extension is not pulled in.