### PR TITLE
Bootloader: don't use debug message boxes on win32.

### DIFF
--- a/bootloader/src/pyi_global.c
+++ b/bootloader/src/pyi_global.c
@@ -187,7 +187,7 @@ mbvs(const char *fmt, ...)
     /* msg[MBTXTLEN-1] = '\0'; */
     va_end(args);
 
-    show_message_box(msg, "Tracing...", MB_ICONINFORMATION);
+    OutputDebugStringA(msg);
 }
     #endif /* if defined(_WIN32) && defined(WINDOWED) */
 #endif /* ifdef LAUNCH_DEBUG */

--- a/bootloader/src/pyi_global.h
+++ b/bootloader/src/pyi_global.h
@@ -112,9 +112,11 @@ void mbothererror(const char *fmt, ...);
 
 #ifdef LAUNCH_DEBUG
     #if defined(_WIN32) && defined(WINDOWED)
+        /* Don't have console, resort to debugger output */
         #define VS mbvs
 void mbvs(const char *fmt, ...);
     #else
+        /* Have console, printf works */
         #define VS pyi_global_printf
     #endif
 #else

--- a/bootloader/src/pyi_global.h
+++ b/bootloader/src/pyi_global.h
@@ -84,7 +84,7 @@ void pyi_global_perror(const char *funcname, const char *fmt, ...);
 #endif
 /*
  * On Windows and with windowed mode (no console) show error messages
- * in message boxes. In windowed mode nothing might be written to console.
+ * in message boxes. In windowed mode nothing is written to console.
  */
 
 #if defined(_WIN32) && defined(WINDOWED)

--- a/doc/when-things-go-wrong.rst
+++ b/doc/when-things-go-wrong.rst
@@ -142,11 +142,17 @@ or just to learn how the runtime works.
 
 Normally the debug progress messages go to standard output.
 If the ``--windowed`` option is used when bundling a Windows app,
-they are displayed as MessageBoxes.
+they are sent to any attached debugger. If you are not using a debugger
+(or don't have one), the DebugView_ the free (beer) tool can be used to
+display such messages. It has to be started before running the bundled
+application.
+
+.. _DebugView: https://docs.microsoft.com/en-us/sysinternals/downloads/debugview
+
 For a ``--windowed`` Mac OS app they are not displayed.
 
-Remember to bundle without ``--debug`` for your production version.
-Users would find the messages annoying.
+Consider bundling without ``--debug`` for your production version.
+Debugging messages require system calls and have an impact on performance.
 
 
 .. _getting python's verbose imports:

--- a/news/4288.feature.rst
+++ b/news/4288.feature.rst
@@ -1,2 +1,2 @@
-On Windows applications built in Windowed mode have their Debug messages
+(Windows): Applications built in windowed mode have their debug messages
 sent to any attached debugger or DebugView instead of message boxes.

--- a/news/4288.feature.rst
+++ b/news/4288.feature.rst
@@ -1,0 +1,2 @@
+On Windows applications built in Windowed mode have their Debug messages
+sent to any attached debugger or DebugView instead of message boxes.


### PR DESCRIPTION
When running a DEBUG WINDOWED application on win32 we don't have any
console to send debug messages to. I find the repeating message boxes
annoying and propose to send the output text to the debugger.
If no debuggers are attached to the process DebugView tool
(https://docs.microsoft.com/en-us/sysinternals/downloads/debugview) can
be used.

If this PR seems useful I will add the changelog item.