### PR TITLE
WIP: Py2 cleanup

### DIFF
--- a/PyInstaller/__main__.py
+++ b/PyInstaller/__main__.py
@@ -56,7 +56,7 @@ def run_makespec(filenames, **opts):
     import PyInstaller.building.makespec
 
     spec_file = PyInstaller.building.makespec.main(filenames, **opts)
-    logger.info('wrote %s' % spec_file)
+    logger.info('wrote {}'.format(spec_file))
     return spec_file
 
 
@@ -100,10 +100,9 @@ def run(pyi_args=None, pyi_config=None):
         # as the first line to stdout.
         # This helps identify PyInstaller, Python and platform version
         #  when users report issues.
-        logger.info('PyInstaller: %s' % __version__)
-        logger.info('Python: %s%s', platform.python_version(),
-                    " (conda)" if is_conda else "")
-        logger.info('Platform: %s' % platform.platform())
+        logger.info('PyInstaller: {}' % __version__)
+        logger.info('Python: {ver}{conda}'.format(ver=platform.python_version(), conda=' (conda)' if is_conda else ''))
+        logger.info('Platform: {}'.format(platform.platform()))
 
         # Skip creating .spec when .spec file is supplied
         if args.filenames[0].endswith('.spec'):

--- a/PyInstaller/__main__.py
+++ b/PyInstaller/__main__.py
@@ -101,7 +101,12 @@ def run(pyi_args=None, pyi_config=None):
         # This helps identify PyInstaller, Python and platform version
         #  when users report issues.
         logger.info('PyInstaller: {}'.format(__version__))
-        logger.info('Python: {ver}{conda}'.format(ver=platform.python_version(), conda=' (conda)' if is_conda else ''))
+        logger.info(
+            'Python: {ver}{conda}'.format(
+                ver=platform.python_version(),
+                conda=' (conda)' if is_conda else ''
+            )
+        )
         logger.info('Platform: {}'.format(platform.platform()))
 
         # Skip creating .spec when .spec file is supplied

--- a/PyInstaller/__main__.py
+++ b/PyInstaller/__main__.py
@@ -100,7 +100,7 @@ def run(pyi_args=None, pyi_config=None):
         # as the first line to stdout.
         # This helps identify PyInstaller, Python and platform version
         #  when users report issues.
-        logger.info('PyInstaller: {}' % __version__)
+        logger.info('PyInstaller: {}'.format(__version__))
         logger.info('Python: {ver}{conda}'.format(ver=platform.python_version(), conda=' (conda)' if is_conda else ''))
         logger.info('Platform: {}'.format(platform.platform()))
 

--- a/PyInstaller/archive/readers.py
+++ b/PyInstaller/archive/readers.py
@@ -151,14 +151,16 @@ class CArchiveReader(ArchiveReader):
         pos = buf.rfind(self.MAGIC)
         if pos == -1:
             raise RuntimeError(
-                "{} is not a valid {} archive file".format(self.path, self.__class__.__name__)
+                "{} is not a valid {} archive file"
+                .format(self.path, self.__class__.__name__)
             )
         filelen = searchpos + pos + self._cookie_size
         (magic, totallen, tocpos, toclen, pyvers, pylib_name) = struct.unpack(
             self._cookie_format, buf[pos:pos+self._cookie_size])
         if magic != self.MAGIC:
             raise RuntimeError(
-                "{} is not a valid {} archive file".format(self.path, self.__class__.__name__)
+                "{} is not a valid {} archive file"
+                .format(self.path, self.__class__.__name__)
             )
 
         self.pkg_start = filelen - totallen

--- a/PyInstaller/archive/readers.py
+++ b/PyInstaller/archive/readers.py
@@ -150,20 +150,23 @@ class CArchiveReader(ArchiveReader):
         buf = self.lib.read(min(filelen, 4096))
         pos = buf.rfind(self.MAGIC)
         if pos == -1:
-            raise RuntimeError("%s is not a valid %s archive file" %
-                               (self.path, self.__class__.__name__))
+            raise RuntimeError(
+                "{} is not a valid {} archive file".format(self.path, self.__class__.__name__)
+            )
         filelen = searchpos + pos + self._cookie_size
         (magic, totallen, tocpos, toclen, pyvers, pylib_name) = struct.unpack(
             self._cookie_format, buf[pos:pos+self._cookie_size])
         if magic != self.MAGIC:
-            raise RuntimeError("%s is not a valid %s archive file" %
-                               (self.path, self.__class__.__name__))
+            raise RuntimeError(
+                "{} is not a valid {} archive file".format(self.path, self.__class__.__name__)
+            )
 
         self.pkg_start = filelen - totallen
         if self.length:
             if totallen != self.length or self.pkg_start != self.start:
-                raise RuntimeError('Problem with embedded archive in %s' %
-                        self.path)
+                raise RuntimeError(
+                    'Problem with embedded archive in {}'.format(self.path)
+                )
         # Verify presence of Python library name.
         if not pylib_name:
             raise RuntimeError('Python library filename not defined in archive.')
@@ -226,13 +229,16 @@ class CArchiveReader(ArchiveReader):
         ndx = self.toc.find(name)
 
         if ndx == -1:
-            raise KeyError("Member '%s' not found in %s" % (name, self.path))
+            raise KeyError(
+                "Member '{}' not found in {}".format(name, self.path)
+            )
         (dpos, dlen, ulen, flag, typcd, nm) = self.toc.get(ndx)
 
         if typcd not in "zZ":
-            raise NotAnArchiveError('%s is not an archive' % name)
+            raise NotAnArchiveError('%s is not an archive'.format(name))
 
         if flag:
-            raise ValueError('Cannot open compressed archive %s in place' %
-                    name)
+            raise ValueError(
+                'Cannot open compressed archive %s in place'.format(name)
+            )
         return CArchiveReader(self.path, self.pkg_start + dpos, dlen)

--- a/PyInstaller/archive/writers.py
+++ b/PyInstaller/archive/writers.py
@@ -139,13 +139,22 @@ class ArchiveWriter(object):
 
                 for module_name, module_tuple in self.toc.items():
                     if type(module_name) not in MARSHALLABLE_TYPES:
-                        print('Module name "{}" ({}) unmarshallable.'.format(module_name, type(module_name)))
+                        print('Module name "{}" ({}) unmarshallable.'
+                              .format(module_name, type(module_name)))
                     if type(module_tuple) not in MARSHALLABLE_TYPES:
-                        print('Module "{}" tuple "{}" ({}) unmarshallable.'.format(module_name, module_tuple, type(module_tuple)))
+                        print('Module "{}" tuple "{}" ({}) unmarshallable.'
+                              .format(module_name, module_tuple, type(module_tuple)))
                     elif type(module_tuple) == tuple:
                         for i in range(len(module_tuple)):
                             if type(module_tuple[i]) not in MARSHALLABLE_TYPES:
-                                print('Module "{}" tuple index {} item "{}" ({}) unmarshallable.'.format(module_name, i, module_tuple[i], type(module_tuple[i])))
+                                print('Module "{}" tuple index {} item "{}" ('
+                                      '{}) unmarshallable.'.format(
+                                          module_name,
+                                          i,
+                                          module_tuple[i],
+                                          type(module_tuple[i])
+                                      )
+                                )
 
             raise
 
@@ -378,7 +387,8 @@ class CArchiveWriter(ArchiveWriter):
                 fh = open(pathnm, 'rb')
                 ulen = os.fstat(fh.fileno()).st_size
         except IOError:
-            print("Cannot find ('{}', '{}', {}, '{}')".format(nm, pathnm, flag, typcd))
+            print("Cannot find ('{}', '{}', {}, '{}')"
+                  .format(nm, pathnm, flag, typcd))
             raise
 
         where = self.lib.tell()

--- a/PyInstaller/archive/writers.py
+++ b/PyInstaller/archive/writers.py
@@ -143,17 +143,19 @@ class ArchiveWriter(object):
                               .format(module_name, type(module_name)))
                     if type(module_tuple) not in MARSHALLABLE_TYPES:
                         print('Module "{}" tuple "{}" ({}) unmarshallable.'
-                              .format(module_name, module_tuple, type(module_tuple)))
+                              .format(module_name, module_tuple,
+                                      type(module_tuple)))
                     elif type(module_tuple) == tuple:
                         for i in range(len(module_tuple)):
                             if type(module_tuple[i]) not in MARSHALLABLE_TYPES:
