### PR TITLE
Fixed installation outside the package folder

### DIFF
--- a/news/4565.bugfix.rst
+++ b/news/4565.bugfix.rst
@@ -1,0 +1,1 @@
+Ensure the package will be installed successfully even if the user isn't running setup.py on the package folder

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,9 @@ import sys
 import os
 from setuptools import setup
 
+# Ensure the package will be installed successfully even if the user isn't running setup.py on the package folder
+os.chdir(os.path.dirname(os.path.abspath(__file__)))
+
 # Hack required to allow compat to not fail when pypiwin32 isn't found
 os.environ["PYINSTALLER_NO_PYWIN32_FAILURE"] = "1"
 from PyInstaller import __version__ as version, HOMEPATH, PLATFORM


### PR DESCRIPTION
Right now, if you try to install PyInstaller running `setup.py install` outside the package folder, you get a `FileNotFoundError`:

```
Traceback (most recent call last):
  File "pyinstaller/setup.py", line 50, in <module>
    long_description = u'\n\n'.join([read('README.rst'),
  File "pyinstaller/setup.py", line 48, in read
    with open(filename, 'r', encoding='utf-8') as fp:
FileNotFoundError: [Errno 2] No such file or directory: 'README.rst'
```
That's because `setup.py` tries to read a few files ('README.rst', 'doc/_dummy-roles.txt' and 'doc/CHANGES.rst') referenced by relative paths, and therefore expect these files to be on the same folder the user is.

This PR fix this by simply using `os.chdir` to change the directory of the execution of `setup.py` to the package folder, no matter where the user is running from.