### PR TITLE
fix windows10 build 2004 error

### DIFF
--- a/PyInstaller/depend/bindepend.py
+++ b/PyInstaller/depend/bindepend.py
@@ -125,7 +125,7 @@ def _getImports_pe(pth):
                 # sym.forwarder is a bytes object. Convert it to a string.
                 forwarder = winutils.convert_dll_name_to_str(sym.forwarder)
                 # sym.forwarder is for example 'KERNEL32.EnterCriticalSection'
-                dll  = forwarder.split('.')[0]
+                dll = forwarder.split('.')[0]
                 dlls.add(dll + ".dll")
 
     pe.close()

--- a/PyInstaller/depend/bindepend.py
+++ b/PyInstaller/depend/bindepend.py
@@ -125,8 +125,7 @@ def _getImports_pe(pth):
                 # sym.forwarder is a bytes object. Convert it to a string.
                 forwarder = winutils.convert_dll_name_to_str(sym.forwarder)
                 # sym.forwarder is for example 'KERNEL32.EnterCriticalSection'
-                dll, _ = forwarder.split('.')
-                dlls.add(dll + ".dll")
+                dlls.add(forwarder.split('.')[0] + ".dll")
 
     pe.close()
     return dlls

--- a/PyInstaller/depend/bindepend.py
+++ b/PyInstaller/depend/bindepend.py
@@ -125,7 +125,8 @@ def _getImports_pe(pth):
                 # sym.forwarder is a bytes object. Convert it to a string.
                 forwarder = winutils.convert_dll_name_to_str(sym.forwarder)
                 # sym.forwarder is for example 'KERNEL32.EnterCriticalSection'
-                dlls.add(forwarder.split('.')[0] + ".dll")
+                dll  = forwarder.split('.')[0]
+                dlls.add(dll + ".dll")
 
     pe.close()
     return dlls


### PR DESCRIPTION
```
6121 WARNING: Can not get binary dependencies for file: C:\Windows\System32\downlevel\api-ms-win-core-localization-l1-2-0.dll
6121 WARNING:   Reason: too many values to unpack (expected 2)
Traceback (most recent call last):
  File "C:\Python37x86\lib\site-packages\PyInstaller\depend\bindepend.py", line 731, in getImports
    return _getImports_pe(pth)
  File "C:\Python37x86\lib\site-packages\PyInstaller\depend\bindepend.py", line 128, in _getImports_pe
    dll, _ = forwarder.split('.')
ValueError: too many values to unpack (expected 2)
6145 WARNING: Can not get binary dependencies for file: C:\Windows\System32\downlevel\api-ms-win-core-memory-l1-1-0.dll
6149 WARNING:   Reason: too many values to unpack (expected 2)
Traceback (most recent call last):
  File "C:\Python37x86\lib\site-packages\PyInstaller\depend\bindepend.py", line 731, in getImports
    return _getImports_pe(pth)
  File "C:\Python37x86\lib\site-packages\PyInstaller\depend\bindepend.py", line 128, in _getImports_pe
    dll, _ = forwarder.split('.')
ValueError: too many values to unpack (expected 2)
6164 WARNING: Can not get binary dependencies for file: C:\Windows\System32\downlevel\api-ms-win-core-processthreads-l1-1-0.dll
6165 WARNING:   Reason: too many values to unpack (expected 2)
Traceback (most recent call last):
  File "C:\Python37x86\lib\site-packages\PyInstaller\depend\bindepend.py", line 731, in getImports
    return _getImports_pe(pth)
  File "C:\Python37x86\lib\site-packages\PyInstaller\depend\bindepend.py", line 128, in _getImports_pe
    dll, _ = forwarder.split('.')
ValueError: too many values to unpack (expected 2)
```