### PR TITLE
Fix default icons still being present in the executable

### DIFF
--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -328,6 +328,8 @@ class EXE(Target):
             icon
                 Windows or OSX only. icon='myicon.ico' to use an icon file or
                 icon='notepad.exe,0' to grab an icon resource.
+                Defaults to use PyInstaller's console or windowed icon.
+                icon=`NONE` to not add any icon.
             version
                 Windows only. version='myversion.txt'. Use grab_version.py to get
                 a version resource from an executable and then edit the output to
@@ -529,8 +531,8 @@ class EXE(Target):
         if not os.path.exists(exe):
             raise SystemExit(_MISSING_BOOTLOADER_ERRORMSG)
 
-        if is_win and (self.icon or self.versrsrc or self.resources or
-                self.uac_admin or self.uac_uiaccess or not is_64bits):
+        if is_win and (self.icon != "NONE" or self.versrsrc or self.resources
+                       or self.uac_admin or self.uac_uiaccess or not is_64bits):
             fd, tmpnm = tempfile.mkstemp(prefix=os.path.basename(exe) + ".",
                                          dir=CONF['workpath'])
             # need to close the file, otherwise copying resources will fail
@@ -538,7 +540,13 @@ class EXE(Target):
             os.close(fd)
             self._copyfile(exe, tmpnm)
             os.chmod(tmpnm, 0o755)
-            if self.icon:
+            if not self.icon:
+                # --icon not specified; use default from bootloader folder
+                self.icon = os.path.join(
+                    os.path.dirname(os.path.dirname(__file__)),
+                    'bootloader', 'images',
+                    'icon-console.ico' if self.console else 'icon-windowed.ico')
+            if self.icon != "NONE":
                 icon.CopyIcons(tmpnm, self.icon)
             if self.versrsrc:
                 versioninfo.SetVersion(tmpnm, self.versrsrc)

--- a/PyInstaller/building/makespec.py
+++ b/PyInstaller/building/makespec.py
@@ -250,11 +250,14 @@ def __add_options(parser):
                         "script is a '.pyw' file. "
                         "This option is ignored in *NIX systems.")
     g.add_argument("-i", "--icon", dest="icon_file",
-                   metavar="<FILE.ico or FILE.exe,ID or FILE.icns>",
+                   metavar='<FILE.ico or FILE.exe,ID or FILE.icns or "NONE">',
                    help="FILE.ico: apply that icon to a Windows executable. "
                         "FILE.exe,ID, extract the icon with ID from an exe. "
                         "FILE.icns: apply the icon to the "
-                        ".app bundle on Mac OS X")
+                        ".app bundle on Mac OS X. "
+                        'Use "NONE" to not apply any icon, '
+                        "thereby making the OS to show some default "
+                        "(default: apply PyInstaller's icon)")
 
     g = parser.add_argument_group('Windows specific options')
     g.add_argument("--version-file",

--- a/PyInstaller/building/utils.py
+++ b/PyInstaller/building/utils.py
@@ -407,7 +407,7 @@ def _make_clean_directory(path):
             except OSError:
                 _rmtree(path)
 
-        os.makedirs(path)
+        os.makedirs(path, exist_ok=True)
 
 
 def _rmtree(path):

--- a/PyInstaller/utils/win32/icon.py
+++ b/PyInstaller/utils/win32/icon.py
@@ -31,7 +31,7 @@ try:
 except AttributeError:
     StringTypes = [ type("") ]
 
-from ...compat import win32api
+from ...compat import win32api, pywintypes
 from ... import config
 
 import PyInstaller.log as logging
@@ -231,7 +231,7 @@ def CopyIcons(dstpath, srcpath):
         # .ico/.exe) then LoadLibraryEx returns a null handle and win32api
         # raises a unique exception with a win error code and a string.
         hsrc = win32api.LoadLibraryEx(srcpath, 0, LOAD_LIBRARY_AS_DATAFILE)
-    except win32api.error as W32E:
+    except pywintypes.error as W32E:
         # We could continue with no icon (i.e. just return) however it seems
         # best to terminate the build with a message.
         raise SystemExit(

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,7 @@
 # As config was originally based on an example by Olivier Grisel. Thanks!
 # https://github.com/ogrisel/python-appveyor-demo/blob/master/appveyor.yml
 
+image: Visual Studio 2019
 clone_depth: 50
 
 

--- a/bootloader/Vagrantfile
+++ b/bootloader/Vagrantfile
@@ -337,7 +337,7 @@ Vagrant.configure(2) do |config|
     b.vm.box = "jhcook/yosemite-clitools"
 
     # Guest additions are not available for OS X and thus no shared folders
-    config.vm.synced_folder "..", "/vagrant", :type => "rsync",
+    b.vm.synced_folder "..", "/vagrant", :type => "rsync",
       # Avoid rsyncing the huge SDKs not used here
       :rsync__args => ["--verbose", "--archive", "--delete", "-z",
                        "--include=bootloader", "--include=PyInstaller",

--- a/bootloader/windows/run.rc
+++ b/bootloader/windows/run.rc
@@ -28,7 +28,7 @@ LANGUAGE LANG_NEUTRAL, SUBLANG_NEUTRAL
 
 // Icon with lowest ID value placed first to ensure application icon
 // remains consistent on all systems.
-IDI_ICON1               ICON    DISCARDABLE     "../../PyInstaller/bootloader/images/icon-console.ico"
+//IDI_ICON1               ICON    DISCARDABLE     "../../PyInstaller/bootloader/images/icon-console.ico"
 
 #ifdef APSTUDIO_INVOKED
 /////////////////////////////////////////////////////////////////////////////

--- a/bootloader/windows/runw.rc
+++ b/bootloader/windows/runw.rc
@@ -28,7 +28,7 @@ LANGUAGE LANG_NEUTRAL, SUBLANG_NEUTRAL
 
 // Icon with lowest ID value placed first to ensure application icon
 // remains consistent on all systems.
-IDI_ICON1               ICON    DISCARDABLE     "../../PyInstaller/bootloader/images/icon-windowed.ico"
+//IDI_ICON1               ICON    DISCARDABLE     "../../PyInstaller/bootloader/images/icon-windowed.ico"
 
 #ifdef APSTUDIO_INVOKED
 /////////////////////////////////////////////////////////////////////////////

--- a/news/2995.bugfix.rst
+++ b/news/2995.bugfix.rst
@@ -1,0 +1,3 @@
+(win32) PyInstaller's default icon is no longer built into the bootloader, but
+added at freeze-time. Thus, when specifiying an icon, only that icon is
+contained in the executable and displaied for a shortcut.

--- a/news/4700.feature.rst
+++ b/news/4700.feature.rst
@@ -1,0 +1,3 @@
+(win32) PyInstaller's console or windowed icon is now added at freeze-time and
+no longer built into the bootloader. Also, using ``--icon=NONE`` allows to not
+apply any icon, thereby making the OS to show some defaultm icon.

--- a/news/870.bugfix.rst
+++ b/news/870.bugfix.rst
@@ -1,0 +1,3 @@
+(win32) PyInstaller's default icon is no longer built into the bootloader, but
+added at freeze-time. Thus, when specifiying an icon, only that icon is
+contained in the executable and displaied for a shortcut.


### PR DESCRIPTION
Fixed default icons still being present in the executable after setting a custom icon.
Added --icon=NONE functionality, so that the OS default icon for the file type will be used.

Closes #870 and #2995 (possibly) 