### PR TITLE
Fix pyi_locale_char2wchar() for debug Python

### DIFF
--- a/bootloader/src/pyi_python.c
+++ b/bootloader/src/pyi_python.c
@@ -74,6 +74,7 @@ DECLPROC(PySys_SetPath);
 DECLPROC(PyUnicode_FromString);
 
 DECLPROC(Py_DecodeLocale);
+DECLPROC(PyMem_RawFree);
 DECLPROC(PyString_FromFormat);
 DECLPROC(PyUnicode_FromFormat);
 DECLPROC(PyUnicode_DecodeFSDefault);
@@ -154,6 +155,7 @@ pyi_python_map_names(HMODULE dll, int pyvers)
         else {
             GETPROC_RENAMED(dll, Py_DecodeLocale, _Py_char2wchar);
         };
+        GETPROC(dll, PyMem_RawFree);
     }
     ;
 

--- a/bootloader/src/pyi_python.h
+++ b/bootloader/src/pyi_python.h
@@ -138,6 +138,7 @@ EXTDECLPROC(int, PySys_SetObject, (char *, PyObject *));
  * On Python 3.0-3.4, this function was called _Py_char2wchar
  */
 EXTDECLPROC(wchar_t *, Py_DecodeLocale, (char *, size_t *));
+EXTDECLPROC(void, PyMem_RawFree, (void *));
 
 /* Used to add PYZ to sys.path */
 EXTDECLPROC(PyObject *, PySys_GetObject, (const char *));

--- a/bootloader/src/pyi_pythonlib.c
+++ b/bootloader/src/pyi_pythonlib.c
@@ -239,7 +239,7 @@ pyi_free_wargv(wchar_t ** wargv)
     wchar_t ** arg = wargv;
 
     while (arg[0]) {
-        free(arg[0]);
+        PI_PyMem_RawFree(arg[0]);
         arg++;
     }
     free(wargv);

--- a/bootloader/src/pyi_pythonlib.c
+++ b/bootloader/src/pyi_pythonlib.c
@@ -379,7 +379,7 @@ pyi_locale_char2wchar(wchar_t * dst, char * src, size_t len)
         return NULL;
     }
     wcsncpy(dst, buffer, len);
-    free(buffer);
+    PI_PyMem_RawFree(buffer);
     return dst;
 #endif /* ifdef _WIN32 */
 }

--- a/news/4441.bugfix.rst
+++ b/news/4441.bugfix.rst
@@ -1,0 +1,5 @@
+Port PyInstaller to Python 3.8: release strings allocated by `Py_DecodeLocale()
+<https://docs.python.org/dev/c-api/sys.html#c.Py_DecodeLocale>`__ using
+`PyMem_RawFree()
+<https://docs.python.org/dev/c-api/memory.html#c.PyMem_RawFree>`__ rather than
+``free()``.

--- a/news/4441.bugfix.rst
+++ b/news/4441.bugfix.rst
@@ -1,4 +1,5 @@
-Port PyInstaller to Python 3.8: release strings allocated by `Py_DecodeLocale()
+Fix PyInstaller for Python compiled in debug mode: release strings allocated by
+`Py_DecodeLocale()
 <https://docs.python.org/dev/c-api/sys.html#c.Py_DecodeLocale>`__ using
 `PyMem_RawFree()
 <https://docs.python.org/dev/c-api/memory.html#c.PyMem_RawFree>`__ rather than


### PR DESCRIPTION
Fix pyi_locale_char2wchar(): Py_DecodeLocale() result must be freed
by PyMem_RawFree(), not directly by free().

When Python is built in debug mode, PyMem_RawFree() uses debug hooks
on top of malloc()/free(). Same error occurs when PYTHONMALLOC=debug
environment variable is used on a release build of Python.

Co-Authored-By: Pablo Galindo <Pablogsal@gmail.com>