### PR TITLE
bootloader: only print "failed to execute" error on non-SystemExit errors

### DIFF
--- a/bootloader/src/pyi_launch.c
+++ b/bootloader/src/pyi_launch.c
@@ -420,7 +420,7 @@ pyi_launch_run_scripts(ARCHIVE_STATUS *status)
             if (!retval) {
                 FATALERROR("Failed to execute script %s\n", ptoc->name);
 
-                #if defined(WINDOWED) && defined(LAUNCH_DEBUG) && !defined(__APPLE__)
+                #if defined(WINDOWED) && defined(LAUNCH_DEBUG)
                 /* Visual C++ requires all variables to be declared before any
                  * statements in a given block. The curly braces below create a
                  * block to make this compiler happy. */
@@ -466,11 +466,11 @@ pyi_launch_run_scripts(ARCHIVE_STATUS *status)
                     Py_DECREF(module);
                 }
 
-                #else /* if defined(WINDOWED) and defined(LAUNCH_DEBUG) and not defined(__APPLE__) */
+                #else /* if defined(WINDOWED) and defined(LAUNCH_DEBUG) */
 
                     PI_PyErr_Print();
 
-                #endif /* if defined(WINDOWED) and defined(LAUNCH_DEBUG) and not defined(__APPLE__) */
+                #endif /* if defined(WINDOWED) and defined(LAUNCH_DEBUG) */
 
                 return -1;
             }

--- a/bootloader/src/pyi_launch.c
+++ b/bootloader/src/pyi_launch.c
@@ -418,6 +418,11 @@ pyi_launch_run_scripts(ARCHIVE_STATUS *status)
              * (Since we evaluate module-level code, which is not allowed to return an
              * object, the Python object returned is always None.) */
             if (!retval) {
+                /* If the error was SystemExit, PyErr_Print calls exit() without
+                 * returning. This means we won't print "Failed to execute" on 
+                 * normal SystemExit's.
+                 */
+                PI_PyErr_Print();
                 FATALERROR("Failed to execute script %s\n", ptoc->name);
 
                 #if defined(WINDOWED) && defined(LAUNCH_DEBUG)
@@ -465,10 +470,6 @@ pyi_launch_run_scripts(ARCHIVE_STATUS *status)
                     Py_DECREF(ptraceback);
                     Py_DECREF(module);
                 }
-
-                #else /* if defined(WINDOWED) and defined(LAUNCH_DEBUG) */
-
-                    PI_PyErr_Print();
 
                 #endif /* if defined(WINDOWED) and defined(LAUNCH_DEBUG) */
 

--- a/news/4213.bootloader.rst
+++ b/news/4213.bootloader.rst
@@ -1,1 +1,1 @@
-In debug and windowed mode on non-macOS platforms, print traceback to help debug pyiboot01_bootstrap errors.
+In debug and windowed mode, show the traceback in dialogs to help debug pyiboot01_bootstrap errors.

--- a/news/4592.bootloader.rst
+++ b/news/4592.bootloader.rst
@@ -1,1 +1,1 @@
-In debug and windowed mode on non-macOS platforms, print traceback to help debug pyiboot01_bootstrap errors.
+In debug and windowed mode, show the traceback in dialogs to help debug pyiboot01_bootstrap errors.


### PR DESCRIPTION
#4592 added a new traceback to the bootloader. That caused an error that was originally reported and fixed in #1869 and 36b6ab3. The error was that `SystemExit` - the standard script exit exception, raised by `sys.exit` and other exit functions, was handled as a normal exception, and the bootloader printed `Failed to execute script X`, before erroring.

This PR fixes this by checking if this error is a SystemExit _first_.

Fixes #4860