### PR TITLE
Fix bug in astropy hook that caused most data files to be missing

### DIFF
--- a/PyInstaller/hooks/hook-astropy.py
+++ b/PyInstaller/hooks/hook-astropy.py
@@ -22,8 +22,8 @@ hiddenimports = collect_submodules('astropy')
 # We now need to include the *_parsetab.py and *_lextab.py files for unit and
 # coordinate parsing, since these are loaded as files rather than imported as
 # sub-modules.
-datas = collect_data_files('astropy', include_py_files=True,
-                           includes=['**/*_parsetab.py', '**/*_lextab.py'])
+datas += collect_data_files('astropy', include_py_files=True,
+                            includes=['**/*_parsetab.py', '**/*_lextab.py'])
 
 # In the Cython code, Astropy imports numpy.lib.recfunctions which isn't
 # automatically discovered by pyinstaller, so we add this as a hidden import.


### PR DESCRIPTION
This fixes a bug introduced in fe0911772f297b4b40b84af22f57de374aae13fd - previously the original ``datas`` determined higher up was being overwritten, so this PR changes back to append.