### PR TITLE
Bootloader: Parse ELF headers to find pydata section

### DIFF
--- a/news/4450.bootloader.rst
+++ b/news/4450.bootloader.rst
@@ -1,0 +1,3 @@
+(Linux) The bootloader now parses ELF headers to find the embedded Python
+payload. This makes the bootloader more robust towards ELF modifications,
+like prelink or staticx, which could previously break the binary.


### PR DESCRIPTION
This PR replaces the "search for cookie from end of file" approach with a minimal ELF parser to find the pydata section.


## Rationale

On Linux the python payload is embedded in a custom ELF section called `pydata`. On execution the bootloader has to find this section in the binary.

Currently booloader searches the last 4096 + sizeof(COOKIE) bytes of the file for a magic string. This works sufficiently well under most circumstances, as the only section following the `pydata` section will be `.shstrtab`, which is usually only a few hundred bytes in size.

When using [staticx](https://github.com/JonathonReinhart/staticx) on a pyinstaller binary, staticx runs [patchelf](https://github.com/NixOS/patchelf) to adjust interpreter and rpath. Patchelf (sometimes) reorders the ELF sections of a binary. Depending on the amount of data ending up behind the pydata section the COOKIE can easily fall out of search range.

We spotted this problem on first on Ubuntu aarch64 JonathonReinhart/staticx#93.

Fixes #3441