### PR TITLE
Fixed #4057 - Ctrl-Z issue

### DIFF
--- a/bootloader/src/pyi_utils.c
+++ b/bootloader/src/pyi_utils.c
@@ -982,7 +982,8 @@ pyi_utils_create_child(const char *thisfile, const ARCHIVE_STATUS* status,
     for (signum = 0; signum < num_signals; ++signum) {
         // don't mess with SIGCHLD/SIGCLD; it affects our ability
         // to wait() for the child to exit
-        if (signum != SIGCHLD && signum != SIGCLD) {
+        // don't change SIGTSP handling to allow Ctrl-Z
+        if (signum != SIGCHLD && signum != SIGCLD && signum != SIGTSTP) {
             signal(signum, handler);
         }
     }

--- a/news/4244.bugfix.rst
+++ b/news/4244.bugfix.rst
@@ -1,0 +1,1 @@
+Fix SIGTSTP signal handling to allow typing Ctrl-Z from terminal.

--- a/tests/functional/test_signals.py
+++ b/tests/functional/test_signals.py
@@ -36,6 +36,10 @@ def test_signal_handled(pyi_builder, signame, ignore):
         pytest.skip(
             'Messing with {} interferes with bootloader'.format(signame)
         )
+    elif signame == 'SIGTSTP':
+        pytest.xfail(
+            '{} is not caught to allow Ctrl-Z'.format(signame)
+        )
 
     verb = 'ignored' if ignore else 'handled'
     app_name = 'test_signal_{}_{}'.format(verb, signame)


### PR DESCRIPTION
Currently, when running a PyInstaller packed program in Linux shell and typing Ctrl-Z, the terminal stops responding. This PR aims at fixing this issue by handling the SIGTSTP signal differently in the PyInstaller bootloader.