### PR TITLE
hooks: importlib_resources: Fix for modern versions

### DIFF
--- a/PyInstaller/hooks/hook-importlib_resources.py
+++ b/PyInstaller/hooks/hook-importlib_resources.py
@@ -9,26 +9,25 @@
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
 """
-`importlib_resources` is a backport of the 3.7+ module `importlib.resources`
+`importlib_resources` is a backport of the 3.9+ module `importlib.resources`
 """
 
 import os
-from PyInstaller.compat import is_py37
-from PyInstaller.utils.hooks import get_module_file_attribute
+from PyInstaller.utils.hooks import get_module_file_attribute, \
+    is_module_satisfies, copy_metadata
 
-# Include the version.txt file, used to set __version__
-res_loc = os.path.dirname(get_module_file_attribute('importlib_resources'))
-datas = [
-    (os.path.join(res_loc, 'version.txt'), 'importlib_resources'),
-]
-
-# Replicate the module's version checks to exclude unused modules.
-if is_py37:
-    # Stdlib now has the implmentation of this, so the backports
-    # aren't used at all
-    excludedmodules = [
-        'importlib_resources._py2',
-        'importlib_resources._py3',
-    ]
+if is_module_satisfies("importlib_resources >= 1.2.0"):
+    # since 1.2.0 importlib.metadata is used
+    datas = copy_metadata('importlib_resources')
 else:
-    excludedmodules = ['importlib_resources._py2']
+    # include the version.txt file, used to set __version__
+    res_loc = os.path.dirname(get_module_file_attribute('importlib_resources'))
+    datas = [
+        (os.path.join(res_loc, 'version.txt'), 'importlib_resources'),
+    ]
+
+if is_module_satisfies("importlib_resources >= 1.3.1"):
+    hiddenimports = ['importlib_resources.trees']
+
+# this is only required for python2 support
+excludedimports = ['importlib_resources._py2']

--- a/news/4889.hooks.rst
+++ b/news/4889.hooks.rst
@@ -1,0 +1,1 @@
+Fix ``importlib_resources`` hook for modern versions (after 1.1.0).


### PR DESCRIPTION
Since 1.2.0 importlib_resources uses importlib.metadata to pick up
package version.
Since 1.3.1 there is a hidden import of `importlib_resources.trees`
(using `__import__()`).

It also looks like this hook used to set `excludedmodules` variable
which is not even a thing as far as I can tell
(likely meant `excludedimports`).

Tested with importlib_resources 1.5.0.

Fixes #4725