### PR TITLE
building: Support arbitrarily large files in onefile mode.

### DIFF
--- a/PyInstaller/archive/writers.py
+++ b/PyInstaller/archive/writers.py
@@ -344,9 +344,9 @@ class CArchiveWriter(ArchiveWriter):
 
         ENTRY must have:
           entry[0] is name (under which it will be saved).
-          entry[1] is fullpathname of the file.
-          entry[2] is a flag for it's storage format (0==uncompressed,
-          1==compressed)
+          entry[1] is fullpathname of the file or a descriptor for
+          a splitted file
+          entry[2] is a flag for it's storage format.
           entry[3] is the entry's type code.
           Version 5:
             If the type code is 'o':
@@ -356,6 +356,7 @@ class CArchiveWriter(ArchiveWriter):
                   W arg (warning option arg)
                   s  (meaning do site.py processing.
         """
+        from ..building import api
         (nm, pathnm, flag, typcd) = entry[:4]
         # FIXME Could we make the version 5 the default one?
         # Version 5 - allow type 'o' = runtime option.
@@ -382,11 +383,11 @@ class CArchiveWriter(ArchiveWriter):
             raise
 
         where = self.lib.tell()
-        assert flag in range(3)
+        assert flag in range(255)
         if not fh and not code_data:
             # no need to write anything
             pass
-        elif flag == 1:
+        elif flag & api.COMPRESSED:
             comprobj = zlib.compressobj(self.LEVEL)
             if code_data is not None:
                 self.lib.write(comprobj.compress(code_data))

--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -826,8 +826,13 @@ class MERGE(object):
             return topath
 
 
-UNCOMPRESSED = 0
-COMPRESSED = 1
+# These parameters are flags (bit fields) that provide information about the
+# way the data is stored in the archive.
+# They can be combined using binary operators
+# TODO Use enum.IntFlag as of minimum supported version 3.6 for
+#  better understanding
+UNCOMPRESSED = 0x0
+COMPRESSED = 0x1
 
 _MISSING_BOOTLOADER_ERRORMSG = """
 Fatal error: PyInstaller does not include a pre-compiled bootloader for your

--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -833,6 +833,7 @@ class MERGE(object):
 #  better understanding
 UNCOMPRESSED = 0x0
 COMPRESSED = 0x1
+SPLITTED = 0x2
 
 _MISSING_BOOTLOADER_ERRORMSG = """
 Fatal error: PyInstaller does not include a pre-compiled bootloader for your

--- a/PyInstaller/utils/cliutils/archive_viewer.py
+++ b/PyInstaller/utils/cliutils/archive_viewer.py
@@ -167,7 +167,7 @@ def show(name, arch):
         print(" Name: (ispkg, pos, len)")
         toc = arch.toc
     else:
-        print(" pos, length, uncompressed, iscompressed, type, name")
+        print(" pos, length, uncompressed, flag, type, name")
         toc = arch.toc.data
     pprint.pprint(toc)
 

--- a/PyInstaller/utils/misc.py
+++ b/PyInstaller/utils/misc.py
@@ -243,3 +243,18 @@ def module_parent_packages(full_modname):
         prefix += '.' + pkg if prefix else pkg
         parents.append(prefix)
     return parents
+
+
+def chunk_sizes(length, n):
+    """Yields the sizes of chunks of a length divided into n sections.
+
+    >>> chunk_sizes(10, 3)
+    [4, 3, 3]
+
+    If param length cannot be divided into n sections without remainder,
+    the first chunk is inflated.
+    """
+    size, rem = divmod(length, n)
+    for _ in range(n):
+        yield size + rem
+        rem = 0

--- a/bootloader/src/pyi_archive.c
+++ b/bootloader/src/pyi_archive.c
@@ -168,7 +168,7 @@ pyi_arch_extract(ARCHIVE_STATUS *status, TOC *ptoc)
         return NULL;
     }
 
-    if (ptoc->cflag == '\1') {
+    if (ptoc->flag & ARCHIVE_FLAG_COMPRESSED) {
         tmp = decompress(data, ptoc);
         free(data);
         data = tmp;

--- a/bootloader/src/pyi_archive.h
+++ b/bootloader/src/pyi_archive.h
@@ -29,13 +29,17 @@
 #define ARCHIVE_ITEM_DATA             'x'  /* data */
 #define ARCHIVE_ITEM_RUNTIME_OPTION   'o'  /* runtime option */
 
+/* Flags for the storage type. */
+#define ARCHIVE_FLAG_UNCOMPRESSED     0x0  /* data is uncompressed */
+#define ARCHIVE_FLAG_COMPRESSED       0x1  /* data is compressed */
+
 /* TOC entry for a CArchive */
 typedef struct _toc {
     int  structlen;  /*len of this one - including full len of name */
     int  pos;        /* pos rel to start of concatenation */
     int  len;        /* len of the data (compressed) */
     int  ulen;       /* len of data (uncompressed) */
-    char cflag;      /* is it compressed (really a byte) */
+    char flag;       /* storage type flag */
     char typcd;      /* type code -'b' binary, 'z' zlib, 'm' module,
                       * 's' script (v3),'x' data, 'o' runtime option  */
     char name[1];    /* the name to save it as */

--- a/bootloader/src/pyi_archive.h
+++ b/bootloader/src/pyi_archive.h
@@ -32,6 +32,7 @@
 /* Flags for the storage type. */
 #define ARCHIVE_FLAG_UNCOMPRESSED     0x0  /* data is uncompressed */
 #define ARCHIVE_FLAG_COMPRESSED       0x1  /* data is compressed */
+#define ARCHIVE_FLAG_SPLITTED         0x2  /* data is splitted into multiple files */
 
 /* TOC entry for a CArchive */
 typedef struct _toc {
@@ -109,6 +110,7 @@ TOC *pyi_arch_increment_toc_ptr(const ARCHIVE_STATUS *status, const TOC* ptoc);
 
 unsigned char *pyi_arch_extract(ARCHIVE_STATUS *status, TOC *ptoc);
 int pyi_arch_extract2fs(ARCHIVE_STATUS *status, TOC *ptoc);
+int pyi_arch_extractSplit2fs(ARCHIVE_STATUS *status, TOC *ptoc);
 
 /**
  * Helpers for embedders

--- a/news/3939.feature.rst
+++ b/news/3939.feature.rst
@@ -1,0 +1,1 @@
+Supported arbitrarily large files in onefile mode.


### PR DESCRIPTION
Previously, the maximum file size in CArchive was 2 GB, otherwise
the size value could not be stored. This was also not very
beneficial, because the bootloader allocates the size of the file
in memory during unpacking, which is a huge amount of data at once.
Now files larger than 512 MiB are divided into several archive entries
and thus unpacked to one file in several steps.

fixes pyinstaller/pyinstaller#3939