### PR TITLE
Don't inform about --noconfirm if being used.

### DIFF
--- a/PyInstaller/building/utils.py
+++ b/PyInstaller/building/utils.py
@@ -423,7 +423,7 @@ def _rmtree(path):
     if choice.strip().lower() == 'y':
         if not CONF['noconfirm']:
             print("On your own risk, you can use the option `--noconfirm` "
-              "to get rid of this question.")
+                  "to get rid of this question.")
         logger.info('Removing dir %s', path)
         shutil.rmtree(path)
     else:

--- a/PyInstaller/building/utils.py
+++ b/PyInstaller/building/utils.py
@@ -421,7 +421,8 @@ def _rmtree(path):
                          '-y option (remove output directory without '
                          'confirmation).' % path)
     if choice.strip().lower() == 'y':
-        print("On your own risk, you can use the option `--noconfirm` "
+        if not CONF['noconfirm']:
+            print("On your own risk, you can use the option `--noconfirm` "
               "to get rid of this question.")
         logger.info('Removing dir %s', path)
         shutil.rmtree(path)

--- a/news/4727.build.rst
+++ b/news/4727.build.rst
@@ -1,0 +1,1 @@
+Do not print info about ``--noconfirm`` when option is already being used.


### PR DESCRIPTION
> On your own risk, you can use the option --noconfirm to get rid of this question

seems unnecessary when already using `--noconfirm` and there is no question to get rid of.