### PR TITLE
Fix MSYS2 dll's are not found by modulegraph

### DIFF
--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -230,9 +230,7 @@ class PKG(Target):
                 # file is contained within python egg, it is added with the egg
                 continue
             if typ in ('BINARY', 'EXTENSION', 'DEPENDENCY'):
-                if self.exclude_binaries and typ != 'DEPENDENCY':
-                    self.dependencies.append((inm, fnm, typ))
-                else:
+                if not self.exclude_binaries:
                     if typ == 'BINARY':
                         # Avoid importing the same binary extension twice. This might
                         # happen if they come from different sources (eg. once from

--- a/PyInstaller/lib/modulegraph/modulegraph.py
+++ b/PyInstaller/lib/modulegraph/modulegraph.py
@@ -89,6 +89,9 @@ _IMPORTABLE_FILETYPE_TO_METADATA = {
     filetype: (filetype, open_mode, imp_type)
     for filetype, open_mode, imp_type in imp.get_suffixes()
 }
+# Reverse sort by length so when comparing filenames the longest match first
+_IMPORTABLE_FILETYPE_EXTS = sorted(_IMPORTABLE_FILETYPE_TO_METADATA,
+                                   key=lambda p: len(p), reverse=True)
 """
 Dictionary mapping the filetypes of importable files to the 3-tuple of metadata
 describing such files returned by the `imp.get_suffixes()` function whose first
@@ -102,16 +105,20 @@ including:
 * C extensions suffixed by the platform-specific shared library filetype (e.g.,
   `.so` under Linux, `.dll` under Windows).
 
-The keys of this dictionary are `.`-prefixed filetypes (e.g., `.py`, `.so');
+The keys of this dictionary are `.`-prefixed filetypes (e.g., `.py`, `.so`) or
+`-`-prefixed filetypes (e.g., `-cpython-37m.dll`[1]);
 the values of this dictionary are 3-tuples whose:
 
-1. First element is the same `.`-prefixed filetype.
+1. First element is the same `.` or `-` prefixed filetype.
 1. Second element is the mode to be passed to the `open()` built-in to open
    files of that filetype under the current platform and Python interpreter
    (e.g., `rU` for the `.py` filetype under Python 2, `r` for the same
    filetype under Python 3).
 1. Third element is a magic number specific to the `imp` module (e.g.,
    `imp.C_EXTENSION` for filetypes corresponding to C extensions).
+
+[1] For example of `-cpython-m37.dll` search on
+    https://packages.msys2.org/package/mingw-w64-x86_64-python3?repo=mingw64
 """
 
 
@@ -3091,8 +3098,16 @@ class ModuleGraph(ObjectGraph):
                 # Else, this is either a module or C extension.
                 else:
                     # In either case, this path must have a filetype.
-                    filetype = os.path.splitext(pathname)[1]
-                    if not filetype:
+                    # os.path.splitext won't work here since we sometimes need
+                    # to match more than just the file extension.
+                    filetype = [filetype
+                                for filetype in _IMPORTABLE_FILETYPE_EXTS
+                                if pathname.endswith(filetype)]
+                    if filetype:
+                        # at least one extension matched,
+                        # pick the first (longest) one
+                        filetype = filetype[0]
+                    else:
                         raise ImportError(
                             'Non-package module %r path %r has no filetype' % (module_name, pathname))
 

--- a/news/4125.bugfix.rst
+++ b/news/4125.bugfix.rst
@@ -1,0 +1,1 @@
+(Windows) Fix MSYS2 dll's are not found by modulegraph.

--- a/news/4417.bugfix.rst
+++ b/news/4417.bugfix.rst
@@ -1,0 +1,1 @@
+(Windows) Fix MSYS2 dll's are not found by modulegraph.


### PR DESCRIPTION
Fixes: #4125

This PR replaces #4240 that was never finished by updating the commit messages to be more descriptive and adding a changelog entry.

1. MINGW Python packages in MSYS2 name Windows dll files with a -cpython-37m.dll extension. Loading a Python module that depends on a dll, for example struct and zlib, results in a ModuleNotFoundError since modulegraph is not looking for files with this naming convention.

2. Fixes double processing of dependencencies when using COLLECT after EXE. When processing of MINGW Python dll files, this results in corrupted file paths, for example when processing the _struct
dll the resulting filepath is dllruct-cpython-37m/_struct-cpython-37m.dll instead of just
_struct-cpython-37m.dll.
