### PR TITLE
Fix loading of extensions for IPython

### DIFF
--- a/PyInstaller/hooks/hook-IPython.py
+++ b/PyInstaller/hooks/hook-IPython.py
@@ -24,3 +24,8 @@ if is_win or is_darwin:
     excludedimports.append(modname_tkinter)
 
 datas = collect_data_files('IPython')
+
+# IPython imports extensions by changing to the extensions directory and using
+# importlib.import_module, so we need to copy over the extensions as if they
+# were data files.
+datas += collect_data_files('IPython.extensions', include_py_files=True)

--- a/news/4271.bugfix.rst
+++ b/news/4271.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed loading of IPython extensions.


### PR DESCRIPTION
IPython imports its own extensions by adding the extensions directory to sys.path and using importlib:

https://github.com/ipython/ipython/blob/master/IPython/core/extensions.py#L79

This means that currently applications built with pyinstaller and including IPython will run into errors such as:

```
Traceback (most recent call last):
  File "IPython/core/shellapp.py", line 261, in init_extensions
  File "IPython/core/extensions.py", line 80, in load_extension
  File "importlib/__init__.py", line 126, in import_module
  File "<frozen importlib._bootstrap>", line 994, in _gcd_import
  File "<frozen importlib._bootstrap>", line 971, in _find_and_load
  File "<frozen importlib._bootstrap>", line 953, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'storemagic'
```

This PR fixes this by making it so that the extensions sub-module is now copied as if it was data (since it's in effect treated as such as opposed to a real sub-module).

