### PR TITLE
Handle explicit namespace packages correctly

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -68,4 +68,4 @@ exclude =
    bootloader
 show-source = True
 # E265 - block comment should start with '# '
-ignore = E265
+ignore = E265,W503

--- a/tests/functional/modules/nspkg-explicit/path1/package/__init__.py
+++ b/tests/functional/modules/nspkg-explicit/path1/package/__init__.py
@@ -1,0 +1,2 @@
+from pkgutil import extend_path
+__path__ = extend_path(__path__, __name__)

--- a/tests/functional/modules/nspkg-explicit/path1/package/sub2.py
+++ b/tests/functional/modules/nspkg-explicit/path1/package/sub2.py
@@ -1,0 +1,1 @@
+""" package.sub2 """

--- a/tests/functional/modules/nspkg-explicit/path2/package/__init__.py
+++ b/tests/functional/modules/nspkg-explicit/path2/package/__init__.py
@@ -1,0 +1,2 @@
+from pkgutil import extend_path
+__path__ = extend_path(__path__, __name__)

--- a/tests/functional/modules/nspkg-explicit/path2/package/nspkg/mod.py
+++ b/tests/functional/modules/nspkg-explicit/path2/package/nspkg/mod.py
@@ -1,0 +1,1 @@
+""" package.nspkg.mod """

--- a/tests/functional/modules/nspkg-explicit/path2/package/sub1.py
+++ b/tests/functional/modules/nspkg-explicit/path2/package/sub1.py
@@ -1,0 +1,1 @@
+""" package.sub1 """

--- a/tests/functional/modules/nspkg-explicit/path2/package/subpackage/__init__.py
+++ b/tests/functional/modules/nspkg-explicit/path2/package/subpackage/__init__.py
@@ -1,0 +1,1 @@
+""" package.subpackage """

--- a/tests/functional/modules/nspkg-explicit/path2/package/subpackage/sub.py
+++ b/tests/functional/modules/nspkg-explicit/path2/package/subpackage/sub.py
@@ -1,0 +1,1 @@
+""" package.subpackage.sub """

--- a/tests/functional/test_import.py
+++ b/tests/functional/test_import.py
@@ -568,6 +568,26 @@ def test_nspkg_pep420(pyi_builder):
     )
 
 
+def test_nspkg_explicit(pyi_builder):
+    # Test inclusion of "explicit" (pkgutil.extend_path or
+    # pkg_resources_declare_namespace-style) namespace packages
+    # Note that mixing pkgutil-style explicit namespace packages with implicit
+    # namespace packages is valid, so we test that here as well. Implicit
+    # namespace pacakges are not supported under Python 3.3 though, so
+    # we skip that part of the test on older Python versions.
+    pathex = glob.glob(os.path.join(_MODULES_DIR, 'nspkg-explicit', 'path*'))
+    pyi_builder.test_source(
+        """
+        import package.sub1
+        import package.sub2
+        import package.subpackage.sub
+        import sys;
+        if sys.version_info[:2] > (3, 2):
+            import package.nspkg.mod
+        """,
+        pyi_args=['--paths', os.pathsep.join(pathex)],
+    )
+
 #--- hooks related stuff ---
 
 def test_pkg_without_hook_for_pkg(pyi_builder, script_dir):


### PR DESCRIPTION
Explicit namespace packages contain a `__init__.py` file and use either
`pkgutil.extend_path` or `pkg_resources.declare_namespace`. These are
currently not handled by PyInstaller.

A namespace package is only special in the sense that it has multiple
entries in the `__path__` attribute, which means that without actually
importing the package the only way to tell if it is a namespace package
is by looking at the contents of the `__init__.py` file. This is
implemented based on the code in
https://github.com/PyCQA/astroid/blob/6076874993b26b141f4adfbcf2a48e703d84298f/astroid/interpreter/_import/spec.py#L236.

Resolves #4425 