### PR TITLE
Hooks: Fix PySide2.QtNetwork hook by mirroring PyQt5 approach.

### DIFF
--- a/PyInstaller/hooks/hook-PySide2.QtNetwork.py
+++ b/PyInstaller/hooks/hook-PySide2.QtNetwork.py
@@ -12,7 +12,6 @@ from PyInstaller.utils.hooks import eval_statement
 from PyInstaller.utils.hooks.qt import add_qt5_dependencies, \
     pyside2_library_info
 from PyInstaller.compat import is_win
-from PyInstaller.depend.bindepend import getfullnameof
 
 # Only proceed if PySide2 can be imported.
 if pyside2_library_info.version:
@@ -23,11 +22,10 @@ if pyside2_library_info.version:
         from PySide2.QtNetwork import QSslSocket
         print(QSslSocket.supportsSsl())""")):
 
-        rel_data_path = ['.']
-        binaries += [
-            # Per http://doc.qt.io/qt-5/ssl.html#enabling-and-disabling-ssl-support,
-            # the SSL libraries are dynamically loaded, implying they exist in
-            # the system path. Include these.
-            (getfullnameof('libeay32.dll'), os.path.join(*rel_data_path)),
-            (getfullnameof('ssleay32.dll'), os.path.join(*rel_data_path)),
-        ]
+        binaries = []
+        for dll in ('libeay32.dll', 'ssleay32.dll', 'libssl-1_1-x64.dll',
+                    'libcrypto-1_1-x64.dllx'):
+            dll_path = os.path.join(
+                pyside2_library_info.location['BinariesPath'], dll)
+            if os.path.exists(dll_path):
+                binaries.append((dll_path, '.'))

--- a/news/4467.hooks.rst
+++ b/news/4467.hooks.rst
@@ -1,0 +1,1 @@
+Fixed PySide2.QtNetwork hook by mirroring PyQt5 approach.

--- a/news/4468.hooks.rst
+++ b/news/4468.hooks.rst
@@ -1,0 +1,1 @@
+Fixed PySide2.QtNetwork hook by mirroring PyQt5 approach.


### PR DESCRIPTION
As described in issue #4467, the PySide2 QtNetwork hook currently breaks PyInstaller for projects using PySide2. This commit changes the hook to mirror [the changes made to the PyQt5 QtNetwork hook](https://github.com/pyinstaller/pyinstaller/commit/47bd7f10de3b343270fd4d34b356f14617d5d3a1#diff-cfc3f87059223ae1b3d84abe9a90e8f0).

Pinging @bjones1 for review.

Resolves #4467.

As a follow up, it would probably make sense to check for and filter out bogus paths added to the binary dependency list somewhere down the line. An invalid binary dependency should never result in trying to add every file in the project tree as a binary dependency.