### PR TITLE
Fix hook-numpy and hook-scipy to account for differences in location of extra dlls on windows

### DIFF
--- a/PyInstaller/hooks/hook-numpy.py
+++ b/PyInstaller/hooks/hook-numpy.py
@@ -21,8 +21,13 @@ from PyInstaller.utils.hooks import get_module_file_attribute
 binaries = []
 
 # package the DLL bundle that official numpy wheels for Windows ship
+# The DLL bundle will either be in extra-dll on windows proper
+# and in .libs if installed on a virtualenv created from MinGW (Git-Bash
+# for example)
 if is_win:
-    dll_glob = os.path.join(os.path.dirname(
-        get_module_file_attribute('numpy')), 'extra-dll', "*.dll")
-    if glob.glob(dll_glob):
-        binaries.append((dll_glob, "."))
+    extra_dll_locations = ['extra-dll', '.libs']
+    for location in extra_dll_locations:
+        dll_glob = os.path.join(os.path.dirname(
+            get_module_file_attribute('numpy')), location, "*.dll")
+        if glob.glob(dll_glob):
+            binaries.append((dll_glob, "."))

--- a/PyInstaller/hooks/hook-scipy.py
+++ b/PyInstaller/hooks/hook-scipy.py
@@ -17,11 +17,16 @@ from PyInstaller.compat import is_win
 binaries = []
 
 # package the DLL bundle that official scipy wheels for Windows ship
+# The DLL bundle will either be in extra-dll on windows proper
+# and in .libs if installed on a virtualenv created from MinGW (Git-Bash
+# for example)
 if is_win:
-    dll_glob = os.path.join(os.path.dirname(
-        get_module_file_attribute('scipy')), 'extra-dll', "*.dll")
-    if glob.glob(dll_glob):
-        binaries.append((dll_glob, "."))
+    extra_dll_locations = ['extra-dll', '.libs']
+    for location in extra_dll_locations:
+        dll_glob = os.path.join(os.path.dirname(
+            get_module_file_attribute('scipy')), location, "*.dll")
+        if glob.glob(dll_glob):
+            binaries.append((dll_glob, "."))
 
 # collect library-wide utility extension modules
 hiddenimports = ['scipy._lib.%s' % m for m in [

--- a/news/4593.hooks.rst
+++ b/news/4593.hooks.rst
@@ -1,0 +1,2 @@
+Fix hook numpy and hook scipy to account for differences in location of extra
+dlls on Windows.


### PR DESCRIPTION
On windows, numpy and scipy package dlls under the extra-dlls directory under site-packages. However, if you install numpy/scipy on windows through a mingw compatible terminal like git bash, then those dlls are packaged under the .libs directory.

hook-numpy and hook-scipy are written based on native windows installs. This breaks if you use pyinstaller from a mingw compatible terminal. Update the hooks to account for this difference.