### PR TITLE
fix issues with new release of PyProj

### DIFF
--- a/PyInstaller/hooks/hook-pyproj.py
+++ b/PyInstaller/hooks/hook-pyproj.py
@@ -9,6 +9,32 @@
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
 
+import os
+import sys
 from PyInstaller.utils.hooks import collect_data_files
+from PyInstaller.compat import is_win
+
+
+hiddenimports = [
+    "pyproj.datadir"
+]
 
 datas = collect_data_files('pyproj')
+
+if hasattr(sys, 'real_prefix'):  # check if in a virtual environment
+    root_path = sys.real_prefix
+else:
+    root_path = sys.prefix
+
+# - conda-specific
+if is_win:
+    tgt_proj_data = os.path.join('Library', 'share', 'proj')
+    src_proj_data = os.path.join(root_path, 'Library', 'share', 'proj')
+
+else:  # both linux and darwin
+    tgt_proj_data = os.path.join('share', 'proj')
+    src_proj_data = os.path.join(root_path, 'share', 'proj')
+
+if os.path.exists(src_proj_data):
+    datas.append((src_proj_data, tgt_proj_data))
+    # a real-time hook takes case to define the path for `PROJ_LIB`

--- a/PyInstaller/loader/rthooks/pyi_rth_pyproj.py
+++ b/PyInstaller/loader/rthooks/pyi_rth_pyproj.py
@@ -1,0 +1,26 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2015-2020, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+import os
+import sys
+
+# Installing `pyproj` Conda packages requires to set `PROJ_LIB`
+
+is_win = sys.platform.startswith('win')
+if is_win:
+
+    proj_data = os.path.join(sys._MEIPASS, 'Library', 'share', 'proj')
+
+else:
+    proj_data = os.path.join(sys._MEIPASS, 'share', 'proj')
+
+if os.path.exists(proj_data):
+    os.environ['PROJ_LIB'] = proj_data


### PR DESCRIPTION
It fixes a couple of issues:

- add a hidden `pyproj.datadir` module: 

  - https://stackoverflow.com/questions/55824830/i-get-error-no-module-named-pyproj-datadir-after-i-made-py-to-exe-with-py
  - https://stackoverflow.com/questions/60848508/pyproj-importerror-cannot-import-name-datadir?noredirect=1&lq=1

-  bundle auxiliary data for `pyproj` Conda package:

   - https://github.com/conda-forge/pyproj-feedstock/issues/29


The adopted approach is similar to the `osgeo` hook and rt-hook.