### PR TITLE
Add hidden imports to pkg resources

### DIFF
--- a/PyInstaller/hooks/hook-packaging.py
+++ b/PyInstaller/hooks/hook-packaging.py
@@ -1,0 +1,13 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2020, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+# Duplicate hook-pkg_resources.py.
+hiddenimports = ["pkg_resources"]

--- a/PyInstaller/hooks/hook-pkg_resources.py
+++ b/PyInstaller/hooks/hook-pkg_resources.py
@@ -20,3 +20,12 @@ hiddenimports = collect_submodules('pkg_resources._vendor')
 hiddenimports.append('pkg_resources.py2_warn')
 
 excludedimports = ['__main__']
+
+# Some more hidden imports. See:
+# https://github.com/pyinstaller/pyinstaller-hooks-contrib/issues/15#issuecomment-663699288
+# `packaging` can either be its own package, or embeded in
+# `pkg_resources._vendor.packaging`, or both.
+# Assume the worst and include both if present.
+hiddenimports += collect_submodules('packaging')
+
+hiddenimports += ['pkg_resources.markers']

--- a/news/5044.hooks.rst
+++ b/news/5044.hooks.rst
@@ -1,0 +1,7 @@
+Fix hidden imports in pkg_resources_ and packaging_
+
+- Add yet more hidden imports to pkg_resources_ hook.
+- Mirror the pkg_resources_ hook for packaging_ which may or may not be duplicate of ``pkg_resources._vendor.packaging``.
+
+.. _pkg_resources: `pkg_resources <https://setuptools.readthedocs.io/en/latest/pkg_resources.html>`
+.. _packaging: `packaging <https://packaging.pypa.io/en/latest/>`


### PR DESCRIPTION
- Add yet more hidden imports to `pkg_resources` hook. 
- Mirror the `pkg_resources` hook for [packaging](https://packaging.pypa.io/en/latest/) which appears to be a mirror of `pkg_resources._vendor.packaging`. 

Fixes pyinstaller/pyinstaller-hooks-contrib#15 (although we can't reproduce that issue). 

I imagine there may be a cleaner way to mirror a hook - if there is I'll change it.
