### PR TITLE
Hooks: Fix sklearn hook for different location of extra dlls on Windows

### DIFF
--- a/PyInstaller/hooks/hook-sklearn.py
+++ b/PyInstaller/hooks/hook-sklearn.py
@@ -1,0 +1,24 @@
+# -----------------------------------------------------------------------------
+# Copyright (c) 2013-2019, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+# -----------------------------------------------------------------------------
+
+import os
+import glob
+from PyInstaller.compat import is_win
+from PyInstaller.utils.hooks import get_module_file_attribute
+
+binaries = []
+
+# package the DLL bundle that official scikit-learn wheels for Windows ship
+if is_win:
+    extra_dll_locations = ['extra-dll', '.libs']
+    for location in extra_dll_locations:
+        dll_glob = os.path.join(os.path.dirname(
+            get_module_file_attribute('sklearn')), location, "*.dll")
+        if glob.glob(dll_glob):
+            binaries.append((dll_glob, "."))


### PR DESCRIPTION
Fixes missing dlls for scikit-learn on Windows.

Same issue as https://github.com/pyinstaller/pyinstaller/pull/4593
