### PR TITLE
hooks: Updating PySide2 hooks for QtWebEngine

### DIFF
--- a/PyInstaller/hooks/hook-PySide2.QtWebEngineWidgets.py
+++ b/PyInstaller/hooks/hook-PySide2.QtWebEngineWidgets.py
@@ -75,10 +75,9 @@ if pyside2_library_info.version:
             # ``os.path.join(*rel_data_path, remove_prefix(...``.
             (os.path.join(pyside2_locations['LibraryExecutablesPath'],
                           'QtWebEngineProcess*'),
-             os.path.join(*(rel_data_path +
-                            [get_relative_path_if_possible(
-                                pyside2_locations['LibraryExecutablesPath'],
-                                pyside2_locations['PrefixPath'] + '/')])))
+             os.path.join(*(rel_data_path + [get_relative_path_if_possible(
+                            pyside2_locations['LibraryExecutablesPath'],
+                            pyside2_locations['PrefixPath'] + '/')])))
         ]
 
     # Add Linux-specific libraries.

--- a/PyInstaller/hooks/hook-PySide2.QtWebEngineWidgets.py
+++ b/PyInstaller/hooks/hook-PySide2.QtWebEngineWidgets.py
@@ -7,7 +7,6 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-from sys import version_info
 import os
 from PyInstaller.utils.hooks.qt import add_qt5_dependencies, \
     pyside2_library_info
@@ -26,10 +25,10 @@ def get_relative_path_if_possible(actual, possible_prefix):
 
 
 def prefix_with_path(prefix_path, *paths):
-    if version_info > (3, 4):
-        return os.path.join(*prefix_path, *paths)  # noqa: E999
-    else:
+    if compat.is_py2:
         return os.path.join(*(prefix_path + list(paths)))
+    else:
+        return os.path.join(*prefix_path, *paths)  # noqa: E999
 
 
 # Ensure PySide2 is importable before adding info depending on it.

--- a/PyInstaller/hooks/hook-PySide2.QtWebEngineWidgets.py
+++ b/PyInstaller/hooks/hook-PySide2.QtWebEngineWidgets.py
@@ -8,7 +8,6 @@
 # -----------------------------------------------------------------------------
 
 import os
-import sys
 from PyInstaller.utils.hooks.qt import add_qt5_dependencies, pyside2_library_info
 from PyInstaller.utils.hooks import remove_prefix, get_module_file_attribute, \
     collect_system_data_files
@@ -33,7 +32,7 @@ if pyside2_library_info.version:
     # Include the web engine process, translations, and resources.
     # According to https://bugreports.qt.io/browse/PYSIDE-642?focusedCommentId=461015&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-461015,
     # there's no subdir for windows
-    if sys.platform == 'win32':
+    if compat.is_win:
         rel_data_path = ['PySide2']
     else:
         rel_data_path = ['PySide2', 'Qt']

--- a/PyInstaller/hooks/hook-PySide2.QtWebEngineWidgets.py
+++ b/PyInstaller/hooks/hook-PySide2.QtWebEngineWidgets.py
@@ -1,11 +1,11 @@
-# -----------------------------------------------------------------------------
+#-----------------------------------------------------------------------------
 # Copyright (c) 2014-2019, PyInstaller Development Team.
 #
 # Distributed under the terms of the GNU General Public License with exception
 # for distributing bootloader.
 #
 # The full license is in the file COPYING.txt, distributed with this software.
-# -----------------------------------------------------------------------------
+#-----------------------------------------------------------------------------
 
 import os
 from PyInstaller.utils.hooks.qt import add_qt5_dependencies, \
@@ -17,9 +17,7 @@ import PyInstaller.compat as compat
 
 
 def get_relative_path_if_possible(actual, possible_prefix):
-    actual_path = os.path.abspath(actual)
-    possible_prefix_path = os.path.abspath(possible_prefix)
-    possible_relative_path = os.path.relpath(actual_path, possible_prefix_path)
+    possible_relative_path = os.path.relpath(actual, possible_prefix)
     if possible_relative_path.startswith(os.pardir):
         return actual
     else:

--- a/PyInstaller/hooks/hook-PySide2.QtWebEngineWidgets.py
+++ b/PyInstaller/hooks/hook-PySide2.QtWebEngineWidgets.py
@@ -60,7 +60,7 @@ if pyside2_library_info.version:
                           locales),
              os.path.join(*(rel_data_path + ['translations',
                                              locales]))),
