### PR TITLE
Hook: Add hook for the google-cloud-kms client library

### DIFF
--- a/PyInstaller/hooks/hook-google.cloud.kms_v1.py
+++ b/PyInstaller/hooks/hook-google.cloud.kms_v1.py
@@ -1,0 +1,15 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2017-2019, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+# Client library URL: https://googleapis.dev/python/cloudkms/latest/
+# Import Example for client library:
+# https://cloud.google.com/kms/docs/reference/libraries#client-libraries-install-python
+
+from PyInstaller.utils.hooks import copy_metadata
+datas = copy_metadata('google-cloud-kms')

--- a/news/4408.hooks.rst
+++ b/news/4408.hooks.rst
@@ -1,0 +1,1 @@
+Add hook for the google-cloud-kms client library.


### PR DESCRIPTION
The google-cloud-kms client library requires a hook in order to be packaged into an executable with PyInstaller

Client library URL: https://googleapis.dev/python/cloudkms/latest/index.html#
Import Example for client library: https://cloud.google.com/kms/docs/reference/libraries#client-libraries-install-python