### PR TITLE
building: Sort replace_paths by descending length.

### DIFF
--- a/PyInstaller/building/utils.py
+++ b/PyInstaller/building/utils.py
@@ -630,8 +630,9 @@ def strip_paths_in_code(co, new_filename=None):
 
     # Paths to remove from filenames embedded in code objects
     replace_paths = sys.path + CONF['pathex']
-    # Make sure paths end with os.sep
-    replace_paths = [os.path.join(f, '') for f in replace_paths]
+    # Make sure paths end with os.sep and the longest paths are first
+    replace_paths = sorted((os.path.join(f, '') for f in replace_paths),
+                           key=len, reverse=True)
 
     if new_filename is None:
         original_filename = os.path.normpath(co.co_filename)

--- a/news/4922.bugfix.rst
+++ b/news/4922.bugfix.rst
@@ -1,0 +1,1 @@
+When stripping the leading parts of paths in compiled code objects, the longest possible import path will now be stripped.


### PR DESCRIPTION
This should result in the removal of the longest possible prefix.
Previously, an empty string at the beginning of sys.path would prevent
this code from doing anything.