### PR TITLE
Add support for Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ dist: xenial
 cache:
   directories:
     - $HOME/.cache/pip
-    - $HOME/py37
+    - $HOME/py38
 
 os:
   - linux
@@ -84,12 +84,12 @@ jobs:
 
     - &test-pyinstaller
       stage: Test - PyInstaller
-      python: 3.7
+      python: 3.8
       script: *script-test-pyinstaller
 
     - &test-libraries
       stage: Test - Libraries
-      python: 3.7
+      python: 3.8
       before_install:
         # Install OpenSSL 1.1. This fixes dynamic linking problems when PyQt5.13 tries
         # to link with OpenSSL 1.1 -- on Ubuntu 16 (xenial), the older OpenSSL
@@ -102,7 +102,7 @@ jobs:
 
     - &lint
       stage: Lint
-      python: 3.7
+      python: 3.8
       script:
         - >
             if [ "$TRAVIS_PULL_REQUEST" != "false" ] ; then
@@ -123,6 +123,13 @@ jobs:
       python: 3.6
     - <<: *lint
       python: 3.6
+
+    - <<: *test-pyinstaller
+      python: 3.7
+    - <<: *test-libraries
+      python: 3.7
+    - <<: *lint
+      python: 3.7
 
     - <<: *test-pyinstaller
       python: nightly

--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -33,6 +33,7 @@ is_64bits = sys.maxsize > 2**32
 is_py35 = sys.version_info >= (3, 5)
 is_py36 = sys.version_info >= (3, 6)
 is_py37 = sys.version_info >= (3, 7)
+is_py38 = sys.version_info >= (3, 8)
 
 is_win = sys.platform.startswith('win')
 is_win_10 = is_win and (platform.win32_ver()[0] == '10')

--- a/PyInstaller/depend/bindepend.py
+++ b/PyInstaller/depend/bindepend.py
@@ -63,17 +63,23 @@ def getfullnameof(mod, xtrapath=None):
     # Contain some dlls in directory like C:\Python27\Lib\site-packages\numpy\core\
     from distutils.sysconfig import get_python_lib
     numpy_core_paths = [os.path.join(get_python_lib(), 'numpy', 'core')]
+    pywin32_paths = [os.path.join(get_python_lib(), 'pywin32_system32')]
     # In virtualenv numpy might be installed directly in real prefix path.
     # Then include this path too.
     if is_venv:
         numpy_core_paths.append(
             os.path.join(base_prefix, 'Lib', 'site-packages', 'numpy', 'core')
         )
+        pywin32_paths.append(
+            os.path.join(base_prefix, 'Lib', 'site-packages',
+                         'pywin32_system32')
+        )
 
     # TODO check if this 'numpy' workaround is still necessary!
     # Search sys.path first!
-    epath = (sys.path + numpy_core_paths + winutils.get_system_path() +
-             compat.getenv('PATH', '').split(os.pathsep))
+    epath = sys.path + numpy_core_paths + pywin32_paths \
+        + winutils.get_system_path() \
+        + compat.getenv('PATH', '').split(os.pathsep)
     if xtrapath is not None:
         if type(xtrapath) == type(''):
             epath.insert(0, xtrapath)

--- a/PyInstaller/hooks/rthooks/pyi_rth_multiprocessing.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_multiprocessing.py
@@ -34,11 +34,16 @@ def _freeze_support():
     # look for those flags and the import statement, then exec() the
     # code ourselves.
 
+    mains = (
+        'from multiprocessing.semaphore_tracker import main',
+        'from multiprocessing.resource_tracker import main',
+        'from multiprocessing.forkserver import main'
+    )
+
     if len(sys.argv) >= 2 and \
             set(sys.argv[1:-2]) == set(_args_from_interpreter_flags()) and \
             sys.argv[-2] == '-c' and \
-            (sys.argv[-1].startswith('from multiprocessing.semaphore_tracker import main') or \
-             sys.argv[-1].startswith('from multiprocessing.forkserver import main')):
+            any(map(sys.argv[-1].startswith, mains)):
         exec(sys.argv[-1])
         sys.exit()
 
@@ -64,6 +69,7 @@ if sys.platform.startswith('win'):
     import multiprocessing.popen_spawn_win32 as forking
 else:
     import multiprocessing.popen_fork as forking
