### PR TITLE
Tests/CI: Scheduled monthly dependency update for march

### DIFF
--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -28,20 +28,20 @@ keyring==19.2.0  # pyup: ignore
 # These packages work with no (known) issues.
 babel==2.8.0
 boto==2.49.0
-boto3==1.11.9
-botocore==1.14.9
+boto3==1.12.11
+botocore==1.15.11
 future==0.18.2
 gevent==1.4.0
 h5py==2.10.0
-markdown==3.1.1
+markdown==3.2.1
 numpy==1.18.1
 pendulum==2.0.5
-phonenumbers==8.11.2
+phonenumbers==8.11.4
 Pillow==7.0.0
 pinyin==0.4.0
 pycparser==2.19
-pycryptodome==3.9.4
-pycryptodomex==3.9.4
+pycryptodome==3.9.7
+pycryptodomex==3.9.7
 pyexcelerate==0.8.0
 pygments==2.5.2
 pylint==2.4.4
@@ -49,12 +49,12 @@ PySide2==5.13.0
 python-dateutil==2.8.1
 pytz==2019.3
 pyusb==1.0.2
-pyzmq==18.1.1
-requests==2.22.0
+pyzmq==19.0.0
+requests==2.23.0
 scipy==1.4.1
 # simplejson is used for text_c_extension
 simplejson==3.17.0
-sphinx==2.3.1
+sphinx==2.4.1
 # Required for test_namespace_package
 sqlalchemy==1.3.13
 Unidecode==1.1.1
@@ -65,14 +65,14 @@ zope.interface==4.7.1
 # Python 3.5 not supported / supported for older versions
 # -------------------------------------------------------
 openpyxl==3.0.3; python_version > '3.5'
-web3==5.4.0; python_version > '3.5'
+web3==5.6.0; python_version > '3.5'
 
 # iPython 7.10.0 and higher dropped Python 3.5 support per https://ipython.readthedocs.io/en/stable/whatsnew/version7.html#stop-support-for-python-3-5-adopt-nep-29.
 ipython==7.12.0; python_version > '3.5'
 ipython==7.9.0; python_version == '3.5'
 
 # pandas 1.0.0 dropped Python 3.5 support.
-pandas==1.0.0; python_version > '3.5'
+pandas==1.0.1; python_version > '3.5'
 pandas==0.25.3; python_version == '3.5'
 
 
@@ -81,7 +81,7 @@ pandas==0.25.3; python_version == '3.5'
 # Wheels are available only on OS X and Win 32. The only Windows 64-bit Python
 # tests run are for Python 3.7, so exclude that. There's no way to simply
 # exclude Windows 64 bit Python.
-pyenchant==2.0.0; sys_platform == 'darwin' or (sys_platform == 'win32' and python_version <= '3.6')
+pyenchant==3.0.1; sys_platform == 'darwin' or (sys_platform == 'win32' and python_version <= '3.6')
 
 # Per https://www.riverbankcomputing.com/pipermail/pyqt/2020-February/042506.html, Windows PyQt5 5.14.0? and 5.14.1? aren't correctly packaged.
 pyqt5==5.13.2; sys_platform == 'win32'


### PR DESCRIPTION
Updated:

* `boto3` to 1.12.11
* `botocore` to 1.15.11
* `markdown` to 3.2.1
* `phonenumbers` to 8.11.4
* `pycryptodome` to 3.9.7
* `pycryptodomex` to 3.9.7
* `pyzmq` to 19.0.0
* `requests` to 2.23.0
* `sphinx` to 2.4.1
* `web3` to 5.6.0
* `pandas` to 1.0.1
* `pyenchant` to 3.0.1