### PR TITLE
modulegraph: Use loaders to get module content. 

### DIFF
--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -652,6 +652,7 @@ SPECIAL_MODULE_TYPES = {
 # dependency graph.
 BINARY_MODULE_TYPES = {
     'Extension',
+    'ExtensionPackage',
 }
 # Object types of valid Python modules in modulegraph dependency graph.
 VALID_MODULE_TYPES = PURE_PYTHON_MODULE_TYPES | SPECIAL_MODULE_TYPES | BINARY_MODULE_TYPES
@@ -686,6 +687,7 @@ MODULE_TYPES_TO_TOC_DICT = {
     'ArchiveModule': 'PYMODULE',
     # Binary modules.
     'Extension': 'EXTENSION',
+    'ExtensionPackage': 'EXTENSION',
     # Special valid modules.
     'BuiltinModule': 'BUILTIN',
     'NamespacePackage': 'PYMODULE',

--- a/PyInstaller/depend/analysis.py
+++ b/PyInstaller/depend/analysis.py
@@ -27,6 +27,8 @@ For reference, the ModuleGraph node types and their contents:
  Package          basename         full path to __init__.py
         packagepath is ['path to package']
         globalnames is set of global names __init__.py defines
+ ExtensionPackage basename         full path to __init__.{so,dll}
+        packagepath is ['path to package']
 
 The main extension here over ModuleGraph is a method to extract nodes
 from the flattened graph and return them as a TOC, or added to a TOC.

--- a/PyInstaller/depend/analysis.py
+++ b/PyInstaller/depend/analysis.py
@@ -535,42 +535,14 @@ class PyiModuleGraph(ModuleGraph):
 
         result = existing_TOC or TOC()
         for node in self.flatten(start=self._top_script_node):
-            # TODO This is terrible. Everything in Python has a type. It's
-            # nonsensical to even speak of "nodes [that] are not typed." How
-            # would that even occur? After all, even "None" has a type! (It's
-            # "NoneType", for the curious.) Remove this, please.
-
             # Skip modules that are in base_library.zip.
             if module_filter.match(node.identifier):
                 continue
-
-            # get node type e.g. Script
-            mg_type = type(node).__name__
-            assert mg_type is not None
-
-            if typecode and not (mg_type in typecode):
-                # Type is not a to be selected one, skip this one
-                continue
-            # Extract the identifier and a path if any.
-            if mg_type == 'Script':
-                # for Script nodes only, identifier is a whole path
-                (name, ext) = os.path.splitext(node.filename)
-                name = os.path.basename(name)
-            else:
-                name = node.identifier
-            path = node.filename if node.filename is not None else ''
-            # Ensure name is really 'str'. Module graph might return
-            # object type 'modulegraph.Alias' which inherits fromm 'str'.
-            # But 'marshal.dumps()' function is able to marshal only 'str'.
-            # Otherwise on Windows PyInstaller might fail with message like:
-            #
-            #   ValueError: unmarshallable object
-            name = str(name)
-            # Translate to the corresponding TOC typecode.
-            toc_type = MODULE_TYPES_TO_TOC_DICT[mg_type]
-            # TOC.append the data. This checks for a pre-existing name
-            # and skips it if it exists.
-            result.append((name, path, toc_type))
+            entry = self._node_to_toc(node, typecode)
+            if entry is not None:
+                # TOC.append the data. This checks for a pre-existing name
+                # and skips it if it exists.
+                result.append(entry)
         return result
 
     def make_pure_toc(self):
@@ -592,6 +564,39 @@ class PyiModuleGraph(ModuleGraph):
         """
         return self._make_toc(BAD_MODULE_TYPES)
 
+    @staticmethod
+    def _node_to_toc(node, typecode=None):
+        # TODO This is terrible. Everything in Python has a type. It's
+        # nonsensical to even speak of "nodes [that] are not typed." How
+        # would that even occur? After all, even "None" has a type! (It's
+        # "NoneType", for the curious.) Remove this, please.
+
+        # get node type e.g. Script
+        mg_type = type(node).__name__
+        assert mg_type is not None
+
+        if typecode and not (mg_type in typecode):
+            # Type is not a to be selected one, skip this one
+            return None
+        # Extract the identifier and a path if any.
+        if mg_type == 'Script':
+            # for Script nodes only, identifier is a whole path
+            (name, ext) = os.path.splitext(node.filename)
+            name = os.path.basename(name)
+        else:
+            name = node.identifier
+        path = node.filename if node.filename is not None else ''
+        # Ensure name is really 'str'. Module graph might return
+        # object type 'modulegraph.Alias' which inherits fromm 'str'.
+        # But 'marshal.dumps()' function is able to marshal only 'str'.
+        # Otherwise on Windows PyInstaller might fail with message like:
+        #
+        #   ValueError: unmarshallable object
+        name = str(name)
+        # Translate to the corresponding TOC typecode.
+        toc_type = MODULE_TYPES_TO_TOC_DICT[mg_type]
+        return (name, path, toc_type)
+
     def nodes_to_toc(self, node_list, existing_TOC=None):
         """
         Given a list of nodes, create a TOC representing those nodes.
@@ -602,15 +607,7 @@ class PyiModuleGraph(ModuleGraph):
         """
         result = existing_TOC or TOC()
         for node in node_list:
-            mg_type = type(node).__name__
-            toc_type = MODULE_TYPES_TO_TOC_DICT[mg_type]
-            if mg_type == "Script" :
-                (name, ext) = os.path.splitext(node.filename)
-                name = os.path.basename(name)
-            else:
-                name = node.identifier
-            path = node.filename if node.filename is not None else ''
-            result.append( (name, path, toc_type) )
+            result.append(self._node_to_toc(node))
         return result
 
     # Return true if the named item is in the graph as a BuiltinModule node.

--- a/PyInstaller/depend/analysis.py
+++ b/PyInstaller/depend/analysis.py
@@ -583,6 +583,13 @@ class PyiModuleGraph(ModuleGraph):
             # for Script nodes only, identifier is a whole path
             (name, ext) = os.path.splitext(node.filename)
             name = os.path.basename(name)
+        elif mg_type == 'ExtensionPackage':
+            # package with __init__ module being an extension module
+            # This needs to end up as e.g. 'mypkg/__init__.so'.
+            # Convert the packages name ('mypkg') into the module name
+            # ('mypkg.__init__') *here* to keep special cases away elsewhere
+            # (where the module name is converted to a filename).
+            name = node.identifier + ".__init__"
         else:
             name = node.identifier
         path = node.filename if node.filename is not None else ''

--- a/PyInstaller/lib/modulegraph/modulegraph.py
+++ b/PyInstaller/lib/modulegraph/modulegraph.py
@@ -847,6 +847,14 @@ class Package(BaseModule):
     pass
 
 
+class ExtensionPackage(Extension, Package):
+    """
+    Graph node representing a package where the __init__ module is an extension
+    module.
+    """
+    pass
+
+
 class NamespacePackage(Package):
     """
     Graph node representing a namespace package.
@@ -2082,6 +2090,7 @@ class ModuleGraph(ObjectGraph):
         self.msgin(2, "load_module", fqname, pathname,
                    loader.__class__.__name__)
         partname = fqname.rpartition(".")[-1]
+
         if loader.is_package(partname):
             if isinstance(loader, NAMESPACE_PACKAGE):
                 pkgpath = loader.namespace_dirs[:]  # copy for safety
@@ -2100,7 +2109,10 @@ class ModuleGraph(ObjectGraph):
                 m.filename = '-'
                 m.packagepath = ns_pkgpath
             else:
-                m = self.createNode(Package, fqname)
+                if isinstance(loader, ExtensionFileLoader):
+                    m = self.createNode(ExtensionPackage, fqname)
+                else:
+                    m = self.createNode(Package, fqname)
                 m.filename = pathname
                 # PEP-302-compliant loaders return the pathname of the
                 # `__init__`-file, not the packge directory.

--- a/news/5157.bugfix.rst
+++ b/news/5157.bugfix.rst
@@ -1,0 +1,2 @@
+Fix endless recursion if a package's ``__init__`` module is an extension
+module.

--- a/news/5157.core.rst
+++ b/news/5157.core.rst
@@ -1,0 +1,2 @@
+Use module loaders to get module content instea of an quirky way semming from
+early Python 2.x times.

--- a/tests/functional/test_regression.py
+++ b/tests/functional/test_regression.py
@@ -10,7 +10,6 @@
 #-----------------------------------------------------------------------------
 
 from importlib.machinery import EXTENSION_SUFFIXES
-import pytest
 
 from PyInstaller.depend import analysis, bindepend
 from PyInstaller.building.build_main import Analysis
@@ -80,7 +79,4 @@ def test_issue_5131(monkeypatch, tmpdir):
     script.write('import mypkg')
     a = Analysis([str(script)],
                  excludes=['encodings', 'pydoc', 'xml', 'distutils'])
-    try:
-        PYZ(a.pure, a.zipped_data)
-    except ValueError:
-        pytest.xfail(reason="solution to be implemented in the next commits")
+    PYZ(a.pure, a.zipped_data)

--- a/tests/unit/test_building_utils.py
+++ b/tests/unit/test_building_utils.py
@@ -12,6 +12,7 @@
 
 import pytest
 import os
+from importlib.machinery import EXTENSION_SUFFIXES
 
 from PyInstaller.building import utils
 
@@ -78,3 +79,17 @@ def test_format_binaries_and_datas_with_bracket(tmpdir):
 
     res = utils.format_binaries_and_datas(datas, str(tmpdir))
     assert res == expected
+
+
+def test_add_to_suffix__extension():
+    toc = [
+        ('mypkg',
+         'lib38/site-packages/mypkg' + EXTENSION_SUFFIXES[0],
+         'EXTENSION'),
+    ]
+    toc = utils.add_suffix_to_extensions(toc)
+    assert toc == [
+        ('mypkg' + EXTENSION_SUFFIXES[0],
+         'lib38/site-packages/mypkg' + EXTENSION_SUFFIXES[0],
+         'EXTENSION'),
+    ]

--- a/tests/unit/test_modulegraph_more.py
+++ b/tests/unit/test_modulegraph_more.py
@@ -75,13 +75,13 @@ def test_package(tmpdir):
 @pytest.mark.parametrize(
     "num, modname, expected_nodetype", (
         # package's __init__ module is an extension
-        (1, "myextpkg", modulegraph.Package),
+        (1, "myextpkg", modulegraph.ExtensionPackage),
         # __init__.py beside the __init__ module being an extension
-        (2, "myextpkg", modulegraph.Package),
+        (2, "myextpkg", modulegraph.ExtensionPackage),
         # Importing a module beside
         (3, "myextpkg.other", modulegraph.Extension),
         # sub-package's __init__ module is an extension
-        (4, "myextpkg.subpkg", modulegraph.Package),
+        (4, "myextpkg.subpkg", modulegraph.ExtensionPackage),
         # importing a module beside, but from a sub-package
         (5, "myextpkg.subpkg.other", modulegraph.Extension),
     ))
@@ -112,7 +112,7 @@ def test_package_init_is_extension(tmpdir, num, modname, expected_nodetype):
     module_file = create_package_files(num)
     node = _import_and_get_node(tmpdir, modname)
     assert node.__class__ is expected_nodetype
-    if expected_nodetype is modulegraph.Package:
+    if expected_nodetype is modulegraph.ExtensionPackage:
         assert node.packagepath == [module_file.dirname]
     else:
         assert node.packagepath is None  # not a package

--- a/tests/unit/test_modulegraph_more.py
+++ b/tests/unit/test_modulegraph_more.py
@@ -110,10 +110,7 @@ def test_package_init_is_extension(tmpdir, num, modname, expected_nodetype):
         return m
 
     module_file = create_package_files(num)
-    try:
-        node = _import_and_get_node(tmpdir, modname)
-    except RecursionError:
-        pytest.xfail(reason="solution to be implemented in the next commits")
+    node = _import_and_get_node(tmpdir, modname)
     assert node.__class__ is expected_nodetype
     if expected_nodetype is modulegraph.Package:
         assert node.packagepath == [module_file.dirname]
@@ -249,11 +246,11 @@ def test_import_order_1(tmpdir):
     # Ensure modulegraph processes modules in the same order as Python does.
 
     class MyModuleGraph(modulegraph.ModuleGraph):
-        def _load_module(self, fqname, fp, pathname, info):
+        def _load_module(self, fqname, pathname, loader):
             if not record or record[-1] != fqname:
                 record.append(fqname) # record non-consecutive entries
-            return super(MyModuleGraph, self)._load_module(fqname, fp,
-                                                           pathname, info)
+            return super(MyModuleGraph, self)._load_module(fqname,
+                                                           pathname, loader)
 
     record = []
 
@@ -292,11 +289,11 @@ def test_import_order_2(tmpdir):
     # Ensure modulegraph processes modules in the same order as Python does.
 
     class MyModuleGraph(modulegraph.ModuleGraph):
-        def _load_module(self, fqname, fp, pathname, info):
+        def _load_module(self, fqname, pathname, loader):
             if not record or record[-1] != fqname:
                 record.append(fqname) # record non-consecutive entries
-            return super(MyModuleGraph, self)._load_module(fqname, fp,
-                                                           pathname, info)
+            return super(MyModuleGraph, self)._load_module(fqname,
+                                                           pathname, loader)
 
     record = []
 


### PR DESCRIPTION
modulegraph's heritage includes code still based on Python 2.x capabilities on
how to find a module and get its source or code. It also contained a anomaly
regarding packages and their ``__init__``-file: If a package was detected,
it's ``__init__`` file was loaded as a module. This, while being ugly, worked
in most cases, but failed if the ``__init__`` module is an extension
module (see #5131, #4346), ending in an infinite loop. This was caused by
modulegraph distinguishing between the package and its ``__init__`` module.

The solution is to switch to "modern" loaders, both being a loader for a
specific type of modules (source, extension, etc.) and having a package
characteristic (property ``is_package()``)

This commit does the following

- In ``_find_module_path()`` no longer return "metadata" but a loader. This
  also removed huge part of this function, making it much easier to understand.
  As a side effect, this asymmetric closing of a file in a completely other
  part of the code (``_safe_import_module``) could be removed.

- Change ``_load_module`` to use the loaders.

- Merge ``_load_package`` into `__load_module``, getting rid of the anomaly
  described above.

- Adjust the test-cases to the new behavior (esp. loader instead of
  metadata-tuple and filehandle)

Please note: Since we plan to change to modulegraph2 soon anyway, I did not
spend too much time on creating a clean solution.

See #4406, closes #5131, #4346.