### PR TITLE
GLib: bundle the spawn helper executables on Windows

### DIFF
--- a/PyInstaller/hooks/hook-gi.repository.GLib.py
+++ b/PyInstaller/hooks/hook-gi.repository.GLib.py
@@ -17,9 +17,20 @@ Tested with GLib 2.44.1, PyGObject 3.16.2, and GObject Introspection 1.44.0 on M
 GLib 2.42.2, PyGObject 3.14.0, and GObject Introspection 1.42 on Windows 7
 """
 
-from PyInstaller.utils.hooks import collect_glib_translations, collect_glib_share_files, get_gi_typelibs
+import os
+import glob
+
+from PyInstaller.utils.hooks import collect_glib_translations, \
+    collect_glib_share_files, get_gi_typelibs, get_gi_libdir
+from PyInstaller.compat import is_win
 
 binaries, datas, hiddenimports = get_gi_typelibs('GLib', '2.0')
 datas += collect_glib_translations('glib20')
 datas += collect_glib_share_files('glib-2.0', 'schemas')
 
+# On Windows, glib needs a spawn helper for g_spawn* API
+if is_win:
+    libdir = get_gi_libdir('GLib', '2.0')
+    pattern = os.path.join(libdir, 'gspawn-*-helper*.exe')
+    for f in glob.glob(pattern):
+        binaries.append((f, '.'))

--- a/news/5000.bugfix.rst
+++ b/news/5000.bugfix.rst
@@ -1,0 +1,1 @@
+(Windows) GLib: bundle the spawn helper executables for `g_spawn*` API.


### PR DESCRIPTION
On Windows, GLib needs a spawn helper (gspawn-winXX-helper.exe and gspawn-winXX-helper-console.exe for non-console and console version, respectively) for g_spawn* API.

Failing to bundle this helper prevents GLib from launching external programs (e.g., opening a web browser when user clicks on a web-site link in a GtkAboutDialog).