### PR TITLE
Fixes issue #4646 by removing _conda infix from lib_name key

### DIFF
--- a/PyInstaller/utils/hooks/qt.py
+++ b/PyInstaller/utils/hooks/qt.py
@@ -508,6 +508,12 @@ def add_qt5_dependencies(hook_file):
         # Mac: rename from ``qt`` to ``qt5`` to match names in Windows/Linux.
         if is_darwin and lib_name.startswith('qt'):
             lib_name = 'qt5' + lib_name[2:]
+
+        # Conda forge has added '_conda' to the Qt DLLs. (E.g. QtGui_conda.dll).
+        # Remove this here.
+        if lib_name.endswith('_conda'):
+            lib_name = lib_name[:-6]
+
         logger.debug('add_qt5_dependencies: raw lib %s -> parsed lib %s',
                      imp, lib_name)
 


### PR DESCRIPTION
Fixes issue #4646 . 

Because conda-forge renames the Qt DLLs (e.g. `QtGui.dll` becomes `QtGui_conda.dll` the resulting `lib_name` is not found in the `_qt_dynamic_dependencies_dict`. Therefore a lot of plugin files and dependencies won't be installed. This PR corrects for that.

