### PR TITLE
Replace PyCrypto with pyaes for bytecode encryption

### DIFF
--- a/PyInstaller/archive/pyz_crypto.py
+++ b/PyInstaller/archive/pyz_crypto.py
@@ -8,35 +8,9 @@
 #-----------------------------------------------------------------------------
 
 import os
+import pyaes
 
 BLOCK_SIZE = 16
-
-
-def import_aes(module_name):
-    """
-    Tries to import the AES module from PyCrypto.
-
-    PyCrypto 2.4 and 2.6 uses different name of the AES extension.
-    """
-    return __import__(module_name, fromlist=[module_name.split('.')[-1]])
-
-
-def get_crypto_hiddenimports():
-    """
-    These module names are appended to the PyInstaller analysis phase.
-    :return: Name of the AES module.
-    """
-    try:
-        # The _AES.so module exists only in PyCrypto 2.6 and later. Try to import
-        # that first.
-        modname = 'Crypto.Cipher._AES'
-        import_aes(modname)
-    except ImportError:
-        # Fallback to AES.so, which should be there in PyCrypto 2.4 and earlier.
-        modname = 'Crypto.Cipher.AES'
-        import_aes(modname)
-    return modname
-
 
 class PyiBlockCipher(object):
     """
@@ -50,15 +24,11 @@ class PyiBlockCipher(object):
             self.key = key.zfill(BLOCK_SIZE)
         assert len(self.key) == BLOCK_SIZE
 
-        # Import the right AES module.
-        self._aesmod = import_aes(get_crypto_hiddenimports())
-
     def encrypt(self, data):
         iv = os.urandom(BLOCK_SIZE)
         return iv + self.__create_cipher(iv).encrypt(data)
 
     def __create_cipher(self, iv):
-        # The 'BlockAlgo' class is stateful, this factory method is used to
-        # re-initialize the block cipher class with each call to encrypt() and
-        # decrypt().
-        return self._aesmod.new(self.key.encode(), self._aesmod.MODE_CFB, iv)
+        # The 'AESModeOfOperationCFB' class is stateful, this factory method is used to
+        # re-initialize the block cipher class with each call to encrypt() and decrypt().
+        return pyaes.AESModeOfOperationCFB(self.key.encode(), iv=iv)

--- a/PyInstaller/archive/pyz_crypto.py
+++ b/PyInstaller/archive/pyz_crypto.py
@@ -30,6 +30,7 @@ class PyiBlockCipher(object):
         return iv + self.__create_cipher(iv).encrypt(data)
 
     def __create_cipher(self, iv):
-        # The 'AESModeOfOperationCFB' class is stateful, this factory method is used to
-        # re-initialize the block cipher class with each call to encrypt() and decrypt().
+        # The 'AESModeOfOperationCFB' class is stateful, this factory method
+        # is used to re-initialize the block cipher class with each call to
+        # encrypt() and decrypt().
         return self._aes.AESModeOfOperationCFB(self.key.encode(), iv=iv)

--- a/PyInstaller/archive/pyz_crypto.py
+++ b/PyInstaller/archive/pyz_crypto.py
@@ -8,7 +8,6 @@
 #-----------------------------------------------------------------------------
 
 import os
-import pyaes
 
 BLOCK_SIZE = 16
 
@@ -17,6 +16,8 @@ class PyiBlockCipher(object):
     This class is used only to encrypt Python modules.
     """
     def __init__(self, key=None):
+        import pyaes
+        self._aes = pyaes
         assert type(key) is str
         if len(key) > BLOCK_SIZE:
             self.key = key[0:BLOCK_SIZE]
@@ -31,4 +32,4 @@ class PyiBlockCipher(object):
     def __create_cipher(self, iv):
         # The 'AESModeOfOperationCFB' class is stateful, this factory method is used to
         # re-initialize the block cipher class with each call to encrypt() and decrypt().
-        return pyaes.AESModeOfOperationCFB(self.key.encode(), iv=iv)
+        return self._aes.AESModeOfOperationCFB(self.key.encode(), iv=iv)

--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -92,6 +92,17 @@ class PYZ(Target):
             # Insert the key as the first module in the list. The key module contains
             # just variables and does not depend on other modules.
             self.dependencies.insert(0, key_file)
