### PR TITLE
Remove a stray news fragment file

### DIFF
--- a/4210.bugfix.rst
+++ b/4210.bugfix.rst
@@ -1,1 +1,0 @@
-(AIX) Include python-malloc labeled libraries in search for libpython.


### PR DESCRIPTION
The `4210.bugfix.rst` file ended up in wrong place during the name fix-up, and should probably be removed.