### PR TITLE
Hooks: Add hook for pysnmp.

### DIFF
--- a/PyInstaller/hooks/hook-pysnmp.py
+++ b/PyInstaller/hooks/hook-pysnmp.py
@@ -9,5 +9,5 @@
 
 from PyInstaller.utils.hooks import collect_submodules, collect_data_files
 
-hiddenimports = collect_submodules('pysnmp')
-datas = collect_data_files('pysnmp', include_py_files=True)
+hiddenimports = collect_submodules('pysnmp.smi.mibs')
+datas = collect_data_files('pysnmp.smi.mibs', include_py_files=True)

--- a/PyInstaller/hooks/hook-pysnmp.py
+++ b/PyInstaller/hooks/hook-pysnmp.py
@@ -1,0 +1,13 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2019, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_submodules, collect_data_files
+
+hiddenimports = collect_submodules('pysnmp')
+datas = collect_data_files('pysnmp', include_py_files=True)

--- a/news/4287.hooks.rst
+++ b/news/4287.hooks.rst
@@ -1,0 +1,1 @@
+Add hook for pysnmp


### PR DESCRIPTION
Closes #4286
Added hook to collect missing `pysnmp` files.
Not sure that this is the best way but it worked for me.