### PR TITLE
Add sounddevice library hook on Windows and macOS

### DIFF
--- a/PyInstaller/hooks/hook-sounddevice.py
+++ b/PyInstaller/hooks/hook-sounddevice.py
@@ -29,4 +29,5 @@ elif is_darwin:
     )
 
 if path is not None and os.path.exists(path):
-    binaries = [(path, os.path.join("_sounddevice_data", "portaudio-binaries"))]
+    binaries = [(path,
+                 os.path.join("_sounddevice_data", "portaudio-binaries"))]

--- a/PyInstaller/hooks/hook-sounddevice.py
+++ b/PyInstaller/hooks/hook-sounddevice.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) 2016-2019, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+# -----------------------------------------------------------------------------
+
+"""
+sounddevice:
+https://github.com/spatialaudio/python-sounddevice/
+"""
+
+import os
+
+from PyInstaller.compat import is_darwin, is_win
+from PyInstaller.utils.hooks import get_package_paths
+
+sfp = get_package_paths("sounddevice")
+
+path = None
+if is_win:
+    path = os.path.join(sfp[0], "_sounddevice_data", "portaudio-binaries")
+elif is_darwin:
+    path = os.path.join(
+        sfp[0], "_sounddevice_data", "portaudio-binaries", "libportaudio.dylib"
+    )
+
+if path is not None and os.path.exists(path):
+    binaries = [(path, os.path.join("_sounddevice_data", "portaudio-binaries"))]

--- a/news/4498.hooks.rst
+++ b/news/4498.hooks.rst
@@ -1,0 +1,1 @@
+Add hook for sounddevice on macOS and Windows


### PR DESCRIPTION
This PR adds a hook to bundle the port audio binary for Windows and macOS that the `sounddevice` library bundles with its wheel. 

Link to library docs: https://python-sounddevice.readthedocs.io/en/0.3.14/
Link to library repo: https://github.com/spatialaudio/python-sounddevice

I took guidance for creating this PR from #4326 
