### PR TITLE
hooks: {PyQt5,PySide2}.QtWebEngineWidgets (linux): prevent use of glob if it has no matches

### DIFF
--- a/PyInstaller/hooks/hook-PyQt5.QtWebEngineWidgets.py
+++ b/PyInstaller/hooks/hook-PyQt5.QtWebEngineWidgets.py
@@ -10,6 +10,7 @@
 #-----------------------------------------------------------------------------
 
 import os
+import glob
 from PyInstaller.utils.hooks.qt import add_qt5_dependencies, pyqt5_library_info
 from PyInstaller.utils.hooks import remove_prefix, get_module_file_attribute, \
     collect_system_data_files
@@ -76,6 +77,6 @@ if pyqt5_library_info.version:
             if os.path.basename(imp).startswith('libnss3.so'):
                 # Find the location of NSS: given a ``/path/to/libnss.so``,
                 # add ``/path/to/nss/*.so`` to get the missing NSS libraries.
-                nss_subdir = os.path.join(os.path.dirname(imp), 'nss')
-                if os.path.exists(nss_subdir):
-                    binaries.append((os.path.join(nss_subdir, '*.so'), 'nss'))
+                nss_glob = os.path.join(os.path.dirname(imp), 'nss', '*.so')
+                if glob.glob(nss_glob):
+                    binaries.append((nss_glob, 'nss'))

--- a/PyInstaller/hooks/hook-PySide2.QtWebEngineWidgets.py
+++ b/PyInstaller/hooks/hook-PySide2.QtWebEngineWidgets.py
@@ -10,6 +10,7 @@
 #-----------------------------------------------------------------------------
 
 import os
+import glob
 from PyInstaller.utils.hooks.qt import add_qt5_dependencies, \
     pyside2_library_info
 from PyInstaller.utils.hooks import get_module_file_attribute, \
@@ -94,6 +95,6 @@ if pyside2_library_info.version:
             if os.path.basename(imp).startswith('libnss3.so'):
                 # Find the location of NSS: given a ``/path/to/libnss.so``,
                 # add ``/path/to/nss/*.so`` to get the missing NSS libraries.
-                nss_subdir = os.path.join(os.path.dirname(imp), 'nss')
-                if os.path.exists(nss_subdir):
-                    binaries.append((os.path.join(nss_subdir, '*.so'), 'nss'))
+                nss_glob = os.path.join(os.path.dirname(imp), 'nss', '*.so')
+                if glob.glob(nss_glob):
+                    binaries.append((nss_glob, 'nss'))

--- a/news/5149.hooks.rst
+++ b/news/5149.hooks.rst
@@ -1,0 +1,2 @@
+(GNU/Linux) {PyQt5,PySide2}.QtWebEngineWidgets: fix search for extra NSS libraries
+to prevent an error on systems where /lib64/nss/*.so comes up empty.


### PR DESCRIPTION
The glob used to search for extra NSS libraries on linux turns out to have no matches on Fedora 32. 

The `/lib64/nss` directory exists, but contains no libraries, and so adding `/lib64/nss/*.so` to `binaries` results in the following error:

```
Unable to find "/lib64/nss/*.so" when adding binary and data files.
```
