### PR TITLE
Hooks: Add hook for ttkwidgets

### DIFF
--- a/PyInstaller/hooks/hook-ttkwidgets.py
+++ b/PyInstaller/hooks/hook-ttkwidgets.py
@@ -29,7 +29,8 @@ Windows 7 (Python 3.5.4 system-wide).
 >>> tree.pack()
 >>> window.mainloop()
 """
-from PyInstaller.utils.hooks import collect_data_files
 
+
+from PyInstaller.utils.hooks import collect_data_files
 
 datas = collect_data_files("ttkwidgets")

--- a/PyInstaller/hooks/hook-ttkwidgets.py
+++ b/PyInstaller/hooks/hook-ttkwidgets.py
@@ -1,0 +1,35 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013-2019, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+"""
+Hook for use with the ttkwidgets package
+
+ttkwidgets provides a set of cross-platform widgets for Tkinter/ttk,
+some of which depend on image files in order to function properly.
+
+These images files are all provided in the `ttkwidgets/assets` folder,
+which has to be copied by PyInstaller.
+
+This hook has been tested on Ubuntu 18.04 (Python 3.6.8 venv) and
+Windows 7 (Python 3.5.4 system-wide).
+
+>>> import tkinter as tk
+>>> from ttkwidgets import CheckboxTreeview
+>>>
+>>> window = tk.Tk()
+>>> tree = CheckboxTreeview(window)
+>>> tree.insert("", tk.END, "test", text="Hello World!")
+>>> tree.insert("test", tk.END, "test2", text="Hello World again!")
+>>> tree.insert("test", tk.END, "test3", text="Hello World again again!")
+>>> tree.pack()
+>>> window.mainloop()
+"""
+from PyInstaller.utils.hooks import collect_data_files
+
+
+datas = collect_data_files("ttkwidgets")

--- a/news/4484.hooks.rst
+++ b/news/4484.hooks.rst
@@ -1,0 +1,1 @@
+Add hook for ttkwidgets.


### PR DESCRIPTION
[ttkwidgets](https://github.com/RedFantom/ttkwidgets) is a package that provides a set of custom widgets for Tkinter/ttk. Some of these widgets use custom images, located in the `ttkwidgets/assets` folder. These files are not copied by PyInstaller by default. Similarly to the situation with #4105 this causes some confusion (RedFantom/ttkwidgets#34) and therefore I would like for a hook to be included with PyInstaller.

I have tested the hook and the files are copied correctly and the resulting executable runs properly after using PyInstaller with the hook.