### PR TITLE
Set PYDYLIB_NAMES correctly when using MSYS2

### DIFF
--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -39,7 +39,8 @@ is_py37 = sys.version_info >= (3, 7)
 
 is_win = sys.platform.startswith('win')
 is_win_10 = is_win and (platform.win32_ver()[0] == '10')
-is_cygwin = sys.platform == 'cygwin'
+is_cygwin = sys.platform == 'cygwin' 
+is_msys = sys.platform == 'msys'  # msys/msys2 report same string
 is_darwin = sys.platform == 'darwin'  # Mac OS X
 
 # Unix platforms
@@ -58,7 +59,7 @@ is_unix = is_linux or is_solar or is_aix or is_freebsd or is_hpux
 
 # On different platforms is different file for dynamic python library.
 _pyver = sys.version_info[:2]
-if is_win or is_cygwin:
+if is_win or is_cygwin or is_msys:
     PYDYLIB_NAMES = {'python%d%d.dll' % _pyver,
                      'libpython%d%d.dll' % _pyver,
                      'libpython%d%dm.dll' % _pyver,


### PR DESCRIPTION
Set and detect msys or msys2 environment. Previous commit ede5e74e8411bf379b4bdfc135db67090601431c does not work, as it failed to add a check to detect what sys.platform reports. MSYS2 reports 'msys' not 'win' or 'cygwin' so PYDYLIB_NAMES never gets set and installation fails.

With this change I could do:
```pip install -e git+https://github.com/crajun/pyinstaller@develop#egg=PyInstaller``` and successfully install, whereas before when even installing from develop branch I'd get the PYDYLIB_NAMES error.