+    import multiprocessing.popen_spawn_posix as spawning
 
 # Patch Popen to re-set _MEIPASS2 from sys._MEIPASS.
 class _Popen(forking.Popen):
@@ -86,3 +92,27 @@ class _Popen(forking.Popen):
                     os.putenv('_MEIPASS2', '')
 
 forking.Popen = _Popen
+
+# fix spawn as well
+# Patch Popen to re-set _MEIPASS2 from sys._MEIPASS.
+if not sys.platform.startswith('win'):
+    class _Spawning_Popen(spawning.Popen):
+        def __init__(self, *args, **kw):
+            if hasattr(sys, 'frozen'):
+                # We have to set original _MEIPASS2 value from sys._MEIPASS
+                # to get --onefile mode working.
+                os.putenv('_MEIPASS2', sys._MEIPASS)
+            try:
+                super(_Spawning_Popen, self).__init__(*args, **kw)
+            finally:
+                if hasattr(sys, 'frozen'):
+                    # On some platforms (e.g. AIX) 'os.unsetenv()' is not
+                    # available. In those cases we cannot delete the variable
+                    # but only set it to the empty string. The bootloader
+                    # can handle this case.
+                    if hasattr(os, 'unsetenv'):
+                        os.unsetenv('_MEIPASS2')
+                    else:
+                        os.putenv('_MEIPASS2', '')
+
+    spawning.Popen = _Spawning_Popen

--- a/PyInstaller/lib/modulegraph/modulegraph.py
+++ b/PyInstaller/lib/modulegraph/modulegraph.py
@@ -3394,7 +3394,15 @@ class ModuleGraph(ObjectGraph):
 
         code_func = type(co)
 