-            # Per the `docs 
+            # Per the `docs
             # <https://doc.qt.io/qt-5.10/qtwebengine-deploying.html#deploying-resources>`_,
             # ``DataPath`` is the base directory for ``resources``.
             #

--- a/PyInstaller/hooks/hook-PySide2.QtWebEngineWidgets.py
+++ b/PyInstaller/hooks/hook-PySide2.QtWebEngineWidgets.py
@@ -27,7 +27,7 @@ def get_relative_path_if_possible(actual, possible_prefix):
 
 def prefix_with_path(prefix_path, *paths):
     if version_info > (3, 4):
-        return os.path.join(*prefix_path, *paths)
+        return os.path.join(*prefix_path, *paths)  # noqa: E999
     else:
         return os.path.join(*(prefix_path + list(paths)))
 

--- a/PyInstaller/hooks/hook-PySide2.QtWebEngineWidgets.py
+++ b/PyInstaller/hooks/hook-PySide2.QtWebEngineWidgets.py
@@ -8,44 +8,82 @@
 #-----------------------------------------------------------------------------
 
 import os
-from PyInstaller.utils.hooks import collect_data_files, get_qmake_path
+import sys
+from pathlib import Path
+from PyInstaller.utils.hooks.qt import add_qt5_dependencies, pyside2_library_info
+from PyInstaller.utils.hooks import remove_prefix, get_module_file_attribute, \
+    collect_system_data_files
+from PyInstaller.depend.bindepend import getImports
 import PyInstaller.compat as compat
 
-hiddenimports = ['PySide2.QtCore',
-                 'PySide2.QtGui',
-                 'PySide2.QtNetwork',
-                 'PySide2.QtWebChannel',
-                 'PySide2.QtWebEngineCore',
-                 ]
+def get_relative_path_if_possible(actual, possible_prefix):
+    actual_path = Path(actual)
+    possible_prefix_path = Path(possible_prefix)
+    try:
+        return str(actual_path.relative_to(possible_prefix_path))
+    except:
+        return actual
 
-# Find the additional files necessary for QtWebEngine.
-datas = (collect_data_files('PySide2', True, os.path.join('Qt', 'resources')) +
-         collect_data_files('PySide2', True, os.path.join('Qt', 'translations')) +
-         [x for x in collect_data_files('PySide2', False, os.path.join('Qt', 'bin'))
-          if x[0].endswith('QtWebEngineProcess.exe')])
+# Ensure PySide2 is importable before adding info depending on it.
+if pyside2_library_info.version:
+    hiddenimports, binaries, datas = add_qt5_dependencies(__file__)
 
-# Note that for QtWebEngineProcess to be able to find icudtl.dat the bundle_identifier
-# must be set to 'org.qt-project.Qt.QtWebEngineCore'. This can be done by passing
-# bundle_identifier='org.qt-project.Qt.QtWebEngineCore' to the BUNDLE command in
-# the .spec file. FIXME: This is not ideal and a better solution is required.
-qmake = get_qmake_path('5')
-if qmake:
-    libdir = compat.exec_command(qmake, "-query", "QT_INSTALL_LIBS").strip()
-
+    # Include the web engine process, translations, and resources.
+    # According to https://bugreports.qt.io/browse/PYSIDE-642?focusedCommentId=461015&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-461015,
+    # there's no subdir for windows
+    rel_data_path = ['PySide2'] if sys.platform == 'win32' else ['PySide2', 'Qt']
     if compat.is_darwin:
