### PR TITLE
Pyinstaller support for Bleak dotnet backend

### DIFF
--- a/PyInstaller/hooks/hook-bleak.py
+++ b/PyInstaller/hooks/hook-bleak.py
@@ -1,0 +1,18 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2020, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+# hook for https://github.com/hbldh/bleak
+
+from PyInstaller.utils.hooks import collect_data_files, collect_dynamic_libs
+from PyInstaller.compat import is_win
+
+if is_win:
+    datas = collect_data_files('bleak', subdir=r'backends\dotnet')
+    binaries = collect_dynamic_libs('bleak')

--- a/news/4649.hooks.rst
+++ b/news/4649.hooks.rst
@@ -1,1 +1,1 @@
-Add hook for Bleak, Bluetooth Low Energy platform Agnostic Klient for Python
+Add hook for Bleak (Bluetooth Low Energy platform Agnostic Klient for Python)

--- a/news/4649.hooks.rst
+++ b/news/4649.hooks.rst
@@ -1,0 +1,1 @@
+Add hook for Bleak, Bluetooth Low Energy platform Agnostic Klient for Python


### PR DESCRIPTION
Tested with `bleak              0.5.1` on Windows 10 Pro 10.0.17763 Build 17763 using `pyinstaller --onefile`