### PR TITLE
Bootloader collect: Detect when file exists at path we want to be dir

### DIFF
--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -721,6 +721,11 @@ class COLLECT(Target):
             todir = os.path.dirname(tofnm)
             if not os.path.exists(todir):
                 os.makedirs(todir)
+            elif not os.path.isdir(todir):
+                raise SystemExit(
+                    "Pyinstaller needs to make a directory, but there "
+                    "already is a file at that path. "
+                    "The file at issue is {!r}".format(todir))
             if typ in ('EXTENSION', 'BINARY'):
                 fnm = checkCache(fnm, strip=self.strip_binaries,
                                  upx=self.upx_binaries,

--- a/news/4591.feature.rst
+++ b/news/4591.feature.rst
@@ -1,0 +1,1 @@
+Better error message when file exists at path we want to be dir.


### PR DESCRIPTION
I have a package called vapoursonic, producing a binary called `vapoursonic` too. File structure is like:

```
-src/
----vapoursonic/
--------main.py
--------config.py
```
and `main.py` imports `config.py` via
```python
import vapoursonic.config
```
During the `COLLECT().assemble()` phase, pyinstaller is trying to copy my packages `*.pyo` files into `$OUTPUTDIR/vapoursonic`, which is correct. However, because my executable name is also `vapoursonic`, pyinstaller checks that the *path* `$OUTPUTDIR/vapoursonic` exists, but doesn't ensure that it's a directory. At this point, the executable already exists and is called `vapoursonic`. Pyinstaller assumes that it is a directory, and tries to copy the `.pyo` into it, resulting in the following error:

```python
NotADirectoryError: [Errno 20] Not a directory: '/home/ripdog/PyCharmProjects/vapoursonic/target/vapoursonic/vapoursonic/config.pyc'
```

This error isn't very useful. I propose adding at least a better error, as in this pull request.

Obviously it would be nice if pyinstaller could detect this issue and dynamically rename the directory to get around it, but that's a lot of engineering effort to spend on an issue few will encounter, and which is fairly easy for the user to fix.