### PR TITLE
Add assertion message to imphook.py assert statement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,6 @@ tests/old_suite/basic/test_pyz_as_external_file.exe.pkg
 # py.test cache folder
 .cache
 *.prof
+
+# Virtual Envs
+/venv

--- a/PyInstaller/depend/imphook.py
+++ b/PyInstaller/depend/imphook.py
@@ -285,12 +285,14 @@ class ModuleHook(object):
 
         # Safety check, see above
         global HOOKS_MODULE_NAMES
-        assert self.hook_module_name not in HOOKS_MODULE_NAMES
+        assert(
+            self.hook_module_name not in HOOKS_MODULE_NAMES,
+            'Custom hook conflict. Please remove one of your custom hooks.'
+        )
         HOOKS_MODULE_NAMES.add(self.hook_module_name)
 
         # Attributes subsequently defined by the _load_hook_module() method.
         self._hook_module = None
-
 
     def __getattr__(self, attr_name):
         '''

--- a/PyInstaller/depend/imphook.py
+++ b/PyInstaller/depend/imphook.py
@@ -285,10 +285,8 @@ class ModuleHook(object):
 
         # Safety check, see above
         global HOOKS_MODULE_NAMES
-        assert(
-            self.hook_module_name not in HOOKS_MODULE_NAMES,
+        assert self.hook_module_name not in HOOKS_MODULE_NAMES, \
             'Custom hook conflict. Please remove the following custom hook: {}'.format(self._hook_name)
-        )
         HOOKS_MODULE_NAMES.add(self.hook_module_name)
 
         # Attributes subsequently defined by the _load_hook_module() method.

--- a/PyInstaller/depend/imphook.py
+++ b/PyInstaller/depend/imphook.py
@@ -286,7 +286,8 @@ class ModuleHook(object):
         # Safety check, see above
         global HOOKS_MODULE_NAMES
         assert self.hook_module_name not in HOOKS_MODULE_NAMES, \
-            'Custom hook conflict. Please remove the following custom hook: {}'.format(self._hook_name)
+            'Custom hook conflict. Please remove the following ' \ 
+            'custom hook: {}'.format(self._hook_name)
         HOOKS_MODULE_NAMES.add(self.hook_module_name)
 
         # Attributes subsequently defined by the _load_hook_module() method.

--- a/PyInstaller/depend/imphook.py
+++ b/PyInstaller/depend/imphook.py
@@ -287,7 +287,7 @@ class ModuleHook(object):
         global HOOKS_MODULE_NAMES
         assert(
             self.hook_module_name not in HOOKS_MODULE_NAMES,
-            'Custom hook conflict. Please remove one of your custom hooks.'
+            'Custom hook conflict. Please remove the following custom hook: {}'.format(self._hook_name)
         )
         HOOKS_MODULE_NAMES.add(self.hook_module_name)
 

--- a/PyInstaller/depend/imphook.py
+++ b/PyInstaller/depend/imphook.py
@@ -286,7 +286,7 @@ class ModuleHook(object):
         # Safety check, see above
         global HOOKS_MODULE_NAMES
         assert self.hook_module_name not in HOOKS_MODULE_NAMES, \
-            'Custom hook conflict. Please remove the following ' \ 
+            'Custom hook conflict. Please remove the following ' \
             'custom hook: {}'.format(self._hook_name)
         HOOKS_MODULE_NAMES.add(self.hook_module_name)
 

--- a/doc/4684.hooks.rst
+++ b/doc/4684.hooks.rst
@@ -1,0 +1,2 @@
+Added an assertion message to allow users to remove custom hooks that conflict
+with pyinstaller ones, allowing users to know whats happening when they get an ``AssertionError``.


### PR DESCRIPTION
Added an assertion message to allow users to remove custom hooks that conflict with pyinstaller ones.

Closes #4626