### PR TITLE
Drop apple traceback

### DIFF
--- a/bootloader/src/pyi_launch.c
+++ b/bootloader/src/pyi_launch.c
@@ -420,7 +420,7 @@ pyi_launch_run_scripts(ARCHIVE_STATUS *status)
             if (!retval) {
                 FATALERROR("Failed to execute script %s\n", ptoc->name);
 
-                #if defined(WINDOWED) && defined(LAUNCH_DEBUG)
+                #if defined(WINDOWED) && defined(LAUNCH_DEBUG) && !defined(__APPLE__)
                 /* Visual C++ requires all variables to be declared before any
                  * statements in a given block. The curly braces below create a
                  * block to make this compiler happy. */
@@ -466,11 +466,11 @@ pyi_launch_run_scripts(ARCHIVE_STATUS *status)
                     Py_DECREF(module);
                 }
 
-                #else /* if defined(WINDOWED) and defined(LAUNCH_DEBUG) */
+                #else /* if defined(WINDOWED) and defined(LAUNCH_DEBUG) and not defined(__APPLE__) */
 
                     PI_PyErr_Print();
 
-                #endif /* if defined(WINDOWED) and defined(LAUNCH_DEBUG) */
+                #endif /* if defined(WINDOWED) and defined(LAUNCH_DEBUG) and not defined(__APPLE__) */
 
                 return -1;
             }

--- a/news/4213.bootloader.rst
+++ b/news/4213.bootloader.rst
@@ -1,1 +1,1 @@
-In debug and windowed mode, print traceback to help debug pyiboot01_bootstrap errors.
+In debug and windowed mode on non-macOS platforms, print traceback to help debug pyiboot01_bootstrap errors.

--- a/news/4592.bootloader.rst
+++ b/news/4592.bootloader.rst
@@ -1,1 +1,1 @@
-In debug and windowed mode, print traceback to help debug pyiboot01_bootstrap errors.
+In debug and windowed mode on non-macOS platforms, print traceback to help debug pyiboot01_bootstrap errors.

--- a/tests/functional/test_libraries.py
+++ b/tests/functional/test_libraries.py
@@ -318,7 +318,6 @@ def test_PyQt5_QWebEngine(pyi_builder, data_dir, monkeypatch):
 
 @PYQT5_NEED_OPENGL
 @QtPyLibs
-@skipif(is_darwin, reason='Issue #4860')
 def test_Qt5_QtQml(pyi_builder, QtPyLib, monkeypatch):
     path_clean(monkeypatch, QtPyLib)
     pytest.importorskip(QtPyLib)


### PR DESCRIPTION
Disable the extra traceback on Apple as a fix.

This is monkey-patch style; this bug needs fixing. However, I doubt it will get fixed in PyInstaller 4.0, and we don't want to release a known bug if possible.

Tempory fix for #4860