### PR TITLE
Fix the hook-googleapi_core.py

### DIFF
--- a/PyInstaller/hooks/hook-google.api_core.py
+++ b/PyInstaller/hooks/hook-google.api_core.py
@@ -11,3 +11,4 @@
 
 from PyInstaller.utils.hooks import copy_metadata
 datas = copy_metadata('google-api-core')
+datas += copy_metadata('google-api-python-client')


### PR DESCRIPTION
add line
datas += copy_metadata('google-api-python-client')

https://stackoverflow.com/questions/29518495/pyinstaller-single-exe-of-program-which-uses-google-api-client-lib/61385725#61385725

Many People having a problem of google-api-python-client
Some API of google needs google-api-python-client  module
It can avoid the error of 
pkg_resources.DistributionNotFound: google-api-python-client 
error