### PR TITLE
hooks: add hook for passlib

### DIFF
--- a/PyInstaller/hooks/hook-passlib.py
+++ b/PyInstaller/hooks/hook-passlib.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013-2019, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+
+hiddenimports = [
+    "passlib.handlers",
+    "passlib.handlers.digests",
+]
+
+

--- a/PyInstaller/hooks/hook-passlib.py
+++ b/PyInstaller/hooks/hook-passlib.py
@@ -7,10 +7,11 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-
+# Handlers are imported by a lazy-load proxy, based on a
+# name-to-package mapping. Collect all handlers to ease packaging.
+# If you want to reduce the size of your application, used
+# `--exclude-module` to remove unused ones.
 hiddenimports = [
     "passlib.handlers",
     "passlib.handlers.digests",
 ]
-
-

--- a/news/4520.hooks.rst
+++ b/news/4520.hooks.rst
@@ -1,0 +1,1 @@
+Add hook for passlib.


### PR DESCRIPTION
Adds a basic hook for passlib. Maybe we need to add more packages to hidden imports but this is enough so I can distribute a small utility script.

This should also fix #649 (which was closed two years ago due to the lack of activity).