### PR TITLE
issue-4211: fix bootloader: library identifers are case sensitive on AIX

### DIFF
--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -769,7 +769,7 @@ def build(ctx):
                 'THR']  # may be used on FreBSD
         staticlibs = []
         if ctx.env.DEST_OS == 'aix':
-            # link statically with zlib
+            # link statically with zlib, case sensitive
             libs.remove('Z')
             staticlibs.append('z')
 

--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -771,7 +771,7 @@ def build(ctx):
         if ctx.env.DEST_OS == 'aix':
             # link statically with zlib
             libs.remove('Z')
-            staticlibs.append('Z')
+            staticlibs.append('z')
 
         if ctx.options.boehmgc:
             libs.append('GC')


### PR DESCRIPTION
Library identifier needs to be changed from 'Z' to 'z'

See #4211