### PR TITLE
hooks: Add hook for scipy.stats._stats

### DIFF
--- a/PyInstaller/hooks/hook-scipy.stats._stats.py
+++ b/PyInstaller/hooks/hook-scipy.stats._stats.py
@@ -1,0 +1,15 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013-2020, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import is_module_satisfies
+
+if is_module_satisfies("scipy >= 1.5.0"):
+    hiddenimports = ['scipy.special.cython_special']

--- a/news/4981.hooks.rst
+++ b/news/4981.hooks.rst
@@ -1,0 +1,1 @@
+Add hook for ``scipy.stats._stats`` (needed for scipy since 1.5.0).


### PR DESCRIPTION
Which is needed for scipy since 1.5.0 (scipy/scipy#11849) as
there is a hidden import of `scipy.special.cython_special`.