### PR TITLE
Hooks: Add hook-gi.repository.HarfBuzz

### DIFF
--- a/PyInstaller/hooks/hook-gi.repository.HarfBuzz.py
+++ b/PyInstaller/hooks/hook-gi.repository.HarfBuzz.py
@@ -1,0 +1,18 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2020, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+"""
+Import hook for PyGObject https://wiki.gnome.org/PyGObject
+"""
+
+from PyInstaller.utils.hooks import get_gi_typelibs
+
+
+binaries, datas, hiddenimports = get_gi_typelibs('HarfBuzz', '0.0')

--- a/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.HarfBuzz.py
+++ b/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.HarfBuzz.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2020, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+def pre_safe_import_module(api):
+    # PyGObject modules loaded through the gi repository are marked as
+    # MissingModules by modulegraph so we convert them to
+    # RuntimeModules so their hooks are loaded and run.
+    api.add_runtime_module(api.module_name)

--- a/news/5133.hooks.rst
+++ b/news/5133.hooks.rst
@@ -1,0 +1,1 @@
+Add hook-gi.repository.HarfBuzz to fix Typelib error with Gtk apps.


### PR DESCRIPTION
Fixes #5129. 

This PR fixes an error for `gi.RepositoryError: Typelib file for namespace 'HarfBuzz', version '0.0' not found`.

The cause of this error is that Gtk and Pango now include HarfBuzz-0.0 as a typelib that needs to be loaded with the other libraries. This change adds hooks for this typelib.