### PR TITLE
hooks: {PyQt5,PySide2}.QtNetwork: fix a typo in SSL DLL name

### DIFF
--- a/PyInstaller/hooks/hook-PyQt5.QtNetwork.py
+++ b/PyInstaller/hooks/hook-PyQt5.QtNetwork.py
@@ -25,7 +25,7 @@ if pyqt5_library_info.version:
 
         binaries = []
         for dll in ('libeay32.dll', 'ssleay32.dll', 'libssl-1_1-x64.dll',
-                    'libcrypto-1_1-x64.dllx'):
+                    'libcrypto-1_1-x64.dll'):
             dll_path = os.path.join(pyqt5_library_info.location['BinariesPath'],
                                     dll)
             if os.path.exists(dll_path):

--- a/PyInstaller/hooks/hook-PySide2.QtNetwork.py
+++ b/PyInstaller/hooks/hook-PySide2.QtNetwork.py
@@ -36,7 +36,7 @@ if pyside2_library_info.version:
         binaries = []
         for location in locations:
             for dll in ('libeay32.dll', 'ssleay32.dll', 'libssl-1_1-x64.dll',
-                        'libcrypto-1_1-x64.dllx'):
+                        'libcrypto-1_1-x64.dll'):
                 dll_path = os.path.join(location, dll)
                 if os.path.exists(dll_path):
                     binaries.append((dll_path, '.'))


### PR DESCRIPTION
Fix a typo in name of the last SSL DLL (removed trailing 'x'). The change is purely cosmetic; the DLL was picked up in spite of the typo, presumably due to being linked by the other DLL.