### PR TITLE
building: Fix struct format strings for versioninfo

### DIFF
--- a/PyInstaller/utils/win32/versioninfo.py
+++ b/PyInstaller/utils/win32/versioninfo.py
@@ -275,11 +275,11 @@ class FixedFileInfo:
          self.fileType,
          self.fileSubtype,
          self.fileDateMS,
-         self.fileDateLS) = struct.unpack('13l', data[i:i+52])
+         self.fileDateLS) = struct.unpack('13L', data[i:i+52])
         return i+52
 
     def toRaw(self):
-        return struct.pack('L12l', self.sig,
+        return struct.pack('13L', self.sig,
                              self.strucVersion,
                              self.fileVersionMS,
                              self.fileVersionLS,

--- a/PyInstaller/utils/win32/versioninfo.py
+++ b/PyInstaller/utils/win32/versioninfo.py
@@ -275,8 +275,8 @@ class FixedFileInfo:
          self.fileType,
          self.fileSubtype,
          self.fileDateMS,
-         self.fileDateLS) = struct.unpack('13L', data[i:i+52])
-        return i+52
+         self.fileDateLS) = struct.unpack('13L', data[i:i + 52])
+        return i + 52
 
     def toRaw(self):
         return struct.pack('13L', self.sig,

--- a/news/4861.bugfix.rst
+++ b/news/4861.bugfix.rst
@@ -1,0 +1,1 @@
+- Fix struct format strings for versioninfo


### PR DESCRIPTION
I think all of the values in this struct should be uint32, especially the ..LS (low word) entries. Otherwise setting a filedate fails.