### PR TITLE
hooks: PyQt5.QtWebEngineWidgets: fix QTWEBENGINEPROCESS_PATH on OSX

### DIFF
--- a/PyInstaller/hooks/rthooks/pyi_rth_pyqt5webengine.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_pyqt5webengine.py
@@ -15,7 +15,7 @@ import sys
 # See ``pyi_rth_qt5.py`: use a "standard" PyQt5 layout.
 if sys.platform == 'darwin':
     os.environ['QTWEBENGINEPROCESS_PATH'] = os.path.normpath(os.path.join(
-        sys._MEIPASS, '..', 'MacOS', 'PyQt5', 'Qt', 'lib',
+        sys._MEIPASS, 'PyQt5', 'Qt', 'lib',
         'QtWebEngineCore.framework', 'Helpers', 'QtWebEngineProcess.app',
         'Contents', 'MacOS', 'QtWebEngineProcess'
     ))

--- a/news/5183.hooks.rst
+++ b/news/5183.hooks.rst
@@ -1,0 +1,1 @@
+(OSX) Fix the QTWEBENGINEPROCESS_PATH set in PyQt5.QtWebEngineWidgets rthook.


### PR DESCRIPTION
The jump from `sys._MEIPASS` to `../MacOS` when setting `QTWEBENGINEPROCESS_PATH` in the PyQt5 QWebEngine rthook causes a `Could not find QtWebEngineProcess` error in a program built in `onedir` mode.

This is because when running a program, e.g., `./dist/program/program`, the `sys._MEIPASS` is `dist/program`, and due to the jump, the `QTWEBENGINEPROCESS_PATH` incorrectly becomes `dist/MacOS/PyQt5/...` instead of `dist/program/PyQt5/...`.

The .app bundle works correctly, because its `sys._MEIPASS` becomes `dist/program.app/Contents/MacOS`, so the jump effectively comes back to the original directory.

This commit removes the `../MacOS` jump, so that `QTWEBENGINEPROCESS_PATH` contains correct path for both `onedir`
and `.app` bundle builds. The path is now set in the same manner as in the corresponding PySide2 rthook, which already works as expected.