### PR TITLE
Hooks: hook-pint should copy metadata.

### DIFF
--- a/PyInstaller/hooks/hook-pint.py
+++ b/PyInstaller/hooks/hook-pint.py
@@ -8,7 +8,8 @@
 #-----------------------------------------------------------------------------
 
 
-from PyInstaller.utils.hooks import collect_data_files
+from PyInstaller.utils.hooks import collect_data_files, copy_metadata
 
 
 datas = collect_data_files('pint')
+datas += copy_metadata('pint')

--- a/news/4280.hooks.rst
+++ b/news/4280.hooks.rst
@@ -1,0 +1,1 @@
+Add hook for `pint <https://github.com/hgrecco/pint>`_.

--- a/news/4280.hooks.rst
+++ b/news/4280.hooks.rst
@@ -1,1 +1,2 @@
-Add hook for `pint <https://github.com/hgrecco/pint>`_.
+Fixed hook for `pint <https://github.com/hgrecco/pint>`_
+to also copy metadata as required to retrieve the version at runtime.


### PR DESCRIPTION
Accessing pint version at runtime requires setuptools metadata.