### PR TITLE
Fallback to a default min macOS version instead of forcing it

### DIFF
--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -544,7 +544,8 @@ def configure(ctx):
         # The following variable fixes 10.7 compatibility.
         # According to OS X doc this variable is equivalent to gcc option:
         #   -mmacosx-version-min=10.7
-        os.environ['MACOSX_DEPLOYMENT_TARGET'] = '10.7'
+        if not os.environ.get('MACOSX_DEPLOYMENT_TARGET'):
+            os.environ['MACOSX_DEPLOYMENT_TARGET'] = '10.7'
 
     ### Libraries
 
@@ -629,8 +630,12 @@ def configure(ctx):
             ctx.env.append_value('LINKFLAGS', '-municode')
 
     if ctx.env.DEST_OS == 'darwin':
-        ctx.env.append_value('CFLAGS', '-mmacosx-version-min=10.7')
-        ctx.env.append_value('LINKFLAGS', '-mmacosx-version-min=10.7')
+        if not any(x for x in ctx.env.CPPFLAGS + ctx.env.CFLAGS
+                   if x.startswith('-mmacosx-version-min=')):
+            ctx.env.append_value('CFLAGS', '-mmacosx-version-min=10.7')
+        if not any(x for x in ctx.env.LDFLAGS + ctx.env.LINKFLAGS
+                   if x.startswith('-mmacosx-version-min=')):
+            ctx.env.append_value('LINKFLAGS', '-mmacosx-version-min=10.7')
 
     # On linux link only with needed libraries.
     # -Wl,--as-needed is on some platforms detected during configure but

--- a/doc/bootloader-building.rst
+++ b/doc/bootloader-building.rst
@@ -121,6 +121,8 @@ Now you can build the bootloader as shown above.
 Alternatively you may want to use the `darwin64` build-guest
 provided by the Vagrantfile (see below).
 
+By default, the build script targets Mac OSX 10.7, which can be overridden by
+exporting the MACOSX_DEPLOYMENT_TARGET environment variable.
 
 .. _cross-building for mac os x:
 

--- a/news/4677.build.rst
+++ b/news/4677.build.rst
@@ -1,0 +1,2 @@
+(OSX) Allow end users to override MACOSX_DEPLOYMENT_TARGET and mmacosx-version-min
+via environment variables and set 10.7 as the fallback value for both.


### PR DESCRIPTION
This allows end users to target a different macOS version using the environment variable
`MACOSX_DEPLOYMENT_TARGET` and specifying `-mmacosx-version-min` in `CPPFLAGS/CFLAGS`
and `LDFLAGS/LINKFLAGS`