### PR TITLE
compat: consider Python<version> as possible library binary path

### DIFF
--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -65,6 +65,7 @@ if is_win or is_cygwin:
 elif is_darwin:
     # libpython%d.%dm.dylib for Conda virtual environment installations
     PYDYLIB_NAMES = {'Python', '.Python',
+                     'Python%d' % _pyver[0],
                      'libpython%d.%d.dylib' % _pyver,
                      'libpython%d.%dm.dylib' % _pyver}
 elif is_aix:

--- a/news/4895.bugfix.rst
+++ b/news/4895.bugfix.rst
@@ -1,0 +1,1 @@
+Consider Python<version> as possible library binary path. Fixes issue where python is not found if Python3 is installed via brew on OSX


### PR DESCRIPTION
Fixes #4893
Python installation in OSX Brew has Python library binary as Python3
which is not considered when importing default binaries