### PR TITLE
Fix --runtime-tmpdir and deletion of temporary files

### DIFF
--- a/news/3301.bugfix.rst
+++ b/news/3301.bugfix.rst
@@ -1,0 +1,1 @@
+(Windows) Fix the ``--runtime-tmpdir`` option by creating paths if they don't exist and expanding environment variables (e.g. %LOCALAPPDATA%).

--- a/news/4579.bugfix.rst
+++ b/news/4579.bugfix.rst
@@ -1,0 +1,1 @@
+(Windows) Fix the ``--runtime-tmpdir`` option by creating paths if they don't exist and expanding environment variables (e.g. %LOCALAPPDATA%).

--- a/news/4720.bugfix.rst
+++ b/news/4720.bugfix.rst
@@ -1,0 +1,1 @@
+(Windows) Fix the ``--runtime-tmpdir`` option by creating paths if they don't exist and expanding environment variables (e.g. %LOCALAPPDATA%).


### PR DESCRIPTION
As background, the --runtime-tmpdir option was failing to extract bundled executables to the specified location.  Usually, they would end up in simply the root directory of the drive (e.g. `C:\` even though `C:\something_else` was specified).  As a result, this option was useless for users who needed it extracted elsewhere besides %TEMP%, as contents in the temporary folder are subject to deletion at any given moment (see relevant issues below).  This is a major problem for long running applications and Window services/daemons, who would find their files in `_MEIPASS` deleted after a week or so (e.g. in my case, `cacert.pem` was being deleted, causing TLS issues).
  
The problem was that the --runtime-tmpdir option did not resolve environment variables, nor did it create directories as necessary.  This resolves issue #4579 and #3301.  It also resolves some TODOs to use wchar instead of char throughout the code.

As manual tests, the following work:
  - `pyinstaller --onefile --runtime-tmpdir ^%LOCALAPPDATA^%\MyNewApp\NestedFolder app.py` (note that carrot signs so that the environment variable is resolved at runtime for each computer the app runs on)
  - `pyinstaller --onefile --runtime-tmpdir C:\Users\ms\randomfolder app.py`
  - `pyinstaller --onefile --runtime-tmpdir . app.py` (unpackages the app in the same directory where it exists)

Where app.py is simply
```
import sys
if __name__ == "__main__":
    print(f"The app is running in directory {sys._MEIPASS}")
```