### PR TITLE
PyInstaller from Python: positional placement of scriptname

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -111,13 +111,13 @@ a list, e.g.
     import PyInstaller.__main__
 
     PyInstaller.__main__.run([
+        os.path.join('my_package', '__main__.py'),
         '--name=%s' % package_name,
         '--onefile',
         '--windowed',
         '--add-binary=%s' % os.path.join('resource', 'path', '*.png'),
         '--add-data=%s' % os.path.join('resource', 'path', '*.txt'),
         '--icon=%s' % os.path.join('resource', 'path', 'icon.ico'),
-        os.path.join('my_package', '__main__.py'),
     ])
 
 


### PR DESCRIPTION
I found that the scriptname needs to come before any of the other parameters, otherwise I'd get an error
`package_model.py: error: unrecognized arguments`

My environment: Windows 10, Python 3.7