### PR TITLE
Update PyQt5 loader to fix #4293

### DIFF
--- a/PyInstaller/loader/rthooks/pyi_rth_pyqt5.py
+++ b/PyInstaller/loader/rthooks/pyi_rth_pyqt5.py
@@ -15,3 +15,5 @@ import sys
 pyqt_path = os.path.join(sys._MEIPASS, 'PyQt5', 'Qt')
 os.environ['QT_PLUGIN_PATH'] = os.path.join(pyqt_path, 'plugins')
 os.environ['QML2_IMPORT_PATH'] = os.path.join(pyqt_path, 'qml')
+if 'PATH' in os.environ:
+    os.environ['PATH'] = sys._MEIPASS + os.pathsep + os.environ['PATH']


### PR DESCRIPTION
Fix the error raised in `PyQt5>=5.12.3` (#4293). Already tested with `PyQtChart`, `PyQtWebEngine`.

Maybe this patch is a particular solution for upgrading PyQt5.
