### PR TITLE
Add hook for django-babel.

### DIFF
--- a/PyInstaller/hooks/hook-django_babel.py
+++ b/PyInstaller/hooks/hook-django_babel.py
@@ -1,0 +1,15 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2019, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+# Tested with django-babel v0.6.2.
+# Hook for https://github.com/python-babel/django-babel
+
+from PyInstaller.utils.hooks import copy_metadata
+datas = copy_metadata('django-babel')
+

--- a/news/4516.hooks.rst
+++ b/news/4516.hooks.rst
@@ -1,0 +1,1 @@
+Add hook for `django-babel <https://github.com/python-babel/django-babel>`_.


### PR DESCRIPTION
_Note: This is a corrected version of #4499. I did something horrible on my fork and ended up rewriting the history and erasing my commits._

Hey,

This PR will add a hook for `django-babel`, fixing #4281. The issue there was that `django-babel` uses `pkg_resources.get_distribution` in their `__init__.py`, without having imported `django-babel` explicitly. This means that when freezing, PyInstaller doesn't import `django-babel` and therefore errors when executing the resulting package.

I have tested this with the script given in the issue:

```
import importlib
import django_babel
import datetime

if __name__ == '__main__':
    print("Hello dear friend, how are you")
    today = datetime.date.today()  
    print(today)
```

I have only tested it in Ubuntu 18.04 though. Hope everything is okay. 

Thanks for Pyinstaller!