### PR TITLE
Add a hook for lark-parser

### DIFF
--- a/PyInstaller/hooks/hook-lark.py
+++ b/PyInstaller/hooks/hook-lark.py
@@ -1,0 +1,14 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2017-2020, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_data_files
+
+datas = collect_data_files('lark')

--- a/news/4776.hooks.rst
+++ b/news/4776.hooks.rst
@@ -1,0 +1,1 @@
+Add a hook for `lark-parser <https://github.com/lark-parser/lark>`_.


### PR DESCRIPTION
Fixes #4776. 

Could be a bad idea: the import name of `lark-parser` clashes with `lark`, an almost not used package. But until something like #831 is implemented, I don't see another good solution.