### PR TITLE
Remove support for python from the windows store

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,7 +74,7 @@ Requirements and Tested Platforms
  - Windows XP or newer.
 
  - We don't support Python installed from the Windows store when not using virtual environments due to 
-   `permission errors <https://pyinstaller.readthedocs.io/en/stable/development/changelog-entries.html>`_ 
+   `permission errors <https://github.com/pyinstaller/pyinstaller/pull/4702>`_ 
    that can't easily be fixed.
     
 - GNU/Linux (32bit/64bit)

--- a/README.rst
+++ b/README.rst
@@ -73,7 +73,7 @@ Requirements and Tested Platforms
 
  - Windows XP or newer.
 
- - We don't support Python installed from the Windows store due to 
+ - We don't support Python installed from the Windows store when not using virtual environments due to 
    `permission errors <https://pyinstaller.readthedocs.io/en/stable/development/changelog-entries.html>`_ 
    that can't easily be fixed.
     

--- a/README.rst
+++ b/README.rst
@@ -72,6 +72,8 @@ Requirements and Tested Platforms
 - Windows (32bit/64bit):
 
  - Windows XP or newer.
+ - We don't support python installed from the windows store due to 
+   permission errors that can't be easily fixed.
     
 - GNU/Linux (32bit/64bit)
 

--- a/README.rst
+++ b/README.rst
@@ -72,8 +72,10 @@ Requirements and Tested Platforms
 - Windows (32bit/64bit):
 
  - Windows XP or newer.
- - We don't support python installed from the windows store due to 
-   permission errors that can't be easily fixed.
+
+ - We don't support Python installed from the Windows store due to 
+   `permission errors <https://pyinstaller.readthedocs.io/en/stable/development/changelog-entries.html>`_ 
+   that can't easily be fixed.
     
 - GNU/Linux (32bit/64bit)
 


### PR DESCRIPTION
When using python from the windows store with PyInstaller, there are permissions errors that require a major mod to the UAC system in the underlying windows kernel to work around. 

It's caused by the damned `WindowsApps` directory, which, for security reasons, even running as *admin* can't even *read* the directory. This means that when PyInstaller (trys to) copy the python dlls and librarys, it fails. You can work around this, but the method risks jailbreaking, which voids warranty. 

This can be "fixed" by saying that we don't support that build of python. (Note that that is actually standard CPython)

Closes #4507 