### PR TITLE
hooks: failed hook outputs exception message

### DIFF
--- a/PyInstaller/exceptions.py
+++ b/PyInstaller/exceptions.py
@@ -12,3 +12,18 @@
 
 class ExecCommandFailed(SystemExit):
     pass
+
+
+class HookError(Exception):
+    """Base class for hook related errors."""
+    pass
+
+
+class ImportErrorWhenRunningHook(HookError):
+    def __str__(self):
+        return ("Failed to import module {0} required by hook for module {1}. "
+                "Please check whether module {0} actually exists and whether "
+                "the hook is compatible with your version of {1}: You might "
+                "want to read more about hooks in the manual and provide "
+                "a pull-request to improve PyInstaller.".format(
+                    self.args[0], self.args[1]))


### PR DESCRIPTION
Please see my attempt to close issue #4537. However when I run PyInstaller with my changes applied, the traceback is still outputted to the terminal instead of the exception message I have created and (tried to) implement. 