### PR TITLE
Doc: Add missing Python 3.8 reference

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,7 @@ Requirements and Tested Platforms
 
 - Python: 
 
- - 3.5-3.7
+ - 3.5-3.8
  - tinyaes_ 1.0+ (only if using bytecode encryption).
    Instead of installing tinyaes, ``pip install pyinstaller[encryption]`` instead.
 


### PR DESCRIPTION
I believe this was overlooked in 9de3b4732f599a878e0b3da8470492beee1b1f19.

Python 3.8 support added in 96ad2961d578ce322f3ea80fc9e1fe5d657a1227