### PR TITLE
added hidden import of newer netcdf4 version

### DIFF
--- a/PyInstaller/hooks/hook-netCDF4.py
+++ b/PyInstaller/hooks/hook-netCDF4.py
@@ -8,5 +8,5 @@
 #-----------------------------------------------------------------------------
 
 
-# netCDF4 (tested with v.1.1.9) has some hidden imports
-hiddenimports = ['netCDF4.utils', 'netcdftime']
+# netCDF4 (tested with v.1.5.1.2) has some hidden imports
+hiddenimports = ['netCDF4.utils', 'netcdftime', 'cftime']


### PR DESCRIPTION
Current `netcdf4` version is `1.5.1.2`. Hook does not contains one of hidden imports. This PR fixes the hook for `netcdf4`. 

Without this change try to bundle this snippet and launch the binary: 

```
from netCDF4 import Dataset
import json

# example showing how python objects (lists, dicts, None, True)
# can be serialized as strings, saved as netCDF attributes,
# and then converted back to python objects using json.
ds = Dataset('json.nc', 'w')
ds.pythonatt1 = json.dumps([u'foo', {u'bar': [u'baz', None, 1.0, 2]}])
ds.pythonatt2 = "true"  # converted to bool
ds.pythonatt3 = "null"  # converted to None
print(ds)
ds.close()
ds = Dataset('json.nc')


def convert_json(s):
    try:
        a = json.loads(s)
        return a
    except:
        return s


x = convert_json(ds.pythonatt1)
print(type(x))
print(x)
print(convert_json(ds.pythonatt2))
print(convert_json(ds.pythonatt3))
ds.close()
```

You will receive the following error: 
```
..............
  File "site-packages\netCDF4\__init__.py", line 3, in <module>
  File "netCDF4\_netCDF4.pyx", line 1197, in init netCDF4._netCDF4
ModuleNotFoundError: No module named 'cftime'
[19380] Failed to execute script main
```