### PR TITLE
depends: Exclude more unix/Linux graphical interface libraries

### DIFF
--- a/PyInstaller/depend/dylib.py
+++ b/PyInstaller/depend/dylib.py
@@ -133,8 +133,9 @@ _unix_excludes = {
     r'libnss_nisplus.*\.so(\..*)?',
     r'libresolv\.so(\..*)?',
     r'libutil\.so(\..*)?',
-    # libGL can reference some hw specific libraries (like nvidia libs).
-    r'libGL\..*',
+    # graphical interface libraries come with graphical stack (see libglvnd)
+    r'libE?(Open)?GLX?(ESv1_CM|ESv2)?(dispatch)?\.so(\..*)?',
+    r'libdrm\.so(\..*)?',
     # libxcb-dri changes ABI frequently (e.g.: between Ubuntu LTS releases) and
     # is usually installed as dependency of the graphics stack anyway. No need
     # to bundle it.


### PR DESCRIPTION
These usually come with the graphical stack,
including them may cause unexpected issues.

First regex picks up everything that comes out of `libglvnd`
(https://github.com/NVIDIA/libglvnd,
https://packages.ubuntu.com/source/focal/libglvnd),
a total of 7 libraries.
The second one is for DRM Linux kernel interface library.

Partially-fixes: #4951

P.S. Please note that I do not have a deep understanding of the graphical stack, this is my best effort.