### PR TITLE
Cleanup: Fix exception causes in winmanifest.py

### DIFF
--- a/PyInstaller/building/makespec.py
+++ b/PyInstaller/building/makespec.py
@@ -66,9 +66,11 @@ path_conversions = (
 def add_data_or_binary(string):
     try:
         src, dest = string.split(add_command_sep)
-    except ValueError:
+    except ValueError as e:
         # Split into SRC and DEST failed, wrong syntax
-        raise argparse.ArgumentError("Wrong syntax, should be SRC{}DEST".format(add_command_sep))
+        raise argparse.ArgumentError(
+            "Wrong syntax, should be SRC{}DEST".format(add_command_sep)
+        ) from e
     if not src or not dest:
         # Syntax was correct, but one or both of SRC and DEST was not given
         raise argparse.ArgumentError("You have to specify both SRC and DEST")

--- a/PyInstaller/depend/analysis.py
+++ b/PyInstaller/depend/analysis.py
@@ -295,7 +295,7 @@ class PyiModuleGraph(ModuleGraph):
             # Remember the node for the first script.
             try:
                 self._top_script_node = super(PyiModuleGraph, self).run_script(pathname)
-            except SyntaxError as e:
+            except SyntaxError:
                 print("\nSyntax error in", pathname, file=sys.stderr)
                 formatted_lines = traceback.format_exc().splitlines(True)
                 print(*formatted_lines[-4:], file=sys.stderr)

--- a/PyInstaller/loader/pyiboot01_bootstrap.py
+++ b/PyInstaller/loader/pyiboot01_bootstrap.py
@@ -143,7 +143,7 @@ try:
             try:
                 super(PyInstallerCDLL, self).__init__(name, *args, **kwargs)
             except Exception as base_error:
-                raise PyInstallerImportError(name)
+                raise PyInstallerImportError(name) from base_error
 
     ctypes.CDLL = PyInstallerCDLL
     ctypes.cdll = LibraryLoader(PyInstallerCDLL)
@@ -154,7 +154,7 @@ try:
             try:
                 super(PyInstallerPyDLL, self).__init__(name, *args, **kwargs)
             except Exception as base_error:
-                raise PyInstallerImportError(name)
+                raise PyInstallerImportError(name) from base_error
 
     ctypes.PyDLL = PyInstallerPyDLL
     ctypes.pydll = LibraryLoader(PyInstallerPyDLL)
@@ -166,7 +166,7 @@ try:
                 try:
                     super(PyInstallerWinDLL, self).__init__(name, *args, **kwargs)
                 except Exception as base_error:
-                    raise PyInstallerImportError(name)
+                    raise PyInstallerImportError(name) from base_error
 
         ctypes.WinDLL = PyInstallerWinDLL
         ctypes.windll = LibraryLoader(PyInstallerWinDLL)
@@ -177,7 +177,7 @@ try:
                 try:
                     super(PyInstallerOleDLL, self).__init__(name, *args, **kwargs)
                 except Exception as base_error:
-                    raise PyInstallerImportError(name)
+                    raise PyInstallerImportError(name) from base_error
 
         ctypes.OleDLL = PyInstallerOleDLL
         ctypes.oledll = LibraryLoader(PyInstallerOleDLL)

--- a/PyInstaller/loader/pyimod02_archive.py
+++ b/PyInstaller/loader/pyimod02_archive.py
@@ -325,6 +325,7 @@ class ZlibArchiveReader(ArchiveReader):
             obj = zlib.decompress(obj)
             if typ in (PYZ_TYPE_MODULE, PYZ_TYPE_PKG):
                 obj = marshal.loads(obj)
-        except EOFError:
-            raise ImportError("PYZ entry '%s' failed to unmarshal" % name)
+        except EOFError as e:
+            raise ImportError("PYZ entry '%s' failed to unmarshal" %
+                              name) from e
         return typ, obj

--- a/PyInstaller/loader/pyimod03_importers.py
+++ b/PyInstaller/loader/pyimod03_importers.py
@@ -298,8 +298,10 @@ class FrozenImporter(object):
             # next line will raise an execpion which will be catched just
             # below and raise the ImportError.
             return self._pyz_archive.extract(fullname)[1]
-        except:
-            raise ImportError('Loader FrozenImporter cannot handle module ' + fullname)
+        except Exception as e:
+            raise ImportError(
+                'Loader FrozenImporter cannot handle module ' + fullname
+            ) from e
 
     def get_source(self, fullname):
         """

--- a/PyInstaller/utils/win32/winmanifest.py
+++ b/PyInstaller/utils/win32/winmanifest.py
@@ -743,7 +743,7 @@ class Manifest(object):
             domtree = minidom.parse(filename_or_file)
         except xml.parsers.expat.ExpatError as e:
             args = ['\n  File "%r"\n   ' % filename, str(e.args[0])]
-            raise ManifestXMLParseError(" ".join(args))
+            raise ManifestXMLParseError(" ".join(args)) from e
         if initialize:
             self.__init__()
         self.filename = filename
@@ -754,7 +754,7 @@ class Manifest(object):
         try:
             domtree = minidom.parseString(xmlstr)
         except xml.parsers.expat.ExpatError as e:
-            raise ManifestXMLParseError(e)
+            raise ManifestXMLParseError(e) from e
         self.load_dom(domtree, initialize)
 
     def same_id(self, manifest, skip_version_check=False):


### PR DESCRIPTION
I recently went over [Matplotlib](https://github.com/matplotlib/matplotlib/pull/16706), [Pandas](https://github.com/pandas-dev/pandas/pull/32322) and [NumPy](https://github.com/numpy/numpy/pull/15731), fixing a small mistake in the way that Python 3's exception chaining is used. If you're interested, I can do it here too. I've done it on just one file right now. 

The mistake is this: In some parts of the code, an exception is being caught and replaced with a more user-friendly error. In these cases the syntax `raise new_error from old_error` needs to be used.

Python 3's exception chaining means it shows not only the traceback of the current exception, but that of the original exception (and possibly more.) This is regardless of `raise from`. The usage of `raise from` tells Python to put a more accurate message between the tracebacks. Instead of this: 

    During handling of the above exception, another exception occurred:

You'll get this: 

    The above exception was the direct cause of the following exception:

The first is inaccurate, because it signifies a bug in the exception-handling code itself, which is a separate situation than wrapping an exception.

Let me know what you think! 