### PR TITLE
Bootloader: win: Add a workaround for Python library loading failure in onefile mode

### DIFF
--- a/bootloader/src/pyi_path.h
+++ b/bootloader/src/pyi_path.h
@@ -23,6 +23,7 @@ void *pyi_path_normalize(char *result, const char *path);
 int pyi_path_fullpath(char *abs, size_t abs_size, const char *rel);
 /* TODO implement. */
 /* void *pyi_path_abspath(char *result, const char *path); */
+int pyi_path_exists(char *path);
 
 int pyi_path_executable(char *execfile, const char *appname);
 void pyi_path_homepath(char *homepath, const char *executable);

--- a/bootloader/src/pyi_pythonlib.c
+++ b/bootloader/src/pyi_pythonlib.c
@@ -97,6 +97,22 @@ pyi_pylib_load(ARCHIVE_STATUS *status)
         return -1;
     }
 
+#ifdef _WIN32
+    /*
+     * If ucrtbase.dll exists in temppath, load it proactively before Python
+     * library loading to avoid Python library loading failure (unresolved
+     * symbol errors) on systems with Universal CRT update not installed.
+     */
+    if (status->has_temp_directory) {
+        char ucrtpath[PATH_MAX];
+        pyi_path_join(ucrtpath, status->temppath, "ucrtbase.dll");
+        if (pyi_path_exists(ucrtpath)) {
+            VS("LOADER: ucrtbase.dll is exists: %s\n", ucrtpath);
+            pyi_utils_dlopen(ucrtpath);
+        }
+    }
+#endif
+
     /*
      * Look for Python library in homepath or temppath.
      * It depends on the value of mainpath.

--- a/news/1566.bootloader.rst
+++ b/news/1566.bootloader.rst
@@ -1,0 +1,4 @@
+(Windows) If bundled with the application, proactivley load ``ucrtbase.dll``
+before loading the Python library. This works around unresolved symbol errors
+when loading ``python35.dll`` (or later) on legacy Windows (7, 8, 8.1) systems
+with Universal CRT update is not installed.

--- a/news/2170.bootloader.rst
+++ b/news/2170.bootloader.rst
@@ -1,0 +1,4 @@
+(Windows) If bundled with the application, proactivley load ``ucrtbase.dll``
+before loading the Python library. This works around unresolved symbol errors
+when loading ``python35.dll`` (or later) on legacy Windows (7, 8, 8.1) systems
+with Universal CRT update is not installed.

--- a/news/4230.bootloader.rst
+++ b/news/4230.bootloader.rst
@@ -1,0 +1,4 @@
+(Windows) If bundled with the application, proactivley load ``ucrtbase.dll``
+before loading the Python library. This works around unresolved symbol errors
+when loading ``python35.dll`` (or later) on legacy Windows (7, 8, 8.1) systems
+with Universal CRT update is not installed.


### PR DESCRIPTION
As #2170 (comment), current PyInstaller onefile mode with Python 3.5 or later has not working properly on legacy windows(7, 8, 8.1) that Universal CRT update is not installed, even though all dependencies related Universal CRT are packaged.
It caused by that that SetDllDirectory function only affects explicit linking(ex-LoadLibrary) not implicit one, so api-ms-win-crt-runtime-l1-1-0.dll couldn’t load ucrtbase.dll on temppath(extractionpath) while Python library loading.
In order to workaround this issue, I put some codes that loading ucrtbase.dll manually before Python library loading if it is packaged.

I've tested and verified it on a clean install of Windows 7 SP1.