### PR TITLE
issue-4211: Skip strip on AIX

### DIFF
--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -456,16 +456,10 @@ def configure(ctx):
             ctx.find_program([assoc_programm(ctx, 'windres')], var='WINRC')
             ctx.load('winres')
 
-    if ctx.env.CC_NAME != 'msvc':
+    if ctx.env.CC_NAME != 'msvc' and ctx.env.DEST_OS != 'aix':
         # This tool allows reducing the size of executables.
         ctx.find_program([assoc_programm(ctx, 'strip')], var='STRIP')
         ctx.load('strip', tooldir='tools')
-        # There is a strip flag for AIX environment
-        if ctx.env.DEST_OS == 'aix':
-            if ctx.env.PYI_ARCH == '32bit':
-                ctx.env.append_value('STRIPFLAGS', '-X32')
-            elif ctx.env.PYI_ARCH == '64bit':
-                ctx.env.append_value('STRIPFLAGS', '-X64')
 
     ### C Compiler optimizations.
     # TODO Set proper optimization flags for MSVC (Visual Studio).


### PR DESCRIPTION
No need strip executable on AIX. Size should not be an issue.

If it is, a user/admin can always strip later. Not having the information only hampers debugging (my personal experience of debugging striped executable).

p.s. - PR based on master. Did not see to build against 'develop'. If needed, I'll remake.