### PR TITLE
cv2: try to bundle opencv_videio_ffmpeg*.dll on Windows

### DIFF
--- a/PyInstaller/hooks/hook-cv2.py
+++ b/PyInstaller/hooks/hook-cv2.py
@@ -9,5 +9,24 @@
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
 
+import glob
+import os
+
+from PyInstaller.utils.hooks import collect_dynamic_libs
+from PyInstaller import compat
 
 hiddenimports = ['numpy'] 
+
+# On Windows, make sure that opencv_videoio_ffmpeg*.dll is bundled
+binaries = []
+if compat.is_win:
+    # If conda is active, look for the DLL in its library path
+    if compat.is_conda:
+        libdir = os.path.join(compat.base_prefix, 'Library', 'bin')
+        pattern = os.path.join(libdir, 'opencv_videoio_ffmpeg*.dll')
+        for f in glob.glob(pattern):
+            binaries.append((f, '.'))
+
+    # Include any DLLs from site-packages/cv2 (opencv_videoio_ffmpeg*.dll
+    # can be found there in the PyPI version)
+    binaries += collect_dynamic_libs('cv2')

--- a/news/4999.bugfix.rst
+++ b/news/4999.bugfix.rst
@@ -1,0 +1,1 @@
+(Windows) cv2: bundle the `opencv_videoio_ffmpeg*.dll`, if available.


### PR DESCRIPTION
Failing to bundle this DLL may result in different behavior between original and distributed version when dealing with video files.

PyPI version seems to install the DLL into site-packages\cv2, while Conda installs it into prefix\Library\bin.