### PR TITLE
Add action for validation of new news fragments in pull requests

### DIFF
--- a/.github/workflows/validate-new-news.yml
+++ b/.github/workflows/validate-new-news.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           git diff --name-status origin/${{ github.base_ref }}
           git diff --name-status origin/${{ github.base_ref }}\
-          | python scripts/verify-news-fragments.py ${{github.event.number}}
+          | python scripts/verify-news-fragments.py
 
       - name: Install towncrier
         run: pip install -q -U setuptools wheel towncrier

--- a/.github/workflows/validate-new-news.yml
+++ b/.github/workflows/validate-new-news.yml
@@ -36,4 +36,4 @@ jobs:
         run: pip install -q -U setuptools wheel towncrier
 
       - name: Run towncrier
-        run: towncrier --yes
+        run: towncrier --draft

--- a/.github/workflows/validate-new-news.yml
+++ b/.github/workflows/validate-new-news.yml
@@ -1,0 +1,39 @@
+---
+name: Validate new news entries
+
+on:
+  pull_request:  # Trigger on PRs to develop
+    branches:
+      - develop
+
+jobs:
+  run:
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Get out of detached head state
+        run: |
+          git fetch origin ${{ github.base_ref }}
+          git fetch origin ${{ github.ref }}
+          git checkout FETCH_HEAD --
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Validate new news items
+        run: |
+          git diff --name-status origin/${{ github.base_ref }}
+          git diff --name-status origin/${{ github.base_ref }}\
+          | python scripts/verify-news-fragments.py ${{github.event.number}}
+
+      - name: Install towncrier
+        run: pip install -q -U setuptools wheel towncrier
+
+      - name: Run towncrier
+        run: towncrier --yes

--- a/scripts/verify-news-fragments.py
+++ b/scripts/verify-news-fragments.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013-2020, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+"""
+Verify that new news entries have valid filenames. Usage:
+
+.. code-block:: bash
+
+    git diff --name-status $COMMIT_ID | python verify-news-fragments.py
+
+If you have a Pull Request number then you can verify that new entries have
+the correct PR number in their filename:
+
+.. code-block:: bash
+
+    git diff --name-status origin/${{ github.base_ref }} \
+    | python verify-news-fragments.py $PR_NUMBER
+
+"""
+
+import re
+import sys
+from pathlib import Path
+
+CHANGELOG_GUIDE = (
+    "https://github.com/pyinstaller/pyinstaller/"
+    "blob/develop/doc/development/changelog-entries.rst#changelog-entries")
+
+CHANGE_TYPES = {'bootloader', 'break', 'bugfix', 'build', 'core', 'doc',
+                'feature', 'hooks', 'moduleloader', 'process', 'tests'}
+
+NEWS_PATTERN = re.compile(r"(\d+)\.(\w+)\.rst")
+
+NEWS_DIR = Path(__file__).absolute().parent.parent / "news"
+
+
+def validate_name(name, pr_num=None):
+    """Check a filename/filepath matches the required format.
+    If **pr** is provided, also check that the filename has the
+    correct PR number.
+
+    Raises ValueError
+    :param name: Name of news fragment file.
+    :type: str, os.Pathlike
+
+    :param pr_num: Pull request number to validate.
+    :type pr_num: int, str, optional
+
+    :raises: ``SystemExit`` if above checks don't pass.
+    """
+    match = NEWS_PATTERN.fullmatch(Path(name).name)
+    if match is None:
+        sys.exit("'{}' does not match '(pr-number).(type).rst' changelog"
+                 "entries format. See:\n{}".format(name, CHANGELOG_GUIDE))
+
+    if match.group(2) not in CHANGE_TYPES:
+        sys.exit("'{}' of of invalid type '{}'. Valid types are:\n{}".format(
+            name, match.group(2), CHANGE_TYPES))
+
+    if (pr_num is not None) and (int(pr_num) != int(match.group(1))):
+        sys.exit("'{}' has pull request number {} but the pull request "
+                 "is actually #{}.".format(name, match.group(1), pr_num))
+
+    print(name, "is ok")
+
+
+def main(pr=None):
+    # Parse the output of `git diff --name-status COMMIT`
+    lines = sys.stdin.readlines()
+
+    for line in lines:
+        try:
+            action, filename = line.split(maxsplit=1)
+        except ValueError:
+            continue
+        filename = Path(filename.strip())
+
+        if action == "A" and filename.parts[0] == "news":
+            if filename.suffix == ".rst":
+                validate_name(filename, pr)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1] if len(sys.argv) == 2 else None)

