### PR TITLE
"bundled?" check doesn't run in python interpreter

### DIFF
--- a/doc/runtime-information.rst
+++ b/doc/runtime-information.rst
@@ -9,7 +9,7 @@ source or whether it is bundled ("frozen"). You can use the following code to
 check "are we bundled?"::
 
     import sys
-    if getattr(sys, 'frozen') and hasattr(sys, '_MEIPASS'):
+    if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
         print('running in a PyInstaller bundle')
     else:
         print('running in a normal Python process')


### PR DESCRIPTION
the "are we bundled?" check code runs in pyinstaller, but not under the python interpreter.   Obviously, the code should run in both configurations.  When my code found this issue, I found someone on StackOverflow had a fix, adding the False default to the getattr function on line 12.  It makes sense to get this fix back into the documentation to prevent this in the future.