### PR TITLE
hooks: Don't rely on virtualenv internals for system distutils detection, fixes #4064

### DIFF
--- a/PyInstaller/hooks/pre_find_module_path/hook-distutils.py
+++ b/PyInstaller/hooks/pre_find_module_path/hook-distutils.py
@@ -27,9 +27,9 @@ def pre_find_module_path(api):
     # Absolute path of the system-wide "distutils" package when run from within
     # a venv or None otherwise.
 
-    # opcode is not a virtualenv module, so we can use it to find the stdlib
+    # opcode is not a virtualenv module, so we can use it to find the stdlib.
     # Technique taken from virtualenv's "distutils" package detection at
-    # https://github.com/pypa/virtualenv/blob/0ab032ce1a/virtualenv_embedded/distutils-init.py#L5
+    # https://github.com/pypa/virtualenv/blob/16.3.0/virtualenv_embedded/distutils-init.py#L5
     import opcode
 
     system_module_path = os.path.normpath(os.path.dirname(opcode.__file__))

--- a/PyInstaller/hooks/pre_find_module_path/hook-distutils.py
+++ b/PyInstaller/hooks/pre_find_module_path/hook-distutils.py
@@ -1,11 +1,11 @@
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 # Copyright (c) 2005-2019, PyInstaller Development Team.
 #
 # Distributed under the terms of the GNU General Public License with exception
 # for distributing bootloader.
 #
 # The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 
 """
 `distutils`-specific pre-find module path hook.
@@ -24,6 +24,7 @@ import sys
 from PyInstaller.utils.hooks import logger
 from PyInstaller import compat
 
+
 def pre_find_module_path(api):
     # Absolute path of the system-wide "distutils" package when run from within
     # a venv or None otherwise.
@@ -38,8 +39,8 @@ def pre_find_module_path(api):
         system_module_path = os.path.join(compat.base_prefix, 'Lib')
     else:
         system_module_path = os.path.join(compat.base_prefix, 'lib',
-            'python' + sys.version[:3])
+                                          'python' + sys.version[:3])
 
     api.search_dirs = [system_module_path]
     logger.info('distutils: retargeting to non-venv dir %r',
-        system_module_path)
+                system_module_path)

--- a/PyInstaller/hooks/pre_find_module_path/hook-distutils.py
+++ b/PyInstaller/hooks/pre_find_module_path/hook-distutils.py
@@ -19,28 +19,23 @@ the latter is intended for use _only_ from within venvs.
 
 import distutils
 import os
-import sys
 
 from PyInstaller.utils.hooks import logger
-from PyInstaller import compat
 
 
 def pre_find_module_path(api):
     # Absolute path of the system-wide "distutils" package when run from within
     # a venv or None otherwise.
 
-    if not compat.is_venv:
-        return
+    # opcode is not a virtualenv module, so we can use it to find the stdlib
+    # Technique taken from virtualenv's "distutils" package detection at
+    # https://github.com/pypa/virtualenv/blob/0ab032ce1a/virtualenv_embedded/distutils-init.py#L5
+    import opcode
 
-    # According to python docs, the system libraries should be in
-    # <sys.prefix>/lib/pythonX.Y, but this doesn't seem to be the
-    # case in windows...
-    if compat.is_win:
-        system_module_path = os.path.join(compat.base_prefix, 'Lib')
-    else:
-        system_module_path = os.path.join(compat.base_prefix, 'lib',
-                                          'python' + sys.version[:3])
-
-    api.search_dirs = [system_module_path]
-    logger.info('distutils: retargeting to non-venv dir %r',
-                system_module_path)
+    system_module_path = os.path.normpath(os.path.dirname(opcode.__file__))
+    loaded_module_path = os.path.normpath(os.path.dirname(distutils.__file__))
+    if system_module_path != loaded_module_path:
+        # Find this package in its parent directory.
+        api.search_dirs = [system_module_path]
+        logger.info('distutils: retargeting to non-venv dir %r',
+                    system_module_path)

--- a/PyInstaller/hooks/pre_find_module_path/hook-distutils.py
+++ b/PyInstaller/hooks/pre_find_module_path/hook-distutils.py
@@ -26,8 +26,15 @@ from PyInstaller.utils.hooks import logger
 def pre_find_module_path(api):
     # Absolute path of the system-wide "distutils" package when run from within
     # a venv or None otherwise.
-    distutils_dir = getattr(distutils, 'distutils_path', None)
-    if distutils_dir is not None:
+
+    # opcode is not a virtualenv module, so we can use it to find the stdlib
+    # Technique taken from virtualenv's "distutils" package detection at
+    # https://github.com/pypa/virtualenv/blob/0ab032ce1a/virtualenv_embedded/distutils-init.py#L5
+    import opcode
+
+    system_module_path = os.path.normpath(os.path.dirname(opcode.__file__))
+    loaded_module_path = os.path.normpath(os.path.dirname(distutils.__file__))
+    if system_module_path != loaded_module_path:
         # Find this package in its parent directory.
-        api.search_dirs = [os.path.dirname(distutils_dir)]
-        logger.info('distutils: retargeting to non-venv dir %r' % distutils_dir)
+        api.search_dirs = [system_module_path]
+        logger.info('distutils: retargeting to non-venv dir %r' % system_module_path)

--- a/news/4064.bugfix.rst
+++ b/news/4064.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed pre-find-module-path hook for `distutils` to be compatible with
+`virtualenv >= 16.3`.

--- a/news/4372.bugfix.rst
+++ b/news/4372.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed pre-find-module-path hook for `distutils` to be compatible with
+`virtualenv >= 16.3`.


### PR DESCRIPTION
When run in a venv, `distutils` present in the venv is not suitable for freezing, instead the system-wide `distutils` should be used. `pyinstaller` relies on a pre-find-module-path hook to change the search path to point to this system-wide `distutils` location.

To do this, it made use of a `distutils_path` attribute that was set in `virtualenv`, which pointed to the system-wide `distutils` dir. This `distutils_path` was never meant to be part `virtualenv`'s public api. Consequently, as part of a [change in `virtualenv 16.3`](https://github.com/pypa/virtualenv/pull/1289), this `distutils_path` points to the `__init.py__` of the system-wide `distutils` when run on python >= 3.4, as opposed to the dir. Consequently, the `os.path.dirname` used in the original hook returns the wrong result.

Rather than continuing to rely on the `distutils_path` attribute, I've tried to directly figure out where the system-wide python libs live using [the same technique `virtualenv` does](https://github.com/pypa/virtualenv/blob/0ab032ce1acc3b0d08893f493bd399b7e035514d/virtualenv_embedded/distutils-init.py#L5), by checking for the `opcode` module location.

Rather new to python hacking, so feedback welcome :)