### PR TITLE
hooks: tkinter: collect Tcl modules directory

### DIFF
--- a/PyInstaller/hooks/hook-_tkinter.py
+++ b/PyInstaller/hooks/hook-_tkinter.py
@@ -16,7 +16,6 @@ import locale
 
 from PyInstaller.compat import is_win, is_darwin, is_unix, is_venv, \
     base_prefix, open_file, text_read_mode
-from PyInstaller.compat import modname_tkinter
 from PyInstaller.depend.bindepend import selectImports, getImports
 from PyInstaller.building.datastruct import Tree
 from PyInstaller.utils.hooks import exec_statement, logger
@@ -143,7 +142,7 @@ def _find_tcl_tk_dir():
     """
     # Python code to get path to TCL_LIBRARY.
     tcl_root = exec_statement(
-        'from %s import Tcl; print(Tcl().eval("info library"))' % modname_tkinter)
+        'from tkinter import Tcl; print(Tcl().eval("info library"))')
     tk_version = exec_statement(
         'from _tkinter import TK_VERSION; print(TK_VERSION)')
 
@@ -219,8 +218,7 @@ def _collect_tcl_modules(tcl_root):
 
     # Obtain Tcl major version.
     tcl_version = exec_statement(
-        'from %s import Tcl; print(Tcl().eval("info tclversion"))'
-        % modname_tkinter)
+        'from tkinter import Tcl; print(Tcl().eval("info tclversion"))')
     tcl_version = tcl_version.split('.')[0]
 
     modules_dirname = 'tcl' + str(tcl_version)

--- a/PyInstaller/hooks/hook-_tkinter.py
+++ b/PyInstaller/hooks/hook-_tkinter.py
@@ -205,6 +205,34 @@ def _find_tcl_tk(hook_api):
     return tcl_tk
 
 
+def _collect_tcl_modules(tcl_root):
+    """
+    Get a list of TOC-style 3-tuples describing Tcl modules. The modules
+    directory is separate from the library/data one, and is located
+    at $tcl_root/../tclX, where X is the major Tcl version.
+
+    Returns
+    -------
+    Tree
+        Such list, if the modules directory exists.
+    """
+
+    # Obtain Tcl major version.
+    tcl_version = exec_statement(
+        'from %s import Tcl; print(Tcl().eval("info tclversion"))'
+        % modname_tkinter)
+    tcl_version = tcl_version.split('.')[0]
+
+    modules_dirname = 'tcl' + str(tcl_version)
+    modules_path = os.path.join(tcl_root, '..', modules_dirname)
+
+    if not os.path.isdir(modules_path):
+        logger.warn('Tcl modules directory %s does not exist.', modules_path)
+        return []
+
+    return Tree(modules_path, prefix=modules_dirname)
+
+
 def _collect_tcl_tk_files(hook_api):
     """
     Get a list of TOC-style 3-tuples describing all external Tcl/Tk data files.
@@ -240,7 +268,10 @@ def _collect_tcl_tk_files(hook_api):
     if is_darwin:
         _warn_if_activetcl_or_teapot_installed(tcl_root, tcltree)
 
-    return (tcltree + tktree)
+    # Collect Tcl modules
+    tclmodulestree = _collect_tcl_modules(tcl_root)
+
+    return (tcltree + tktree + tclmodulestree)
 
 
 def hook(hook_api):

--- a/news/5175.hooks.rst
+++ b/news/5175.hooks.rst
@@ -1,0 +1,1 @@
+Update ``tkinter`` hook to collect Tcl modules directory (``tcl8``) in addition to Tcl/Tk data directories.


### PR DESCRIPTION
This is (hopefully) the last fix in the current series of attempts to sort out the `tkinter` and `Tcl/Tk` issues on OSX. It comes after #5013 and #5172, and addresses an issue with .app bundles. After this, I can get simple tkinter applications running in both `onedir` and `.app bundle` mode, with both python that uses system Tcl/Tk (3.6.5) and the one that uses its own Tcl/Tk (3.7.6).

-----
The Tcl modules directory is separate from the data/library one, and is typically located at `tcl_root/../tclX`, where `tcl_root` is the Tcl data/library directory and `X` is the Tcl major version.

In most (simple?) cases, failing to collect this directory does not seem to cause any issues. One notable exception are .app  bundles on OSX, which "open and close immediately" due to the following exception, caused by the missing msgcat module:
```
_tkinter.TclError: invalid command name "msgcat::mc"
```