-        binaries = [
-            (os.path.join(libdir, 'QtWebEngineCore.framework', 'Versions', '5',
-                          'Helpers', 'QtWebEngineProcess.app', 'Contents', 'MacOS', 'QtWebEngineProcess'),
-             os.path.join('QtWebEngineProcess.app', 'Contents', 'MacOS'))
+        # This is based on the layout of the Mac wheel from PyPi.
+        data_path = pyside2_library_info.location['DataPath']
+        libraries = ['QtCore', 'QtWebEngineCore', 'QtQuick', 'QtQml', 'QtNetwork',
+                     'QtGui', 'QtWebChannel', 'QtPositioning']
+        for i in libraries:
+            datas += collect_system_data_files(
+                os.path.join(data_path, 'lib', i + '.framework'),
+                os.path.join(*(rel_data_path + ['lib'])), True)
+        datas += [(os.path.join(data_path, 'lib', 'QtWebEngineCore.framework',
+                                'Resources'), os.curdir)]
+    else:
+        locales = 'qtwebengine_locales'
+        resources = 'resources'
+        datas += [
+            # Gather translations needed by Chromium.
+            (os.path.join(pyside2_library_info.location['TranslationsPath'], locales),
+             os.path.join(*(rel_data_path + ['translations', locales]))),
+            # Per the `docs <https://doc.qt.io/qt-5.10/qtwebengine-deploying.html#deploying-resources>`_,
+            # ``DataPath`` is the base directory for ``resources``.
+            #
+            # When Python 3.4 goes EOL (see `PEP 448`_, this is better written as
+            # ``os.path.join(*rel_data_path, resources)``.
+            (os.path.join(pyside2_library_info.location['DataPath'], resources),
+             os.path.join(*(rel_data_path + [resources]))),
+            # Include the webengine process. The ``LibraryExecutablesPath`` is only
+            # valid on Windows and Linux.
+            #
+            # Again, rewrite when Python 3.4 is EOL to
+            # ``os.path.join(*rel_data_path, remove_prefix(...``.
+            (os.path.join(pyside2_library_info.location['LibraryExecutablesPath'],
+                          'QtWebEngineProcess*'),
+             os.path.join(*(rel_data_path +
+                          [get_relative_path_if_possible(pyside2_library_info.location['LibraryExecutablesPath'],
+                                        pyside2_library_info.location['PrefixPath'] + '/')])))
         ]
 
-        resources_dir = os.path.join(libdir, 'QtWebEngineCore.framework', 'Versions', '5', 'Resources')
-        datas += [
-            (os.path.join(resources_dir, 'icudtl.dat'), '.'),
-            (os.path.join(resources_dir, 'qtwebengine_resources.pak'), '.'),
-            # The distributed Info.plist has LSUIElement set to true, which prevents the
-            # icon from appearing in the dock.
-            (os.path.join(libdir, 'QtWebEngineCore.framework', 'Versions', '5',
-                          'Helpers', 'QtWebEngineProcess.app', 'Contents', 'Info.plist'),
-             os.path.join('QtWebEngineProcess.app', 'Contents'))
-        ]
+    # Add Linux-specific libraries.
+    if compat.is_linux:
+        # The automatic library detection fails for `NSS
+        # <https://packages.ubuntu.com/search?keywords=libnss3>`_, which is used by
+        # QtWebEngine. In some distributions, the ``libnss`` supporting libraries
+        # are stored in a subdirectory ``nss``. Since ``libnss`` is not statically
+        # linked to these, but dynamically loads them, we need to search for and add
+        # them.
+        #
+        # First, get all libraries linked to ``PyQt5.QtWebEngineWidgets``.
+        for imp in getImports(get_module_file_attribute('PySide2.QtWebEngineWidgets')):
+            # Look for ``libnss3.so``.
+            if os.path.basename(imp).startswith('libnss3.so'):
+                # Find the location of NSS: given a ``/path/to/libnss.so``,
+                # add ``/path/to/nss/*.so`` to get the missing NSS libraries.
+                nss_subdir = os.path.join(os.path.dirname(imp), 'nss')
+                if os.path.exists(nss_subdir):
+                    binaries.append((os.path.join(nss_subdir, '*.so'), 'nss'))

--- a/PyInstaller/hooks/hook-PySide2.py
+++ b/PyInstaller/hooks/hook-PySide2.py
@@ -6,24 +6,24 @@
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
-import os.path
+from os import path, curdir
 
 from PyInstaller.utils.hooks import collect_system_data_files
 from PyInstaller.utils.hooks.qt import pyside2_library_info, get_qt_binaries
-import PyInstaller.compat as compat
+from PyInstaller.compat import is_win
 
 hiddenimports = ['shiboken2']
 
 # Collect the ``qt.conf`` file.
-if compat.is_win:
-    target_qt_conf_dir = '.'
+if is_win:
+    target_qt_conf_dir = curdir
 else:
     target_qt_conf_dir = 'PySide2'
 
 datas = [x for x in
          collect_system_data_files(pyside2_library_info.location['PrefixPath'],
                                    target_qt_conf_dir)
-         if os.path.basename(x[0]) == 'qt.conf']
+         if path.basename(x[0]) == 'qt.conf']
 
 # Collect required Qt binaries.
 binaries = get_qt_binaries(pyside2_library_info)

--- a/PyInstaller/hooks/hook-PySide2.py
+++ b/PyInstaller/hooks/hook-PySide2.py
@@ -6,8 +6,8 @@
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
-from os import path, curdir
 
+import os
 from PyInstaller.utils.hooks import collect_system_data_files
 from PyInstaller.utils.hooks.qt import pyside2_library_info, get_qt_binaries
 from PyInstaller.compat import is_win
