### PR TITLE
depend: exempt OSX system Tcl/Tk libs from relative path rewrite

### DIFF
--- a/PyInstaller/depend/dylib.py
+++ b/PyInstaller/depend/dylib.py
@@ -302,12 +302,27 @@ def mac_set_relative_dylib_deps(libname, distname):
         """
         For system libraries is still used absolute path. It is unchanged.
         """
-        # Match non system dynamic libraries.
-        if not util.in_system_path(pth):
-            # Use relative path to dependent dynamic libraries based on the
-            # location of the executable.
-            return os.path.join('@loader_path', parent_dir,
-                os.path.basename(pth))
+        # Leave system dynamic libraries unchanged
+        if util.in_system_path(pth):
+            return None
+
+        # The older python.org builds that use system Tcl/Tk framework
+        # have their _tkinter.cpython-*-darwin.so library linked against
+        # /Library/Frameworks/Tcl.framework/Versions/8.5/Tcl and
+        # /Library/Frameworks/Tk.framework/Versions/8.5/Tk, although the
+        # actual frameworks are located in /System/Library/Frameworks.
+        # Therefore, they slip through the above in_system_path() check,
+        # and we need to exempt them manually.
+        _exemptions = [
+            '/Library/Frameworks/Tcl.framework/',
+            '/Library/Frameworks/Tk.framework/'
+        ]
+        if any([x in pth for x in _exemptions]):
+            return None
+
+        # Use relative path to dependent dynamic libraries based on the
+        # location of the executable.
+        return os.path.join('@loader_path', parent_dir, os.path.basename(pth))
 
     # Rewrite mach headers with @loader_path.
     dll = MachO(libname)

--- a/news/5172.core.rst
+++ b/news/5172.core.rst
@@ -1,0 +1,2 @@
+(OSX) Exempt the ``Tcl``/``Tk`` dynamic libraries in the system framework from relative path overwrite. 
+Fixes missing ``Tcl``/``Tk`` dynlib on older python.org builds that still make use of the system framework.


### PR DESCRIPTION
The older python.org builds that use system Tcl/Tk framework have their `_tkinter.cpython-*-darwin.so` library linked against `/Library/Frameworks/Tcl.framework/Versions/8.5/Tcl` and `/Library/Frameworks/Tk.framework/Versions/8.5/Tk`, although the actual frameworks are located in `/System/Library/Frameworks`.

Therefore, we fail to recognize these libraries as system ones, and rewrite their paths with relative ones. The resulting program fails to run due to missing libraries (as we do not bundle them).

To fix the issue, these two libraries need to be explicitly exempted from the path overwrite.