### PR TITLE
Fix soundfile hook on windows; only include dll

### DIFF
--- a/PyInstaller/hooks/hook-soundfile.py
+++ b/PyInstaller/hooks/hook-soundfile.py
@@ -26,7 +26,9 @@ sfp = get_package_paths('soundfile')
 # an external dependency (libsndfile) is used on GNU/Linux
 path = None
 if is_win:
-    path = os.path.join(sfp[0], '_soundfile_data')
+    path = os.path.join(sfp[0], '_soundfile_data', 'libsndfile64bit.dll')
+    if not os.path.exists(path):
+        path = os.path.join(sfp[0], '_soundfile_data', 'libsndfile32bit.dll')
 elif is_darwin:
     path = os.path.join(sfp[0], '_soundfile_data', 'libsndfile.dylib')
 

--- a/news/4765.hooks.rst
+++ b/news/4765.hooks.rst
@@ -1,0 +1,1 @@
+Fix soundfile on windows. Only point to dll. 


### PR DESCRIPTION
Fixing the soundfile issue also on windows. [1]

[1] https://github.com/pyinstaller/pyinstaller/issues/4325#issuecomment-535833910