### PR TITLE
Conditional platform-specific dependencies can sometimes be problematic

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,13 @@ REQUIREMENTS = [
     'setuptools',
     'altgraph',
 ]
+REQUIREMENTS_WINDOWS = [
+    'pywin32-ctypes >= 0.2.0',
+    'pefile >= 2017.8.1',
+]
+REQUIREMENTS_MAC = [
+    'macholib >= 1.8',
+]
 
 # dis3 is used for our version of modulegraph
 if sys.version_info < (3,):
@@ -31,11 +38,9 @@ if sys.version_info < (3,):
 
 # For Windows install PyWin32 if not already installed.
 if sys.platform.startswith('win'):
-    REQUIREMENTS += ['pywin32-ctypes >= 0.2.0',
-                     'pefile >= 2017.8.1']
-
-if sys.platform == 'darwin':
-    REQUIREMENTS.append('macholib >= 1.8')
+    REQUIREMENTS.extend(REQUIREMENTS_WINDOWS)
+elif sys.platform == 'darwin':
+    REQUIREMENTS.extend(REQUIREMENTS_MAC)
 
 
 # Create long description from README.rst and doc/CHANGES.rst.
@@ -148,6 +153,12 @@ class MyBDist_Egg(bdist_egg):
 
 setup(
     install_requires=REQUIREMENTS,
+    extras_require={
+        # Extras to explicitly install conditional platform-specific dependencies
+        'windows': REQUIREMENTS_WINDOWS,
+        'mac': REQUIREMENTS_MAC,
+        'all': REQUIREMENTS_WINDOWS + REQUIREMENTS_MAC,
+    },
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
 
     name='PyInstaller',


### PR DESCRIPTION
I recently tried to incorperate PyInstaller into a project I'm working on in order to produce frozen binaries for Windows, macOS, and Linux. Since PyInstaller doesn't have cross-compilation capabilities I decided to use a continous integration system (GitHub Actions) for the different platform compile targets. The build matrix for my continous integration workflow is as follows:

```yaml
freeze:
  name: Build frozen binaries
  # PyInstaller does NOT have cross-compilation capabilities so an operating system build matrix must be used.
  runs-on: ${{ matrix.os }}
  strategy:
    matrix:
      os:
        - windows-latest
        - ubuntu-latest
        - macOS-latest
  steps:
    - uses: actions/checkout@v1
    - name: Set up Python 3.7
      uses: actions/setup-python@v1
      with:
        python-version: 3.7
    - name: Install development dependencies
      # language=BASH
      run: |
        pip3 install --upgrade pip pipenv
        pipenv install --system --deploy --ignore-pipfile --dev
    - name: Print Python platform
      run: python3 -c "import sys; print(sys.platform)"
    - name: Verify PyInstaller installation
      continue-on-error: true
      run: pyinstaller --version
```

Unfortunately this build matrix fails because the platform-specific PyInstaller package dependencies for both Windows & macOS are missed from the project's pinned package dependencies. This can be fixed by manually reinstalling PyInstaller for each project instance in order to pick up the missed conditional dependencies but this is inconvenient and not very portable. A better solution is to provide a way to explictly include the different conditional platform-specific dependencies as setuputils [install extras](https://setuptools.readthedocs.io/en/stable/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies). With these install extras projects that include PyInstaller and wish to target more than a single platform can explicitly install all of PyInstaller's conditional platform-specific dependencies in order to assure that compilation will work portably across different platforms when using locked package dependencies.