### PR TITLE
Make notebook hook more robust to whether directories actually exist

### DIFF
--- a/PyInstaller/hooks/hook-notebook.py
+++ b/PyInstaller/hooks/hook-notebook.py
@@ -7,6 +7,7 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 # -----------------------------------------------------------------------------
 
+import os
 from PyInstaller.utils.hooks import collect_data_files, collect_submodules
 from jupyter_core.paths import ENV_JUPYTER_PATH, ENV_CONFIG_PATH
 
@@ -17,5 +18,5 @@ hiddenimports.append('notebook.services.shutdown')
 datas = collect_data_files('notebook')
 
 # Collect share and etc folder for pre-installed extensions
-datas += [(path, 'share/jupyter') for path in ENV_JUPYTER_PATH]
-datas += [(path, 'etc/jupyter') for path in ENV_CONFIG_PATH]
+datas += [(path, 'share/jupyter') for path in ENV_JUPYTER_PATH if os.path.exists(path)]
+datas += [(path, 'etc/jupyter') for path in ENV_CONFIG_PATH if os.path.exists(path)]

--- a/PyInstaller/hooks/hook-notebook.py
+++ b/PyInstaller/hooks/hook-notebook.py
@@ -18,5 +18,5 @@ hiddenimports.append('notebook.services.shutdown')
 datas = collect_data_files('notebook')
 
 # Collect share and etc folder for pre-installed extensions
-datas += [(path, 'share/jupyter') for path in jupyter_config_path() if os.path.exists(path)]
-datas += [(path, 'etc/jupyter') for path in jupyter_path() if os.path.exists(path)]
+datas += [(path, 'share/jupyter') for path in jupyter_path() if os.path.exists(path)]
+datas += [(path, 'etc/jupyter') for path in jupyter_config_path() if os.path.exists(path)]

--- a/PyInstaller/hooks/hook-notebook.py
+++ b/PyInstaller/hooks/hook-notebook.py
@@ -18,5 +18,7 @@ hiddenimports.append('notebook.services.shutdown')
 datas = collect_data_files('notebook')
 
 # Collect share and etc folder for pre-installed extensions
-datas += [(path, 'share/jupyter') for path in jupyter_path() if os.path.exists(path)]
-datas += [(path, 'etc/jupyter') for path in jupyter_config_path() if os.path.exists(path)]
+datas += [(path, 'share/jupyter')
+          for path in jupyter_path() if os.path.exists(path)]
+datas += [(path, 'etc/jupyter')
+          for path in jupyter_config_path() if os.path.exists(path)]

--- a/PyInstaller/hooks/hook-notebook.py
+++ b/PyInstaller/hooks/hook-notebook.py
@@ -9,7 +9,7 @@
 
 import os
 from PyInstaller.utils.hooks import collect_data_files, collect_submodules
-from jupyter_core.paths import ENV_JUPYTER_PATH, ENV_CONFIG_PATH
+from jupyter_core.paths import jupyter_config_path, jupyter_path
 
 # collect modules for handlers
 hiddenimports = collect_submodules('notebook', filter=lambda name: name.endswith('.handles'))
@@ -18,5 +18,5 @@ hiddenimports.append('notebook.services.shutdown')
 datas = collect_data_files('notebook')
 
 # Collect share and etc folder for pre-installed extensions
-datas += [(path, 'share/jupyter') for path in ENV_JUPYTER_PATH if os.path.exists(path)]
-datas += [(path, 'etc/jupyter') for path in ENV_CONFIG_PATH if os.path.exists(path)]
+datas += [(path, 'share/jupyter') for path in jupyter_config_path() if os.path.exists(path)]
+datas += [(path, 'etc/jupyter') for path in jupyter_path() if os.path.exists(path)]

--- a/news/4270.bugfix.rst
+++ b/news/4270.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed hook for 'notebook' to only include existing directories in datas.

--- a/news/4270.bugfix.rst
+++ b/news/4270.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed hook for 'notebook' to only include existing directories in datas.

--- a/news/4270.hooks.rst
+++ b/news/4270.hooks.rst
@@ -1,0 +1,2 @@
+* Updated hook for 'notebook' to look in all Jupyter paths reported by jupyter_core
+* Fixed hook for 'notebook' to only include directories that actually exist in datas.

--- a/news/4270.hooks.rst
+++ b/news/4270.hooks.rst
@@ -1,2 +1,2 @@
 * Updated hook for 'notebook' to look in all Jupyter paths reported by jupyter_core.
-* Fixed hook for 'notebook' to only include directories that actually exist in datas.
+* Fixed hook for 'notebook' to only include directories that actually exist.

--- a/news/4270.hooks.rst
+++ b/news/4270.hooks.rst
@@ -1,2 +1,2 @@
-* Updated hook for 'notebook' to look in all Jupyter paths reported by jupyter_core
+* Updated hook for 'notebook' to look in all Jupyter paths reported by jupyter_core.
 * Fixed hook for 'notebook' to only include directories that actually exist in datas.


### PR DESCRIPTION
When trying to build an application inside a docker image where Jupyter packages were installed as a user installation (within the home directory) I ran into an issue where the paths returned by ``jupyter_core.paths`` don't necessarily exist:

```
33598 INFO: Loading module hook "hook-scipy.py"...
33599 INFO: Loading module hook "hook-sqlite3.py"...
33651 INFO: Loading module hook "hook-notebook.py"...
Unable to find "/usr/share/jupyter" when adding binary and data files.
##[error]Bash exited with code '1'.
##[section]Finishing: Building application
```

This PR simply updates the hook for the ``notebook`` package to make sure that paths are only included in ``datas`` if they actually exist.

I've also switched to using the helper functions instead of the constants from ``jupyter_core`` - the helper functions return more possible paths, including the etc and share folders in user directories or elsewhere.