### PR TITLE
Hooks: hook-PyQt5 tries to put qt.conf out of dist directory on Linux

### DIFF
--- a/PyInstaller/hooks/hook-PyQt5.py
+++ b/PyInstaller/hooks/hook-PyQt5.py
@@ -21,10 +21,16 @@ if pyqt5_library_info.version:
     ]
 
     # Collect the ``qt.conf`` file.
-    datas = [x for x in
-             collect_system_data_files(pyqt5_library_info.location['PrefixPath'],
-                                       'PyQt5')
-             if os.path.basename(x[0]) == 'qt.conf']
+    system_data_files = collect_system_data_files(pyqt5_library_info.location['PrefixPath'], 'PyQt5')
+    datas = []
+    for source, dest in system_data_files:
+        if os.path.basename(source) == 'qt.conf':
+            # 'dest' on Linux is returned as an absolute path (same as the source)
+            # while on Windows we have 'dest' as relative.
+            # However we should place qt.conf along with the main executable
+            # as per the Qt docs.
+            datas.append((source, '.'))
+            break
 
     # Collect required Qt binaries.
     binaries = get_qt_binaries(pyqt5_library_info)


### PR DESCRIPTION
On Debian SID building a PyQt5 app fails with the error message:

Security-Alert: try to store file outside of dist-directory. Aborting.
'/usr/lib/x86_64-linux-gnu/qt5/qt.conf'

The qt.conf destination should be "the directory containing the
application executable" as per the Qt docs.