### PR TITLE
modulegraph: Detect C-extension

### DIFF
--- a/tests/unit/test_modulegraph/testdata/syspath/myextpkg/__init__.py
+++ b/tests/unit/test_modulegraph/testdata/syspath/myextpkg/__init__.py
@@ -1,0 +1,1 @@
+""" fake package """

--- a/tests/unit/test_modulegraph/testdata/syspath/myextpkg/__init__.pyd
+++ b/tests/unit/test_modulegraph/testdata/syspath/myextpkg/__init__.pyd
@@ -1,0 +1,1 @@
+""" fake extension """

--- a/tests/unit/test_modulegraph/testdata/syspath/myextpkg/__init__.so
+++ b/tests/unit/test_modulegraph/testdata/syspath/myextpkg/__init__.so
@@ -1,0 +1,1 @@
+""" fake extension """


### PR DESCRIPTION
It first determines if the module's filetype is a C-extension, which will return the correct metadata.

Fixes #4346 (Fixes part of #4406)

*pydantic* has a file structure like `pydantic/__init__.pyd`.
Before this patch, `ModuleGraph._find_module_path()` had detected it as `imp.PKG_DIRECTORY`.
After fixed, detected it as `imp.C_EXTENSION`.