+            import copy
+            copy_file =  ('copy',
+                          copy.__file__,
+                          'PYMODULE')
+
+            pyaes_file = ('pyimod00_pyaes',
+                          os.path.join(CONF['workpath'], 'pyimod00_pyaes.pyc'),
+                          'PYMODULE')
+
+            self.dependencies.insert(2, copy_file)
+            self.dependencies.insert(3, pyaes_file)
         # Compile the top-level modules so that they end up in the CArchive and can be
         # imported by the bootstrap script.
         self.dependencies = misc.compile_py_files(self.dependencies, CONF['workpath'])

--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -93,9 +93,9 @@ class PYZ(Target):
             # just variables and does not depend on other modules.
             self.dependencies.insert(0, key_file)
             import copy
-            copy_file =  ('copy',
-                          copy.__file__,
-                          'PYMODULE')
+            copy_file = ('copy',
+                         copy.__file__,
+                         'PYMODULE')
 
             pyaes_file = ('pyimod00_pyaes',
                           os.path.join(CONF['workpath'], 'pyimod00_pyaes.pyc'),

--- a/PyInstaller/building/build_main.py
+++ b/PyInstaller/building/build_main.py
@@ -223,8 +223,11 @@ class Analysis(Target):
             with open_file(pyi_crypto_key_path, 'w', encoding='utf-8') as f:
                 f.write(text_type('# -*- coding: utf-8 -*-\n'
                                   'key = %r\n' % cipher.key))
+
             logger.info('Adding dependencies on pyi_crypto.py module')
-            self.hiddenimports.append(pyz_crypto.get_crypto_hiddenimports())
+            pyaes_path = os.path.join(CONF['workpath'], 'pyimod00_pyaes.py')
+            import pyaes.aes
+            shutil.copy(pyaes.aes.__file__, pyaes_path)
 
         self.excludes = excludes or []
         self.scripts = TOC()

--- a/PyInstaller/building/makespec.py
+++ b/PyInstaller/building/makespec.py
@@ -377,10 +377,11 @@ def main(scripts, name=None, onefile=None,
     if key:
         # Tries to import pyaes since we need it for bytecode obfuscation.
         try:
-            import pyaes
+            import pyaes  # noqa: F401
         except ImportError:
-            logger.error('We need pyaes to use byte-code obfuscation but we could not')
-            logger.error('find it. You can install it with pip by running:')
+            logger.error('We need pyaes to use byte-code obfuscation but ')
+            logger.error('we could not find it. ')
+            logger.error('You can install it with pip by running:')
             logger.error('  pip install pyaes')
             sys.exit(1)
         cipher_init = cipher_init_template % {'key': key}

--- a/PyInstaller/building/makespec.py
+++ b/PyInstaller/building/makespec.py
@@ -375,18 +375,13 @@ def main(scripts, name=None, onefile=None,
     scripts = list(map(Path, scripts))
 
     if key:
-        # Tries to import PyCrypto since we need it for bytecode obfuscation. Also make sure its
-        # version is >= 2.4.
+        # Tries to import pyaes since we need it for bytecode obfuscation.
         try:
-            import Crypto
-            is_version_acceptable = LooseVersion(Crypto.__version__) >= LooseVersion('2.4')
-            if not is_version_acceptable:
-                logger.error('PyCrypto version must be >= 2.4, older versions are not supported.')
-                sys.exit(1)
+            import pyaes
         except ImportError:
-            logger.error('We need PyCrypto >= 2.4 to use byte-code obfuscation but we could not')
+            logger.error('We need pyaes to use byte-code obfuscation but we could not')
             logger.error('find it. You can install it with pip by running:')
-            logger.error('  pip install PyCrypto')
+            logger.error('  pip install pyaes')
             sys.exit(1)
         cipher_init = cipher_init_template % {'key': key}
     else:

--- a/PyInstaller/loader/pyimod02_archive.py
+++ b/PyInstaller/loader/pyimod02_archive.py
@@ -262,9 +262,9 @@ class Cipher(object):
         assert len(self.key) == CRYPT_BLOCK_SIZE
 
     def __create_cipher(self, iv):
-        # The 'AESModeOfOperationCFB' class is stateful, this factory method is
-        # used to re-initialize the block cipher class with each call to encrypt()
-        # and decrypt().
+        # The 'AESModeOfOperationCFB' class is stateful, this factory method
+        # is used to re-initialize the block cipher class with each call to
+        # encrypt() and decrypt().
         return self._aes.AESModeOfOperationCFB(self.key.encode(), iv=iv)
 
     def decrypt(self, data):

--- a/PyInstaller/loader/pyimod02_archive.py
+++ b/PyInstaller/loader/pyimod02_archive.py
@@ -251,7 +251,9 @@ class Cipher(object):
         # the generated 'pyi_crypto_key' module.
         import pyimod00_crypto_key
         key = pyimod00_crypto_key.key
+        import pyimod00_pyaes
 
+        self._aes = pyimod00_pyaes
         assert type(key) is str
         if len(key) > CRYPT_BLOCK_SIZE:
             self.key = key[0:CRYPT_BLOCK_SIZE]
@@ -259,53 +261,11 @@ class Cipher(object):
             self.key = key.zfill(CRYPT_BLOCK_SIZE)
         assert len(self.key) == CRYPT_BLOCK_SIZE
 
-        # Import the right AES module.
-        self._aes = self._import_aesmod()
-
-    def _import_aesmod(self):
-        """
-        Tries to import the AES module from PyCrypto.
-
-        PyCrypto 2.4 and 2.6 uses different name of the AES extension.
-        """
-        # The _AES.so module exists only in PyCrypto 2.6 and later. Try to import
-        # that first.
-        modname = 'Crypto.Cipher._AES'
-
-        if sys.version_info[0] == 2:
-            # Not-so-easy way: at bootstrap time we have to load the module from the
-            # temporary directory in a manner similar to pyi_importers.CExtensionImporter.
-            from pyimod03_importers import CExtensionImporter
-            importer = CExtensionImporter()
-            # NOTE: We _must_ call find_module first.
-            mod = importer.find_module(modname)
-            # Fallback to AES.so, which should be there in PyCrypto 2.4 and earlier.
-            if not mod:
-                modname = 'Crypto.Cipher.AES'
-                mod = importer.find_module(modname)
-                if not mod:
-                    # Raise import error if none of the AES modules is found.
-                    raise ImportError(modname)
-            mod = mod.load_module(modname)
-        else:
-            kwargs = dict(fromlist=['Crypto', 'Cipher'])
-            try:
-                mod = __import__(modname, **kwargs)
-            except ImportError:
-                modname = 'Crypto.Cipher.AES'
-                mod = __import__(modname, **kwargs)
-
-        # Issue #1663: Remove the AES module from sys.modules list. Otherwise
-        # it interferes with using 'Crypto.Cipher' module in users' code.
-        if modname in sys.modules:
-            del sys.modules[modname]
-        return mod
-
     def __create_cipher(self, iv):
-        # The 'BlockAlgo' class is stateful, this factory method is used to
-        # re-initialize the block cipher class with each call to encrypt() and
-        # decrypt().
-        return self._aes.new(self.key, self._aes.MODE_CFB, iv)
+        # The 'AESModeOfOperationCFB' class is stateful, this factory method is
+        # used to re-initialize the block cipher class with each call to encrypt()
+        # and decrypt().
+        return self._aes.AESModeOfOperationCFB(self.key.encode(), iv=iv)
 
     def decrypt(self, data):
         return self.__create_cipher(data[:CRYPT_BLOCK_SIZE]).decrypt(data[CRYPT_BLOCK_SIZE:])
@@ -344,10 +304,7 @@ class ZlibArchiveReader(ArchiveReader):
 
         super(ZlibArchiveReader, self).__init__(path, offset)
 
-        # Try to import the key module. If the key module is not available
-        # then it means that encryption is disabled.
         try:
-            import pyimod00_crypto_key
             self.cipher = Cipher()
         except ImportError:
             self.cipher = None

--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,7 @@ Requirements and Tested Platforms
 - Python: 
 
  - 2.7 or 3.4-3.7
- - PyCrypto_ 2.4+ (only if using bytecode encryption)
+ - pyaes (only if using bytecode encryption)
 
 - Windows (32bit/64bit):
 


### PR DESCRIPTION
PyCrypto is unsupported and doesn't work on Python 3.6+. [pyaes](https://github.com/ricmoo/pyaes) is an AES implementation in pure Python available via pip that I've found works as a replacement. 

This is my first "big" open source contribution so please let me know anything I did wrong and how I can improve.