### PR TITLE
Hooks: hook files for issue 4209

### DIFF
--- a/PyInstaller/hooks/hook-firebase_admin.py
+++ b/PyInstaller/hooks/hook-firebase_admin.py
@@ -8,5 +8,6 @@
 #-----------------------------------------------------------------------------
 
 from PyInstaller.utils.hooks import copy_metadata
+
 datas = copy_metadata('google-api-core')
 datas = copy_metadata('firebase-admin')

--- a/PyInstaller/hooks/hook-firebase_admin.py
+++ b/PyInstaller/hooks/hook-firebase_admin.py
@@ -1,0 +1,12 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013-2018, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import copy_metadata
+datas = copy_metadata('google-api-core')
+datas = copy_metadata('firebase-admin')

--- a/PyInstaller/hooks/hook-firestore.py
+++ b/PyInstaller/hooks/hook-firestore.py
@@ -1,0 +1,18 @@
+#tsd 5-1-19
+# from https://github.com/MartinSahlen/cloud-functions-python/issues/56
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013-2018, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+from PyInstaller.utils.hooks import copy_metadata
+datas = copy_metadata('google-cloud-core')
+datas += copy_metadata('google-cloud-firestore')
+datas += copy_metadata('google-api-core')
+
+#pythonhosted.org/pyinstaller/hooks.html#understanding-pyinstaller-hooks
+#
+

--- a/PyInstaller/hooks/hook-firestore.py
+++ b/PyInstaller/hooks/hook-firestore.py
@@ -1,5 +1,3 @@
-#tsd 5-1-19
-# from https://github.com/MartinSahlen/cloud-functions-python/issues/56
 #-----------------------------------------------------------------------------
 # Copyright (c) 2013-2018, PyInstaller Development Team.
 #
@@ -8,11 +6,9 @@
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
+# from https://github.com/MartinSahlen/cloud-functions-python/issues/56
+
 from PyInstaller.utils.hooks import copy_metadata
 datas = copy_metadata('google-cloud-core')
 datas += copy_metadata('google-cloud-firestore')
 datas += copy_metadata('google-api-core')
-
-#pythonhosted.org/pyinstaller/hooks.html#understanding-pyinstaller-hooks
-#
-

--- a/PyInstaller/hooks/hook-firestore.py
+++ b/PyInstaller/hooks/hook-firestore.py
@@ -6,9 +6,11 @@
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
+
 # from https://github.com/MartinSahlen/cloud-functions-python/issues/56
 
 from PyInstaller.utils.hooks import copy_metadata
+
 datas = copy_metadata('google-cloud-core')
 datas += copy_metadata('google-cloud-firestore')
 datas += copy_metadata('google-api-core')

--- a/PyInstaller/hooks/hook-grpc.py
+++ b/PyInstaller/hooks/hook-grpc.py
@@ -1,0 +1,15 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013-2018, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+# from stackoverflow.com/questions/55848884/google-cloud-firestore-doesnt-get-added-to-pyinstaller-build
+from PyInstaller.utils.hooks import copy_metadata, collect_data_files
+
+datas = collect_data_files('grpc')
+
+

--- a/PyInstaller/hooks/hook-grpc.py
+++ b/PyInstaller/hooks/hook-grpc.py
@@ -8,8 +8,7 @@
 #-----------------------------------------------------------------------------
 
 # from stackoverflow.com/questions/55848884/google-cloud-firestore-doesnt-get-added-to-pyinstaller-build
+
 from PyInstaller.utils.hooks import copy_metadata, collect_data_files
 
 datas = collect_data_files('grpc')
-
-

--- a/PyInstaller/hooks/hook-grpc.py
+++ b/PyInstaller/hooks/hook-grpc.py
@@ -7,8 +7,9 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-# from stackoverflow.com/questions/55848884/google-cloud-firestore-doesnt-get-added-to-pyinstaller-build
+# from stackoverflow.com/questions/55848884/[continue on nextline]
+#google-cloud-firestore-doesnt-get-added-to-pyinstaller-build
 
-from PyInstaller.utils.hooks import copy_metadata, collect_data_files
+from PyInstaller.utils.hooks import collect_data_files
 
 datas = collect_data_files('grpc')

--- a/news/4314.hooks.rst
+++ b/news/4314.hooks.rst
@@ -1,0 +1,7 @@
+add hook-firestore.py
+
+add hook-grpc.py
+
+add hook-firebase_admin.py
+
+The above hooks are need for 'google-cloud-firestore' platform. hook-grpc.py will also retrieve the needed certificate.


### PR DESCRIPTION
hook-firestore.py not hook-google-cloud-firestore.py
hook-firebase_admin.py
hook-grpc.py

hook-firestore.py

from MartinSahlen/cloud-functions-python#56
from PyInstaller.utils.hooks import copy_metadata
datas = copy_metadata('google-cloud-core')
datas += copy_metadata('google-cloud-firestore')
datas += copy_metadata('google-api-core')

hook-firebase_admin.py
from PyInstaller.utils.hooks import copy_metadata
datas = copy_metadata('google-api-core')
datas += copy_metadata('firebase-admin')

hook-grpc.py

from stackoverflow.com/questions/55848884/google-cloud-firestore-doesnt-get-added-to-pyinstaller-build
from PyInstaller.utils.hooks import copy_metadata, collect_data_files

datas = collect_data_files('grpc')

needs all the resources not just the py files