### PR TITLE
Add cygwin support

### DIFF
--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -500,7 +500,7 @@ class EXE(Target):
         """
         # Having console/windowed bootolader makes sense only on Windows and
         # Mac OS X.
-        if is_win or is_darwin:
+        if is_win or is_darwin or is_cygwin:
             if not self.console:
                 exe = exe + 'w'
         # There are two types of bootloaders:

--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -54,6 +54,7 @@ DESTOS_TO_SYSTEM = {
     'sunos': platform.system(),  ## FIXME: inhibits cross-compile
     'hpux': 'HP-UX',
     'aix': 'AIX',
+    'cygwin': platform.system(),
 }
 
 # Map from platform.system() to waf's DEST_OS
@@ -66,6 +67,7 @@ SYSTEM_TO_BUILDOS = {
     'SunOS': 'sunos',
     'HP-UX': 'hpux',
     'AIX': 'aix',
+    platform.system(): 'cygwin', 
 }
 
 # waf's name of the system we are building on
@@ -777,11 +779,11 @@ class make_all(BuildContext):
         Options.commands = ['build_debug', 'build_release']
         # On Windows and Mac OS X we also need console/windowed bootloaders.
         # On other platforms they make no sense.
-        if ctx.env.DEST_OS in ('win32', 'darwin'):
+        if ctx.env.DEST_OS in ('win32', 'darwin', 'cygwin'):
             Options.commands += ['build_debugw', 'build_releasew']
         # Install bootloaders.
         Options.commands += ['install_debug', 'install_release']
-        if ctx.env.DEST_OS in ('win32', 'darwin'):
+        if ctx.env.DEST_OS in ('win32', 'darwin', 'cygwin'):
             Options.commands += ['install_debugw', 'install_releasew']
 
 


### PR DESCRIPTION
Hi, I am successfully using these modifications to get pyinstaller to run a PyQt5 program under windows/cygwin. Decision for cygwin is that I have to use a third party library, which is only POSIX compatible at the moment.

While it is working, I have sometimes signal/slot problems in PyQt5. However, I do not think that they are related to pyinstaller.

I would be happy for a review.