### PR TITLE
Add a hook for the webrtcvad package

### DIFF
--- a/PyInstaller/hooks/hook-webrtcvad.py
+++ b/PyInstaller/hooks/hook-webrtcvad.py
@@ -1,0 +1,12 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2018-2019, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import copy_metadata
+
+datas = copy_metadata("webrtcvad")

--- a/news/4276.hooks.rst
+++ b/news/4276.hooks.rst
@@ -1,0 +1,1 @@
+Add hook for webrtcvad.


### PR DESCRIPTION
Add a hook for webrtcvad package as required in  #3357.
Successfully tested with:
PyInstaller: 3.4
Python: 3.5.3
Platform: Linux-4.15.0-51-generic-x86_64-with-debian-9.9