### PR TITLE
hook-django uses DJANGO_SETTINGS_MODULE if set to support nonstandard…

### DIFF
--- a/PyInstaller/hooks/hook-django.py
+++ b/PyInstaller/hooks/hook-django.py
@@ -73,7 +73,11 @@ if root_dir:
              'django.contrib.sites.migrations',
     ]
     # Include migration scripts of Django-based apps too.
-    installed_apps = eval(get_module_attribute(package_name + '.settings', 'INSTALLED_APPS'))
+    django_settings_module = os.environ.get('DJANGO_SETTINGS_MODULE', None)
+    if django_settings_module is not None:
+        installed_apps = eval(get_module_attribute(django_settings_module, 'INSTALLED_APPS'))
+    else:
+        installed_apps = eval(get_module_attribute(package_name + '.settings', 'INSTALLED_APPS'))
     migration_modules.extend(set(app + '.migrations' for app in installed_apps))
     # Copy migration files.
     for mod in migration_modules:


### PR DESCRIPTION
… django applications

This is a work in progress. I'm really new to pyinstaller. I'd like to start a discussion about this change.

I'm working with a django application that has non-standard settings and pyinstaller broke for me.