### PR TITLE
Add puremagic support

### DIFF
--- a/PyInstaller/hooks/hook-puremagic.py
+++ b/PyInstaller/hooks/hook-puremagic.py
@@ -1,0 +1,14 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2020, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_data_files
+
+datas = collect_data_files("puremagic")

--- a/news/4709.hooks.rst
+++ b/news/4709.hooks.rst
@@ -1,0 +1,1 @@
+Add hook for puremagic (identify a file based off it's magic numbers)


### PR DESCRIPTION
Puremagic depends on data files  that are not collected by default, making the module unusable if they are not supplied together in the final bundle.