### PR TITLE
Add pyarrow hook

### DIFF
--- a/PyInstaller/hooks/hook-pyarrow.py
+++ b/PyInstaller/hooks/hook-pyarrow.py
@@ -1,11 +1,11 @@
- #-----------------------------------------------------------------------------
-+# Copyright (c) 2005-2019, PyInstaller Development Team.
- #
- # Distributed under the terms of the GNU General Public License with exception
- # for distributing bootloader.
- #
- # The full license is in the file COPYING.txt, distributed with this software.
- #-----------------------------------------------------------------------------
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2019, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
 
 # Hook for https://pypi.org/project/pyarrow/
 
@@ -18,6 +18,4 @@ hiddenimports = [
 ]
 
 datas = collect_data_files('pyarrow')
-
 binaries = collect_dynamic_libs('pyarrow')
-

--- a/PyInstaller/hooks/hook-pyarrow.py
+++ b/PyInstaller/hooks/hook-pyarrow.py
@@ -1,0 +1,23 @@
+ #-----------------------------------------------------------------------------
++# Copyright (c) 2005-2019, PyInstaller Development Team.
+ #
+ # Distributed under the terms of the GNU General Public License with exception
+ # for distributing bootloader.
+ #
+ # The full license is in the file COPYING.txt, distributed with this software.
+ #-----------------------------------------------------------------------------
+
+# Hook for https://pypi.org/project/pyarrow/
+
+from PyInstaller.utils.hooks import collect_data_files, collect_dynamic_libs
+
+hiddenimports = [
+    "pyarrow._parquet",
+    "pyarrow.lib",
+    "pyarrow.compat",
+]
+
+datas = collect_data_files('pyarrow')
+
+binaries = collect_dynamic_libs('pyarrow')
+

--- a/news/3720.hooks.rst
+++ b/news/3720.hooks.rst
@@ -1,0 +1,1 @@
+Add hook for `pyarrow <https://pypi.org/project/pyarrow/>`_.

--- a/news/4517.hooks.rst
+++ b/news/4517.hooks.rst
@@ -1,0 +1,1 @@
+Add hook for `pyarrow <https://pypi.org/project/pyarrow/>`_.


### PR DESCRIPTION
_Note: This is a corrected version of #4500. I did something horrible on my fork and ended up rewriting the history and erasing my commits._

Hey,

I saw #3720 and decided to pull the code into an appropriate hook and submit a PR for it. I have removed `pyarrow.formatting` and `pyarrow.compat.*` from the hidden imports as PyInstaller was alerting that those modules could not be found after installing `pyarrow`.

Thanks,
Hugo