### PR TITLE
Depend: Handle ldconfig failure gracefully

### DIFF
--- a/news/4261.bugfix.rst
+++ b/news/4261.bugfix.rst
@@ -1,0 +1,1 @@
+Do not fail the build when ldconfig is missing/inoperable

--- a/news/4261.bugfix.rst
+++ b/news/4261.bugfix.rst
@@ -1,1 +1,1 @@
-Do not fail the build when ldconfig is missing/inoperable
+Do not fail the build when ``ldconfig`` is missing/inoperable.


### PR DESCRIPTION
In case `ldconfig` is not available in the environment PyInstaller
currently aborts package creation as the `OSError` exception is not
handled. This change catches the execption and logs a warning, while
leaving the LD cache in disabled state. This can allow the package
creation to continue.

This can be very helpful in the following situation: users can populate
`LD_LIBRARY_PATH` with the library paths they want PyInstaller to look
for library dependencies for. If all libraries are found in these
locations the LD cache logic won't be triggered. If however a library
not needed on the platform (e.g. a Windows DLL on Unix) is picked up as
a `ctypes` dependency, it won't be found on the library path and
execution will reach the LD cache logic. In certain sandbox
environments, like a `chroot` `ldconfig` won't be operation so this will
lead to a failure. The generated package would still be correct without
the LD cache as the missing library is not actually used, but the
`ldconfig` problem halts execution.

I consolidated the setup for the FreeBSD-specific code path to avoid
duplicating the exception handler.