### PR TITLE
Correctly locate macos python.org built-in tcl/tk

### DIFF
--- a/PyInstaller/hooks/hook-_tkinter.py
+++ b/PyInstaller/hooks/hook-_tkinter.py
@@ -107,12 +107,13 @@ See https://github.com/pyinstaller/pyinstaller/issues/621 for more information.
             """ % init_resource)
 
 
-def _find_tcl_tk_darwin_frameworks(binaries):
+def _find_tcl_tk_darwin_system_frameworks(binaries):
     """
     Get an OS X-specific 2-tuple of the absolute paths of the top-level
     external data directories for both Tcl and Tk, respectively.
 
-    Under OS X, Tcl and Tk are installed as Frameworks requiring special care.
+    This function finds the OS X system installation of Tcl and Tk.
+    System OS X Tcl and Tk are installed as Frameworks requiring special care.
 
     Returns
     -------
@@ -186,10 +187,15 @@ def _find_tcl_tk(hook_api):
 
         # _tkinter depends on Tcl/Tk compiled as frameworks.
         path_to_tcl = bins[0][1]
-        if 'Library/Frameworks' in path_to_tcl:
-            tcl_tk = _find_tcl_tk_darwin_frameworks(bins)
+        # OS X system installation of Tcl/Tk.
+        # [/System]/Library/Frameworks/Tcl.framework/Resources/Scripts/Tcl
+        if 'Library/Frameworks/Tcl.framework' in path_to_tcl:
+            tcl_tk = _find_tcl_tk_darwin_system_frameworks(bins)
         # Tcl/Tk compiled as on Linux other Unixes.
-        # For example this is the case of Tcl/Tk from macports.
+        # This is the case of Tcl/Tk from macports and Tck/Tk built into
+        # python.org OS X python distributions.
+        # python.org built-in tcl/tk is located at
+        # /Library/Frameworks/Python.framework/Versions/3.x/lib/libtcl8.6.dylib
         else:
             tcl_tk = _find_tcl_tk_dir()
 

--- a/news/5013.hooks.rst
+++ b/news/5013.hooks.rst
@@ -1,0 +1,2 @@
+(OSX) Correctly locate the tcl/tk framework bundled with official
+python.org python builds from v.3.6.5 on.


### PR DESCRIPTION
The python.org OS X python distributions installs a built-in version tcl/tk in a path similar to the system installation. This makes pyinstaller confused and think the python.org built-in tcl/tk is the system installation. This pull request fixes this issue. See https://github.com/pyinstaller/pyinstaller/issues/3753#issuecomment-432464838 .

Resolves #3753 .