### PR TITLE
Hooks: Add webassets hook.

### DIFF
--- a/PyInstaller/hooks/hook-webassets.py
+++ b/PyInstaller/hooks/hook-webassets.py
@@ -1,0 +1,13 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2020, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+from PyInstaller.utils.hooks import collect_data_files
+
+datas = collect_data_files('webassets', include_py_files=True)

--- a/news/4760.hooks.rst
+++ b/news/4760.hooks.rst
@@ -1,0 +1,1 @@
+Add a hook for `webassets <https://webassets.readthedocs.io>`_.


### PR DESCRIPTION
#### Problem
[`webassets`](https://webassets.readthedocs.io/) filters are not included in the generated bundle.

#### Solution
- Add a hook to include the library `.py` files.
- Add reference to `news/` change log. 

#### Related issues
#3283

<hr />

Thanks so much for the awesome tool.