### PR TITLE
add hook for class workflow

### DIFF
--- a/PyInstaller/hooks/hook-workflow.py
+++ b/PyInstaller/hooks/hook-workflow.py
@@ -1,0 +1,11 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013-2020, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import copy_metadata
+datas = copy_metadata('workflow')


### PR DESCRIPTION
if someone uses class workflow (https://github.com/inveniosoftware-contrib/workflow) and uses pyinstaller to pack the code, the executable file will not run with "get version fail" 

add hook for workflow will solve this problem
