### PR TITLE
bokeh==2.0.0 requires bokeh/_sri.json

### DIFF
--- a/PyInstaller/hooks/hook-bokeh.py
+++ b/PyInstaller/hooks/hook-bokeh.py
@@ -15,7 +15,9 @@ from PyInstaller.utils.hooks import collect_data_files
 # core/_templates/*
 # server/static/**/*
 # subcommands/*.py
+# bokeh/_sri.json
 
 datas = collect_data_files('bokeh.core') + \
         collect_data_files('bokeh.server') + \
-        collect_data_files('bokeh.command.subcommands', include_py_files=True)
+        collect_data_files('bokeh.command.subcommands', include_py_files=True) + \
+        collect_data_files('bokeh')

--- a/news/4742.hooks.rst
+++ b/news/4742.hooks.rst
@@ -1,0 +1,1 @@
+Update Bokeh hook for v2.0.0.

--- a/news/4746.hooks.rst
+++ b/news/4746.hooks.rst
@@ -1,0 +1,1 @@
+Update Bokeh hook for v2.0.0.


### PR DESCRIPTION
Per Bryan at Bokeh:

> _sri.json is a new file that must be present in the package.

I simply added `collect_data_files('bokeh')` to datas to include `bokeh/_sri.json`.

https://discourse.bokeh.org/t/bokeh-2-0-0-and-pyinstaller/4904