### PR TITLE
wscript - adding extra flag for AIX strip confuses the AIX loader during "setup.py build"

### DIFF
--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -642,12 +642,6 @@ def configure(ctx):
         # This tool allows reducing the size of executables.
         ctx.find_program([assoc_programm(ctx, 'strip')], var='STRIP')
         ctx.load('strip', tooldir='tools')
-        # There is a strip flag for AIX environment
-        if ctx.env.DEST_OS == 'aix':
-            if ctx.env.PYI_ARCH == '32bit':
-                ctx.env.append_value('STRIPFLAGS', '-X32')
-            elif ctx.env.PYI_ARCH == '64bit':
-                ctx.env.append_value('STRIPFLAGS', '-X64')
 
     def windowed(name, baseenv):
         """Setup windowed environment based on `baseenv`."""


### PR DESCRIPTION
With an emphasis on getting the build of bootstrap successful - do not bother with `strip` automatically.

For a README.aix, or equivalent - document the necessity to call `strip` manually, if deemed necessary. 

Question: where to actually put this comment.

Note: if automatic `strip` is mandatory I will need assistance, as mentioned in the issue #4211 