### PR TITLE
docs: Add zlib to build requirements.

### DIFF
--- a/doc/bootloader-building.rst
+++ b/doc/bootloader-building.rst
@@ -71,26 +71,14 @@ You can run the following to install everything required:
 
 * On Debian- or Ubuntu-like systems::
 
-    sudo apt-get install build-essential
+    sudo apt-get install build-essential zlib1g-dev
 
 * On Fedora, RedHat and derivates::
 
     sudo yum groupinstall "Development Tools"
-
-* For other Distributions please consult the distributions documentation.
-
-If your distribution doesn't already have it you will also have to
-install ``zlib-devel``.
-
-* On Debian- or Ubuntu-like systems::
-
-    sudo apt-get install zlib1g-dev
-
-* On Fedora, RedHat and derivates::
-
     sudo yum install zlib-devel
 
-* For other Distributions again please consult the distribution's documentation.
+* For other Distributions please consult the distributions documentation.
 
 Now you can build the bootloader as shown above.
 

--- a/doc/bootloader-building.rst
+++ b/doc/bootloader-building.rst
@@ -79,6 +79,19 @@ You can run the following to install everything required:
 
 * For other Distributions please consult the distributions documentation.
 
+If your distribution doesn't already have it you will also have to
+install ``zlib-devel``.
+
+* On Debian- or Ubuntu-like systems::
+
+    sudo apt-get install zlib1g-dev
+
+* On Fedora, RedHat and derivates::
+
+    sudo yum install zlib-devel
+
+* For other Distributions again please consult the distribution's documentation.
+
 Now you can build the bootloader as shown above.
 
 Alternatively you may want to use the `linux64` build-guest

--- a/news/5130.doc.rst
+++ b/news/5130.doc.rst
@@ -1,0 +1,1 @@
+Add zlib to build the requirements in the Building the Bootlooder section of the docs.


### PR DESCRIPTION
Include a couple of sentences in the building the bootloader section of the docs to say *building the bootoader requires `zlib-devel`*. Fixes #5101.

@simaoafonso-pwt Can you confirm that I have the correct `yum` command - I just pulled it off the web and can't verify it myself.
