### PR TITLE
loader: prevent local directory from shadowing system library

### DIFF
--- a/PyInstaller/loader/pyiboot01_bootstrap.py
+++ b/PyInstaller/loader/pyiboot01_bootstrap.py
@@ -126,7 +126,7 @@ try:
     def _frozen_name(name):
         if name:
             frozen_name = os.path.join(sys._MEIPASS, os.path.basename(name))
-            if os.path.exists(frozen_name):
+            if os.path.exists(frozen_name) and not os.path.isdir(frozen_name):
                 name = frozen_name
         return name
 

--- a/news/5182.core.rst
+++ b/news/5182.core.rst
@@ -1,0 +1,1 @@
+Prevent a local directory with clashing name from shadowing a system library.


### PR DESCRIPTION
When loading a system dynamic library via `ctypes.CDLL()` in a frozen progam, a local directory in `sys._MEIPASS` with a clashing basename ends up preventing the library from being loaded.

To fix this, use `os.path.isdir()` in addition to `os.path.exists()` to decide whether to use frozen or original library name.

Fixes #5178.