### PR TITLE
Hooks: Make the soundfile hook platform aware

### DIFF
--- a/PyInstaller/hooks/hook-soundfile.py
+++ b/PyInstaller/hooks/hook-soundfile.py
@@ -13,18 +13,20 @@ https://github.com/bastibe/SoundFile
 """
 
 import os
-import platform
+
+from PyInstaller.compat import is_win, is_darwin
 from PyInstaller.utils.hooks import get_package_paths
 
 # get path of soundfile
 sfp = get_package_paths('soundfile')
 
-# add the packaged files on OSX and Windows, libsndfile is an external dependency on Linux
+# add binaries packaged by soundfile on OSX and Windows
+# an external dependency (libsndfile) is used on GNU/Linux
 path = None
-if platform.system() == 'Windows':
-    path = os.path.abspath(os.path.join(sfp[0], '_soundfile_data'))
-elif platform.system() == 'Darwin':
-    path = os.path.abspath(os.path.join(sfp[0], '_soundfile_data', 'libsndfile.dylib'))
+if is_win:
+    path = os.path.join(sfp[0], '_soundfile_data')
+elif is_darwin:
+    path = os.path.join(sfp[0], '_soundfile_data', 'libsndfile.dylib')
 
 if path is not None and os.path.exists(path):
     binaries = [(path, "_soundfile_data")]

--- a/PyInstaller/hooks/hook-soundfile.py
+++ b/PyInstaller/hooks/hook-soundfile.py
@@ -13,11 +13,18 @@ https://github.com/bastibe/SoundFile
 """
 
 import os
+import platform
 from PyInstaller.utils.hooks import get_package_paths
 
 # get path of soundfile
 sfp = get_package_paths('soundfile')
 
-# add the binaries
-bins = os.path.join(sfp[0], "_soundfile_data")
-binaries = [(bins, "_soundfile_data")]
+# add the packaged files on OSX and Windows, libsndfile is an external dependency on Linux
+path = None
+if platform.system() == 'Windows':
+    path = os.path.abspath(os.path.join(sfp[0], '_soundfile_data'))
+elif platform.system() == 'Darwin':
+    path = os.path.abspath(os.path.join(sfp[0], '_soundfile_data', 'libsndfile.dylib'))
+
+if path is not None and os.path.exists(path):
+    binaries = [(path, "_soundfile_data")]

--- a/news/4325.hooks.rst
+++ b/news/4325.hooks.rst
@@ -1,0 +1,1 @@
+Fix pysoundfile hook to bundle files correctly on both OSX and Windows.


### PR DESCRIPTION
The hook exists to package the libsndfile binary when required.
However pysoundfile only bundles libsndfile on OSX and Windows,
on Linux it relies on a system package. Attempting to include
_soundfile_data on Linux therefore results in an unexpected
exception as per #4325.

Furthermore the bundled files are different on OSX and Windows
so the data required has to be platform specific.

Closes #4325.