-                                print('Module "{}" tuple index {} item "{}" ('
-                                      '{}) unmarshallable.'.format(
-                                          module_name,
-                                          i,
-                                          module_tuple[i],
-                                          type(module_tuple[i])
-                                      )
+                                print(
+                                    'Module "{}" tuple index {} item "{}" ('
+                                    '{}) unmarshallable.'.format(
+                                        module_name,
+                                        i,
+                                        module_tuple[i],
+                                        type(module_tuple[i])
+                                    )
                                 )
 
             raise

--- a/PyInstaller/archive/writers.py
+++ b/PyInstaller/archive/writers.py
@@ -139,13 +139,13 @@ class ArchiveWriter(object):
 
                 for module_name, module_tuple in self.toc.items():
                     if type(module_name) not in MARSHALLABLE_TYPES:
-                        print('Module name "%s" (%s) unmarshallable.' % (module_name, type(module_name)))
+                        print('Module name "{}" ({}) unmarshallable.'.format(module_name, type(module_name)))
                     if type(module_tuple) not in MARSHALLABLE_TYPES:
-                        print('Module "%s" tuple "%s" (%s) unmarshallable.' % (module_name, module_tuple, type(module_tuple)))
+                        print('Module "{}" tuple "{}" ({}) unmarshallable.'.format(module_name, module_tuple, type(module_tuple)))
                     elif type(module_tuple) == tuple:
                         for i in range(len(module_tuple)):
                             if type(module_tuple[i]) not in MARSHALLABLE_TYPES:
-                                print('Module "%s" tuple index %s item "%s" (%s) unmarshallable.' % (module_name, i, module_tuple[i], type(module_tuple[i])))
+                                print('Module "{}" tuple index {} item "{}" ({}) unmarshallable.'.format(module_name, i, module_tuple[i], type(module_tuple[i])))
 
             raise
 
@@ -378,7 +378,7 @@ class CArchiveWriter(ArchiveWriter):
                 fh = open(pathnm, 'rb')
                 ulen = os.fstat(fh.fileno()).st_size
         except IOError:
-            print("Cannot find ('%s', '%s', %s, '%s')" % (nm, pathnm, flag, typcd))
+            print("Cannot find ('{}', '{}', {}, '{}')".format(nm, pathnm, flag, typcd))
             raise
 
         where = self.lib.tell()

--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -15,7 +15,6 @@ Various classes and functions to provide some backwards-compatibility
 with previous versions of Python onward.
 """
 
-import io
 import os
 import platform
 import site
@@ -57,39 +56,39 @@ is_unix = is_linux or is_solar or is_aix or is_freebsd or is_hpux or is_openbsd
 # On different platforms is different file for dynamic python library.
 _pyver = sys.version_info[:2]
 if is_win or is_cygwin:
-    PYDYLIB_NAMES = {'python%d%d.dll' % _pyver,
-                     'libpython%d%d.dll' % _pyver,
-                     'libpython%d%dm.dll' % _pyver,
-                     'libpython%d.%d.dll' % _pyver,
-                     'libpython%d.%dm.dll' % _pyver}  # For MSYS2 environment
+    PYDYLIB_NAMES = {'python{}{}.dll'.format(*_pyver),
+                     'libpython{}{}.dll'.format(*_pyver),
+                     'libpython{}{}m.dll'.format(*_pyver),
+                     'libpython{}.{}.dll'.format(*_pyver),
+                     'libpython{}.{}.dll'.format(*_pyver)}  # For MSYS2 environment
 elif is_darwin:
     # libpython%d.%dm.dylib for Conda virtual environment installations
     PYDYLIB_NAMES = {'Python', '.Python',
-                     'libpython%d.%d.dylib' % _pyver,
-                     'libpython%d.%dm.dylib' % _pyver}
+                     'libpython{}.{}.dylib'.format(*_pyver),
+                     'libpython{}.{}.dylib'.format(*_pyver)}
 elif is_aix:
     # Shared libs on AIX are archives with shared object members, thus the ".a" suffix.
     # However, python 2.7.11 built with XLC produces libpython?.?.so file, too.
-    PYDYLIB_NAMES = {'libpython%d.%d.a' % _pyver,
-                     'libpython%d.%d.so' % _pyver}
+    PYDYLIB_NAMES = {'libpython{}.{}.a'.format(*_pyver),
+                     'libpython{}.{}.so'.format(*_pyver)}
 elif is_freebsd:
-    PYDYLIB_NAMES = {'libpython%d.%d.so.1' % _pyver,
-                     'libpython%d.%dm.so.1' % _pyver,
-                     'libpython%d.%d.so.1.0' % _pyver,
-                     'libpython%d.%dm.so.1.0' % _pyver}
+    PYDYLIB_NAMES = {'libpython{}.{}.so.1' % _pyver,
+                     'libpython{}.{}m.so.1' % _pyver,
+                     'libpython{}.{}.so.1.0' % _pyver,
+                     'libpython{}.{}m.so.1.0' % _pyver}
 elif is_openbsd:
-    PYDYLIB_NAMES = {'libpython%d.%d.so.0.0' % _pyver,
-                     'libpython%d.%dm.so.0.0' % _pyver}
+    PYDYLIB_NAMES = {'libpython{}.{}.so.0.0' % _pyver,
+                     'libpython{}.{}m.so.0.0' % _pyver}
 elif is_hpux:
-    PYDYLIB_NAMES = {'libpython%d.%d.so' % _pyver}
+    PYDYLIB_NAMES = {'libpython{}.{}.so' % _pyver}
 elif is_unix:
     # Other *nix platforms.
     # Python 2 .so library on Linux is: libpython2.7.so.1.0
     # Python 3 .so library on Linux is: libpython3.2mu.so.1.0, libpython3.3m.so.1.0
-    PYDYLIB_NAMES = {'libpython%d.%d.so.1.0' % _pyver,
-                     'libpython%d.%dm.so.1.0' % _pyver,
-                     'libpython%d.%dmu.so.1.0' % _pyver,
-                     'libpython%d.%dm.so' % _pyver}
+    PYDYLIB_NAMES = {'libpython{}.{}.so.1.0' % _pyver,
+                     'libpython{}.{}m.so.1.0' % _pyver,
+                     'libpython{}.{}mu.so.1.0' % _pyver,
+                     'libpython{}.{}m.so' % _pyver}
 else:
     raise SystemExit('Your platform is not yet supported. '
                      'Please define constant PYDYLIB_NAMES for your platform.')

--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -60,7 +60,7 @@ if is_win or is_cygwin:
                      'libpython{}{}.dll'.format(*_pyver),
                      'libpython{}{}m.dll'.format(*_pyver),
                      'libpython{}.{}.dll'.format(*_pyver),
-                     'libpython{}.{}.dll'.format(*_pyver)}  # For MSYS2 environment
+                     'libpython{}.{}.dll'.format(*_pyver)}  # For MSYS2
 elif is_darwin:
     # libpython%d.%dm.dylib for Conda virtual environment installations
     PYDYLIB_NAMES = {'Python', '.Python',

--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -72,23 +72,23 @@ elif is_aix:
     PYDYLIB_NAMES = {'libpython{}.{}.a'.format(*_pyver),
                      'libpython{}.{}.so'.format(*_pyver)}
 elif is_freebsd:
-    PYDYLIB_NAMES = {'libpython{}.{}.so.1' % _pyver,
-                     'libpython{}.{}m.so.1' % _pyver,
-                     'libpython{}.{}.so.1.0' % _pyver,
-                     'libpython{}.{}m.so.1.0' % _pyver}
+    PYDYLIB_NAMES = {'libpython{}.{}.so.1'.format(*_pyver),
+                     'libpython{}.{}m.so.1'.format(*_pyver),
+                     'libpython{}.{}.so.1.0'.format(*_pyver),
+                     'libpython{}.{}m.so.1.0'.format(*_pyver)}
 elif is_openbsd:
-    PYDYLIB_NAMES = {'libpython{}.{}.so.0.0' % _pyver,
-                     'libpython{}.{}m.so.0.0' % _pyver}
+    PYDYLIB_NAMES = {'libpython{}.{}.so.0.0'.format(*_pyver),
+                     'libpython{}.{}m.so.0.0'.format(*_pyver)}
 elif is_hpux:
-    PYDYLIB_NAMES = {'libpython{}.{}.so' % _pyver}
+    PYDYLIB_NAMES = {'libpython{}.{}.so'.format(*_pyver)}
 elif is_unix:
     # Other *nix platforms.
     # Python 2 .so library on Linux is: libpython2.7.so.1.0
     # Python 3 .so library on Linux is: libpython3.2mu.so.1.0, libpython3.3m.so.1.0
-    PYDYLIB_NAMES = {'libpython{}.{}.so.1.0' % _pyver,
-                     'libpython{}.{}m.so.1.0' % _pyver,
-                     'libpython{}.{}mu.so.1.0' % _pyver,
-                     'libpython{}.{}m.so' % _pyver}
+    PYDYLIB_NAMES = {'libpython{}.{}.so.1.0'.format(*_pyver),
+                     'libpython{}.{}m.so.1.0'.format(*_pyver),
+                     'libpython{}.{}mu.so.1.0'.format(*_pyver),
+                     'libpython{}.{}m.so'.format(*_pyver)}
 else:
     raise SystemExit('Your platform is not yet supported. '
                      'Please define constant PYDYLIB_NAMES for your platform.')
@@ -341,7 +341,7 @@ def exec_command(*cmdargs, **kwargs):
         if raise_ENOENT and e.errno == errno.ENOENT:
             raise
         print('--' * 20, file=sys.stderr)
-        print("Error running '%s':" % " ".join(cmdargs), file=sys.stderr)
+        print("Error running '{}':".format(" ".join(cmdargs)), file=sys.stderr)
         print(e, file=sys.stderr)
         print('--' * 20, file=sys.stderr)
         raise ExecCommandFailed("Error: Executing command failed!")

--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -528,7 +528,7 @@ def __wrap_python(args, kwargs):
         # the current value using the `-e` option of the `arch` command.
         if 'DYLD_LIBRARY_PATH' in os.environ:
             path = os.environ['DYLD_LIBRARY_PATH']
-            py_prefix += ['-e', 'DYLD_LIBRARY_PATH=%s' % path]
+            py_prefix += ['-e', 'DYLD_LIBRARY_PATH={}'.format(path)]
         cmdargs = py_prefix + cmdargs
 
     if _PYOPTS:

--- a/PyInstaller/configure.py
+++ b/PyInstaller/configure.py
@@ -45,12 +45,12 @@ def test_UPX(config, upx_dir):
             pass
         else:
             logger.info('An exception occured when testing for UPX:')
-            logger.info('  %r', e)
+            logger.info(' {0!r}'.format(e))
     if hasUPX:
         is_available = 'available'
     else:
         is_available = 'not available'
-    logger.info('UPX is %s.', is_available)
+    logger.info('UPX is {}.'.format(is_available))
     config['hasUPX'] = hasUPX
     config['upx_dir'] = upx_dir
 

--- a/PyInstaller/log.py
+++ b/PyInstaller/log.py
@@ -43,6 +43,6 @@ def __process_options(parser, opts):
     try:
         level = getattr(logging, opts.loglevel.upper())
     except AttributeError:
-        parser.error('Unknown log level `%s`' % opts.loglevel)
+        parser.error('Unknown log level `{}`'.format(opts.loglevel))
     else:
         logger.setLevel(level)

--- a/PyInstaller/utils/cliutils/archive_viewer.py
+++ b/PyInstaller/utils/cliutils/archive_viewer.py
@@ -227,8 +227,8 @@ class ZlibArchive(pyimod02_archive.ZlibArchiveReader):
         """
         self.lib.seek(self.start)  # default - magic is at start of file.
         if self.lib.read(len(self.MAGIC)) != self.MAGIC:
-            raise RuntimeError("%s is not a valid %s archive file"
-                               % (self.path, self.__class__.__name__))
+            raise RuntimeError("{} is not a valid {} archive file"
+                               "".format(self.path, self.__class__.__name__))
         if self.lib.read(len(self.pymagic)) != self.pymagic:
             print("Warning: pyz is from a different Python version",
                   file=sys.stderr)

--- a/PyInstaller/utils/cliutils/bindepend.py
+++ b/PyInstaller/utils/cliutils/bindepend.py
@@ -19,7 +19,7 @@ import argparse
 
 
 import PyInstaller.depend.bindepend
-from PyInstaller import is_win
+from PyInstaller.compat import is_win
 import PyInstaller.log
 
 

--- a/PyInstaller/utils/cliutils/grab_version.py
+++ b/PyInstaller/utils/cliutils/grab_version.py
@@ -35,7 +35,7 @@ def run():
             raise SystemExit("Error: VersionInfo resource not found in exe")
         with codecs.open(args.out_filename, 'w', 'utf-8') as fp:
             fp.write(u"%s" % (vs,))
-        print(('Version info written to: %s' % args.out_filename))
+        print(('Version info written to: {}'.format(args.out_filename)))
     except KeyboardInterrupt:
         raise SystemExit("Aborted by user request.")
 

--- a/PyInstaller/utils/cliutils/makespec.py
+++ b/PyInstaller/utils/cliutils/makespec.py
@@ -38,7 +38,7 @@ def run():
 
     try:
         name = PyInstaller.building.makespec.main(args.scriptname, **vars(args))
-        print('wrote %s' % name)
+        print('wrote {}'.format(name))
         print('now run pyinstaller.py to build the executable')
     except KeyboardInterrupt:
         raise SystemExit("Aborted by user request.")

--- a/PyInstaller/utils/cliutils/set_version.py
+++ b/PyInstaller/utils/cliutils/set_version.py
@@ -27,7 +27,7 @@ def run():
     try:
         import PyInstaller.utils.win32.versioninfo
         vs = PyInstaller.utils.win32.versioninfo.SetVersion(exe_file, info_file)
-        print(('Version info set in: %s' % exe_file))
+        print('Version info set in: {}'.format(exe_file))
     except KeyboardInterrupt:
         raise SystemExit("Aborted by user request.")
 

--- a/PyInstaller/utils/hooks/__init__.py
+++ b/PyInstaller/utils/hooks/__init__.py
@@ -970,9 +970,9 @@ def requirements_for_package(package_name):
             required_packages = dist_to_packages[requirement.key]
             hiddenimports.extend(required_packages)
         else:
-            logger.warning('Unable to find package for requirement {} from '
-                           'package {}.'.format(
-                            requirement.project_name, package_name))
+            logger.warning(
+                'Unable to find package for requirement {} from package {}.'
+                .format(requirement.project_name, package_name))
 
     logger.info(
         'Packages required by {}:\n{}'.format(package_name, hiddenimports)
@@ -991,7 +991,8 @@ def collect_all(package_name, include_py_files=True):
     try:
         datas += copy_metadata(package_name)
     except Exception as e:
-        logger.warning('Unable to copy metadata for {}: {}'.format(package_name, e))
+        logger.warning(
+            'Unable to copy metadata for {}: {}'.format(package_name, e))
     datas += collect_data_files(package_name, include_py_files)
     binaries = collect_dynamic_libs(package_name)
     hiddenimports = collect_submodules(package_name)

--- a/PyInstaller/utils/hooks/__init__.py
+++ b/PyInstaller/utils/hooks/__init__.py
@@ -281,7 +281,8 @@ def get_module_attribute(module_name, attr_name):
 
     if attr_value == attr_value_if_undefined:
         raise AttributeError(
-            'Module {mod!r} has no attribute {an!r}'.format(mod=module_name, an=attr_name))
+            'Module {mod!r} has no attribute {an!r}'
+            .format(mod=module_name, an=attr_name))
     else:
         return attr_value
 
@@ -562,7 +563,8 @@ def collect_submodules(package, filter=lambda name: True):
     logger.debug('Collecting submodules for {}'.format(package))
     # Skip a module which is not a package.
     if not is_package(package):
-        logger.debug('collect_submodules - Module {} is not a package.'.format(package))
+        logger.debug(
+            'collect_submodules - Module {} is not a package.'.format(package))
         return []
 
     # Determine the filesystem path to the specified package.
@@ -969,9 +971,12 @@ def requirements_for_package(package_name):
             hiddenimports.extend(required_packages)
         else:
             logger.warning('Unable to find package for requirement {} from '
-                           'package {}.'.format(requirement.project_name, package_name))
+                           'package {}.'.format(
+                            requirement.project_name, package_name))
 
