### PR TITLE
loader.pyiboot01: add renamed env var to replace VIRTUAL_ENV

### DIFF
--- a/PyInstaller/loader/pyiboot01_bootstrap.py
+++ b/PyInstaller/loader/pyiboot01_bootstrap.py
@@ -47,12 +47,24 @@ sys.base_exec_prefix = sys.exec_prefix
 # Some packages behaves differently when running inside virtual environment.
 # E.g. IPython tries to append path VIRTUAL_ENV to sys.path.
 # For the frozen app we want to prevent this behavior.
-VIRTENV = 'VIRTUAL_ENV'
-if VIRTENV in os.environ:
+#
+# But, even though we have enough reason to delete VIRTUAL_ENV in environment,
+# we should still keep the original data for those who relies on it essentially,
+# provide another way to access it when necessary.
+preserved_env_prefix = 'PYINSTALLER_PRESERVED_'  # could be used for other preserved env in the future
+env_virtual_env = 'VIRTUAL_ENV'
+preserved_env_virtual_env = preserved_env_prefix + env_virtual_env
+
+# NOTE the best way to decide which environment variables to preserve is by
+# passing an option `--preserve-env` to pyinstaller or spec file, then store
+# the preserved ones in the bundle app, get them here to loop and handle,
+# this is intended to be implemented in this feature branch.
+if env_virtual_env in os.environ:
     # On some platforms (e.g. AIX) 'os.unsetenv()' is not available and then
     # deleting the var from os.environ does not delete it from the environment.
-    os.environ[VIRTENV] = ''
-    del os.environ[VIRTENV]
+    os.environ[preserved_env_virtual_env] = os.environ[env_virtual_env]
+    os.environ[env_virtual_env] = ''
+    del os.environ[env_virtual_env]
 
 
 # Ensure sys.path contains absolute paths. Otherwise import of other python


### PR DESCRIPTION
even though we have enough reason to delete VIRTUAL_ENV in environment,
we should still keep the original data for those who relies on it essentially,
provide another way to access it when necessary.