### PR TITLE
skip libreadline.so lib

### DIFF
--- a/PyInstaller/depend/dylib.py
+++ b/PyInstaller/depend/dylib.py
@@ -139,6 +139,7 @@ _unix_excludes = set([
     # to bundle it.
     r'libxcb\.so(\..*)?',
     r'libxcb-dri.*\.so(\..*)?',
+    r'libreadline\.so(\..*)?',
 ])
 
 _aix_excludes = set([


### PR DESCRIPTION
In continue to the conversation here [4657](https://github.com/pyinstaller/pyinstaller/issues/4657)
skip collection of `libreadline.so` lib