### PR TITLE
building: Allow usage of VSVersionInfo again.

### DIFF
--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -425,7 +425,7 @@ class EXE(Target):
 
             if self.versrsrc:
                 if (not isinstance(self.versrsrc, versioninfo.VSVersionInfo)
-                        and not os.path.isabs(self.versrsrc)):
+                    and not os.path.isabs(self.versrsrc)):
                     # relative version-info path is relative to spec file
                     self.versrsrc = os.path.join(
                         CONF['specpath'], self.versrsrc)

--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -424,7 +424,8 @@ class EXE(Target):
                                  "", "OPTION"))
 
             if self.versrsrc:
-                if not os.path.isabs(self.versrsrc):
+                if (not isinstance(self.versrsrc, versioninfo.VSVersionInfo)
+                        and not os.path.isabs(self.versrsrc)):
                     # relative version-info path is relative to spec file
                     self.versrsrc = os.path.join(
                         CONF['specpath'], self.versrsrc)

--- a/news/4381.bugfix.rst
+++ b/news/4381.bugfix.rst
@@ -1,0 +1,1 @@
+(Windows) Allow usage of `VSVersionInfo` as version argument to EXE again.

--- a/news/4539.bugfix.rst
+++ b/news/4539.bugfix.rst
@@ -1,0 +1,1 @@
+(Windows) Allow usage of `VSVersionInfo` as version argument to EXE again.


### PR DESCRIPTION
fixes #4381