### PR TITLE
Add hook for the iminuit module

### DIFF
--- a/PyInstaller/hooks/hook-iminuit.py
+++ b/PyInstaller/hooks/hook-iminuit.py
@@ -1,0 +1,19 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013-2020, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_submodules
+
+hiddenimports = []
+
+# the iminuit package contains tests which aren't needed when distributing
+for mod in collect_submodules('iminuit'):
+    if not mod.startswith('iminuit.tests'):
+        hiddenimports.append(mod)


### PR DESCRIPTION
iminuit (https://github.com/scikit-hep/iminuit) imports submodules via a cython module (_libiminuit.pyx). These are missed in the standard pyinstaller analysis. This patch adds the hidden imports, excluding the test subpackage.

This problem can be seen with a simple example program which does

     import iminuit

iminuit is a useful numerical optimization package, based around the MINIIT2 library.