-    logger.info('Packages required by {}:\n{}'.format(package_name, hiddenimports))
+    logger.info(
+        'Packages required by {}:\n{}'.format(package_name, hiddenimports)
+    )
     return hiddenimports
 
 

--- a/PyInstaller/utils/hooks/gi.py
+++ b/PyInstaller/utils/hooks/gi.py
@@ -86,7 +86,8 @@ def get_gi_typelibs(module, version):
             for lib in typelibs_data['sharedlib'].split(','):
                 path = findSystemLibrary(lib.strip())
                 if path:
-                    logger.debug('Found shared library {} at {}'.format(lib, path))
+                    logger.debug(
+                        'Found shared library {} at {}'.format(lib, path))
                     binaries.append((path, '.'))
 
         d = gir_library_path_fix(typelibs_data['typelib'])

--- a/PyInstaller/utils/hooks/gi.py
+++ b/PyInstaller/utils/hooks/gi.py
@@ -33,18 +33,17 @@ def get_gi_libdir(module, version):
         gi.require_version("GIRepository", "2.0")
         from gi.repository import GIRepository
         repo = GIRepository.Repository.get_default()
-        module, version = (%r, %r)
+        module, version = ({0!r}, {1!s})
         repo.require(module, version,
                      GIRepository.RepositoryLoadFlags.IREPOSITORY_LOAD_FLAG_LAZY)
         print(repo.get_shared_library(module))