-        if hasattr(co, 'co_kwonlyargcount'):
+        if hasattr(co, 'co_posonlyargcount'):  # >= 3.8
+            return code_func(
+                co.co_argcount, co.co_posonlyargcount,
+                co.co_kwonlyargcount, co.co_nlocals,
+                co.co_stacksize, co.co_flags, co.co_code,
+                tuple(consts), co.co_names, co.co_varnames,
+                new_filename, co.co_name, co.co_firstlineno,
+                co.co_lnotab, co.co_freevars, co.co_cellvars)
+        elif hasattr(co, 'co_kwonlyargcount'):
             return code_func(
                         co.co_argcount, co.co_kwonlyargcount, co.co_nlocals,
                         co.co_stacksize, co.co_flags, co.co_code,

--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,7 @@ but is not tested against them as part of the continuous integration tests.
 Main Advantages
 ---------------
 
-- Works out-of-the-box with any Python version 3.5-3.7.
+- Works out-of-the-box with any Python version 3.5-3.8.
 - Fully multi-platform, and uses the OS support to load the dynamic libraries,
   thus ensuring full compatibility.
 - Correctly bundles the major Python packages such as numpy, PyQt4, PyQt5,

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,26 @@ environment:
   APPVEYOR_SAVE_CACHE_ON_ERROR: true
 
   matrix:
+    - PYTHON: C:\Python38-x64
+      PYTHON_VERSION: 3.8
+      PYTHON_ARCH: 64
+      TEST_LIBRARIES_ONLY: True
+
+    - PYTHON: C:\Python38-x64
+      PYTHON_VERSION: 3.8
+      PYTHON_ARCH: 64
+      TEST_LIBRARIES_ONLY: False
+
+    - PYTHON: C:\Python38
+      PYTHON_VERSION: 3.8
+      PYTHON_ARCH: 32
+      TEST_LIBRARIES_ONLY: True
+
+    - PYTHON: C:\Python38
+      PYTHON_VERSION: 3.8
+      PYTHON_ARCH: 32
+      TEST_LIBRARIES_ONLY: False
+
     - PYTHON: C:\Python37-x64
       PYTHON_VERSION: 3.7
       PYTHON_ARCH: 64

--- a/doc/hooks.rst
+++ b/doc/hooks.rst
@@ -248,8 +248,8 @@ for example::
 
    from PyInstaller.compat import modname_tkinter, is_win
 
-``is_py35``, ``is_py36``, ``is_py37``:
-   True when the current version of Python is at least 3.5, 3.6, or 3.7 respectively.
+``is_py35``, ``is_py36``, ``is_py37``, ``is_py38``:
+   True when the current version of Python is at least 3.5, 3.6, 3.7, or 3.8 respectively.
 
 ``is_win``:
    True in a Windows system.

--- a/news/4986.feature.rst
+++ b/news/4986.feature.rst
@@ -1,0 +1,1 @@
+Add support for Python 3.8.

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ classifiers =
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
     Programming Language :: Python :: Implementation :: CPython
     Topic :: Software Development
     Topic :: Software Development :: Build Tools

--- a/tests/functional/test_hooks/test_matplotlib.py
+++ b/tests/functional/test_hooks/test_matplotlib.py
@@ -14,6 +14,7 @@ Functional tests for Matplotlib.
 """
 
 import pytest
+from PyInstaller.compat import is_py38
 from PyInstaller.utils.tests import importorskip
 
 
@@ -23,9 +24,9 @@ from PyInstaller.utils.tests import importorskip
 # * "backend_name" is the name of a Matplotlib backend to be tested below.
 # * "package_name" is the name of the external package required by this backend.
 # * "rcParams_key" is the name of a Matplotlib parameter to be set before testing
-#   this backend or "None" if no parameter is to be set.
+#   this backend or "None" if no parameter is to be set. Ignored >= Py3.8.
 # * "rcParams_value" is the value to set that parameter to if "rcParams_key" is
-#   not "None" or ignored otherwise.
+#   not "None" or ignored otherwise. Ignored >= Py3.8
 backend_rcParams_key_values = [
     # PySide.
     ('Qt4Agg', 'PySide', 'backend.qt4', 'PySide'),
@@ -97,7 +98,10 @@ def test_matplotlib(
         backend_name, rcParams_key, rcParams_value))
 
     # Configure Matplotlib *BEFORE* calling any Matplotlib functions.
-    matplotlib.rcParams[rcParams_key] = rcParams_value
+    if {is_py38!r}:
+        import {package_name}
+    else:
+        matplotlib.rcParams[rcParams_key] = rcParams_value
 
     # Enable the desired backend *BEFORE* plotting with this backend.
     matplotlib.use(backend_name)
@@ -121,8 +125,10 @@ def test_matplotlib(
     from mpl_toolkits import axes_grid1
     '''.format(
         backend_name=backend_name,
+        package_name=package_name,
         rcParams_key=rcParams_key,
         rcParams_value=rcParams_value,
+        is_py38=is_py38
     ))
 
     # Test this script.

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -85,7 +85,7 @@ scipy<=1.5.0; python_version == '3.5'  # pyup: ignore
 # Special cases
 # -------------
 # Wheels are available only on OS X and Win 32. The only Windows 64-bit Python
-# tests run are for Python 3.7, so exclude that. There's no way to simply
+# tests run are for Python 3.7-3.8, so exclude that. There's no way to simply
 # exclude Windows 64 bit Python.
 pyenchant==3.1.1; sys_platform == 'darwin' or (sys_platform == 'win32' and python_version <= '3.6')
 

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -18,7 +18,8 @@
 # - v. 2.2 and above fails.
 Django==2.1.8  # pyup: ignore
 # - v 3.1.0 fails.
-matplotlib==3.0.3  # pyup: ignore
+matplotlib==3.0.3; python_version < '3.8'  # pyup: ignore
+matplotlib==3.2.2; python_version >= '3.8'  # pyup: ignore
 # - v 21.1.0 fails; earlier versions not tested.
 keyring==19.2.0  # pyup: ignore
 

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -43,7 +43,7 @@ pycryptodomex==3.9.8
 pyexcelerate==0.9.0
 pygments==2.6.1
 pylint==2.5.3
-PySide2==5.13.0
+PySide2==5.14.0
 python-dateutil==2.8.1
 pytz==2020.1
 pyusb==1.0.2


### PR DESCRIPTION
This attempt adds initial support for Python 3.8.  Closes #4311.  Changes include:

* add `compat.is_py38` flag
* add `code.co_posonlyargcount` to `modulegraph`
* fix multiprocessing spawn in 3.8 (fixes #4865)
* fix PyiModuleGraph test, due to import changes in builtin modules
* CI and small documentation updates

While Python 3.8 introduced a brand-new configuration API for the bootloader, [investigation indicates](https://github.com/pyinstaller/pyinstaller/issues/4311#issuecomment-652633894) that the new API remains optional for 3.8.