### PR TITLE
hooks: PySide2.QtWebEngineWidgets (macOS): collect QtQmlModels.framework

### DIFF
--- a/PyInstaller/hooks/hook-PySide2.QtWebEngineWidgets.py
+++ b/PyInstaller/hooks/hook-PySide2.QtWebEngineWidgets.py
@@ -47,7 +47,7 @@ if pyside2_library_info.version:
         # This is based on the layout of the Mac wheel from PyPi.
         data_path = pyside2_locations['DataPath']
         libraries = ['QtCore', 'QtWebEngineCore', 'QtQuick', 'QtQml',
-                     'QtNetwork', 'QtGui', 'QtWebChannel',
+                     'QtQmlModels', 'QtNetwork', 'QtGui', 'QtWebChannel',
                      'QtPositioning']
         for i in libraries:
             datas += collect_system_data_files(

--- a/news/5150.hooks.rst
+++ b/news/5150.hooks.rst
@@ -1,0 +1,1 @@
+(OSX) PySide2.QtWebEngineWidgets: add QtQmlModels to included libraries. 


### PR DESCRIPTION
Added `QtQmlModels` to the list of libraries for which .framework directory needs to be collected on macOS. Without it, `QWebEngineView` fails to load a page and spams console with messages about `QtQmlModels` library not being loaded.

The issue is currently masked by #5058, but once that is resolved, `test_PySide2_QWebEngine` will likely start failing with timeout on macOS, because failing to load the page will prevent the timer for exiting the test program from being triggered.