### PR TITLE
Fix strip_paths_in_code() for Python 3.8

### DIFF
--- a/PyInstaller/building/utils.py
+++ b/PyInstaller/building/utils.py
@@ -657,8 +657,10 @@ def strip_paths_in_code(co, new_filename=None):
         for const_co in co.co_consts
     )
 
+    if hasattr(co, 'co_posonlyargcount'):
+        return co.replace(co_consts=consts)
     # co_kwonlyargcount added in some version of Python 3
-    if hasattr(co, 'co_kwonlyargcount'):
+    elif hasattr(co, 'co_kwonlyargcount'):
         return code_func(co.co_argcount, co.co_kwonlyargcount, co.co_nlocals, co.co_stacksize,
                      co.co_flags, co.co_code, consts, co.co_names,
                      co.co_varnames, new_filename, co.co_name,

--- a/news/4440.bugfix.rst
+++ b/news/4440.bugfix.rst
@@ -1,0 +1,6 @@
+Port PyInstaller to Python 3.8: use the new ``CodeType.replace()`` method if
+available. The ``CodeType`` constructor has new mandatory parameters in Python
+3.8: see `PEP 570: Positional-Only Parameters
+<https://www.python.org/dev/peps/pep-0570/>`_. Using ``CodeType.replace()``,
+PyInstaller doesn't have to be updated anymore when ``CodeType`` constructor
+changes.


### PR DESCRIPTION
strip_paths_in_code() now uses CodeType.replace() if available to
support the new CodeType construction (PEP 570: Positional-Only
Parameters).

Co-Authored-By: Pablo Galindo Pablogsal@gmail.com