### PR TITLE
Hooks: Fix gdk-pixbuf-query-loaders not in path in Ubuntu

### DIFF
--- a/PyInstaller/hooks/hook-gi.repository.GdkPixbuf.py
+++ b/PyInstaller/hooks/hook-gi.repository.GdkPixbuf.py
@@ -15,7 +15,6 @@ import os
 import subprocess
 
 from PyInstaller.config import CONF
-from PyInstaller import compat
 from PyInstaller.compat import (
     exec_command_stdout, is_darwin, is_win, is_linux, open_file, which)
 from PyInstaller.utils.hooks import (
@@ -26,116 +25,139 @@ loaders_path = os.path.join('gdk-pixbuf-2.0', '2.10.0', 'loaders')
 destpath = "lib/gdk-pixbuf-2.0/2.10.0/loaders"
 cachedest = "lib/gdk-pixbuf-2.0/2.10.0"
 
-# If the "gdk-pixbuf-query-loaders" command is not in the current ${PATH}, GDK
-# and thus GdkPixbuf is unavailable. Return with a non-fatal warning.
+# If the "gdk-pixbuf-query-loaders" command is not in the current ${PATH}, or
+# is not in the GI lib path, GDK and thus GdkPixbuf is unavailable. Return with
+# a non-fatal warning.
 gdk_pixbuf_query_loaders = None
 
-if compat.architecture == '64bit':
-    # CentOS/Fedora package as -64
-    cmds = ['gdk-pixbuf-query-loaders-64', 'gdk-pixbuf-query-loaders']
-else:
-    cmds = ['gdk-pixbuf-query-loaders']
-
-for cmd in cmds:
-    gdk_pixbuf_query_loaders = which(cmd)
-    if gdk_pixbuf_query_loaders is not None:
-        break
-
-if gdk_pixbuf_query_loaders is None:
-    logger.warning(
-        '"hook-gi.repository.GdkPixbuf" ignored, since GDK not found '
-        '(i.e., "gdk-pixbuf-query-loaders" not in $PATH).'
-    )
-# Else, GDK is available. Let's do this.
-else:
-    binaries, datas, hiddenimports = get_gi_typelibs('GdkPixbuf', '2.0')
-    datas += collect_glib_translations('gdk-pixbuf')
-
+try:
     libdir = get_gi_libdir('GdkPixbuf', '2.0')
+except ValueError:
+    logger.warning(
+        '"hook-gi.repository.GdkPixbuf" ignored, '
+        'since GdkPixbuf library not found'
+    )
+    libdir = None
 
-    # To add support for a new platform, add a new "elif" branch below with the
-    # proper is_<platform>() test and glob for finding loaders on that platform.
-    if is_win:
-        ext = "*.dll"
-    elif is_darwin or is_linux:
-        ext = "*.so"
+if libdir:
 
-    # If loader detection is supported on this platform, bundle all detected
-    # loaders and an updated loader cache.
-    if ext:
-        loader_libs = []
+    # Distributions either package gdk-pixbuf-query-loaders in the GI libs
+    # directory (not on the path), or on the path with or without a -x64 suffix
+    # depending on the architecture
+    cmds = [
+        os.path.join(libdir, 'gdk-pixbuf-2.0/gdk-pixbuf-query-loaders'),
+        'gdk-pixbuf-query-loaders-64',
+        'gdk-pixbuf-query-loaders',
+    ]
 
-        # Bundle all found loaders with this user application.
-        pattern = os.path.join(libdir, loaders_path, ext)
-        for f in glob.glob(pattern):
-            binaries.append((f, destpath))
-            loader_libs.append(f)
+    for cmd in cmds:
+        gdk_pixbuf_query_loaders = which(cmd)
+        if gdk_pixbuf_query_loaders is not None:
+            break
 
-        # Sometimes the loaders are stored in a different directory from
-        # the library (msys2)
-        if not loader_libs:
-            pattern = os.path.join(libdir, '..', 'lib', loaders_path, ext)
+    if gdk_pixbuf_query_loaders is None:
+        logger.warning(
+            '"hook-gi.repository.GdkPixbuf" ignored, since '
+            '"gdk-pixbuf-query-loaders" is not in $PATH or gi lib dir.'
+        )
+
+    # Else, GDK is available. Let's do this.
+    else:
+        binaries, datas, hiddenimports = get_gi_typelibs('GdkPixbuf', '2.0')
+        datas += collect_glib_translations('gdk-pixbuf')
+
+        # To add support for a new platform, add a new "elif" branch below with
+        # the proper is_<platform>() test and glob for finding loaders on that
+        # platform.
+        if is_win:
+            ext = "*.dll"
+        elif is_darwin or is_linux:
+            ext = "*.so"
+
+        # If loader detection is supported on this platform, bundle all
+        # detected loaders and an updated loader cache.
+        if ext:
+            loader_libs = []
+
+            # Bundle all found loaders with this user application.
+            pattern = os.path.join(libdir, loaders_path, ext)
             for f in glob.glob(pattern):
                 binaries.append((f, destpath))
                 loader_libs.append(f)
 
-        # Filename of the loader cache to be written below.
-        cachefile = os.path.join(CONF['workpath'], 'loaders.cache')
+            # Sometimes the loaders are stored in a different directory from
+            # the library (msys2)
+            if not loader_libs:
+                pattern = os.path.join(libdir, '..', 'lib', loaders_path, ext)
+                for f in glob.glob(pattern):
+                    binaries.append((f, destpath))
+                    loader_libs.append(f)
 
-        # Run the "gdk-pixbuf-query-loaders" command and capture its standard
-        # output providing an updated loader cache; then write this output to
-        # the loader cache bundled with this frozen application.
-        #
-        # On OSX we use @executable_path to specify a path relative to the
-        # generated bundle. However, on non-Windows we need to rewrite the
-        # loader cache because it isn't relocatable by default. See
-        # https://bugzilla.gnome.org/show_bug.cgi?id=737523
-        #
-        # To make it easier to rewrite, we just always write @executable_path,
-        # since its significantly easier to find/replace at runtime. :)
-        #
-        # If we need to rewrite it...
-        if not is_win:
-            # To permit string munging, decode the encoded bytes output by this
-            # command (i.e., enable the "universal_newlines" option). Note that:
+            # Filename of the loader cache to be written below.
+            cachefile = os.path.join(CONF['workpath'], 'loaders.cache')
+
+            # Run the "gdk-pixbuf-query-loaders" command and capture its
+            # standard output providing an updated loader cache; then write
+            # this output to the loader cache bundled with this frozen
+            # application.
             #
-            # * Under Python 2.7, "cachedata" will be a decoded "unicode" object.
-            # * Under Python 3.x, "cachedata" will be a decoded "str" object.
+            # On OSX we use @executable_path to specify a path relative to the
+            # generated bundle. However, on non-Windows we need to rewrite the
+            # loader cache because it isn't relocatable by default. See
+            # https://bugzilla.gnome.org/show_bug.cgi?id=737523
             #
-            # On Fedora, the default loaders cache is /usr/lib64, but the libdir
-            # is actually /lib64. To get around this, we pass the path to the
-            # loader command, and it will create a cache with the right path.
-            cachedata = exec_command_stdout(gdk_pixbuf_query_loaders,
-                                            *loader_libs)
+            # To make it easier to rewrite, we just always write
+            # @executable_path, since its significantly easier to find/replace
+            # at runtime. :)
+            #
+            # If we need to rewrite it...
+            if not is_win:
+                # To permit string munging, decode the encoded bytes output by
+                # this command (i.e., enable the "universal_newlines" option).
+                # Note that:
+                #
+                # * Under Python 2.7, "cachedata" will be a decoded "unicode"
+                # object. * Under Python 3.x, "cachedata" will be a decoded
+                # "str" object.
+                #
+                # On Fedora, the default loaders cache is /usr/lib64, but the
+                # libdir is actually /lib64. To get around this, we pass the
+                # path to the loader command, and it will create a cache with
+                # the right path.
+                cachedata = exec_command_stdout(gdk_pixbuf_query_loaders,
+                                                *loader_libs)
 
-            cd = []
-            prefix = '"' + os.path.join(libdir, 'gdk-pixbuf-2.0', '2.10.0')
-            plen = len(prefix)
+                cd = []
+                prefix = '"' + os.path.join(libdir, 'gdk-pixbuf-2.0', '2.10.0')
+                plen = len(prefix)
 
-            # For each line in the updated loader cache...
-            for line in cachedata.splitlines():
-                if line.startswith('#'):
-                    continue
-                if line.startswith(prefix):
-                    line = '"@executable_path/' + cachedest + line[plen:]
-                cd.append(line)
+                # For each line in the updated loader cache...
+                for line in cachedata.splitlines():
+                    if line.startswith('#'):
+                        continue
+                    if line.startswith(prefix):
+                        line = '"@executable_path/' + cachedest + line[plen:]
+                    cd.append(line)
 
-            # Rejoin these lines in a manner preserving this object's "unicode"
-            # type under Python 2.
-            cachedata = u'\n'.join(cd)
+                # Rejoin these lines in a manner preserving this object's
+                # "unicode" type under Python 2.
+                cachedata = u'\n'.join(cd)
 
-            # Write the updated loader cache to this file.
-            with open_file(cachefile, 'w') as fp:
-                fp.write(cachedata)
-        # Else, GdkPixbuf will do the right thing on Windows, so no changes to
-        # the loader cache are required. For efficiency and reliability, this
-        # command's encoded byte output is written as is without being decoded.
+                # Write the updated loader cache to this file.
+                with open_file(cachefile, 'w') as fp:
+                    fp.write(cachedata)
+            # Else, GdkPixbuf will do the right thing on Windows, so no changes
+            # to the loader cache are required. For efficiency and reliability,
+            # this command's encoded byte output is written as is without being
+            # decoded.
+            else:
+                with open_file(cachefile, 'wb') as fp:
+                    fp.write(subprocess.check_output(gdk_pixbuf_query_loaders))
+
+            # Bundle this loader cache with this frozen application.
+            datas.append((cachefile, cachedest))
+        # Else, loader detection is unsupported on this platform.
         else:
-            with open_file(cachefile, 'wb') as fp:
-                fp.write(subprocess.check_output(gdk_pixbuf_query_loaders))
-
-        # Bundle this loader cache with this frozen application.
-        datas.append((cachefile, cachedest))
-    # Else, loader detection is unsupported on this platform.
-    else:
-        logger.warning('GdkPixbuf loader bundling unsupported on your platform.')
+            logger.warning(
+                'GdkPixbuf loader bundling unsupported on your platform.'
+            )

--- a/news/4486.hooks.rst
+++ b/news/4486.hooks.rst
@@ -1,0 +1,1 @@
+(GNU/Linux) Make hook for GdkPixbuf compatible with Ubuntu and Debian.


### PR DESCRIPTION
Fix #4485. The current GdkPixbuf hook assumes that gdk-pixbuf-query-loaders is in the PATH. In Ubuntu and Debian it is located in the GI libs directory. This change adds the GI lib directory
command to be searched with the other commands on the path.

Signed-off-by: Dan Yeaw <dan@yeaw.me>