### PR TITLE
bootloader: search for python malloc labeled shared libraries (AIX)

### DIFF
--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -68,10 +68,12 @@ elif is_darwin:
                      'libpython%d.%d.dylib' % _pyver,
                      'libpython%d.%dm.dylib' % _pyver}
 elif is_aix:
-    # Shared libs on AIX are archives with shared object members, thus the ".a" suffix.
-    # However, python 2.7.11 built with XLC produces libpython?.?.so file, too.
+    # Shared libs on AIX may be archives with shared object members, thus the ".a" suffix.
+    # However, starting with python 2.7.11 libpython?.?.so files are also produced.
     PYDYLIB_NAMES = {'libpython%d.%d.a' % _pyver,
-                     'libpython%d.%d.so' % _pyver}
+                     'libpython%d.%dm.a' % _pyver,
+                     'libpython%d.%d.so' % _pyver,
+                     'libpython%d.%dm.so' % _pyver}
 elif is_freebsd:
     PYDYLIB_NAMES = {'libpython%d.%d.so.1' % _pyver,
                      'libpython%d.%dm.so.1' % _pyver,

--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -68,8 +68,9 @@ elif is_darwin:
                      'libpython%d.%d.dylib' % _pyver,
                      'libpython%d.%dm.dylib' % _pyver}
 elif is_aix:
-    # Shared libs on AIX may be archives with shared object members, thus the ".a" suffix.
-    # However, starting with python 2.7.11 libpython?.?.so files are also produced.
+    # Shared libs on AIX may be archives with shared object members,
+    # Hence the ".a" suffix. However, starting with python 2.7.11
+    # libpython?.?.so and Python3 libpython3.?m.so files are produced.
     PYDYLIB_NAMES = {'libpython%d.%d.a' % _pyver,
                      'libpython%d.%dm.a' % _pyver,
                      'libpython%d.%d.so' % _pyver,

--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -69,8 +69,8 @@ elif is_darwin:
                      'libpython%d.%dm.dylib' % _pyver}
 elif is_aix:
     # Shared libs on AIX may be archives with shared object members,
-    # Hence the ".a" suffix. However, starting with python 2.7.11
-    # libpython?.?.so and Python3 libpython3.?m.so files are produced.
+    # hence the ".a" suffix. However, starting with python 2.7.11
+    # libpython?.?.so and Python3 libpython?.?m.so files are produced.
     PYDYLIB_NAMES = {'libpython%d.%d.a' % _pyver,
                      'libpython%d.%dm.a' % _pyver,
                      'libpython%d.%d.so' % _pyver,

--- a/news/4210.bug.rst
+++ b/news/4210.bug.rst
@@ -1,1 +1,1 @@
-(AIX) depend: include python-malloc labeled libraries in search for libpython
+(AIX) Include python-malloc labeled libraries in search for libpython

--- a/news/4210.bug.rst
+++ b/news/4210.bug.rst
@@ -1,1 +1,1 @@
-(AIX) bootloader: include python-malloc labeled libraries in search for libpython
+(AIX) depend: include python-malloc labeled libraries in search for libpython

--- a/news/4210.bug.rst
+++ b/news/4210.bug.rst
@@ -1,1 +1,1 @@
-(AIX) Include python-malloc labeled libraries in search for libpython
+(AIX) Include python-malloc labeled libraries in search for libpython.

--- a/news/4210.bug.rst
+++ b/news/4210.bug.rst
@@ -1,0 +1,1 @@
+(AIX) bootloader: include python-malloc labeled libraries in search for libpython

--- a/news/4738.bug.rst
+++ b/news/4738.bug.rst
@@ -1,0 +1,1 @@
+(AIX) Include python-malloc labeled libraries in search for libpython.


### PR DESCRIPTION
(AIX) add pattern to find libpython3.Xm.so

Closes #4210