### PR TITLE
Cleanup: Fix exception causes all over the codebase

### DIFF
--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -307,7 +307,9 @@ def exec_command(*cmdargs, **kwargs):
         print("Error running '%s':" % " ".join(cmdargs), file=sys.stderr)
         print(e, file=sys.stderr)
         print('--' * 20, file=sys.stderr)
-        raise ExecCommandFailed("Error: Executing command failed!")
+        new_exception = ExecCommandFailed("Error: Executing command failed!")
+        new_exception.__cause__ = e
+        raise new_exception
 
     # stdout/stderr are returned as a byte array NOT as string.
     # Thus we need to convert that to proper encoding.

--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -307,9 +307,7 @@ def exec_command(*cmdargs, **kwargs):
         print("Error running '%s':" % " ".join(cmdargs), file=sys.stderr)
         print(e, file=sys.stderr)
         print('--' * 20, file=sys.stderr)
-        new_exception = ExecCommandFailed("Error: Executing command failed!")
-        new_exception.__cause__ = e
-        raise new_exception
+        raise ExecCommandFailed("Error: Executing command failed!") from e
 
     # stdout/stderr are returned as a byte array NOT as string.
     # Thus we need to convert that to proper encoding.

--- a/PyInstaller/loader/pyimod03_importers.py
+++ b/PyInstaller/loader/pyimod03_importers.py
@@ -282,8 +282,10 @@ class FrozenImporter(object):
         if fullname in self.toc:
             try:
                 return self._pyz_archive.is_package(fullname)
-            except Exception:
-                raise ImportError('Loader FrozenImporter cannot handle module ' + fullname)
+            except Exception as e:
+                raise ImportError(
+                    'Loader FrozenImporter cannot handle module ' + fullname
+                ) from e
         else:
             raise ImportError('Loader FrozenImporter cannot handle module ' + fullname)
 

--- a/PyInstaller/utils/hooks/__init__.py
+++ b/PyInstaller/utils/hooks/__init__.py
@@ -293,7 +293,7 @@ def get_module_file_attribute(package):
         if not attr:
             raise ImportError('Unable to load module attributes')
     # Second try to import module in a subprocess. Might raise ImportError.
-    except (AttributeError, ImportError):
+    except (AttributeError, ImportError) as e:
         # Statement to return __file__ attribute of a package.
         __file__statement = """
             import %s as p
@@ -305,7 +305,7 @@ def get_module_file_attribute(package):
         """
         attr = exec_statement(__file__statement % package)
         if not attr.strip():
-            raise ImportError('Unable to load module attribute')
+            raise ImportError('Unable to load module attribute') from e
     return attr
 
 

--- a/PyInstaller/utils/win32/icon.py
+++ b/PyInstaller/utils/win32/icon.py
@@ -58,8 +58,8 @@ class Structure:
             return self._fields_[index]
         try:
             return self.__dict__[name]
-        except KeyError:
-            raise AttributeError(name)
+        except KeyError as e:
+            raise AttributeError(name) from e
 
     def __setattr__(self, name, value):
         if name in self._names_:


### PR DESCRIPTION
@Legorooj This is the final installment of #4928 .

In the compat.py module I was careful not to use Python 3-specific syntax, since I'm not sure if it might run on Python 2. Also, I avoided test files.