### PR TITLE
Bootloader build: Add traceback to debug pyiboot01

### DIFF
--- a/bootloader/src/pyi_python.c
+++ b/bootloader/src/pyi_python.c
@@ -57,6 +57,7 @@ DECLPROC(PyDict_GetItemString);
 DECLPROC(PyErr_Clear);
 DECLPROC(PyErr_Occurred);
 DECLPROC(PyErr_Print);
+DECLPROC(PyErr_Fetch);
 
 DECLPROC(PyImport_AddModule);
 DECLPROC(PyImport_ExecCodeModule);
@@ -66,7 +67,10 @@ DECLPROC(PyList_New);
 DECLPROC(PyLong_AsLong);
 DECLPROC(PyModule_GetDict);
 DECLPROC(PyObject_CallFunction);
+DECLPROC(PyObject_CallFunctionObjArgs);
 DECLPROC(PyObject_SetAttrString);
+DECLPROC(PyObject_GetAttrString);
+DECLPROC(PyObject_Str);
 DECLPROC(PyRun_SimpleString);
 DECLPROC(PySys_AddWarnOption);
 DECLPROC(PySys_SetArgvEx);
@@ -79,6 +83,7 @@ DECLPROC(Py_DecodeLocale);
 DECLPROC(PyUnicode_FromFormat);
 DECLPROC(PyUnicode_DecodeFSDefault);
 DECLPROC(PyUnicode_Decode);
+DECLPROC(PyUnicode_AsUTF8);
 
 DECLPROC(PyEval_EvalCode);
 DECLPROC(PyMarshal_ReadObjectFromString);
@@ -116,6 +121,7 @@ pyi_python_map_names(HMODULE dll, int pyvers)
     GETPROC(dll, PyErr_Clear);
     GETPROC(dll, PyErr_Occurred);
     GETPROC(dll, PyErr_Print);
+    GETPROC(dll, PyErr_Fetch);
     GETPROC(dll, PyImport_AddModule);
     GETPROC(dll, PyImport_ExecCodeModule);
     GETPROC(dll, PyImport_ImportModule);
@@ -124,7 +130,11 @@ pyi_python_map_names(HMODULE dll, int pyvers)
     GETPROC(dll, PyLong_AsLong);
     GETPROC(dll, PyModule_GetDict);
     GETPROC(dll, PyObject_CallFunction);
+    GETPROC(dll, PyObject_CallFunctionObjArgs);
     GETPROC(dll, PyObject_SetAttrString);
+    GETPROC(dll, PyObject_GetAttrString);
+    GETPROC(dll, PyObject_Str);
+
     GETPROC(dll, PyRun_SimpleString);
 
     GETPROC(dll, PySys_AddWarnOption);
@@ -142,6 +152,7 @@ pyi_python_map_names(HMODULE dll, int pyvers)
     GETPROC(dll, PyUnicode_FromFormat);
     GETPROC(dll, PyUnicode_Decode);
     GETPROC(dll, PyUnicode_DecodeFSDefault);
+    GETPROC(dll, PyUnicode_AsUTF8);
 
     VS("LOADER: Loaded functions from Python library.\n");
 

--- a/bootloader/src/pyi_python.h
+++ b/bootloader/src/pyi_python.h
@@ -123,6 +123,7 @@ EXTDECLPROC(PyObject *, Py_BuildValue, (char *, ...));
 /* Create a Unicode object from the char buffer. The bytes will be interpreted as being UTF-8 encoded. */
 EXTDECLPROC(PyObject *, PyUnicode_FromString, (const char *));
 EXTDECLPROC(PyObject *, PyObject_CallFunction, (PyObject *, char *, ...));
+EXTDECLPROC(PyObject *, PyObject_CallFunctionObjArgs, (PyObject *, ...));
 EXTDECLPROC(PyObject *, PyModule_GetDict, (PyObject *));
 EXTDECLPROC(PyObject *, PyDict_GetItemString, (PyObject *, char *));
 EXTDECLPROC(void, PyErr_Clear, (void) );
@@ -150,6 +151,12 @@ EXTDECLPROC(PyObject *, PyUnicode_Decode,
 /* Used to load and execute marshalled code objects */
 EXTDECLPROC(PyObject *, PyEval_EvalCode, (PyObject *, PyObject *, PyObject *));
 EXTDECLPROC(PyObject *, PyMarshal_ReadObjectFromString, (const char *, size_t));  /* Py_ssize_t */
+
+/* Used to get traceback information while launching run scripts */
+EXTDECLPROC(void, PyErr_Fetch, (PyObject **, PyObject **, PyObject **));
+EXTDECLPROC(PyObject *, PyObject_Str, (PyObject *));
+EXTDECLPROC(PyObject *, PyObject_GetAttrString, (PyObject *, const char *));
+EXTDECLPROC(const char *, PyUnicode_AsUTF8, (PyObject *));
 
 /*
  * Macros for reference counting through exported functions

--- a/news/4213.bootloader.rst
+++ b/news/4213.bootloader.rst
@@ -1,0 +1,1 @@
+In debug and windowed mode, print traceback to help debug pyiboot01_bootstrap errors.

--- a/news/4592.bootloader.rst
+++ b/news/4592.bootloader.rst
@@ -1,0 +1,1 @@
+In debug and windowed mode, print traceback to help debug pyiboot01_bootstrap errors.


### PR DESCRIPTION
Adds the Python traceback information to debug errors during pyiboot01_bootstrap when running in Windows in windowed mode. This will allow debugging errors like in Issue #4213.

In order to get the full traceback, you need to use `--debug=noarchive`. I have tried to test this as much as I can for Python 2.7 and < Python 3.7 compatibility using a minimal example, but I don't have a full test app to duplicate pyiboot01_bootloader errors with.

Signed-off-by: Dan Yeaw <dyeaw@ford.com>