### PR TITLE
Change the package name to lowercase

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-name = PyInstaller
+name = pyinstaller
 version = attr: PyInstaller.__version__
 url = http://www.pyinstaller.org/
 


### PR DESCRIPTION
@htgoebel I love statistics. You may have noticed that on some repos (eg https://github.com/numpy/numpy) there's a little button at the top, along with "star" and other such things. It lists the packages dependant on pyinstaller, and I think - I'm quite sure - we don't have one because our *PyPI* package name isn't the same as what everyone installs in a requirements.txt: `PyInstaller` on PyPI, and `pyinstaller` in requirements.txt etc. I know for a fact that case doesn't matter on PyPI, and won't affect anything at all, so can we try changing it to see if "dependants" shows up?