### PR TITLE
Update the assertion message in imphook.py

### DIFF
--- a/PyInstaller/depend/imphook.py
+++ b/PyInstaller/depend/imphook.py
@@ -285,7 +285,7 @@ class ModuleHook(object):
 
         # Safety check, see above
         global HOOKS_MODULE_NAMES
-        assert self.hook_module_name not in HOOKS_MODULE_NAMES
+        assert self.hook_module_name not in HOOKS_MODULE_NAMES, 'Custom hook conflict. Please remove {} from custom hooks'.format(self.hook_module_name)
         HOOKS_MODULE_NAMES.add(self.hook_module_name)
 
         # Attributes subsequently defined by the _load_hook_module() method.


### PR DESCRIPTION
Allows the error from #4626 to be fixed by the user by making the problem clear.

This is a temporary fix, I'm going to submit another PR with a new cmdline option (and all that that entails) `--prefer-custom` so that when passed, PyInstaller will use custom hooks over PyInstaller ones, and when not passed, custom hooks that conflict with default ones will be ignored - not passed will be the default.