### PR TITLE
Fix for #5058: collect_system_data_files() scans parent

### DIFF
--- a/PyInstaller/hooks/hook-PyQt5.QtWebEngineWidgets.py
+++ b/PyInstaller/hooks/hook-PyQt5.QtWebEngineWidgets.py
@@ -29,9 +29,10 @@ if pyqt5_library_info.version:
                      'QtQmlModels', 'QtNetwork', 'QtGui', 'QtWebChannel',
                      'QtPositioning']
         for i in libraries:
+            framework_dir = i + '.framework'
             datas += collect_system_data_files(
-                os.path.join(data_path, 'lib', i + '.framework'),
-                os.path.join(*(rel_data_path + ['lib'])), True)
+                os.path.join(data_path, 'lib', framework_dir),
+                os.path.join(*rel_data_path, 'lib', framework_dir), True)
         datas += [(os.path.join(data_path, 'lib', 'QtWebEngineCore.framework',
                                 'Resources'), os.curdir)]
     else:

--- a/PyInstaller/hooks/hook-PyQt5.py
+++ b/PyInstaller/hooks/hook-PyQt5.py
@@ -25,7 +25,7 @@ if pyqt5_library_info.version:
     # Collect the ``qt.conf`` file.
     datas = [x for x in
              collect_system_data_files(pyqt5_library_info.location['PrefixPath'],
-                                       'PyQt5')
+                                       os.path.join('PyQt5', 'Qt'))
              if os.path.basename(x[0]) == 'qt.conf']
 
     # Collect required Qt binaries.

--- a/PyInstaller/hooks/hook-PySide2.QtWebEngineWidgets.py
+++ b/PyInstaller/hooks/hook-PySide2.QtWebEngineWidgets.py
@@ -50,9 +50,10 @@ if pyside2_library_info.version:
                      'QtQmlModels', 'QtNetwork', 'QtGui', 'QtWebChannel',
                      'QtPositioning']
         for i in libraries:
+            framework_dir = i + '.framework'
             datas += collect_system_data_files(
-                os.path.join(data_path, 'lib', i + '.framework'),
-                prefix_with_path(rel_data_path, 'lib'), True)
+                os.path.join(data_path, 'lib', framework_dir),
+                prefix_with_path(rel_data_path, 'lib', framework_dir), True)
         datas += [(os.path.join(data_path, 'lib', 'QtWebEngineCore.framework',
                                 'Resources'), os.curdir)]
     else:

--- a/PyInstaller/hooks/hook-PySide2.py
+++ b/PyInstaller/hooks/hook-PySide2.py
@@ -21,13 +21,13 @@ if pyside2_library_info.version:
 
     # Collect the ``qt.conf`` file.
     if is_win:
-        target_qt_conf_dir = os.curdir
+        target_qt_conf_dir = ['PySide2']
     else:
-        target_qt_conf_dir = 'PySide2'
+        target_qt_conf_dir = ['PySide2', 'Qt']
 
     datas = [x for x in
              collect_system_data_files(pyside2_library_info.location['PrefixPath'],
-                                       target_qt_conf_dir)
+                                       os.path.join(*target_qt_conf_dir))
              if os.path.basename(x[0]) == 'qt.conf']
 
     # Collect required Qt binaries.

--- a/PyInstaller/utils/hooks/__init__.py
+++ b/PyInstaller/utils/hooks/__init__.py
@@ -790,7 +790,6 @@ def collect_system_data_files(path, destdir=None, include_py_files=False):
     # which may not be true on Windows; Windows allows Linux path separators in
     # filenames. Fix this by normalizing the path.
     path = os.path.normpath(path)
-    path = os.path.dirname(path)
     # Ensure `path` ends with a single slash
     # Subtle difference on Windows: In some cases `dirname` keeps the
     # trailing slash, e.g. dirname("//aaa/bbb/"), see issue #4707.

--- a/PyInstaller/utils/hooks/gi.py
+++ b/PyInstaller/utils/hooks/gi.py
@@ -216,7 +216,7 @@ def collect_glib_share_files(*path):
     if glib_data_dirs is None:
         return []
 
-    destdir = os.path.join('share', *path[:-1])
+    destdir = os.path.join('share', *path)
 
     # TODO: will this return too much?
     collected = []
@@ -233,7 +233,7 @@ def collect_glib_etc_files(*path):
     if glib_config_dirs is None:
         return []
 
-    destdir = os.path.join('etc', *path[:-1])
+    destdir = os.path.join('etc', *path)
 
     # TODO: will this return too much?
     collected = []

--- a/news/5110.hooks.rst
+++ b/news/5110.hooks.rst
@@ -1,0 +1,2 @@
+Fix `collect_system_data_files` to scan the given input path instead of its parent.
+File paths returned by `collect_all_system_data` are now relative to the input path.


### PR DESCRIPTION
Fixes #5058 by removing the jump to the parent directory in `collect_system_data_files`. 

This changes the returned paths to the collected files - the paths are not prefixed by the last component of the input search path anymore. Therefore all hooks using `collect_system_data_files` need to be adjusted in order to avoid misplacing the files in the dist directory.