### PR TITLE
Fix installation of Qt5 translations on Windows

### DIFF
--- a/PyInstaller/utils/hooks/qt.py
+++ b/PyInstaller/utils/hooks/qt.py
@@ -554,9 +554,7 @@ def add_qt5_dependencies(hook_file):
         if glob.glob(src):
             datas.append((
                 src, os.path.join(
-                    # The PySide2 Windows wheels place translations in a
-                    # different location.
-                    namespace, 'Qt' if is_PyQt5 and not is_win else '',
+                    namespace, 'Qt' if is_PyQt5 else '',
                     'translations'
                 )
             ))


### PR DESCRIPTION
On all platforms the Qt5 translations get placed in a `Qt` subfolder, as opposed to Qt4 where this subfolder is seemingly not used.

But the current code makes an exception for Windows, where it also does not create the subfolder. This is wrong for versions of PyQt5 currently available via pip (see #4429 ). I tested with PyQt 5.8 (the oldest available version), PyQt 5.10 and PyQt 5.13.1. In all cases the `Qt` subfolder was required.

This patch simplifies the situation by removing the special case for Windows.

Fixes #4429