### PR TITLE
Bootloader build: Fix GCC warnings for strncpy and strncat

### DIFF
--- a/bootloader/src/mkdtemp.h
+++ b/bootloader/src/mkdtemp.h
@@ -17,6 +17,8 @@
 #ifndef __MKDTEMP__
 #define __MKDTEMP__
 
+#include <stddef.h>
+
 static char*
 mkdtemp(char *template)
 {

--- a/bootloader/src/pyi_archive.c
+++ b/bootloader/src/pyi_archive.c
@@ -476,14 +476,29 @@ pyi_arch_set_paths(ARCHIVE_STATUS *status, char const * archivePath,
     return 0;
 }
 
-/* Setup the archive with python modules. (this always needs to be done) */
+/* Setup the archive with python modules and the paths required by rest of
+ * this module (this always needs to be done).
+ * Sets f_archivename, f_homepath, f_mainpath
+ */
 bool
-pyi_arch_setup(ARCHIVE_STATUS *status, char const * archivePath, char const * archiveName)
+pyi_arch_setup(ARCHIVE_STATUS *status, char const * archivePath)
 {
-    /* Set up paths */
-    if (pyi_arch_set_paths(status, archivePath, archiveName)) {
+    /* Get the archive Path */
+    if (strlen(archivePath) >= PATH_MAX) {
+        // Should never come here, since `archivePath` was already processed
+        // by pyi_path_executable or pyi_path_archivefile.
         return false;
     }
+
+    strcpy(status->archivename, archivePath);
+    /* Set homepath to where the archive is */
+    pyi_path_dirname(status->homepath, archivePath);
+    /*
+     * Initial value of mainpath is homepath. It might be overriden
+     * by temppath if it is available.
+     */
+    status->has_temp_directory = false;
+    strcpy(status->mainpath, status->homepath);
 
     /* Open the archive */
     if (pyi_arch_open(status)) {

--- a/bootloader/src/pyi_archive.c
+++ b/bootloader/src/pyi_archive.c
@@ -477,12 +477,12 @@ pyi_arch_set_paths(ARCHIVE_STATUS *status, char const * archivePath,
 }
 
 /* Setup the archive with python modules. (this always needs to be done) */
-int
+bool
 pyi_arch_setup(ARCHIVE_STATUS *status, char const * archivePath, char const * archiveName)
 {
     /* Set up paths */
     if (pyi_arch_set_paths(status, archivePath, archiveName)) {
-        return -1;
+        return false;
     }
 
     /* Open the archive */
@@ -491,10 +491,9 @@ pyi_arch_setup(ARCHIVE_STATUS *status, char const * archivePath, char const * ar
         /* otherwise the open file-handle will be reused when */
         /* testing the next file. */
         pyi_arch_close_fp(status);
-        return -1;
+        return false;
     }
-    ;
-    return 0;
+    return true;
 }
 
 /*

--- a/bootloader/src/pyi_archive.c
+++ b/bootloader/src/pyi_archive.c
@@ -447,35 +447,6 @@ pyi_arch_open(ARCHIVE_STATUS *status)
     return 0;
 }
 
-/*
- * Set up paths required by rest of this module.
- * Sets f_archivename, f_homepath, f_mainpath
- */
-int
-pyi_arch_set_paths(ARCHIVE_STATUS *status, char const * archivePath,
-                   char const * archiveName)
-{
-    /* Set homepath to where the archive is */
-    if (snprintf(status->homepath, PATH_MAX, "%s", archivePath) >= PATH_MAX) {
-      return -1;
-    }
-
-    /* Get the archive Path */
-    if (snprintf(status->archivename, PATH_MAX,
-                 "%s%s", archivePath, archiveName) >= PATH_MAX) {
-        return -1;
-    }
-
-    /*
-     * Initial value of mainpath is homepath. It might be overriden
-     * by temppath if it is available.
-     */
-    status->has_temp_directory = false;
-    strcpy(status->mainpath, status->homepath); // homepath fits into PATH_MAX
-
-    return 0;
-}
-
 /* Setup the archive with python modules and the paths required by rest of
  * this module (this always needs to be done).
  * Sets f_archivename, f_homepath, f_mainpath

--- a/bootloader/src/pyi_archive.c
+++ b/bootloader/src/pyi_archive.c
@@ -22,7 +22,6 @@
 /* TODO verify windows includes */
     #include <winsock.h>  /* ntohl */
 #else
-    #include <limits.h>  /* PATH_MAX - not available on windows. */
     #ifdef __FreeBSD__
 /* freebsd issue #188316 */
         #include <arpa/inet.h>  /* ntohl */

--- a/bootloader/src/pyi_archive.c
+++ b/bootloader/src/pyi_archive.c
@@ -455,28 +455,23 @@ int
 pyi_arch_set_paths(ARCHIVE_STATUS *status, char const * archivePath,
                    char const * archiveName)
 {
-    size_t pathlen, namelen;
-
-    pathlen = strnlen(archivePath, PATH_MAX);
-    namelen = strnlen(archiveName, PATH_MAX);
-
-    if (pathlen+namelen+1 > PATH_MAX) {
-        return -1;
+    /* Set homepath to where the archive is */
+    if (snprintf(status->homepath, PATH_MAX, "%s", archivePath) >= PATH_MAX) {
+      return -1;
     }
 
     /* Get the archive Path */
-    strcpy(status->archivename, archivePath);
-    strcat(status->archivename, archiveName);
-
-    /* Set homepath to where the archive is */
-    strcpy(status->homepath, archivePath);
+    if (snprintf(status->archivename, PATH_MAX,
+                 "%s%s", archivePath, archiveName) >= PATH_MAX) {
+        return -1;
+    }
 
     /*
      * Initial value of mainpath is homepath. It might be overriden
      * by temppath if it is available.
      */
     status->has_temp_directory = false;
-    strcpy(status->mainpath, status->homepath);
+    strcpy(status->mainpath, status->homepath); // homepath fits into PATH_MAX
 
     return 0;
 }

--- a/bootloader/src/pyi_archive.h
+++ b/bootloader/src/pyi_archive.h
@@ -129,17 +129,9 @@ void pyi_arch_status_free(ARCHIVE_STATUS *status);
 /*
  * Setup the paths and open the archive
  *
- * @param archivePath  The path (with trailing backslash) to the archive.
+ * @param archivePath  The path including filename to the archive.
  *
- * @param archiveName  The file name of the archive, without a path.
- *
- * @param workpath     The path (with trailing backslash) to where
- *                     the binaries were extracted. If they have not
- *                     benn extracted yet, this is NULL. If they have,
- *                     this will either be archivePath, or a temp dir
- *                     where the user has write permissions.
- *
- * @return 0 on success, non-zero otherwise.
+ * @return true on success, false otherwise.
  */
 bool pyi_arch_setup(ARCHIVE_STATUS *status, char const * archivePath);
 

--- a/bootloader/src/pyi_archive.h
+++ b/bootloader/src/pyi_archive.h
@@ -143,7 +143,7 @@ void pyi_arch_status_free(ARCHIVE_STATUS *status);
  *
  * @return 0 on success, non-zero otherwise.
  */
-int pyi_arch_setup(ARCHIVE_STATUS *status, char const * archivePath,
+bool pyi_arch_setup(ARCHIVE_STATUS *status, char const * archivePath,
                    char const * archiveName);
 
 TOC *getFirstTocEntry(ARCHIVE_STATUS *status);

--- a/bootloader/src/pyi_archive.h
+++ b/bootloader/src/pyi_archive.h
@@ -18,6 +18,9 @@
 #ifndef PYI_ARCHIVE_H
 #define PYI_ARCHIVE_H
 
+#include "pyi_global.h"
+#include <stdio.h>  /* FILE */
+
 /* Types of CArchive items. */
 #define ARCHIVE_ITEM_BINARY           'b'  /* binary */
 #define ARCHIVE_ITEM_DEPENDENCY       'd'  /* runtime option */

--- a/bootloader/src/pyi_archive.h
+++ b/bootloader/src/pyi_archive.h
@@ -118,8 +118,6 @@ extern int pyvers;
 /**
  * The gory detail level
  */
-int pyi_arch_set_paths(ARCHIVE_STATUS *status, char const * archivePath,
-                       char const * archiveName);
 int pyi_arch_open(ARCHIVE_STATUS *status);
 
 /*

--- a/bootloader/src/pyi_archive.h
+++ b/bootloader/src/pyi_archive.h
@@ -143,8 +143,7 @@ void pyi_arch_status_free(ARCHIVE_STATUS *status);
  *
  * @return 0 on success, non-zero otherwise.
  */
-bool pyi_arch_setup(ARCHIVE_STATUS *status, char const * archivePath,
-                   char const * archiveName);
+bool pyi_arch_setup(ARCHIVE_STATUS *status, char const * archivePath);
 
 TOC *getFirstTocEntry(ARCHIVE_STATUS *status);
 TOC *getNextTocEntry(ARCHIVE_STATUS *status, TOC *entry);

--- a/bootloader/src/pyi_global.h
+++ b/bootloader/src/pyi_global.h
@@ -145,12 +145,14 @@ void mbvs(const char *fmt, ...);
  */
     #define PYI_SEPSTR     "\\"
     #define PYI_PATHSEPSTR ";"
+    #define PYI_CURDIRSTR  "."
 #else
     #define PYI_PATHSEP    ':'
     #define PYI_CURDIR     '.'
     #define PYI_SEP        '/'
     #define PYI_SEPSTR     "/"
     #define PYI_PATHSEPSTR ":"
+    #define PYI_CURDIRSTR  "."
 #endif
 
 /* Strings are usually terminated by this character. */

--- a/bootloader/src/pyi_global.h
+++ b/bootloader/src/pyi_global.h
@@ -73,7 +73,10 @@ typedef int bool;
     #endif
     #define PATH_MAX 4096  /* Default value on Linux. */
 #elif __APPLE__
+    #include <limits.h>
     #define PATH_MAX 1024  /* Recommended value for OSX. */
+#else
+    #include <limits.h>  /* PATH_MAX */
 #endif
 
 /*

--- a/bootloader/src/pyi_launch.c
+++ b/bootloader/src/pyi_launch.c
@@ -43,6 +43,7 @@
 #include <sys/stat.h> /* struct stat */
 
 /* PyInstaller headers. */
+#include "pyi_launch.h"
 #include "pyi_global.h"
 #include "pyi_path.h"
 #include "pyi_archive.h"

--- a/bootloader/src/pyi_launch.c
+++ b/bootloader/src/pyi_launch.c
@@ -547,9 +547,9 @@ pyi_launch_initialize(ARCHIVE_STATUS * status)
     manifest = pyi_arch_get_option(status, "pyi-windows-manifest-filename");
 
     if (NULL != manifest) {
-        manifest = pyi_path_join(NULL, status->mainpath, manifest);
-        CreateActContext(manifest);
-        free(manifest);
+        char manifest_path[PATH_MAX];
+        pyi_path_join(manifest_path, status->mainpath, manifest);
+        CreateActContext(manifest_path);
     }
 #endif /* if defined(_WIN32) */
 }

--- a/bootloader/src/pyi_launch.c
+++ b/bootloader/src/pyi_launch.c
@@ -79,16 +79,20 @@ checkFile(char *buf, const char *fmt, ...)
 static int
 splitName(char *path, char *filename, const char *item)
 {
-    char name[PATH_MAX];
+    char *p;
 
     VS("LOADER: Splitting item into path and filename\n");
-    if (snprintf(name, PATH_MAX, "%s", item) >= PATH_MAX) {
+    // copy directly into destination buffer and manipulate there
+    if (snprintf(path, PATH_MAX, "%s", item) >= PATH_MAX) {
         return -1;
     }
-    // `name` fits into PATH_MAX, so will all substrings
-    strcpy(path, strtok(name, ":"));
-    strcpy(filename, strtok(NULL, ":"));
-
+    p = strchr(path, ':');
+    if (p == NULL) { // No colon in string
+        return -1;
+    };
+    p[0] ='\0'; // terminate path part
+    // `path` fits into PATH_MAX, so will all substrings
+    strcpy(filename, ++p);
     if (path[0] == 0 || filename[0] == 0) {
         return -1;
     }

--- a/bootloader/src/pyi_launch.c
+++ b/bootloader/src/pyi_launch.c
@@ -33,7 +33,6 @@
         #include <netinet/in.h>  /* ntohl */
     #endif
     #include <langinfo.h> /* CODESET, nl_langinfo */
-    #include <limits.h>   /* PATH_MAX */
     #include <stdlib.h>   /* malloc */
 #endif
 #include <locale.h>  /* setlocale */

--- a/bootloader/src/pyi_launch.c
+++ b/bootloader/src/pyi_launch.c
@@ -60,7 +60,7 @@
  * declarations are not necessary.
  */
 
-static int
+int
 checkFile(char *buf, const char *fmt, ...)
 {
     va_list args;
@@ -76,7 +76,7 @@ checkFile(char *buf, const char *fmt, ...)
 }
 
 /* Splits the item in the form path:filename */
-static int
+int
 splitName(char *path, char *filename, const char *item)
 {
     char *p;

--- a/bootloader/src/pyi_launch.c
+++ b/bootloader/src/pyi_launch.c
@@ -366,17 +366,12 @@ int
 pyi_launch_run_scripts(ARCHIVE_STATUS *status)
 {
     unsigned char *data;
-    const char *pvalue_cchar, *tb_cchar;
     char buf[PATH_MAX];
-    char *char_pvalue, *char_tb, *module_name;
     TOC * ptoc = status->tocbuff;
     PyObject *__main__;
     PyObject *__file__;
     PyObject *main_dict;
     PyObject *code, *retval;
-    PyObject *ptype, *pvalue, *pvalue_str;
-    PyObject *ptraceback, *tb, *tb_str;
-    PyObject *module, *func;
 
     __main__ = PI_PyImport_AddModule("__main__");
 
@@ -430,6 +425,12 @@ pyi_launch_run_scripts(ARCHIVE_STATUS *status)
                      * resp. NullWriter (see pyiboot01_bootstrap.py), thus
                      * PyErr_Print() below will not show any traceback. With
                      * debug, print the traceback to a message box. */
+
+                    const char *pvalue_cchar, *tb_cchar;
+                    char *char_pvalue, *char_tb, *module_name;
+                    PyObject *ptype, *pvalue, *pvalue_str;
+                    PyObject *ptraceback, *tb, *tb_str;
+                    PyObject *module, *func;
 
                     /* First get the value of the error */
                     PI_PyErr_Fetch(&ptype, &pvalue, &ptraceback);

--- a/bootloader/src/pyi_launch.c
+++ b/bootloader/src/pyi_launch.c
@@ -545,7 +545,10 @@ pyi_launch_initialize(ARCHIVE_STATUS * status)
 
     if (NULL != manifest) {
         char manifest_path[PATH_MAX];
-        pyi_path_join(manifest_path, status->mainpath, manifest);
+        if (pyi_path_join(manifest_path, status->mainpath, manifest) == NULL) {
+            FATALERROR("Path of manifest-file (%s) length exceeds "
+                       "buffer[%d] space\n", status->mainpath, PATH_MAX);
+        };
         CreateActContext(manifest_path);
     }
 #endif /* if defined(_WIN32) */

--- a/bootloader/src/pyi_launch.c
+++ b/bootloader/src/pyi_launch.c
@@ -67,7 +67,9 @@ checkFile(char *buf, const char *fmt, ...)
     struct stat tmp;
 
     va_start(args, fmt);
-    vsnprintf(buf, PATH_MAX, fmt, args);
+    if (vsnprintf(buf, PATH_MAX, fmt, args) >= PATH_MAX) {
+        return -1;
+    };
     va_end(args);
 
     return stat(buf, &tmp);

--- a/bootloader/src/pyi_launch.h
+++ b/bootloader/src/pyi_launch.h
@@ -17,6 +17,8 @@
 #ifndef PYI_LAUNCH_H
 #define PYI_LAUNCH_H
 
+#include "pyi_archive.h"
+
 /*****************************************************************
 * The following 4 entries are for applications which may need to
 * use to 2 steps to execute

--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -46,7 +46,6 @@ pyi_main(int argc, char * argv[])
     char archivefile[PATH_MAX];
     int rc = 0;
     char *extractionpath = NULL;
-    wchar_t * dllpath_w;
 
 #ifdef _MSC_VER
     /* Visual C runtime incorrectly buffers stderr */
@@ -112,6 +111,7 @@ pyi_main(int argc, char * argv[])
 
     if (extractionpath) {
         /* Add extraction folder to DLL search path */
+        wchar_t * dllpath_w;
         dllpath_w = pyi_win32_utils_from_utf8(NULL, extractionpath, 0);
         SetDllDirectory(dllpath_w);
         VS("LOADER: SetDllDirectory(%s)\n", extractionpath);

--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -87,12 +87,11 @@ pyi_main(int argc, char * argv[])
 
     VS("LOADER: _MEIPASS2 is %s\n", (extractionpath ? extractionpath : "NULL"));
 
-    if (! pyi_arch_setup(archive_status, homepath, &executable[strlen(homepath)])) {
-        if (! pyi_arch_setup(archive_status, homepath, &archivefile[strlen(homepath)])) {
+    if ((! pyi_arch_setup(archive_status, executable)) &&
+        (! pyi_arch_setup(archive_status, archivefile))) {
             FATALERROR("Cannot open self %s or archive %s\n",
                        executable, archivefile);
             return -1;
-        }
     }
 
     /* These are used only in pyi_pylib_set_sys_argv, which converts to wchar_t */

--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -27,6 +27,7 @@
 #include <string.h> /* memset */
 
 /* PyInstaller headers. */
+#include "pyi_main.h"
 #include "pyi_global.h"  /* PATH_MAX */
 #include "pyi_path.h"
 #include "pyi_archive.h"

--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -59,10 +59,11 @@ pyi_main(int argc, char * argv[])
     if (archive_status == NULL) {
         return -1;
     }
-
-    pyi_path_executable(executable, argv[0]);
-    pyi_path_archivefile(archivefile, executable);
-    pyi_path_homepath(homepath, executable);
+    if ((! pyi_path_executable(executable, argv[0])) ||
+        (! pyi_path_archivefile(archivefile, executable)) ||
+        (! pyi_path_homepath(homepath, executable))) {
+        return -1;
+    }
 
     /* For the curious:
      * On Windows, the UTF-8 form of MEIPASS2 is passed to pyi_setenv, which

--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -21,15 +21,13 @@
 #ifdef _WIN32
     #include <windows.h>
     #include <wchar.h>
-#else
-    #include <limits.h>  /* PATH_MAX */
 #endif
 #include <stdio.h>  /* FILE */
 #include <stdlib.h> /* calloc */
 #include <string.h> /* memset */
 
 /* PyInstaller headers. */
-#include "pyi_global.h"  /* PATH_MAX for win32 */
+#include "pyi_global.h"  /* PATH_MAX */
 #include "pyi_path.h"
 #include "pyi_archive.h"
 #include "pyi_utils.h"

--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -126,8 +126,8 @@ pyi_main(int argc, char * argv[])
          *  we pass it through status variable
          */
         if (strcmp(homepath, extractionpath) != 0) {
-            strncpy(archive_status->temppath, extractionpath, PATH_MAX);
-            if (archive_status->temppath[PATH_MAX-1] != '\0') {
+            if (snprintf(archive_status->temppath, PATH_MAX,
+                         "%s", extractionpath) >= PATH_MAX) {
                 VS("LOADER: temppath exceeds PATH_MAX\n");
                 return -1;
             }

--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -86,8 +86,8 @@ pyi_main(int argc, char * argv[])
 
     VS("LOADER: _MEIPASS2 is %s\n", (extractionpath ? extractionpath : "NULL"));
 
-    if (pyi_arch_setup(archive_status, homepath, &executable[strlen(homepath)])) {
-        if (pyi_arch_setup(archive_status, homepath, &archivefile[strlen(homepath)])) {
+    if (! pyi_arch_setup(archive_status, homepath, &executable[strlen(homepath)])) {
+        if (! pyi_arch_setup(archive_status, homepath, &archivefile[strlen(homepath)])) {
             FATALERROR("Cannot open self %s or archive %s\n",
                        executable, archivefile);
             return -1;

--- a/bootloader/src/pyi_path.c
+++ b/bootloader/src/pyi_path.c
@@ -286,8 +286,7 @@ pyi_path_executable(char *execfile, const char *appname)
         if (-1 == result) {
             /* Searching $PATH failed, user is crazy. */
             VS("LOADER: Searching $PATH failed for %s", appname);
-            strncpy(buffer, appname, PATH_MAX);
-            if (buffer[PATH_MAX-1] != '\0') {
+            if (snprintf(buffer, PATH_MAX, "%s", "appname") >= PATH_MAX) {
                 VS("LOADER: Appname too large %s\n", appname);
                 return -1;
             }

--- a/bootloader/src/pyi_path.c
+++ b/bootloader/src/pyi_path.c
@@ -149,13 +149,6 @@ pyi_path_join(char *result, const char *path1, const char *path2)
     return result;
 }
 
-/* Normalize a pathname. Return result in new buffer. */
-/* TODO implement this function */
-void
-pyi_path_normalize(char *result, const char *path)
-{
-}
-
 
 #if !defined(_WIN32) && !defined(__APPLE__)
 /*

--- a/bootloader/src/pyi_path.c
+++ b/bootloader/src/pyi_path.c
@@ -310,12 +310,13 @@ pyi_path_executable(char *execfile, const char *appname)
 /*
  * Return absolute path to homepath. It is the directory containing executable.
  */
-void
+bool
 pyi_path_homepath(char *homepath, const char *thisfile)
 {
     /* Fill in here (directory of thisfile). */
-    pyi_path_dirname(homepath, thisfile);
+    bool rc = pyi_path_dirname(homepath, thisfile);
     VS("LOADER: homepath is %s\n", homepath);
+    return rc;
 }
 
 /*

--- a/bootloader/src/pyi_path.c
+++ b/bootloader/src/pyi_path.c
@@ -240,7 +240,7 @@ pyi_search_path(char * result, const char * appname)
  * execfile - buffer where to put path to executable.
  * appname - usually the item argv[0].
  */
-int
+bool
 pyi_path_executable(char *execfile, const char *appname)
 {
     char buffer[PATH_MAX];
@@ -252,12 +252,12 @@ pyi_path_executable(char *execfile, const char *appname)
      */
     if (!GetModuleFileNameW(NULL, modulename_w, PATH_MAX)) {
         FATAL_WINERROR("GetModuleFileNameW", "Failed to get executable path.");
-        return -1;
+        return false;
     }
 
     if (!pyi_win32_utils_to_utf8(execfile, modulename_w, PATH_MAX)) {
         FATALERROR("Failed to convert executable path to UTF-8.");
-        return -1;
+        return false;
     }
 
 #elif __APPLE__
@@ -268,12 +268,12 @@ pyi_path_executable(char *execfile, const char *appname)
      */
     if (_NSGetExecutablePath(buffer, &length) != 0) {
         FATALERROR("System error - unable to load!\n");
-        return -1;
+        return false;
     }
 
     if (pyi_path_fullpath(execfile, PATH_MAX, buffer) == false) {
         VS("LOADER: Cannot get fullpath for %s\n", execfile);
-        return -1;
+        return false;
     }
 
 #else /* ifdef _WIN32 */
@@ -283,7 +283,7 @@ pyi_path_executable(char *execfile, const char *appname)
          */
         if (pyi_path_fullpath_keep_basename(execfile, appname) == false) {
             VS("LOADER: Cannot get fullpath for %s\n", execfile);
-            return -1;
+            return false;
         }
     }
     else {
@@ -294,17 +294,17 @@ pyi_path_executable(char *execfile, const char *appname)
             VS("LOADER: Searching $PATH failed for %s", appname);
             if (snprintf(buffer, PATH_MAX, "%s", "appname") >= PATH_MAX) {
                 VS("LOADER: Appname too large %s\n", appname);
-                return -1;
+                return false;
             }
         }
         if (pyi_path_fullpath_keep_basename(execfile, buffer) == false) {
             VS("LOADER: Cannot get fullpath for %s\n", execfile);
-            return -1;
+            return false;
         }
     }
 #endif /* ifdef _WIN32 */
     VS("LOADER: executable is %s\n", execfile);
-    return 0;
+    return true;
 }
 
 /*

--- a/bootloader/src/pyi_path.c
+++ b/bootloader/src/pyi_path.c
@@ -326,14 +326,15 @@ pyi_path_homepath(char *homepath, const char *thisfile)
  * archivefile - buffer where to put path the .pkg.
  * thisfile    - usually the executable's filename.
  */
-void
+bool
 pyi_path_archivefile(char *archivefile, const char *thisfile)
 {
-    strcpy(archivefile, thisfile);
 #ifdef _WIN32
+    strcpy(archivefile, thisfile);
     strcpy(archivefile + strlen(archivefile) - 3, "pkg");
+    return true;
 #else
-    strcat(archivefile, ".pkg");
+    return (snprintf(archivefile, PATH_MAX, "%s.pkg", thisfile) < PATH_MAX);
 #endif
 }
 

--- a/bootloader/src/pyi_path.c
+++ b/bootloader/src/pyi_path.c
@@ -175,7 +175,7 @@ pyi_path_fullpath_keep_basename(char *abs, const char *rel)
     if (realpath(dirname, full_dirname) == NULL) {
         return false;
     }
-    return (pyi_path_join(abs, full_dirname, basename) == NULL);
+    return (pyi_path_join(abs, full_dirname, basename) != NULL);
 }
 #endif
 

--- a/bootloader/src/pyi_path.c
+++ b/bootloader/src/pyi_path.c
@@ -37,6 +37,7 @@
 #include <string.h>
 
 /* PyInstaller headers. */
+#include "pyi_path.h"
 #include "pyi_global.h"  /* PATH_MAX */
 #include "pyi_utils.h"
 #include "pyi_win32_utils.h"

--- a/bootloader/src/pyi_path.c
+++ b/bootloader/src/pyi_path.c
@@ -364,6 +364,4 @@ pyi_path_fopen(const char* filename, const char* mode)
     pyi_win32_utils_from_utf8(wmode, mode, 10);
     return _wfopen(wfilename, wmode);
 }
-#else
-    #define pyi_path_fopen(x, y)    fopen(x, y)
 #endif

--- a/bootloader/src/pyi_path.c
+++ b/bootloader/src/pyi_path.c
@@ -129,28 +129,31 @@ pyi_path_basename(char *result, const char *path)
 char *
 pyi_path_join(char *result, const char *path1, const char *path2)
 {
-    size_t len = 0;
-    memset(result, 0, PATH_MAX);
-    /* Copy path1 to result without null terminator */
-    strcpy(result, path1);
-    /* Append trailing slash if missing. */
-    len = strlen(result);
-
-    if (result[len - 1] != PYI_SEP) {
-        result[len] = PYI_SEP;
-        result[len + 1] = PYI_NULLCHAR;
+    size_t len, len2;
+    /* Copy path1 to result */
+    len = snprintf(result, PATH_MAX, "%s", path1);
+    if (len >= PATH_MAX-1) {
+        return NULL;
     }
+    /* Append trailing slash if missing. */
+    if (result[len-1] != PYI_SEP) {
+        result[len++] = PYI_SEP;
+        result[len++] = PYI_NULLCHAR;
+    }
+    len = PATH_MAX - len;
+    len2 = strlen(path2);
+    if (len2 >= len) {
+        return NULL;
+    };
     /* Remove trailing slash from path2 if present. */
-    len = strlen(path2);
-
-    if (path2[len - 1] == PYI_SEP) {
+    if (path2[len2 - 1] == PYI_SEP) {
         /* Append path2 without slash. */
-        strcat(result, path2);
+        strncat(result, path2, len);
         result[strlen(result) - 1] = PYI_NULLCHAR;
     }
     else {
         /* path2 does not end with slash. */
-        strcat(result, path2);
+        strncat(result, path2, len);
     }
     return result;
 }

--- a/bootloader/src/pyi_path.c
+++ b/bootloader/src/pyi_path.c
@@ -54,7 +54,7 @@ pyi_path_dirname(char *result, const char *path)
     char *match = NULL;
 
     /* Copy path to result and then just write '\0' to the place with path separator. */
-    strncpy(result, path, strlen(path) + 1);
+    strncpy(result, path, PATH_MAX);
     /* Remove separator from the end. */
     len = strlen(result);
 
@@ -127,7 +127,7 @@ pyi_path_join(char *result, const char *path1, const char *path2)
     size_t len = 0;
     memset(result, 0, PATH_MAX);
     /* Copy path1 to result without null terminator */
-    strncpy(result, path1, strlen(path1));
+    strcpy(result, path1);
     /* Append trailing slash if missing. */
     len = strlen(result);
 
@@ -140,7 +140,8 @@ pyi_path_join(char *result, const char *path1, const char *path2)
 
     if (path2[len - 1] == PYI_SEP) {
         /* Append path2 without slash. */
-        strncat(result, path2, len - 2);
+        strcat(result, path2);
+        result[strlen(result) - 1] = PYI_NULLCHAR;
     }
     else {
         /* path2 does not end with slash. */

--- a/bootloader/src/pyi_path.c
+++ b/bootloader/src/pyi_path.c
@@ -29,7 +29,6 @@
     #include <mach-o/dyld.h> /* _NSGetExecutablePath() */
 #else
     #include <libgen.h>  /* basename() */
-    #include <limits.h>  /* PATH_MAX */
     #include <unistd.h>  /* unlink */
 #endif
 

--- a/bootloader/src/pyi_path.c
+++ b/bootloader/src/pyi_path.c
@@ -205,40 +205,20 @@ pyi_path_exists(char * path)
 int
 pyi_search_path(char * result, const char * appname)
 {
-    char * path = pyi_getenv("PATH");
-    char dirname[PATH_MAX + 1];
-    char filename[PATH_MAX + 1];
+    char *path = pyi_getenv("PATH"); // returns a copy
+    char *dirname;
 
     if (NULL == path) {
         return -1;
     }
 
-    while (1) {
-        char *delim = strchr(path, PYI_PATHSEP);
-
-        if (delim) {
-            size_t len = delim - path;
-
-            if (len > PATH_MAX) {
-                len = PATH_MAX;
-            }
-            strncpy(dirname, path, len);
-            *(dirname + len) = '\0';
-        }
-        else {  /* last $PATH element */
-            strncpy(dirname, path, PATH_MAX);
-        }
-        pyi_path_join(filename, dirname, appname);
-
-        if (pyi_path_exists(filename)) {
-            strncpy(result, filename, PATH_MAX);
+    dirname = strtok(path, PYI_PATHSEPSTR);
+    while (dirname != NULL) {
+        pyi_path_join(result, dirname, appname);
+        if (pyi_path_exists(result)) {
             return 0;
         }
-
-        if (!delim) {
-            break;
-        }
-        path = delim + 1;
+        dirname = strtok(NULL, PYI_PATHSEPSTR);
     }
     return -1;
 }

--- a/bootloader/src/pyi_path.c
+++ b/bootloader/src/pyi_path.c
@@ -210,25 +210,25 @@ pyi_path_exists(char * path)
 /* Search $PATH for the program named 'appname' and return its full path.
  * 'result' should be a buffer of at least PATH_MAX characters.
  */
-int
+bool
 pyi_search_path(char * result, const char * appname)
 {
     char *path = pyi_getenv("PATH"); // returns a copy
     char *dirname;
 
     if (NULL == path) {
-        return -1;
+        return false;
     }
 
     dirname = strtok(path, PYI_PATHSEPSTR);
     while (dirname != NULL) {
         if ((pyi_path_join(result, dirname, appname) != NULL)
             && pyi_path_exists(result)) {
-            return 0;
+            return true;
         }
         dirname = strtok(NULL, PYI_PATHSEPSTR);
     }
-    return -1;
+    return false;
 }
 
 /*
@@ -244,7 +244,6 @@ int
 pyi_path_executable(char *execfile, const char *appname)
 {
     char buffer[PATH_MAX];
-    size_t result = -1;
 
 #ifdef _WIN32
     wchar_t modulename_w[PATH_MAX];
@@ -290,8 +289,7 @@ pyi_path_executable(char *execfile, const char *appname)
     else {
         /* No absolute or relative path, just program name: search $PATH.
          */
-        result = pyi_search_path(buffer, appname);
-        if (-1 == result) {
+        if (! pyi_search_path(buffer, appname)) {
             /* Searching $PATH failed, user is crazy. */
             VS("LOADER: Searching $PATH failed for %s", appname);
             if (snprintf(buffer, PATH_MAX, "%s", "appname") >= PATH_MAX) {

--- a/bootloader/src/pyi_path.c
+++ b/bootloader/src/pyi_path.c
@@ -55,15 +55,15 @@ pyi_path_dirname(char *result, const char *path)
 
     /* Copy path to result and then just write '\0' to the place with path separator. */
     strncpy(result, path, PATH_MAX);
-    /* Remove separator from the end. */
-    len = strlen(result);
 
-    if (result[len] == PYI_SEP) {
+    /* Remove separator from the end. */
+    len = strlen(result)-1;
+    if (len >= 0 && result[len] == PYI_SEP) {
         result[len] = PYI_NULLCHAR;
     }
+
     /* Remove the rest of the string. */
     match = strrchr(result, PYI_SEP);
-
     if (match != NULL) {
         *match = PYI_NULLCHAR;
     }

--- a/bootloader/src/pyi_path.c
+++ b/bootloader/src/pyi_path.c
@@ -46,7 +46,7 @@
  * Giving a fullpath, it will copy to the buffer a string
  * which contains the path without last component.
  */
-void
+bool
 pyi_path_dirname(char *result, const char *path)
 {
 #ifndef HAVE_DIRNAME
@@ -54,7 +54,9 @@ pyi_path_dirname(char *result, const char *path)
     char *match = NULL;
 
     /* Copy path to result and then just write '\0' to the place with path separator. */
-    strncpy(result, path, PATH_MAX);
+    if (snprintf(result, PATH_MAX, "%s", path) >= PATH_MAX) {
+        return false;
+    }
 
     /* Remove separator from the end. */
     len = strlen(result)-1;
@@ -77,18 +79,20 @@ pyi_path_dirname(char *result, const char *path)
     char *dirpart = NULL;
     char tmp[PATH_MAX];
     /* Copy path to 'tmp' because dirname() modifies the original string! */
-    strcpy(tmp, path);
-
+    if (snprintf(tmp, PATH_MAX, "%s", path) >= PATH_MAX) {
+        return false;
+    }
     dirpart = (char *) dirname((char *) tmp);  /* _XOPEN_SOURCE - no 'const'. */
-    strcpy(result, dirpart);
+    strncpy(result, dirpart, PATH_MAX);
 #endif /* ifndef HAVE_DIRNAME */
+    return true;
 }
 
 /*
  * Returns the last component of the path in filename. Return result
  * in new buffer.
  */
-void
+bool
 pyi_path_basename(char *result, const char *path)
 {
 #ifndef HAVE_BASENAME
@@ -107,6 +111,7 @@ pyi_path_basename(char *result, const char *path)
     base = (char *) basename((char *) path);  /* _XOPEN_SOURCE - no 'const'. */
     strcpy(result, base);
 #endif /* ifndef HAVE_BASENAME */
+    return true;
 }
 
 /*

--- a/bootloader/src/pyi_path.c
+++ b/bootloader/src/pyi_path.c
@@ -125,20 +125,7 @@ char *
 pyi_path_join(char *result, const char *path1, const char *path2)
 {
     size_t len = 0;
-
-    if (NULL == result) {
-        len = strlen(path1) + strlen(path2) + 2;
-        result = malloc(len);
-
-        if (NULL == result) {
-            return NULL;
-        }
-
-        memset(result, 0, len);
-    }
-    else {
-        memset(result, 0, PATH_MAX);
-    }
+    memset(result, 0, PATH_MAX);
     /* Copy path1 to result without null terminator */
     strncpy(result, path1, strlen(path1));
     /* Append trailing slash if missing. */

--- a/bootloader/src/pyi_path.c
+++ b/bootloader/src/pyi_path.c
@@ -222,8 +222,8 @@ pyi_search_path(char * result, const char * appname)
 
     dirname = strtok(path, PYI_PATHSEPSTR);
     while (dirname != NULL) {
-        pyi_path_join(result, dirname, appname);
-        if (pyi_path_exists(result)) {
+        if ((pyi_path_join(result, dirname, appname) != NULL)
+            && pyi_path_exists(result)) {
             return 0;
         }
         dirname = strtok(NULL, PYI_PATHSEPSTR);

--- a/bootloader/src/pyi_path.h
+++ b/bootloader/src/pyi_path.h
@@ -22,7 +22,6 @@
 void *pyi_path_basename(char *result, const char *path);
 void *pyi_path_dirname(char *result, const char *path);
 void *pyi_path_join(char *result, const char *path1, const char *path2);
-void *pyi_path_normalize(char *result, const char *path);
 int pyi_path_fullpath(char *abs, size_t abs_size, const char *rel);
 /* TODO implement. */
 /* void *pyi_path_abspath(char *result, const char *path); */

--- a/bootloader/src/pyi_path.h
+++ b/bootloader/src/pyi_path.h
@@ -31,7 +31,7 @@ int pyi_path_exists(char *path);
 
 bool pyi_path_executable(char *execfile, const char *appname);
 bool pyi_path_homepath(char *homepath, const char *executable);
-void pyi_path_archivefile(char *archivefile, const char *executable);
+bool pyi_path_archivefile(char *archivefile, const char *executable);
 
 #ifdef _WIN32
 FILE *pyi_path_fopen(const char *filename, const char *mode);

--- a/bootloader/src/pyi_path.h
+++ b/bootloader/src/pyi_path.h
@@ -21,8 +21,8 @@
 #include "pyi_global.h"
 
 /* Path manipulation. Result is added to the supplied buffer. */
-void pyi_path_basename(char *result, const char *path);
-void pyi_path_dirname(char *result, const char *path);
+bool pyi_path_basename(char *result, const char *path);
+bool pyi_path_dirname(char *result, const char *path);
 char *pyi_path_join(char *result, const char *path1, const char *path2);
 int pyi_path_fullpath(char *abs, size_t abs_size, const char *rel);
 /* TODO implement. */

--- a/bootloader/src/pyi_path.h
+++ b/bootloader/src/pyi_path.h
@@ -29,7 +29,7 @@ int pyi_path_fullpath(char *abs, size_t abs_size, const char *rel);
 /* void *pyi_path_abspath(char *result, const char *path); */
 int pyi_path_exists(char *path);
 
-int pyi_path_executable(char *execfile, const char *appname);
+bool pyi_path_executable(char *execfile, const char *appname);
 void pyi_path_homepath(char *homepath, const char *executable);
 void pyi_path_archivefile(char *archivefile, const char *executable);
 

--- a/bootloader/src/pyi_path.h
+++ b/bootloader/src/pyi_path.h
@@ -21,9 +21,9 @@
 #include "pyi_global.h"
 
 /* Path manipulation. Result is added to the supplied buffer. */
-void *pyi_path_basename(char *result, const char *path);
-void *pyi_path_dirname(char *result, const char *path);
-void *pyi_path_join(char *result, const char *path1, const char *path2);
+void pyi_path_basename(char *result, const char *path);
+void pyi_path_dirname(char *result, const char *path);
+char *pyi_path_join(char *result, const char *path1, const char *path2);
 int pyi_path_fullpath(char *abs, size_t abs_size, const char *rel);
 /* TODO implement. */
 /* void *pyi_path_abspath(char *result, const char *path); */

--- a/bootloader/src/pyi_path.h
+++ b/bootloader/src/pyi_path.h
@@ -30,7 +30,7 @@ int pyi_path_fullpath(char *abs, size_t abs_size, const char *rel);
 int pyi_path_exists(char *path);
 
 bool pyi_path_executable(char *execfile, const char *appname);
-void pyi_path_homepath(char *homepath, const char *executable);
+bool pyi_path_homepath(char *homepath, const char *executable);
 void pyi_path_archivefile(char *archivefile, const char *executable);
 
 #ifdef _WIN32

--- a/bootloader/src/pyi_path.h
+++ b/bootloader/src/pyi_path.h
@@ -18,6 +18,8 @@
 #ifndef PYI_PATH_H
 #define PYI_PATH_H
 
+#include "pyi_global.h"
+
 /* Path manipulation. Result is added to the supplied buffer. */
 void *pyi_path_basename(char *result, const char *path);
 void *pyi_path_dirname(char *result, const char *path);

--- a/bootloader/src/pyi_pythonlib.c
+++ b/bootloader/src/pyi_pythonlib.c
@@ -109,7 +109,11 @@ pyi_pylib_load(ARCHIVE_STATUS *status)
      */
     if (status->has_temp_directory) {
         char ucrtpath[PATH_MAX];
-        pyi_path_join(ucrtpath, status->temppath, "ucrtbase.dll");
+        if (pyi_path_join(ucrtpath,
+                          status->temppath, "ucrtbase.dll") == NULL) {
+            FATALERROR("Path of ucrtbase.dll (%s) length exceeds "
+                       "buffer[%d] space\n", status->temppath, PATH_MAX);
+        };
         if (pyi_path_exists(ucrtpath)) {
             VS("LOADER: ucrtbase.dll found: %s\n", ucrtpath);
             pyi_utils_dlopen(ucrtpath);
@@ -121,7 +125,10 @@ pyi_pylib_load(ARCHIVE_STATUS *status)
      * Look for Python library in homepath or temppath.
      * It depends on the value of mainpath.
      */
-    pyi_path_join(dllpath, status->mainpath, dllname);
+    if (pyi_path_join(dllpath, status->mainpath, dllname) == NULL) {
+        FATALERROR("Path of DLL (%s) length exceeds buffer[%d] space\n",
+                   status->mainpath, PATH_MAX);
+    };
 
     VS("LOADER: Python library: %s\n", dllpath);
 

--- a/bootloader/src/pyi_pythonlib.c
+++ b/bootloader/src/pyi_pythonlib.c
@@ -414,11 +414,11 @@ pyi_pylib_start_python(ARCHIVE_STATUS *status)
 
     /* Set sys.path */
     /* sys.path = [base_library, mainpath] */
-    strncpy(pypath, status->mainpath, strlen(status->mainpath));
-    strncat(pypath, PYI_SEPSTR, strlen(PYI_SEPSTR));
-    strncat(pypath, "base_library.zip", strlen("base_library.zip"));
-    strncat(pypath, PYI_PATHSEPSTR, strlen(PYI_PATHSEPSTR));
-    strncat(pypath, status->mainpath, strlen(status->mainpath));
+    strncpy(pypath, status->mainpath, PATH_MAX);
+    strncat(pypath, PYI_SEPSTR, PATH_MAX);
+    strncat(pypath, "base_library.zip", PATH_MAX);
+    strncat(pypath, PYI_PATHSEPSTR, PATH_MAX);
+    strncat(pypath, status->mainpath, PATH_MAX);
 
     /*
      * E must set sys.path to have base_library.zip before

--- a/bootloader/src/pyi_pythonlib.c
+++ b/bootloader/src/pyi_pythonlib.c
@@ -58,7 +58,6 @@ pyi_pylib_load(ARCHIVE_STATUS *status)
     dylib_t dll;
     char dllpath[PATH_MAX];
     char dllname[DLLNAME_LEN];
-    char *p;
     size_t len;
 
 /*
@@ -72,6 +71,7 @@ pyi_pylib_load(ARCHIVE_STATUS *status)
      * Determine if shared lib is in libpython?.?.so or
      * libpython?.?.a(libpython?.?.so) format
      */
+    char *p;
     if ((p = strrchr(status->cookie.pylibname, '.')) != NULL && strcmp(p, ".a") == 0) {
       /*
        * On AIX 'ar' archives are used for both static and shared object.

--- a/bootloader/src/pyi_pythonlib.c
+++ b/bootloader/src/pyi_pythonlib.c
@@ -41,6 +41,7 @@
 #include <locale.h>  /* setlocale */
 
 /* PyInstaller headers. */
+#include "pyi_pythonlib.h"
 #include "pyi_global.h"
 #include "pyi_path.h"
 #include "pyi_archive.h"

--- a/bootloader/src/pyi_pythonlib.c
+++ b/bootloader/src/pyi_pythonlib.c
@@ -27,7 +27,6 @@
     #include <winsock.h> /* ntohl */
 #else
     #include <dlfcn.h>  /* dlerror */
-    #include <limits.h> /* PATH_MAX */
     #ifdef __FreeBSD__
 /* freebsd issue #188316 */
         #include <arpa/inet.h>  /* ntohl */

--- a/bootloader/src/pyi_pythonlib.h
+++ b/bootloader/src/pyi_pythonlib.h
@@ -18,6 +18,8 @@
 #ifndef PYI_PYTHONLIB_H
 #define PYI_PYTHONLIB_H
 
+#include "pyi_archive.h"
+
 int pyi_pylib_attach(ARCHIVE_STATUS *status, int *loadedNew);
 int pyi_pylib_load(ARCHIVE_STATUS *status);  /* note - pyi_pylib_attach will call this if not already loaded */
 int pyi_pylib_start_python(ARCHIVE_STATUS *status);

--- a/bootloader/src/pyi_utils.c
+++ b/bootloader/src/pyi_utils.c
@@ -557,11 +557,8 @@ pyi_open_target(const char *path, const char* name_)
     char *dir;
     size_t len;
 
-    strncpy(fnm, path, PATH_MAX);
-    strncpy(name, name_, PATH_MAX);
-
-    /* Check if the path names could be copied */
-    if (fnm[PATH_MAX-1] != '\0' || name[PATH_MAX-1] != '\0') {
+    if (snprintf(fnm, PATH_MAX, "%s", path) >= PATH_MAX ||
+        snprintf(name, PATH_MAX, "%s", name_) >= PATH_MAX) {
         return NULL;
     }
 

--- a/bootloader/src/pyi_utils.c
+++ b/bootloader/src/pyi_utils.c
@@ -42,7 +42,6 @@
     #else
         #include <dlfcn.h>
     #endif
-    #include <limits.h>  /* PATH_MAX */
     #include <signal.h>  /* kill, */
     #include <sys/wait.h>
     #include <unistd.h>  /* rmdir, unlink, mkdtemp */

--- a/bootloader/src/pyi_win32_utils.c
+++ b/bootloader/src/pyi_win32_utils.c
@@ -178,6 +178,10 @@ pyi_win32_wcs_to_mbs(const wchar_t *wstr)
     }
 
     str = (char *)calloc(len + 1, sizeof(char));
+    if (str == NULL) {
+        FATAL_WINERROR("win32_wcs_to_mbs", "Out of memory.");
+        return NULL;
+    };
 
     ret = WideCharToMultiByte(CP_ACP,    /* CodePage */
                               0,         /* dwFlags */
@@ -213,6 +217,9 @@ pyi_win32_argv_to_utf8(int argc, wchar_t **wargv)
     char ** argv;
 
     argv = (char **)calloc(argc + 1, sizeof(char *));
+    if (argv == NULL) {
+        return NULL;
+    };
 
     for (i = 0; i < argc; i++) {
         argv[i] = pyi_win32_utils_to_utf8(NULL, wargv[i], 0);
@@ -244,6 +251,9 @@ pyi_win32_wargv_from_utf8(int argc, char **argv)
     wchar_t ** wargv;
 
     wargv = (wchar_t **)calloc(argc + 1, sizeof(wchar_t *));
+    if (wargv == NULL) {
+        return NULL;
+    };
 
     for (i = 0; i < argc; i++) {
         wargv[i] = pyi_win32_utils_from_utf8(NULL, argv[i], 0);
@@ -303,6 +313,10 @@ pyi_win32_utils_to_utf8(char *str, const wchar_t *wstr, size_t len)
         }
 
         output = (char *)calloc(len + 1, sizeof(char));
+        if (output == NULL) {
+            FATAL_WINERROR("win32_utils_to_utf8", "Out of memory.");
+            return NULL;
+        };
     }
     else {
         output = str;
@@ -363,6 +377,10 @@ pyi_win32_utils_from_utf8(wchar_t *wstr, const char *str, size_t wlen)
         }
 
         output = (wchar_t *)calloc(wlen + 1, sizeof(wchar_t));
+        if (output == NULL) {
+            FATAL_WINERROR("win32_utils_from_utf8", "Out of memory.");
+            return NULL;
+        };
     }
     else {
         output = wstr;

--- a/bootloader/tests/test_launch.c
+++ b/bootloader/tests/test_launch.c
@@ -1,0 +1,104 @@
+// -----------------------------------------------------------------------------
+// Copyright (c) 2020, PyInstaller Development Team.
+//
+// Distributed under the terms of the GNU General Public License (version 2
+// or later) with exception for distributing the bootloader.
+//
+// The full license is in the file COPYING.txt, distributed with this software.
+//
+// SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+// -----------------------------------------------------------------------------
+
+#include <sys/types.h>
+#include <stdarg.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "pyi_global.h"
+#include <errno.h>
+
+#include <setjmp.h> // required fo cmocka :-(
+#include <cmocka.h>
+
+int checkFile(char *buf, const char *fmt, ...);
+
+static void test_checkFile(void **state) {
+    char result[PATH_MAX];
+
+    // TODO: use some mocks to determine stat() output
+
+    errno = 0;
+    assert_int_equal(-1, checkFile(result, "%s%s%s.pkg", "a1", "bb", "cc", "dd"));
+    assert_int_not_equal(errno, 0); // formatting passed, stat failed
+    assert_string_equal(result, "a1bbcc.pkg");
+
+    errno = 0;
+    assert_int_equal(-1, checkFile(result, "%s", ""));
+    assert_int_not_equal(errno, 0); // formatting passed, stat failed
+    assert_string_equal(result, "");
+
+    char *path2 = (char *) malloc(PATH_MAX+10);
+    memset(path2, 'a', PATH_MAX+8);
+    // a few bytes more
+    errno = 0;
+    path2[PATH_MAX+8] = '\0';
+    assert_int_equal(-1, checkFile(result, "%s%s%s.pkg", "a1", path2, "ccc"));
+    assert_int_equal(errno, 0); // formatting formatting failed
+    // exact length
+    errno = 0;
+    path2[PATH_MAX] = '\0';
+    assert_int_equal(-1, checkFile(result, "%s", path2));
+    assert_int_equal(errno, 0); // formatting formatting failed
+    // one byte less
+    errno = 0;
+    path2[PATH_MAX-1] = '\0';
+    assert_int_equal(-1, checkFile(result, "%s", path2));
+    assert_int_not_equal(errno, 0); // formatting passed, stat failed
+}
+
+int splitName(char *path, char *filename, const char *item);
+
+static void test_splitName(void **state) {
+    char path[PATH_MAX];
+    char filename[PATH_MAX];
+
+    // TODO: use some mocks to determine
+
+    assert_int_equal(0, splitName(path, filename, "aaa:bbb"));
+    assert_string_equal(path, "aaa");
+    assert_string_equal(filename, "bbb");
+
+    assert_int_equal(-1, splitName(path, filename, ""));
+    assert_int_equal(-1, splitName(path, filename, ":"));
+    assert_int_equal(-1, splitName(path, filename, "aaa"));
+    assert_int_equal(-1, splitName(path, filename, "aaa:"));
+    assert_int_equal(-1, splitName(path, filename, ":bbb"));
+
+    // these cases are not expected to occur in real life
+    assert_int_equal(0, splitName(path, filename, "aaa:::"));
+    assert_string_equal(filename, "::");
+    assert_int_equal(-1, splitName(path, filename, ":::bbb"));
+
+    char *path2 = (char *) malloc(PATH_MAX+10);
+    memset(path2, 'a', PATH_MAX+8);
+    path2[10] = ':';
+    // a few bytes more
+    path2[PATH_MAX+8] = '\0';
+    assert_int_equal(-1, splitName(path, filename, path2));
+    // exact length
+    path2[PATH_MAX] = '\0';
+    assert_int_equal(-1, splitName(path, filename, path2));
+    // one byte less
+    path2[PATH_MAX-1] = '\0';
+    assert_int_equal(0, splitName(path, filename, path2));
+    assert_string_equal(path, "aaaaaaaaaa");
+}
+
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_checkFile),
+        cmocka_unit_test(test_splitName),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/bootloader/tests/test_path.c
+++ b/bootloader/tests/test_path.c
@@ -1,0 +1,124 @@
+// -----------------------------------------------------------------------------
+// Copyright (c) 2020, PyInstaller Development Team.
+//
+// Distributed under the terms of the GNU General Public License (version 2
+// or later) with exception for distributing the bootloader.
+//
+// The full license is in the file COPYING.txt, distributed with this software.
+//
+// SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+// -----------------------------------------------------------------------------
+
+#include <sys/types.h>
+#include <stdarg.h>
+#include <string.h>
+
+#include "pyi_global.h"
+#include "pyi_path.h"
+
+#include <setjmp.h> // required fo cmocka :-(
+#include <cmocka.h>
+
+
+static void test_dirname(void **state) {
+    char result[PATH_MAX];
+
+    pyi_path_dirname(result, "/a1/bb/cc/dd");
+    assert_string_equal(result, "/a1/bb/cc");
+
+    pyi_path_dirname(result, "/a2/bb/cc/dd/");
+    assert_string_equal(result, "/a2/bb/cc");
+
+    pyi_path_dirname(result, "d3d");
+    assert_string_equal(result, PYI_CURDIRSTR);
+
+    pyi_path_dirname(result, "d5d/");
+    assert_string_equal(result, PYI_CURDIRSTR);
+
+    pyi_path_dirname(result, "");
+    assert_string_equal(result, PYI_CURDIRSTR);
+}
+
+
+static void test_basename(void **state) {
+    char result[PATH_MAX];
+    char input[PATH_MAX];
+    // basename()'s second argument is not `const`, thus using a constant
+    // string yields to segementation fault.
+
+    strcpy(input, "/aa/bb/cc/d1d");
+    pyi_path_basename(result, input);
+    assert_string_equal(result, "d1d");
+
+    strcpy(input, "d3dd");
+    pyi_path_basename(result, input);
+    assert_string_equal(result, "d3dd");
+
+    /* These cases are not correctly handled by our implementation of
+     * basename(). But this is okay, since we use basename() only to determine
+     * the application path based on argv[0].
+     *
+    strcpy(input, "/aa/bb/cc/d2d/");
+    pyi_path_basename(result, input);
+    assert_string_equal(result, "d2d");
+
+    strcpy(input, "d4dd/");
+    pyi_path_basename(result, input);
+    assert_string_equal(result, "d4dd");
+
+    strcpy(input, "");
+    pyi_path_basename(result, input);
+    assert_string_equal(result, PYI_CURDIRSTR);
+    */
+}
+
+
+static void test_join(void **state) {
+    char path1[PATH_MAX];
+    char path2[PATH_MAX];
+    char result[PATH_MAX];
+    char *r;
+
+    r = pyi_path_join((char *)result, "lalala", "mememe");
+    assert_ptr_equal(r, &result);
+    assert_string_equal(result, "lalala/mememe");
+
+    r = pyi_path_join((char *)result, "lalala/", "mememe");
+    assert_ptr_equal(r, &result);
+    assert_string_equal(result, "lalala/mememe");
+
+    r = pyi_path_join((char *)result, "lalala/", "mememe/");
+    assert_ptr_equal(r, &result);
+    assert_string_equal(result, "lalala/mememe");
+
+    r = pyi_path_join((char *)result, "lal/ala/", "mem/eme/");
+    assert_ptr_equal(r, &result);
+    assert_string_equal(result, "lal/ala/mem/eme");
+
+    memset(path1, 'a', PATH_MAX); path1[PATH_MAX-1] = '\0';
+    memset(path2, 'b', PATH_MAX); path2[PATH_MAX-1] = '\0';
+    assert_int_equal(strlen(path1), PATH_MAX-1);
+    assert_int_equal(strlen(path2), PATH_MAX-1);
+    //r = pyi_path_join((char *)result, (char *)path1,  (char *)path2);
+    //assert_ptr_equal(r, &result);
+    //assert_string_equal(result, path1);
+}
+
+
+int pyi_search_path(char *result, const char *appname);
+
+static void test_search_path(void **state) {
+    char result[PATH_MAX];
+    pyi_search_path(result, "my-app");
+}
+
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_dirname),
+        cmocka_unit_test(test_basename),
+        cmocka_unit_test(test_join),
+        cmocka_unit_test(test_search_path),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/bootloader/tests/test_path.c
+++ b/bootloader/tests/test_path.c
@@ -12,6 +12,7 @@
 #include <sys/types.h>
 #include <stdarg.h>
 #include <string.h>
+#include <stdlib.h>
 
 #include "pyi_global.h"
 #include "pyi_path.h"
@@ -23,20 +24,32 @@
 static void test_dirname(void **state) {
     char result[PATH_MAX];
 
-    pyi_path_dirname(result, "/a1/bb/cc/dd");
+    assert_true(pyi_path_dirname(result, "/a1/bb/cc/dd"));
     assert_string_equal(result, "/a1/bb/cc");
 
-    pyi_path_dirname(result, "/a2/bb/cc/dd/");
+    assert_true(pyi_path_dirname(result, "/a2/bb/cc/dd/"));
     assert_string_equal(result, "/a2/bb/cc");
 
-    pyi_path_dirname(result, "d3d");
+    assert_true(pyi_path_dirname(result, "d3d"));
     assert_string_equal(result, PYI_CURDIRSTR);
 
-    pyi_path_dirname(result, "d5d/");
+    assert_true(pyi_path_dirname(result, "d5d/"));
     assert_string_equal(result, PYI_CURDIRSTR);
 
-    pyi_path_dirname(result, "");
+    assert_true(pyi_path_dirname(result, ""));
     assert_string_equal(result, PYI_CURDIRSTR);
+
+    char *path2 = (char *) malloc(PATH_MAX+10);
+    memset(path2, 'a', PATH_MAX+8);
+    // a few bytes more
+    path2[PATH_MAX+8] = '\0';
+    assert_false(pyi_path_dirname(result, path2));
+    // exact length
+    path2[PATH_MAX] = '\0';
+    assert_false(pyi_path_dirname(result, path2));
+    // one byte less
+    path2[PATH_MAX-1] = '\0';
+    assert_true(pyi_path_dirname(result, path2));
 }
 
 

--- a/bootloader/tests/test_path.c
+++ b/bootloader/tests/test_path.c
@@ -104,17 +104,61 @@ static void test_join(void **state) {
     assert_ptr_equal(r, &result);
     assert_string_equal(result, "lalala/mememe");
 
+    r = pyi_path_join((char *)result, "lalala", "mememe/");
+    assert_ptr_equal(r, &result);
+    assert_string_equal(result, "lalala/mememe");
+
     r = pyi_path_join((char *)result, "lal/ala/", "mem/eme/");
     assert_ptr_equal(r, &result);
     assert_string_equal(result, "lal/ala/mem/eme");
+
+    // First string empty is not handled
+    r = pyi_path_join((char *)result, "", "mememe");
+    assert_ptr_equal(r, &result);
+    assert_string_equal(result, "/mememe");
 
     memset(path1, 'a', PATH_MAX); path1[PATH_MAX-1] = '\0';
     memset(path2, 'b', PATH_MAX); path2[PATH_MAX-1] = '\0';
     assert_int_equal(strlen(path1), PATH_MAX-1);
     assert_int_equal(strlen(path2), PATH_MAX-1);
-    //r = pyi_path_join((char *)result, (char *)path1,  (char *)path2);
-    //assert_ptr_equal(r, &result);
-    //assert_string_equal(result, path1);
+    assert_ptr_equal(NULL, pyi_path_join(result, path1, path2));
+
+    // tests near max lenght of path1
+    assert_ptr_equal(NULL, pyi_path_join(result, path1, ""));
+    path1[PATH_MAX-2] = '\0';
+    assert_ptr_equal(NULL, pyi_path_join(result, path1, ""));
+    path1[PATH_MAX-3] = '\0';
+    assert_ptr_equal(r, pyi_path_join(result, path1, ""));
+    assert_int_equal(strlen(result), PATH_MAX-2); // -2 no trailing slash in path1
+    assert_ptr_equal(NULL, pyi_path_join(result, path1, "x"));
+    path1[PATH_MAX-4] = '\0';
+    assert_ptr_equal(r, pyi_path_join(result, path1, "x"));
+    assert_int_equal(strlen(result), PATH_MAX-2); // -2 no trailing slash in path1
+    assert_ptr_equal(NULL, pyi_path_join(result, path1, "xx"));
+
+    // tests near max lenght of path2
+    assert_ptr_equal(NULL, pyi_path_join(result, "", path2));
+    assert_ptr_equal(NULL, pyi_path_join(result, "x", path2));
+    path2[PATH_MAX-2] = '\0';
+    assert_ptr_equal(NULL, pyi_path_join(result, "", path2)); // stash takes space!
+    assert_ptr_equal(NULL, pyi_path_join(result, "x", path2));
+    path2[PATH_MAX-3] = '\0';
+    assert_ptr_equal(r, pyi_path_join(result, "", path2));
+    assert_ptr_equal(NULL, pyi_path_join(result, "x", path2));
+    path2[PATH_MAX-4] = '\0';
+    assert_ptr_equal(r, pyi_path_join(result, "", path2));
+    assert_ptr_equal(r, pyi_path_join(result, "x", path2));
+    // we don't count exaclty if slashes are contained
+    assert_int_equal(strlen(result), PATH_MAX-2);
+    assert_ptr_equal(NULL, pyi_path_join(result, "xx", path2));
+    path2[PATH_MAX-4] = '/';
+    assert_int_equal(path2[strlen(path2)], 0);
+    assert_int_equal(path2[strlen(path2)-1], '/');
+    assert_ptr_equal(r, pyi_path_join(result, "", path2));
+    // we don't count exaclty if slashes are contained
+    assert_int_equal(strlen(result), PATH_MAX-3);
+    assert_int_equal(result[strlen(result)-1], 'b'); // trailing slash removed
+    assert_ptr_equal(NULL, pyi_path_join(result, "x", path2));
 }
 
 

--- a/bootloader/tests/wscript
+++ b/bootloader/tests/wscript
@@ -1,0 +1,29 @@
+# -*- mode: python -*- vim: filetype=python
+# -----------------------------------------------------------------------------
+# Copyright (c) 2014-2020, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+# -----------------------------------------------------------------------------
+
+def configure(ctx):
+    ctx.check_cc(lib='cmocka', mandatory=False, uselib_store='CMOCKA')
+
+def build(ctx):
+
+    def test_program(name):
+        ctx.program(
+            source= ["test_%s.c" % name],
+            target="test_%s" % name,
+            includes='../src',
+            use=ctx.env.link_with_dynlibs + ["CMOCKA", "OBJECTS"],
+            stlib=ctx.env.link_with_staticlibs,
+            install_path=None,
+        )
+
+    if "LIB_CMOCKA" in ctx.env:
+        test_program("path")

--- a/bootloader/tests/wscript
+++ b/bootloader/tests/wscript
@@ -27,3 +27,4 @@ def build(ctx):
 
     if "LIB_CMOCKA" in ctx.env:
         test_program("path")
+        test_program("launch")

--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -581,6 +581,8 @@ def configure(ctx):
             ctx.env.append_value('DEFINES', 'GC_DEBUG')
             ctx.env.append_value('DEFINES', 'SAVE_CALL_CHAIN')
 
+    ctx.recurse("tests")
+
     ### Functions
 
     # The old ``function_name`` parameter to ``check_cc`` is no longer
@@ -699,7 +701,6 @@ def configure(ctx):
     ## setup windowed RELEASE environment
     windowed('releasew', release_env)
 
-
 # TODO Use 'strip' command to decrease the size of compiled bootloaders.
 def build(ctx):
     if not ctx.variant:
@@ -730,15 +731,21 @@ def build(ctx):
         # Do not strip bootloaders when using MSVC.
         features = ''
 
+    ctx.objects(source=ctx.path.ant_glob('src/*.c', excl="src/main.c"),
+                includes='src windows zlib',
+                target="OBJECTS")
+
+    ctx.env.link_with_dynlibs = []
+    ctx.env.link_with_staticlibs = []
     if ctx.env.DEST_OS == 'win32':
         # Use different RC file (icon) for console/windowed mode - remove '_d'
         icon_rc = 'windows/' + exe_name.replace('_d', '') + '.rc'
         # On Windows we need to link library zlib statically.
         ctx.program(
-            source=ctx.path.ant_glob(['src/*.c', icon_rc]),
+            source=['src/main.c', icon_rc],
             target=exe_name,
             install_path=install_path,
-            use='USER32 COMCTL32 KERNEL32 ADVAPI32 WS2_32 Z',
+            use='OBJECTS USER32 COMCTL32 KERNEL32 ADVAPI32 WS2_32 Z',
             includes='src windows zlib',
             features=features,
         )
@@ -758,14 +765,19 @@ def build(ctx):
         if ctx.options.boehmgc:
             libs.append('GC')
 
+        ctx.env.link_with_dynlibs = libs
+        ctx.env.link_with_staticlibs = staticlibs
+
         ctx.program(
-            source=ctx.path.ant_glob('src/*.c'),
+            source='src/main.c',
             target=exe_name,
             includes='src',
-            use=libs,
+            use=libs + ["OBJECTS"],
             stlib=staticlibs,
             install_path=install_path,
             features=features)
+
+    ctx.recurse("tests")
 
 
 class make_all(BuildContext):

--- a/news/4585.bootloader.rst
+++ b/news/4585.bootloader.rst
@@ -1,0 +1,1 @@
+Fix GCC warnings for strncpy and strncat in bootloader.


### PR DESCRIPTION
Fixes Issue #4196, picks up work from PR #4219.

GCC 8.1 and later added checks to prevent using strncpy and strncat with the bounds depending on the length of the source str. In order to fix this, a few approaches were made:
1. Where guards already existed to ensure that added paths weren't
larger than the PATH_MAX, I changed to strcpy / strcat which don't take
a length parameter.
2. Where path length checks didn't exist, I set the bounds of the strncpy and strncat to PATH_MAX.

Signed-off-by: Dan Yeaw <dyeaw@ford.com>