### PR TITLE
hooks: Add "sqlalchemy.ext.baked" to sqlalchemy hook.

### DIFF
--- a/PyInstaller/hooks/hook-sqlalchemy.py
+++ b/PyInstaller/hooks/hook-sqlalchemy.py
@@ -24,6 +24,9 @@ excludedimports = ['sqlalchemy.testing']
 # are not. We should explicitly include database backends.
 hiddenimports = ['pysqlite2', 'MySQLdb', 'psycopg2']
 
+# add sqlalchemy.ext.baked to hidden imports
+hiddenimports.append("sqlalchemy.ext.baked")
+
 # In SQLAlchemy >= 0.6, the "sqlalchemy.dialects" package provides dialects.
 if is_module_satisfies('sqlalchemy >= 0.6'):
     dialects = exec_statement("import sqlalchemy.dialects;print(sqlalchemy.dialects.__all__)")

--- a/PyInstaller/hooks/hook-sqlalchemy.py
+++ b/PyInstaller/hooks/hook-sqlalchemy.py
@@ -22,10 +22,7 @@ excludedimports = ['sqlalchemy.testing']
 # include most common database bindings
 # some database bindings are detected and include some
 # are not. We should explicitly include database backends.
-hiddenimports = ['pysqlite2', 'MySQLdb', 'psycopg2']
-
-# add sqlalchemy.ext.baked to hidden imports
-hiddenimports.append("sqlalchemy.ext.baked")
+hiddenimports = ['pysqlite2', 'MySQLdb', 'psycopg2', 'sqlalchemy.ext.baked']
 
 # In SQLAlchemy >= 0.6, the "sqlalchemy.dialects" package provides dialects.
 if is_module_satisfies('sqlalchemy >= 0.6'):

--- a/news/5128.hooks.rst
+++ b/news/5128.hooks.rst
@@ -1,1 +1,1 @@
-Update ``sqlalchemy`` hook to support v1.3.19 and later,  by adding ``pysqlite2``, ``MySQLdb`` and ``psycopg2`` as hidden imports.
+Update ``sqlalchemy`` hook to support v1.3.19 and later,  by adding ``sqlalchemy.ext.baked`` as a hidden import

--- a/news/5128.hooks.rst
+++ b/news/5128.hooks.rst
@@ -1,0 +1,1 @@
+Updated a hook for sqlalchemy, by adding a hidden import.

--- a/news/5128.hooks.rst
+++ b/news/5128.hooks.rst
@@ -1,1 +1,1 @@
-Updated a hook for sqlalchemy, by adding a hidden import.
+Update ``sqlalchemy`` hook to support v1.3.19 and later,  by adding ``pysqlite2``, ``MySQLdb`` and ``psycopg2`` as hidden imports.


### PR DESCRIPTION
Closes #5106, added "sqlalchemy.ext.baked" to the hidden imports
list of sqlalchemy hook file hook-sqlalchemy.py. This is because it was
missing.