@@ -16,14 +16,14 @@ hiddenimports = ['shiboken2']
 
 # Collect the ``qt.conf`` file.
 if is_win:
-    target_qt_conf_dir = curdir
+    target_qt_conf_dir = os.curdir
 else:
     target_qt_conf_dir = 'PySide2'
 
 datas = [x for x in
          collect_system_data_files(pyside2_library_info.location['PrefixPath'],
                                    target_qt_conf_dir)
-         if path.basename(x[0]) == 'qt.conf']
+         if os.path.basename(x[0]) == 'qt.conf']
 
 # Collect required Qt binaries.
 binaries = get_qt_binaries(pyside2_library_info)

--- a/PyInstaller/hooks/hook-PySide2.py
+++ b/PyInstaller/hooks/hook-PySide2.py
@@ -16,9 +16,9 @@ hiddenimports = ['shiboken2']
 
 # Collect the ``qt.conf`` file.
 if compat.is_win:
-	target_qt_conf_dir = '.'
+    target_qt_conf_dir = '.'
 else:
-	target_qt_conf_dir = 'PySide2'
+    target_qt_conf_dir = 'PySide2'
 
 datas = [x for x in
          collect_system_data_files(pyside2_library_info.location['PrefixPath'],

--- a/PyInstaller/hooks/hook-PySide2.py
+++ b/PyInstaller/hooks/hook-PySide2.py
@@ -10,13 +10,18 @@ import os.path
 
 from PyInstaller.utils.hooks import collect_system_data_files
 from PyInstaller.utils.hooks.qt import pyside2_library_info, get_qt_binaries
+import PyInstaller.compat as compat
 
 hiddenimports = ['shiboken2']
 
 # Collect the ``qt.conf`` file.
+target_qt_conf_dir = 'PySide2'
+if compat.is_win:
+	target_qt_conf_dir = '.'
+
 datas = [x for x in
          collect_system_data_files(pyside2_library_info.location['PrefixPath'],
-                                   'PySide2')
+                                   target_qt_conf_dir)
          if os.path.basename(x[0]) == 'qt.conf']
 
 # Collect required Qt binaries.

--- a/PyInstaller/hooks/hook-PySide2.py
+++ b/PyInstaller/hooks/hook-PySide2.py
@@ -15,9 +15,10 @@ import PyInstaller.compat as compat
 hiddenimports = ['shiboken2']
 
 # Collect the ``qt.conf`` file.
-target_qt_conf_dir = 'PySide2'
 if compat.is_win:
 	target_qt_conf_dir = '.'
+else:
+	target_qt_conf_dir = 'PySide2'
 
 datas = [x for x in
          collect_system_data_files(pyside2_library_info.location['PrefixPath'],

--- a/PyInstaller/loader/rthooks/pyi_rth_pyside2webengine.py
+++ b/PyInstaller/loader/rthooks/pyi_rth_pyside2webengine.py
@@ -10,10 +10,9 @@
 import os
 import sys
 
-# See ``pyi_rth_qt5.py`: use a "standard" PyQt5 layout.
 if sys.platform == 'darwin':
     os.environ['QTWEBENGINEPROCESS_PATH'] = os.path.normpath(os.path.join(
-        sys._MEIPASS, '..', 'MacOS', 'PySide2', 'Qt', 'lib',
+        sys._MEIPASS, 'PySide2', 'Qt', 'lib',
         'QtWebEngineCore.framework', 'Helpers', 'QtWebEngineProcess.app',
         'Contents', 'MacOS', 'QtWebEngineProcess'
     ))

--- a/news/4377.bugfix.rst
+++ b/news/4377.bugfix.rst
@@ -1,3 +1,0 @@
-Update hooks related to PySide2.QtWebEngineWidgets, ensure the relevant
-supporting files required for a QtWebEngineView are copied into the 
-distribution.

--- a/news/4377.bugfix.rst
+++ b/news/4377.bugfix.rst
@@ -1,0 +1,3 @@
+Update hooks related to PySide2.QtWebEngineWidgets, ensure the relevant
+supporting files required for a QtWebEngineView are copied into the 
+distribution.

--- a/news/4377.hooks.rst
+++ b/news/4377.hooks.rst
@@ -1,0 +1,3 @@
+Update hooks related to PySide2.QtWebEngineWidgets, ensure the relevant
+supporting files required for a QtWebEngineView are copied into the
+distribution.

--- a/tests/functional/data/PySide2_QWebEngine/test_web_page.html
+++ b/tests/functional/data/PySide2_QWebEngine/test_web_page.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang=en>
+    <head>
+        <meta charset=utf-8>
+        <title>Test web page</title>
+    </head>
+    <body>
+        <p>This is a test web page.</p>
+    </body>
+</html>

--- a/tests/functional/data/PySide2_QWebEngine/test_web_page.html
+++ b/tests/functional/data/PySide2_QWebEngine/test_web_page.html
@@ -1,10 +1,11 @@
 <!doctype html>
-<html lang=en>
+<html lang="en">
     <head>
-        <meta charset=utf-8>
+        <meta charset="utf-8">
         <title>Test web page</title>
     </head>
     <body>
-        <p>This is a test web page.</p>
+        <p>This is a test web page with internationalised characters.</p>
+        <p>HЯ⾀ÄÉÖÜ</p>
     </body>
 </html>

--- a/tests/functional/test_libraries.py
+++ b/tests/functional/test_libraries.py
@@ -435,7 +435,7 @@ def test_Qt5_QTranslate(pyi_builder, monkeypatch, QtPyLib):
 @importorskip('PySide2')
 def test_PySide2_QWebEngine(pyi_builder, data_dir):
     if is_darwin:
-        # QWebEngine on OS X only work with a onedir build -- onefile builds 
+        # QWebEngine on OS X only work with a onedir build -- onefile builds
         # don't work. Skip the test execution for onefile builds.
         if pyi_builder._mode != 'onedir':
             pytest.skip('The QWebEngine .app bundle '

--- a/tests/functional/test_libraries.py
+++ b/tests/functional/test_libraries.py
@@ -435,7 +435,7 @@ def test_Qt5_QTranslate(pyi_builder, monkeypatch, QtPyLib):
 @importorskip('PySide2')
 def test_PySide2_QWebEngine(pyi_builder, data_dir):
     if is_darwin:
-        # QWebEngine on OS X only work with a onedir build -- onefile builds
+        # QWebEngine on OS X only works with a onedir build -- onefile builds
         # don't work. Skip the test execution for onefile builds.
         if pyi_builder._mode != 'onedir':
             pytest.skip('The QWebEngine .app bundle '

--- a/tests/functional/test_libraries.py
+++ b/tests/functional/test_libraries.py
@@ -407,6 +407,13 @@ def test_PyQt5_Qt(pyi_builder):
 
 @importorskip('PySide2')
 def test_PySide2_QWebEngine(pyi_builder, data_dir):
+    if is_darwin:
+        # This tests running the QWebEngine on OS X. To do so, the test must
+        # run only a onedir build -- onefile builds don't work.
+        if pyi_builder._mode != 'onedir':
+            pytest.skip('The QWebEngine .app bundle '
+                        'only supports onedir mode.')
+
     pyi_builder.test_source(get_QWebEngine_html('PySide2', data_dir),
                             **USE_WINDOWED_KWARG)
 

--- a/tests/functional/test_libraries.py
+++ b/tests/functional/test_libraries.py
@@ -405,7 +405,6 @@ def test_PyQt5_Qt(pyi_builder):
                             **USE_WINDOWED_KWARG)
 
 
-@xfail(True, reason="Hook is old and needs updating.")
 @importorskip('PySide2')
 def test_PySide2_QWebEngine(pyi_builder, data_dir):
     pyi_builder.test_source(get_QWebEngine_html('PySide2', data_dir),


### PR DESCRIPTION
There existing PySide2 QtWebEngine hooks seem to be outdated. In particular, the expected location for supporting files like locales, processes, etc. differ between platforms and from the more mature `PyQt5` module. As a result, they are not copied into the distribution folder correctly because they can't be found. 

For example, the windows layout for the `PySide2` module does not have a `Qt` subdirectory, so many files are not copied over with the [existing hook](https://github.com/pyinstaller/pyinstaller/compare/develop...tangm:4331-missing-pyside2-qtwebengine-files?expand=1#diff-a97672366bee4f42c1427c26d31f099bL21-L25).

This tries to adapt the more updated `PyQt5` hook for `PySide2`, taking into account some input from the [official QT for python bugtracker](https://bugreports.qt.io/browse/PYSIDE-642), like the [suggested windows layout](https://bugreports.qt.io/browse/PYSIDE-642?focusedCommentId=461015&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-461015). 

I'm not familiar enough with QT or its Python bindings to know what the blessed approach is, just working off my observations, so any feedback or suggestions welcome!