### PR TITLE
Hooks: add hook for mip.

### DIFF
--- a/PyInstaller/hooks/hook-mip.py
+++ b/PyInstaller/hooks/hook-mip.py
@@ -1,0 +1,10 @@
+import os
+from PyInstaller.utils.hooks import get_package_paths
+
+datas = []
+_, mip_path = get_package_paths("mip")
+lib_path = os.path.join(mip_path, "libraries")
+
+for f in os.listdir(lib_path):
+    if f.endswith(".so") or f.endswith(".dll") or f.endswith(".dylib"):
+        datas.append((os.path.join(lib_path, f), "mip/libraries"))

--- a/news/4762.hooks.rst
+++ b/news/4762.hooks.rst
@@ -1,0 +1,1 @@
+Add hook for mip.

--- a/tests/functional/test_libraries.py
+++ b/tests/functional/test_libraries.py
@@ -877,3 +877,19 @@ def test_argon2(pyi_builder):
         hash = ph.hash("s3kr3tp4ssw0rd")
         ph.verify(hash, "s3kr3tp4ssw0rd")
         """)
+
+
+# https://github.com/coin-or/python-mip/issues/76
+@importorskip('mip')
+def test_mip(pyi_builder):
+    pyi_builder.test_source("""
+        from mip import *
+        m = Model(sense=MAXIMIZE, solver_name=CBC)
+        v1 = m.add_var(var_type=BINARY)
+        v2 = m.add_var(var_type=BINARY)
+        m.add_constr(v1 + v2 == 1)
+        m.objective = 2 * v1 + 3 * v2
+        m.optimize()
+        print(v1.x, v2.x)
+        """)
+


### PR DESCRIPTION
### Problem
PyInstaller misses bundled dynamic libraries that are used by the `mip` library. See https://github.com/coin-or/python-mip/issues/76 for more detail.

### Solution
• Add a hook.
• Add a unit test.

### Questions
I use `datas` rather than `binaries` because otherwise my mac will crash with `ValueError: Unknown Mach-O header: …` on the non-mac(?) binaries. Is that the right way to go?