### PR TITLE
Hooks: Add flask_restx hook.

### DIFF
--- a/PyInstaller/hooks/hook-flask_restx.py
+++ b/PyInstaller/hooks/hook-flask_restx.py
@@ -1,0 +1,13 @@
+# -----------------------------------------------------------------------------
+# Copyright (c) 2005-2020, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+# -----------------------------------------------------------------------------
+from PyInstaller.utils.hooks import collect_data_files
+
+datas = collect_data_files('flask_restx', include_py_files=True)

--- a/news/5163.hooks.rst
+++ b/news/5163.hooks.rst
@@ -1,0 +1,1 @@
+Add a hook for `flask_restx <https://flask-restx.readthedocs.io>`_.


### PR DESCRIPTION
**Problem**:
After packaging a flask app that utilizes [`flask_restx`](https://flask-restx.readthedocs.io)  extension, I'm getting an error that indicates the package template files are missing.

**Solution**:
- Add a file hook to include the extension template files.
- Add a reference to the news changelog.

**Related Issues**:
#5162