### PR TITLE
Update SQLAlchemy hook for v1.4.0

### DIFF
--- a/PyInstaller/hooks/hook-sqlalchemy.py
+++ b/PyInstaller/hooks/hook-sqlalchemy.py
@@ -55,7 +55,10 @@ def hook(hook_api):
         return
 
     # this parser is very simplistic but seems to catch all cases as of V1.1
-    depend_regex = re.compile(r'@util.dependencies\([\'"](.*?)[\'"]\)')
+    if is_module_satisfies('sqlalchemy >= 1.4.0b'):
+        depend_regex = re.compile(r'@util.preload_module\([\'"](.*?)[\'"]\)')
+    else:
+        depend_regex = re.compile(r'@util.dependencies\([\'"](.*?)[\'"]\)')
 
     hidden_imports_set = set()
     known_imports = set()


### PR DESCRIPTION
SQLAlchemy v1.4.0 is still in development but I'm already using it and others might be as well. This is a tracking PR which allows PyInstaller to work with the next release of SQLAlachmey. When SQLAlachemy 1.4.0 is released I'll change this from Draft to ready for review.