### PR TITLE
hooks: Stopped hooks collecting bytecode files.

### DIFF
--- a/PyInstaller/utils/hooks/__init__.py
+++ b/PyInstaller/utils/hooks/__init__.py
@@ -729,6 +729,10 @@ def collect_data_files(package, include_py_files=False, subdir=None,
     if not include_py_files:
         excludes += ['**/*' + s for s in ALL_SUFFIXES]
 
+    # Exclude .pyo files if include_py_files is False.
+    if not include_py_files and ".pyo" not in ALL_SUFFIXES:
+        excludes.append('**/*.pyo')
+
     # If not specified, include all files. Follow the same process as the
     # excludes.
     includes = list(includes) if includes else ["**/*"]

--- a/news/5141.hooks.rst
+++ b/news/5141.hooks.rst
@@ -1,0 +1,1 @@
+Prevent .pyo files from being collected by collect_data_files when include_py_files is False.


### PR DESCRIPTION
utils.hooks.collect_all() were collecting _pycache__, py.c and py.o files. This needed to stop because bytecode files were being kept after tests were run. Closes #5115.

