### PR TITLE
Fix shapely hook on windows

### DIFF
--- a/PyInstaller/hooks/hook-shapely.py
+++ b/PyInstaller/hooks/hook-shapely.py
@@ -40,8 +40,8 @@ if compat.is_win:
     if dll_path is None:
         raise SystemExit(
             "Error: geos_c.dll not found, required by hook-shapely.py.\n"
-            "Please check your installation or provide a pull request to PyInstaller\n"
-            "to update hook-shapely.py.")
+            "Please check your installation or provide a pull request to "
+            "PyInstaller to update hook-shapely.py.")
     binaries += [(dll_path, '.')]
 elif compat.is_linux:
     lib_dir = os.path.join(pkg_dir, '.libs')

--- a/PyInstaller/hooks/hook-shapely.py
+++ b/PyInstaller/hooks/hook-shapely.py
@@ -26,14 +26,17 @@ binaries = []
 if compat.is_win:
     # Search conda directory if conda is active, then search standard
     # directory. This is the same order of precidence used in shapely.
-    lib_paths = ''
+    standard_path = os.path.join(pkg_dir, 'DLLs')
+    lib_paths = [standard_path, os.environ['PATH']]
     if compat.is_conda:
-        lib_paths = os.path.join(compat.base_prefix, 'Library', 'bin')
-        lib_paths += os.pathsep
-    lib_paths += os.path.join(pkg_dir, 'DLLs')
+        conda_path = os.path.join(compat.base_prefix, 'Library', 'bin')
+        lib_paths.insert(0, conda_path)
     original_path = os.environ['PATH']
-    os.environ['PATH'] = lib_paths + os.pathsep + original_path
-    dll_path = find_library('geos_c')
+    try:
+        os.environ['PATH'] = os.pathsep.join(lib_paths)
+        dll_path = find_library('geos_c')
+    finally:
+        os.environ['PATH'] = original_path
     if dll_path is None:
         raise SystemExit(
             "Error: geos_c.dll not found, required by hook-shapely.py.\n"

--- a/news/2834.hooks.rst
+++ b/news/2834.hooks.rst
@@ -1,0 +1,1 @@
+Fix shapely hook on Windows for non-conda shapely installations.

--- a/news/4749.hooks.rst
+++ b/news/4749.hooks.rst
@@ -1,0 +1,1 @@
+Fix shapely hook on Windows for non-conda shapely installations.


### PR DESCRIPTION
This is a continuation of PR #3842, which fixes the shapely hook on windows.

This pull request makes the following changes:
1. Only include the geos_c.dll file, as geos.dll is not used by shapely.
2. Search the appropriate directories for geos_c.dll to account for both conda and vanilla python usage. The method used here is similar to that used in shapely itself. 

Closes #2834