### PR TITLE
Wrap get_makefile_filename to fix test case on CentOS 7.

### DIFF
--- a/tests/functional/scripts/pyi_python_makefile.py
+++ b/tests/functional/scripts/pyi_python_makefile.py
@@ -24,7 +24,12 @@ files = [config_h]
 
 # On Windows Makefile does not exist.
 if not sys.platform.startswith('win'):
-    makefile = sysconfig.get_makefile_filename()
+    get_makefile_filename = getattr(
+        sysconfig,
+        'get_makefile_filename',
+        getattr(sysconfig, '_get_makefile_filename', lambda: None),
+    )
+    makefile = get_makefile_filename()
     print(('Makefile: ' + makefile))
     files.append(makefile)
 


### PR DESCRIPTION
Fixes #5030.