### PR TITLE
utils/hooks: match qt5 library names with suffixes.

### DIFF
--- a/PyInstaller/utils/hooks/qt.py
+++ b/PyInstaller/utils/hooks/qt.py
@@ -508,6 +508,11 @@ def add_qt5_dependencies(hook_file):
         # Mac: rename from ``qt`` to ``qt5`` to match names in Windows/Linux.
         if is_darwin and lib_name.startswith('qt'):
             lib_name = 'qt5' + lib_name[2:]
+
+        # match libs with QT_LIBINFIX set to '_conda', i.e. conda-forge builds
+        if lib_name.endswith('_conda'):
+            lib_name = lib_name[:-6]
+
         logger.debug('add_qt5_dependencies: raw lib %s -> parsed lib %s',
                      imp, lib_name)
 

--- a/news/4636.hooks.rst
+++ b/news/4636.hooks.rst
@@ -1,0 +1,1 @@
+Fix detecting Qt5 libraries and dependencies from conda-forge builds.


### PR DESCRIPTION
E.g. conda-forge builds of qt5 have QT_LIBINFIX set to '_conda', thus
generating library binaries called 'Qt5Core_conda.dll' for example on
Windows. Since lib_name is generated from the library's filename, it
won't be found in the '_qt_dynamic_dependencies_dict', leading to
missing hiddenimports, translations and plugins.

If lib_name was not found in the dependencies dictionary, this matches
the dependencies dictionary's keys as prefix to the lib_name, searching
longest keys first.