### PR TITLE
CI: increase testing on macOS

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -49,6 +49,16 @@ jobs:
         # Make sure the help options print.
         python -m pyinstaller -h
 
-    - name: Run tests
+    - name: Run Functional tests
       run: |
         pytest -n 3 --maxfail 3 --durations 10 tests/unit tests/functional --ignore tests/functional/test_libraries.py
+
+    - name: Run Library tests
+      run: |
+        pytest -n 3 --maxfail 3 --durations 10 tests/functional/test_libraries.py
+        # The ``run_tests`` script is invoked with the ``-c`` option to
+        # specify a ``pytest.ini``, rather than allowing pytest to find
+        # something unexpected in the filesystem (it searches from the root
+        # dir all the way to the top of the filesystem per
+        # https://docs.pytest.org/en/latest/customize.html).
+        python -m PyInstaller.utils.run_tests -c PyInstaller/utils/pytest.ini

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Homebrew setup
       run: |
         brew update
-        brew install freetype
+        brew install freetype pkg-config
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,0 +1,49 @@
+name: Testing + Lint
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  test_macos:
+
+    runs-on: macos-latest
+    strategy:
+      max-parallel: 3
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        # Update pip.
+        python -m pip install -U pip setuptools wheel | cat
+
+        # Install dependencies for tests.
+        pip install --progress-bar=off -U -r tests/requirements-tools.txt -r tests/requirements-libraries.txt
+
+        # Install PyInstaller Hook Sample, to ensure that tests declared in
+        # entry-points are discovered.
+        pip install https://github.com/pyinstaller/hooksample/archive/v4.0rc1.zip
+
+        # Compile bootloader
+        cd bootloader
+        python waf distclean all
+        cd ..
+
+        # Install PyInstaller.
+        pip install --progress-bar=off -e .
+
+        # Make sure the help options print.
+        python -m pyinstaller -h
+
+    - name: Run tests
+      run: |
+        pytest -n 3 --maxfail 3 --durations 10 tests/unit tests/functional --ignore tests/functional/test_libraries.py

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -21,6 +21,11 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
+    - name: Homebrew setup
+      run: |
+        brew update
+        brew install freetype
+
     - name: Install dependencies
       run: |
         # Update pip.


### PR DESCRIPTION
PR adds a GitHub action to test across Python 3.6, 3.7, 3.8 on macOS. You can see the file in action on my fork, https://github.com/andyfaff/pyinstaller/actions. I think this will only become active on this repository once it's merged. There are a few test failures which stop the entire script running to completion.