### PR TITLE
PySide2.QtNetwork: search for SSL DLLs in both PrefixPath and BinariesPath

### DIFF
--- a/PyInstaller/hooks/hook-PySide2.QtNetwork.py
+++ b/PyInstaller/hooks/hook-PySide2.QtNetwork.py
@@ -24,10 +24,19 @@ if pyside2_library_info.version:
         from PySide2.QtNetwork import QSslSocket
         print(QSslSocket.supportsSsl())""")):
 
+        # PyPI version of PySide2 requires user to manually install SSL
+        # libraries into the PrefixPath. Other versions (e.g., the one
+        # provided by Conda) put the libraries into the BinariesPath.
+        # Accommodate both options by searching both locations...
+        locations = (
+            pyside2_library_info.location['BinariesPath'],
+            pyside2_library_info.location['PrefixPath']
+        )
+
         binaries = []
-        for dll in ('libeay32.dll', 'ssleay32.dll', 'libssl-1_1-x64.dll',
-                    'libcrypto-1_1-x64.dllx'):
-            dll_path = os.path.join(
-                pyside2_library_info.location['BinariesPath'], dll)
-            if os.path.exists(dll_path):
-                binaries.append((dll_path, '.'))
+        for location in locations:
+            for dll in ('libeay32.dll', 'ssleay32.dll', 'libssl-1_1-x64.dll',
+                        'libcrypto-1_1-x64.dllx'):
+                dll_path = os.path.join(location, dll)
+                if os.path.exists(dll_path):
+                    binaries.append((dll_path, '.'))

--- a/news/4998.bugfix.rst
+++ b/news/4998.bugfix.rst
@@ -1,0 +1,1 @@
+(Windows) PySide2.QtNetwork: search for SSL DLLs in `PrefixPath` in addition to `BinariesPath`.


### PR DESCRIPTION
Under Windows, the PyPI version of PySide2 requires user to manually install SSL DLLs into the Lib\site-packages\PySide2 directory, which corresponds to the 'PrefixPath' in the pyside2_library_info.location.

Therefore, search for the DLLs in 'PrefixPath' in addition to the 'BinariesPath' (which is used by other versions, e.g., the one provided by Anaconda).