--- a/scripts/verify-news-fragments.py
+++ b/scripts/verify-news-fragments.py
@@ -16,14 +16,6 @@ Verify that new news entries have valid filenames. Usage:
 
     git diff --name-status $COMMIT_ID | python verify-news-fragments.py
 
-If you have a Pull Request number then you can verify that new entries have
-the correct PR number in their filename:
-
-.. code-block:: bash
-
-    git diff --name-status origin/${{ github.base_ref }} \
-    | python verify-news-fragments.py $PR_NUMBER
-
 """
 
 import re
@@ -42,17 +34,11 @@ NEWS_PATTERN = re.compile(r"(\d+)\.(\w+)\.rst")
 NEWS_DIR = Path(__file__).absolute().parent.parent / "news"
 
 
-def validate_name(name, pr_num=None):
+def validate_name(name):
     """Check a filename/filepath matches the required format.
-    If **pr** is provided, also check that the filename has the
-    correct PR number.
 
-    Raises ValueError
     :param name: Name of news fragment file.
     :type: str, os.Pathlike
-
-    :param pr_num: Pull request number to validate.
-    :type pr_num: int, str, optional
 
     :raises: ``SystemExit`` if above checks don't pass.
     """
@@ -65,14 +51,10 @@ def validate_name(name, pr_num=None):
         sys.exit("'{}' of of invalid type '{}'. Valid types are:\n{}".format(
             name, match.group(2), CHANGE_TYPES))
 
-    if (pr_num is not None) and (int(pr_num) != int(match.group(1))):
-        sys.exit("'{}' has pull request number {} but the pull request "
-                 "is actually #{}.".format(name, match.group(1), pr_num))
-
     print(name, "is ok")
 
 
-def main(pr=None):
+def main():
     # Parse the output of `git diff --name-status COMMIT`
     lines = sys.stdin.readlines()
 
@@ -85,8 +67,8 @@ def main(pr=None):
 
         if action == "A" and filename.parts[0] == "news":
             if filename.suffix == ".rst":
-                validate_name(filename, pr)
+                validate_name(filename)
 
 
 if __name__ == "__main__":
-    main(sys.argv[1] if len(sys.argv) == 2 else None)
+    main()


### PR DESCRIPTION
Add action to enforce our change-log format on pull requests. Fixes #5070.

## Does what

The brain of the operation is the new script [scripts/verify-news-fragments.py](https://github.com/bwoodsend/pyinstaller/blob/verify-news-fragment-filenames/scripts/verify-news-fragments.py) which reads a `git diff` for new files, filters for new news fragments, then validates them.

This script is invoked by the new workflow [.github/workflows/validate-new-news.yml](https://github.com/bwoodsend/pyinstaller/blob/efcf1cdab3e324f1c2d638f499805826daa91ca5/.github/workflows/validate-new-news.yml) which is very similar to the lint action we already have. Provided the above script doesn't fin any issues, this action then calls `towncrier` to ensure that works too.

## To see it in action

I created a [mock pull request](https://github.com/bwoodsend/pyinstaller/pull/4) to my own fork, to which I've committed:

- A [totally invalidly formatted name](https://github.com/bwoodsend/pyinstaller/runs/966537437#step:5:8).
- An item with an [invalid change type](https://github.com/bwoodsend/pyinstaller/runs/966543758#step:5:8).
- One with the [wrong PR number](https://github.com/bwoodsend/pyinstaller/runs/966559267#step:5:8).
- And [one that works](https://github.com/bwoodsend/pyinstaller/runs/966565030#step:5:8) and is able to run `towncrier`.

## Still to do

Somewhat ironically, I haven't added the changelog entry for this PR yet. I'm assuming it should be `xxx.process.rst`?
