### PR TITLE
Bootloader build: Fix .rc.o file not found with MinGW-w64

### DIFF
--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -360,6 +360,9 @@ def set_arch_flags(ctx):
             ctx.env.WINRCFLAGS = ['--target=pe-i386']
         else:
             ctx.env.WINRCFLAGS = ['--target=pe-x86-64']
+        # Since WINRC config changed above, must set other options as well
+        ctx.env.WINRC_TGT_F = '-o'
+        ctx.env.WINRC_SRC_F = '-i'
 
 
 def configure(ctx):

--- a/news/4501.build.rst
+++ b/news/4501.build.rst
@@ -1,0 +1,1 @@
+(MinGW-w64) Fix .rc.o file not found error.

--- a/news/4586.build.rst
+++ b/news/4586.build.rst
@@ -1,0 +1,1 @@
+(MinGW-w64) Fix .rc.o file not found error.


### PR DESCRIPTION
Fixes issue #4501. Fixes part of #4513.

When trying to build the bootloader with MinGW-w64, it was giving a windres.exe: windows\run.rc.o: No such file or directory error.

The error was caused because waf only sets the target and source arguments, WINRC_TGT_F and WINRC_SRC_F, when there is no WINRC configuration already set. PyInstaller with MinGW-w64 is setting the WINRCFLAGS which changes the WINRC configuration. The fix for this is to set the WINRC_TGT_F and WINR_SRC_F values manually.

Signed-off-by: Dan Yeaw <dyeaw@ford.com>