-    """
-    statement %= (module, version)
+    """.format(module, version)
     libs = exec_statement(statement).split(',')
     for lib in libs:
         path = findSystemLibrary(lib.strip())
         return os.path.normpath(os.path.dirname(path))
 
-    raise ValueError("Could not find libdir for %s-%s" % (module, version))
+    raise ValueError("Could not find libdir for {}-{}".format(module, version))
 
 
 def get_gi_typelibs(module, version):
@@ -64,17 +63,16 @@ def get_gi_typelibs(module, version):
         gi.require_version("GIRepository", "2.0")
         from gi.repository import GIRepository
         repo = GIRepository.Repository.get_default()
-        module, version = (%r, %r)
+        module, version = ({0!r}, {1!r})
         repo.require(module, version,
                      GIRepository.RepositoryLoadFlags.IREPOSITORY_LOAD_FLAG_LAZY)
         get_deps = getattr(repo, 'get_immediate_dependencies', None)
         if not get_deps:
             get_deps = repo.get_dependencies
-        print({'sharedlib': repo.get_shared_library(module),
+        print({{'sharedlib': repo.get_shared_library(module),
                'typelib': repo.get_typelib_path(module),
-               'deps': get_deps(module) or []})
-    """
-    statement %= (module, version)
+               'deps': get_deps(module) or []}})
+    """.format(module, version)
     typelibs_data = eval_statement(statement)
     if not typelibs_data:
         logger.error("gi repository 'GIRepository 2.0' not found. "
@@ -82,18 +80,18 @@ def get_gi_typelibs(module, version):
                      "lib64girepository-gir2.0 is installed.")
         # :todo: should we raise a SystemError here?
     else:
-        logger.debug("Adding files for %s %s", module, version)
+        logger.debug("Adding files for {} {}".format(module, version))
 
         if typelibs_data['sharedlib']:
             for lib in typelibs_data['sharedlib'].split(','):
                 path = findSystemLibrary(lib.strip())
                 if path:
-                    logger.debug('Found shared library %s at %s', lib, path)
+                    logger.debug('Found shared library {} at {}'.format(lib, path))
                     binaries.append((path, '.'))
 
         d = gir_library_path_fix(typelibs_data['typelib'])
         if d:
-            logger.debug('Found gir typelib at %s', d)
+            logger.debug('Found gir typelib at {}'.format(d))
             datas.append(d)
 
         hiddenimports += collect_submodules('gi.overrides',
@@ -102,7 +100,7 @@ def get_gi_typelibs(module, version):
         # Load dependencies recursively
         for dep in typelibs_data['deps']:
             m, _ = dep.rsplit('-', 1)
-            hiddenimports += ['gi.repository.%s' % m]
+            hiddenimports += ['gi.repository.{}'.format(m)]
 
     return binaries, datas, hiddenimports
 
@@ -133,14 +131,14 @@ def gir_library_path_fix(path):
         gir_file = os.path.join(gir_path, gir_name)
 
         if not os.path.exists(gir_path):
-            logger.error('Unable to find gir directory: %s.\n'
+            logger.error('Unable to find gir directory: {}.\n'
                          'Try installing your platforms gobject-introspection '
-                         'package.', gir_path)
+                         'package.'.format(gir_path))
             return None
         if not os.path.exists(gir_file):
-            logger.error('Unable to find gir file: %s.\n'
+            logger.error('Unable to find gir file: {}.\n'
                          'Try installing your platforms gobject-introspection '
-                         'package.', gir_file)
+                         'package.'.format(gir_file))
             return None
 
         with open_file(gir_file, text_read_mode, encoding='utf-8') as f:

--- a/PyInstaller/utils/hooks/qt.py
+++ b/PyInstaller/utils/hooks/qt.py
@@ -52,7 +52,7 @@ class Qt5LibraryInfo:
 
                 import json
                 try:
-                    from %s.QtCore import QLibraryInfo, QCoreApplication
+                    from {}.QtCore import QLibraryInfo, QCoreApplication
                 except:
                     print('False')
                 else:
@@ -60,23 +60,23 @@ class Qt5LibraryInfo:
                     # instantiated.
                     app = QCoreApplication(sys.argv)
                     paths = [x for x in dir(QLibraryInfo) if x.endswith('Path')]
-                    location = {x: QLibraryInfo.location(getattr(QLibraryInfo, x))
-                                for x in paths}
+                    location = {{x: QLibraryInfo.location(getattr(QLibraryInfo, x))
+                                for x in paths}}
                     try:
                         version = QLibraryInfo.version().segments()
                     except AttributeError:
                         version = []
-                    print(json.dumps({
+                    print(json.dumps({{
                         'isDebugBuild': QLibraryInfo.isDebugBuild(),
                         'version': version,
                         'location': location,
-                    }))
-            """ % self.namespace)
+                    }}))
+            """.format(self.namespace))
             try:
                 qli = json.loads(json_str)
             except Exception as e:
-                logger.warning('Cannot read QLibraryInfo output: raised %s when '
-                               'decoding:\n%s', str(e), json_str)
+                logger.warning('Cannot read QLibraryInfo output: raised {} when '
+                               'decoding:\n{}'.format(str(e), json_str))
                 qli = False
 
             # If PyQt5/PySide2 can't be imported, record that.
@@ -162,7 +162,7 @@ def qt_plugins_binaries(plugin_type, namespace):
     elif is_win and namespace in ['PyQt5', 'PySide2']:
         files = [f for f in files if not f.endswith("d.dll")]
 
-    logger.debug("Found plugin files %s for plugin %s", files, plugin_type)
+    logger.debug("Found plugin files {} for plugin {}".format(files, plugin_type))
     if namespace in ['PyQt4', 'PySide']:
         plugin_dir = 'qt4_plugins'
     elif namespace == 'PyQt5':
@@ -201,7 +201,7 @@ def qt_menu_nib_dir(namespace):
         path = os.path.join(location, 'qt_menu.nib')
         if os.path.exists(path):
             menu_dir = path
-            logger.debug('Found qt_menu.nib for %s at %s', namespace, path)
+            logger.debug('Found qt_menu.nib for {} at {}'.format(namespace, path))
             break
     if not menu_dir:
         raise Exception("""
@@ -245,12 +245,13 @@ def get_qmake_path(version=''):
             # version string is probably just ASCII
             versionstring = versionstring.decode('utf8')
             if versionstring.find(version) == 0:
-                logger.debug('Found qmake version "%s" at "%s".',
-                             versionstring, qmake)
+                logger.debug('Found qmake version "{}" at "{}".'
+                             .format(versionstring, qmake))
                 return qmake
         except (OSError, subprocess.CalledProcessError):
             pass
-    logger.debug('Could not find qmake matching version "%s".', version)
+    logger.debug('Could not find qmake matching version "{}".'
+                 .format(version))
     return None
 
 
@@ -477,8 +478,8 @@ def add_qt5_dependencies(hook_file):
 
     # Look up the module returned by this import.
     module = get_module_file_attribute(module_name)
-    logger.debug('add_qt5_dependencies: Examining %s, based on hook of %s.',
-                 module, hook_file)
+    logger.debug('add_qt5_dependencies: Examining {}, based on hook of {}.'
+                 .format(module, hook_file))
 
     # Walk through all the static dependencies of a dynamically-linked library
     # (``.so``/``.dll``/``.dylib``).
@@ -513,13 +514,12 @@ def add_qt5_dependencies(hook_file):
         if lib_name.endswith('_conda'):
             lib_name = lib_name[:-6]
 
-        logger.debug('add_qt5_dependencies: raw lib %s -> parsed lib %s',
-                     imp, lib_name)
+        logger.debug('add_qt5_dependencies: raw lib {} -> parsed lib {}'.format(imp, lib_name))
 
         # Follow only Qt dependencies.
         if lib_name in _qt_dynamic_dependencies_dict:
             # Follow these to find additional dependencies.
-            logger.debug('add_qt5_dependencies: Import of %s.', imp)
+            logger.debug('add_qt5_dependencies: Import of {}.'.format(imp))
             imports.update(getImports(imp))
             # Look up which plugins and translations are needed.
             dd = _qt_dynamic_dependencies_dict[lib_name]
@@ -559,16 +559,16 @@ def add_qt5_dependencies(hook_file):
                 )
             ))
         else:
-            logger.warning('Unable to find Qt5 translations %s. These '
-                           'translations were not packaged.', src)
+            logger.warning('Unable to find Qt5 translations {}. These '
+                           'translations were not packaged.'.format(src))
     # Change hiddenimports to a list.
     hiddenimports = list(hiddenimports)
 
-    logger.debug('add_qt5_dependencies: imports from %s:\n'
-                 '  hiddenimports = %s\n'
-                 '  binaries = %s\n'
-                 '  datas = %s',
-                 hook_name, hiddenimports, binaries, datas)
+    logger.debug('add_qt5_dependencies: imports from {}:\n'
+                 '  hiddenimports = {}\n'
+                 '  binaries = {}\n'
+                 '  datas = {}'
+                 .format(hook_name, hiddenimports, binaries, datas))
     return hiddenimports, binaries, datas
 
 

--- a/PyInstaller/utils/hooks/qt.py
+++ b/PyInstaller/utils/hooks/qt.py
@@ -59,8 +59,8 @@ class Qt5LibraryInfo:
                     # QLibraryInfo isn't always valid until a QCoreApplication is
                     # instantiated.
                     app = QCoreApplication(sys.argv)
-                    paths = [x for x in dir(QLibraryInfo) if x.endswith('Path')]
-                    location ={{x:QLibraryInfo.location(getattr(QLibraryInfo,x))
+                    paths =[x for x in dir(QLibraryInfo) if x.endswith('Path')]
+                    location={{x:QLibraryInfo.location(getattr(QLibraryInfo,x))
                                 for x in paths}}
                     try:
                         version = QLibraryInfo.version().segments()
@@ -519,7 +519,7 @@ def add_qt5_dependencies(hook_file):
 
         logger.debug(
             'add_qt5_dependencies: raw lib {} -> parsed lib {}'
-                .format(imp, lib_name))
+            .format(imp, lib_name))
 
         # Follow only Qt dependencies.
         if lib_name in _qt_dynamic_dependencies_dict:

--- a/PyInstaller/utils/hooks/qt.py
+++ b/PyInstaller/utils/hooks/qt.py
@@ -60,7 +60,7 @@ class Qt5LibraryInfo:
                     # instantiated.
                     app = QCoreApplication(sys.argv)
                     paths = [x for x in dir(QLibraryInfo) if x.endswith('Path')]
-                    location = {{x: QLibraryInfo.location(getattr(QLibraryInfo, x))
+                    location ={{x:QLibraryInfo.location(getattr(QLibraryInfo,x))
                                 for x in paths}}
                     try:
                         version = QLibraryInfo.version().segments()
@@ -75,8 +75,9 @@ class Qt5LibraryInfo:
             try:
                 qli = json.loads(json_str)
             except Exception as e:
-                logger.warning('Cannot read QLibraryInfo output: raised {} when '
-                               'decoding:\n{}'.format(str(e), json_str))
+                logger.warning(
+                    'Cannot read QLibraryInfo output: raised {} when '
+                    'decoding:\n{}'.format(str(e), json_str))
                 qli = False
 
             # If PyQt5/PySide2 can't be imported, record that.
@@ -162,7 +163,8 @@ def qt_plugins_binaries(plugin_type, namespace):
     elif is_win and namespace in ['PyQt5', 'PySide2']:
         files = [f for f in files if not f.endswith("d.dll")]
 
-    logger.debug("Found plugin files {} for plugin {}".format(files, plugin_type))
+    logger.debug(
+        "Found plugin files {} for plugin {}".format(files, plugin_type))
     if namespace in ['PyQt4', 'PySide']:
         plugin_dir = 'qt4_plugins'
     elif namespace == 'PyQt5':
@@ -201,7 +203,8 @@ def qt_menu_nib_dir(namespace):
         path = os.path.join(location, 'qt_menu.nib')
         if os.path.exists(path):
             menu_dir = path
-            logger.debug('Found qt_menu.nib for {} at {}'.format(namespace, path))
+            logger.debug(
+                'Found qt_menu.nib for {} at {}'.format(namespace, path))
             break
     if not menu_dir:
         raise Exception("""
@@ -514,7 +517,9 @@ def add_qt5_dependencies(hook_file):
         if lib_name.endswith('_conda'):
             lib_name = lib_name[:-6]
 
-        logger.debug('add_qt5_dependencies: raw lib {} -> parsed lib {}'.format(imp, lib_name))
+        logger.debug(
+            'add_qt5_dependencies: raw lib {} -> parsed lib {}'
+                .format(imp, lib_name))
 
         # Follow only Qt dependencies.
         if lib_name in _qt_dynamic_dependencies_dict:

--- a/PyInstaller/utils/hooks/win32.py
+++ b/PyInstaller/utils/hooks/win32.py
@@ -48,9 +48,9 @@ def get_pywin32_module_file_attribute(module_name):
     """
     statement = """
         from PyInstaller.utils.win32 import winutils
-        module = winutils.import_pywin32_module('%s')
+        module = winutils.import_pywin32_module('{}')
         print(module.__file__)
     """
-    return exec_statement(statement % module_name)
+    return exec_statement(statement.format(module_name))
 
 __all__ = ('get_pywin32_module_file_attribute', )

--- a/PyInstaller/utils/misc.py
+++ b/PyInstaller/utils/misc.py
@@ -143,14 +143,10 @@ def compile_py_files(toc, workpath):
         # We need to perform a build ourselves if obj_fnm doesn't exist,
         # or if src_fnm is newer than obj_fnm, or if obj_fnm was created
         # by a different Python version.
-        # TODO: explain why this does read()[:4] (reading all the file)
-        # instead of just read(4)? Yes for many a .pyc file, it is all
-        # in one sector so there's no difference in I/O but still it
-        # seems inelegant to copy it all then subscript 4 bytes.
         needs_compile = mtime(src_fnm) > mtime(obj_fnm)
         if not needs_compile:
             with open(obj_fnm, 'rb') as fh:
-                needs_compile = fh.read()[:4] != BYTECODE_MAGIC
+                needs_compile = fh.read(4) != BYTECODE_MAGIC
         if needs_compile:
             try:
                 # TODO: there should be no need to repeat the compile,
@@ -180,15 +176,14 @@ def compile_py_files(toc, workpath):
                     os.makedirs(leading)
 
                 obj_fnm = os.path.join(leading, mod_name + ext)
-                # TODO see above regarding read()[:4] versus read(4)
                 needs_compile = mtime(src_fnm) > mtime(obj_fnm)
                 if not needs_compile:
                     with open(obj_fnm, 'rb') as fh:
-                        needs_compile = fh.read()[:4] != BYTECODE_MAGIC
+                        needs_compile = fh.read(4) != BYTECODE_MAGIC
                 if needs_compile:
                     # TODO see above todo regarding using node.code
                     py_compile.compile(src_fnm, obj_fnm)
-                    logger.debug("compiled %s", src_fnm)
+                    logger.debug("compiled {}".format(src_fnm))
         # if we get to here, obj_fnm is the path to the compiled module nm.py
         new_toc.append((nm, obj_fnm, typ))
 

--- a/PyInstaller/utils/win32/icon.py
+++ b/PyInstaller/utils/win32/icon.py
@@ -154,10 +154,12 @@ def CopyIcons_FromIco(dstpath, srcpath, id=1):
         data = f.grp_icon_dir()
         data = data + f.grp_icondir_entries(iconid)
         win32api.UpdateResource(hdst, RT_GROUP_ICON, i, data)
-        logger.info("Writing RT_GROUP_ICON {:d} resource with {:d} bytes".format(i, len(data)))
+        logger.info("Writing RT_GROUP_ICON {:d} resource with {:d} bytes"
+                    .format(i, len(data)))
         for data in f.images:
             win32api.UpdateResource(hdst, RT_ICON, iconid, data)
-            logger.info("Writing RT_ICON {:d} resource with {:d} bytes".format(iconid, len(data)))
+            logger.info("Writing RT_ICON {:d} resource with {:d} bytes"
+                        .format(iconid, len(data)))
             iconid = iconid + 1
 
     win32api.EndUpdateResource(hdst, 0)

--- a/PyInstaller/utils/win32/icon.py
+++ b/PyInstaller/utils/win32/icon.py
@@ -46,10 +46,10 @@ class Structure:
             indexes[nm] = i
 
     def dump(self):
-        logger.info("DUMP of %s", self)
+        logger.info("DUMP of {}".format(self))
         for name in self._names_:
             if not name.startswith('_'):
-                logger.info("%20s = %s", name, getattr(self, name))
+                logger.info("{:>20} = {}".format(name, getattr(self, name)))
         logger.info("")
 
     def __getattr__(self, name):
@@ -143,7 +143,7 @@ def CopyIcons_FromIco(dstpath, srcpath, id=1):
     :param str srcpath: list of 1 or more .ico file paths
     '''
     icons = map(IconFile, srcpath)
-    logger.info("Copying icons from %s", srcpath)
+    logger.info("Copying icons from {}".format(srcpath))
 
     hdst = win32api.BeginUpdateResource(dstpath, 0)
 
@@ -154,10 +154,10 @@ def CopyIcons_FromIco(dstpath, srcpath, id=1):
         data = f.grp_icon_dir()
         data = data + f.grp_icondir_entries(iconid)
         win32api.UpdateResource(hdst, RT_GROUP_ICON, i, data)
-        logger.info("Writing RT_GROUP_ICON %d resource with %d bytes", i, len(data))
+        logger.info("Writing RT_GROUP_ICON {:d} resource with {:d} bytes".format(i, len(data)))
         for data in f.images:
             win32api.UpdateResource(hdst, RT_ICON, iconid, data)
-            logger.info("Writing RT_ICON %d resource with %d bytes", iconid, len(data))
+            logger.info("Writing RT_ICON {:d} resource with {:d} bytes".format(iconid, len(data)))
             iconid = iconid + 1
 
     win32api.EndUpdateResource(hdst, 0)
@@ -220,9 +220,9 @@ def CopyIcons(dstpath, srcpath):
     if not os.path.isabs(srcpath):
         srcpath = os.path.join(config.CONF['specpath'], srcpath)
     if index is not None:
-        logger.info("Copying icon from %s, %d", srcpath, index)
+        logger.info("Copying icon from {}, {:d}".format(srcpath, index))
     else:
-        logger.info("Copying icons from %s", srcpath)
+        logger.info("Copying icons from {}".format(srcpath))
 
     try:
         # Attempt to load the .ico or .exe containing the icon into memory

--- a/PyInstaller/utils/win32/versioninfo.py
+++ b/PyInstaller/utils/win32/versioninfo.py
@@ -302,26 +302,28 @@ class FixedFileInfo:
         fd = (self.fileDateMS, self.fileDateLS)
         tmp = [
             'FixedFileInfo(',
-            '# filevers and prodvers should be always a tuple with four items: (1, 2, 3, 4)',
+            '# filevers and prodvers should be always a tuple with four items: '
+            '(1, 2, 3, 4)',
             '# Set not needed items to zero 0.',
-           'filevers={},'.format(fv),
-           'prodvers={},'.format(pv),
-           "# Contains a bitmask that specifies the valid bits 'flags'r",
-           'mask={},'.format(hex(self.fileFlagsMask)),
-           '# Contains a bitmask that specifies the Boolean attributes of the file.',
-           'flags={},'.format(hex(self.fileFlags)),
-           '# The operating system for which this file was designed.',
-           '# 0x4 - NT and there is no need to change it.',
-           'OS={},'.format(hex(self.fileOS)),
-           '# The general type of file.',
-           '# 0x1 - the file is an application.',
-           'fileType={},'.format(hex(self.fileType)),
-           '# The function of the file.',
-           '# 0x0 - the function is not defined for this fileType',
-           'subtype={},'.format(hex(self.fileSubtype)),
-           '# Creation date and time stamp.',
-           'date={}'.format(fd),
-           ')'
+            'filevers={},'.format(fv),
+            'prodvers={},'.format(pv),
+            "# Contains a bitmask that specifies the valid bits 'flags'r",
+            'mask={},'.format(hex(self.fileFlagsMask)),
+            '# Contains a bitmask that specifies the Boolean attributes of the'
+            ' file.',
+            'flags={},'.format(hex(self.fileFlags)),
+            '# The operating system for which this file was designed.',
+            '# 0x4 - NT and there is no need to change it.',
+            'OS={},'.format(hex(self.fileOS)),
+            '# The general type of file.',
+            '# 0x1 - the file is an application.',
+            'fileType={},'.format(hex(self.fileType)),
+            '# The function of the file.',
+            '# 0x0 - the function is not defined for this fileType',
+            'subtype={},'.format(hex(self.fileSubtype)),
+            '# Creation date and time stamp.',
+            'date={}'.format(fd),
+            ')'
         ]
         return ('\n' + indent + '  ').join(tmp)
 

--- a/PyInstaller/utils/win32/versioninfo.py
+++ b/PyInstaller/utils/win32/versioninfo.py
@@ -302,8 +302,8 @@ class FixedFileInfo:
         fd = (self.fileDateMS, self.fileDateLS)
         tmp = [
             'FixedFileInfo(',
-            '# filevers and prodvers should be always a tuple with four items: '
-            '(1, 2, 3, 4)',
+            '# filevers and prodvers should be always a tuple with four items:'
+            ' (1, 2, 3, 4)',
             '# Set not needed items to zero 0.',
             'filevers={},'.format(fv),
             'prodvers={},'.format(pv),

--- a/PyInstaller/utils/win32/versioninfo.py
+++ b/PyInstaller/utils/win32/versioninfo.py
@@ -21,7 +21,7 @@ import pefile
 
 
 # TODO implement read/write version information with pefile library.
-# PE version info doc: http://msdn.microsoft.com/en-us/library/ms646981.aspx
+# PE version info doc: https://docs.microsoft.com/en-us/windows/win32/menurc/version-information
 def pefile_read_version(filename):
     """
     Return structure like:
@@ -29,25 +29,25 @@ def pefile_read_version(filename):
     {
         # Translation independent information.
         # VS_FIXEDFILEINFO - Contains version information about a file. This information is language and code page independent.
-        u'FileVersion':      (1, 2, 3, 4),
-        u'ProductVersion':   (9, 10, 11, 12),
+        'FileVersion':      (1, 2, 3, 4),
+        'ProductVersion':   (9, 10, 11, 12),
 
         # PE files might contain several translations of version information.
         # VS_VERSIONINFO - Depicts the organization of data in a file-version resource. It is the root structure that contains all other file-version information structures.
-        u'translations': {
+        'translations': {
             'lang_id1' : {
-                u'Comments':         u'日本語, Unicode 対応.',
-                u'CompanyName':      u'your company.',
-                u'FileDescription':  u'your file desc.',
-                u'FileVersion':      u'1, 2, 3, 4',
-                u'InternalName':     u'your internal name.',
-                u'LegalCopyright':   u'your legal copyright.',
-                u'LegalTrademarks':  u'your legal trademarks.',
-                u'OriginalFilename': u'your original filename.',
-                u'PrivateBuild':     u'5, 6, 7, 8',
-                u'ProductName':      u'your product name',
-                u'ProductVersion':   u'9, 10, 11, 12',
-                u'SpecialBuild':     u'13, 14, 15, 16',
+                'Comments':         '日本語, Unicode 対応.',
+                'CompanyName':      'your company.',
+                'FileDescription':  'your file desc.',
+                'FileVersion':      '1, 2, 3, 4',
+                'InternalName':     'your internal name.',
+                'LegalCopyright':   'your legal copyright.',
+                'LegalTrademarks':  'your legal trademarks.',
+                'OriginalFilename': 'your original filename.',
+                'PrivateBuild':     '5, 6, 7, 8',
+                'ProductName':      'your product name',
+                'ProductVersion':   '9, 10, 11, 12',
+                'SpecialBuild':     '13, 14, 15, 16',
             },
 
             'lang_id2' : {
@@ -154,7 +154,7 @@ class VSVersionInfo:
         while i < sublen:
             j = i
             i, (csublen, cvallen, ctyp, nm) = parseCommon(data, i)
-            if nm.strip() == u'StringFileInfo':
+            if nm.strip() == 'StringFileInfo':
                 sfi = StringFileInfo()
                 k = sfi.fromRaw(csublen, cvallen, nm, data, i, j+csublen)
                 self.kids.append(sfi)
@@ -169,7 +169,7 @@ class VSVersionInfo:
         return i
 
     def toRaw(self):
-        raw_name = getRaw(u'VS_VERSION_INFO')
+        raw_name = getRaw('VS_VERSION_INFO')
         rawffi = self.ffi.toRaw()
         vallen = len(rawffi)
         typ = 0
@@ -186,22 +186,22 @@ class VSVersionInfo:
         return (struct.pack('hhh', sublen, vallen, typ)
                 + raw_name + b'\000\000' + pad + rawffi + pad2 + tmp)
 
-    def __str__(self, indent=u''):
-        indent = indent + u'  '
-        tmp = [kid.__str__(indent+u'  ')
+    def __str__(self, indent=''):
+        indent = indent + '  '
+        tmp = [kid.__str__(indent+'  ')
                for kid in self.kids]
-        tmp = u', \n'.join(tmp)
-        return (u"""# UTF-8
+        tmp = ', \n'.join(tmp)
+        return (""""# UTF-8
 #
 # For more details about fixed file info 'ffi' see:
 # http://msdn.microsoft.com/en-us/library/ms646997.aspx
 VSVersionInfo(
-%sffi=%s,
-%skids=[
-%s
-%s]
+{}ffi={},
+{}kids=[
+{}
+{}]
 )
-""" % (indent, self.ffi.__str__(indent), indent, tmp, indent))
+""".format(indent, self.ffi.__str__(indent), indent, tmp, indent))
 
 
 def parseCommon(data, start=0):
@@ -293,35 +293,35 @@ class FixedFileInfo:
                              self.fileDateMS,
                              self.fileDateLS)
 
-    def __str__(self, indent=u''):
+    def __str__(self, indent=''):
         fv = (self.fileVersionMS >> 16, self.fileVersionMS & 0xffff,
               self.fileVersionLS >> 16, self.fileVersionLS & 0xFFFF)
         pv = (self.productVersionMS >> 16, self.productVersionMS & 0xffff,
               self.productVersionLS >> 16, self.productVersionLS & 0xFFFF)
         fd = (self.fileDateMS, self.fileDateLS)
-        tmp = [u'FixedFileInfo(',
-            u'# filevers and prodvers should be always a tuple with four items: (1, 2, 3, 4)',
-            u'# Set not needed items to zero 0.',
-            u'filevers=%s,' % (fv,),
-            u'prodvers=%s,' % (pv,),
-            u"# Contains a bitmask that specifies the valid bits 'flags'r",
-            u'mask=%s,' % hex(self.fileFlagsMask),
-            u'# Contains a bitmask that specifies the Boolean attributes of the file.',
-            u'flags=%s,' % hex(self.fileFlags),
-            u'# The operating system for which this file was designed.',
-            u'# 0x4 - NT and there is no need to change it.',
-            u'OS=%s,' % hex(self.fileOS),
-            u'# The general type of file.',
-            u'# 0x1 - the file is an application.',
-            u'fileType=%s,' % hex(self.fileType),
-            u'# The function of the file.',
-            u'# 0x0 - the function is not defined for this fileType',
-            u'subtype=%s,' % hex(self.fileSubtype),
-            u'# Creation date and time stamp.',
-            u'date=%s' % (fd,),
-            u')'
+        tmp = ['FixedFileInfo(',
+               '# filevers and prodvers should be always a tuple with four items: (1, 2, 3, 4)',
+               '# Set not needed items to zero 0.',
+               'filevers={},'.format(fv),
+               'prodvers={},'.format(pv),
+               "# Contains a bitmask that specifies the valid bits 'flags'r",
+               'mask={},'.format(hex(self.fileFlagsMask)),
+               '# Contains a bitmask that specifies the Boolean attributes of the file.',
+               'flags={},'.format(hex(self.fileFlags)),
+               '# The operating system for which this file was designed.',
+               '# 0x4 - NT and there is no need to change it.',
+               'OS={},'.format(hex(self.fileOS)),
+               '# The general type of file.',
+               '# 0x1 - the file is an application.',
+               'fileType={},'.format(hex(self.fileType)),
+               '# The function of the file.',
+               '# 0x0 - the function is not defined for this fileType',
+               'subtype={},'.format(hex(self.fileSubtype)),
+               '# Creation date and time stamp.',
+               'date={}'.format(fd),
+               ')'
         ]
-        return (u'\n'+indent+u'  ').join(tmp)
+        return ('\n'+indent+'  ').join(tmp)
 
 
 class StringFileInfo(object):
@@ -335,7 +335,7 @@ class StringFileInfo(object):
     StringTable Children[];   // list of zero or more String structures
     """
     def __init__(self, kids=None):
-        self.name = u'StringFileInfo'
+        self.name = 'StringFileInfo'
         self.kids = kids or []
 
     def fromRaw(self, sublen, vallen, name, data, i, limit):
@@ -360,13 +360,13 @@ class StringFileInfo(object):
         return (struct.pack('hhh', sublen, vallen, typ)
                 + raw_name + b'\000\000' + pad + tmp)
 
-    def __str__(self, indent=u''):
-        newindent = indent + u'  '
+    def __str__(self, indent=''):
+        newindent = indent + '  '
         tmp = [kid.__str__(newindent)
                for kid in self.kids]
-        tmp = u', \n'.join(tmp)
-        return (u'%sStringFileInfo(\n%s[\n%s\n%s])'
-                % (indent, newindent, tmp, newindent))
+        tmp = ', \n'.join(tmp)
+        return ('{}StringFileInfo(\n{}[\n{}\n{}])'
+                .format(indent, newindent, tmp, newindent))
 
 
 class StringTable:
@@ -378,7 +378,7 @@ class StringTable:
     String Children[];    // list of zero or more String structures.
     """
     def __init__(self, name=None, kids=None):
-        self.name = name or u''
+        self.name = name or ''
         self.kids = kids or []
 
     def fromRaw(self, data, i, limit):
@@ -408,11 +408,11 @@ class StringTable:
         return (struct.pack('hhh', sublen, vallen, typ)
                 + raw_name + b'\000\000' + tmp)
 
-    def __str__(self, indent=u''):
-        newindent = indent + u'  '
-        tmp = (u',\n%s' % newindent).join(str(kid) for kid in self.kids)
-        return (u"%sStringTable(\n%su'%s',\n%s[%s])"
-                % (indent, newindent, self.name, newindent, tmp))
+    def __str__(self, indent=''):
+        newindent = indent + '  '
+        tmp = (',\n{}'.format(newindent)).join(str(kid) for kid in self.kids)
+        return ("{}StringTable(\n{}'{}',\n{}[{}])"
+                .format(indent, newindent, self.name, newindent, tmp))
 
 
 class StringStruct:
@@ -425,8 +425,8 @@ class StringStruct:
     String Value[];
     """
     def __init__(self, name=None, val=None):
-        self.name = name or u''
-        self.val = val or u''
+        self.name = name or ''
+        self.val = val or ''
 
     def fromRaw(self, data, i, limit):
         i, (sublen, vallen, typ, self.name) = parseCommon(data, i)
@@ -452,7 +452,7 @@ class StringStruct:
         return abcd
 
     def __str__(self, indent=''):
-        return u"StringStruct(u'%s', u'%s')" % (self.name, self.val)
+        return "StringStruct('{}', '{}')".format(self.name, self.val)
 
 
 def parseCodePage(data, i, limit):
@@ -488,7 +488,7 @@ class VarFileInfo:
     def toRaw(self):
         self.vallen = 0
         self.wType = 1
-        self.name = u'VarFileInfo'
+        self.name = 'VarFileInfo'
         raw_name = getRaw(self.name)
         sublen = 6 + len(raw_name) + 2
         pad = b''
@@ -500,8 +500,8 @@ class VarFileInfo:
                 + raw_name + b'\000\000' + pad + tmp)
 
     def __str__(self, indent=''):
-        return (indent + "VarFileInfo([%s])" %
-                ', '.join(str(kid) for kid in self.kids))
+        return (indent + "VarFileInfo([{}])"
+                .format(', '.join(str(kid) for kid in self.kids)))
 
 
 class VarStruct:
@@ -517,7 +517,7 @@ class VarStruct:
                           // and code-page identifiers
     """
     def __init__(self, name=None, kids=None):
-        self.name = name or u''
+        self.name = name or ''
         self.kids = kids or []
 
     def fromRaw(self, data, i, limit):
@@ -542,8 +542,8 @@ class VarStruct:
         return (struct.pack('hhh', self.sublen, self.wValueLength, self.wType)
                 + raw_name + b'\000\000' + pad + tmp)
 
-    def __str__(self, indent=u''):
-        return u"VarStruct(u'%s', %r)" % (self.name, self.kids)
+    def __str__(self, indent=''):
+        return "VarStruct('{}', {!r})".format(self.name, self.kids)
 
 
 def SetVersion(exenm, versionfile):

--- a/PyInstaller/utils/win32/versioninfo.py
+++ b/PyInstaller/utils/win32/versioninfo.py
@@ -21,7 +21,8 @@ import pefile
 
 
 # TODO implement read/write version information with pefile library.
-# PE version info doc: https://docs.microsoft.com/en-us/windows/win32/menurc/version-information
+# PE version info doc:
+#   https://docs.microsoft.com/en-us/windows/win32/menurc/version-information
 def pefile_read_version(filename):
     """
     Return structure like:
@@ -188,7 +189,7 @@ class VSVersionInfo:
 
     def __str__(self, indent=''):
         indent = indent + '  '
-        tmp = [kid.__str__(indent+'  ')
+        tmp = [kid.__str__(indent + '  ')
                for kid in self.kids]
         tmp = ', \n'.join(tmp)
         return (""""# UTF-8
@@ -299,29 +300,30 @@ class FixedFileInfo:
         pv = (self.productVersionMS >> 16, self.productVersionMS & 0xffff,
               self.productVersionLS >> 16, self.productVersionLS & 0xFFFF)
         fd = (self.fileDateMS, self.fileDateLS)
-        tmp = ['FixedFileInfo(',
-               '# filevers and prodvers should be always a tuple with four items: (1, 2, 3, 4)',
-               '# Set not needed items to zero 0.',
-               'filevers={},'.format(fv),
-               'prodvers={},'.format(pv),
-               "# Contains a bitmask that specifies the valid bits 'flags'r",
-               'mask={},'.format(hex(self.fileFlagsMask)),
-               '# Contains a bitmask that specifies the Boolean attributes of the file.',
-               'flags={},'.format(hex(self.fileFlags)),
-               '# The operating system for which this file was designed.',
-               '# 0x4 - NT and there is no need to change it.',
-               'OS={},'.format(hex(self.fileOS)),
-               '# The general type of file.',
-               '# 0x1 - the file is an application.',
-               'fileType={},'.format(hex(self.fileType)),
-               '# The function of the file.',
-               '# 0x0 - the function is not defined for this fileType',
-               'subtype={},'.format(hex(self.fileSubtype)),
-               '# Creation date and time stamp.',
-               'date={}'.format(fd),
-               ')'
+        tmp = [
+            'FixedFileInfo(',
+            '# filevers and prodvers should be always a tuple with four items: (1, 2, 3, 4)',
+            '# Set not needed items to zero 0.',
+           'filevers={},'.format(fv),
+           'prodvers={},'.format(pv),
+           "# Contains a bitmask that specifies the valid bits 'flags'r",
+           'mask={},'.format(hex(self.fileFlagsMask)),
+           '# Contains a bitmask that specifies the Boolean attributes of the file.',
+           'flags={},'.format(hex(self.fileFlags)),
+           '# The operating system for which this file was designed.',
+           '# 0x4 - NT and there is no need to change it.',
+           'OS={},'.format(hex(self.fileOS)),
+           '# The general type of file.',
+           '# 0x1 - the file is an application.',
+           'fileType={},'.format(hex(self.fileType)),
+           '# The function of the file.',
+           '# 0x0 - the function is not defined for this fileType',
+           'subtype={},'.format(hex(self.fileSubtype)),
+           '# Creation date and time stamp.',
+           'date={}'.format(fd),
+           ')'
         ]
-        return ('\n'+indent+'  ').join(tmp)
+        return ('\n' + indent + '  ').join(tmp)
 
 
 class StringFileInfo(object):

--- a/PyInstaller/utils/win32/winresource.py
+++ b/PyInstaller/utils/win32/winresource.py
@@ -199,8 +199,8 @@ def UpdateResources(dstpath, data, type_, names=None, languages=None):
     for type_ in res:
         for name in res[type_]:
             for language in res[type_][name]:
-                logger.info("Updating resource type %s name %s language %s",
-                            type_, name, language)
+                logger.info("Updating resource type {} name {} language {}"
+                            .format(type_, name, language))
                 win32api.UpdateResource(hdst, type_, name, data, language)
     win32api.EndUpdateResource(hdst, 0)
 


### PR DESCRIPTION
After dropping support for python 2, there are huge amounts of inefficient code, including old style string formatting, using `def` where lambda would be better, etc. This PR aims to remove all python 2 support, and clean up after python 2.

I plan to review every python file in pyinstaller and update them.

- [x] `PyInstaller`
- [x] `PyInstaller.archive`
- [x] `PyInstaller.utils`
- [ ] `PyInstaller.building`
- [ ] `PyInstaller.depend`
- [ ] `PyInstaller.loader`

I'm not using the standard commit prefixes, because they don't really fit properly. 