### PR TITLE
Hook for tensorflow 2.0 and astor (imported by tensorflow)

### DIFF
--- a/PyInstaller/hooks/hook-astor.py
+++ b/PyInstaller/hooks/hook-astor.py
@@ -1,0 +1,14 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013-2020, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_data_files
+
+datas = collect_data_files('astor')

--- a/PyInstaller/hooks/hook-tensorflow.py
+++ b/PyInstaller/hooks/hook-tensorflow.py
@@ -1,0 +1,12 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013-2020, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+hiddenimports = ['tensorflow_core']

--- a/PyInstaller/hooks/hook-tensorflow_core.python.py
+++ b/PyInstaller/hooks/hook-tensorflow_core.python.py
@@ -1,0 +1,15 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013-2020, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_submodules, collect_data_files
+
+hiddenimports = collect_submodules('tensorflow_core')
+datas = collect_data_files('tensorflow_core')

--- a/news/4704.hooks.rst
+++ b/news/4704.hooks.rst
@@ -1,0 +1,6 @@
+To support tensorflow module forwarding logic, a new hook for tensorflow_core was added.
+https://github.com/pyinstaller/pyinstaller/issues/4400
+
+To resolve missing astor VERSION file in tensorflow import, a new hook for astor was created.
+This is also part of the fix for:
+https://github.com/pyinstaller/pyinstaller/issues/4400

--- a/tests/functional/test_libraries.py
+++ b/tests/functional/test_libraries.py
@@ -75,6 +75,15 @@ def test_enchant(pyi_builder):
     pyi_builder.test_script('pyi_lib_enchant.py')
 
 
+@importorskip('tensorflow')
+def test_tensorflow(pyi_builder):
+    pyi_builder.test_source(
+        """
+        from tensorflow import *
+        """
+    )
+
+
 @importorskip('gevent')
 def test_gevent(pyi_builder):
     pyi_builder.test_source(


### PR DESCRIPTION
Closes #4400
Closes #3754
Closes #4438
Closes #2828
Closes #3103
Closes #3709

As discussed on:
https://github.com/pyinstaller/pyinstaller/issues/4400

This PR should close - #4400 

This should resolve the import error caused by tensorflow farward import logic. 

The astor hook is to resolve this issue:
https://stackoverflow.com/questions/59702200/pyinstaller-tensorflow-bundle-fails

I've noticed this issue as well on my machine