### PR TITLE
bootloader: pyi_path_fullpath: use _wfullpath()

### DIFF
--- a/bootloader/src/pyi_path.c
+++ b/bootloader/src/pyi_path.c
@@ -186,8 +186,20 @@ int
 pyi_path_fullpath(char *abs, size_t abs_size, const char *rel)
 {
 #ifdef _WIN32
-    /* TODO use _wfullpath - wchar_t function. */
-    return _fullpath(abs, rel, abs_size) != NULL;
+    wchar_t wrel[PATH_MAX + 1];
+    wchar_t *wabs = NULL;
+
+    pyi_win32_utils_from_utf8(wrel, rel, PATH_MAX);
+
+    wabs = _wfullpath(NULL, wrel, PATH_MAX);
+    if (wabs == NULL) {
+        return 0;
+    }
+
+    char *ret = pyi_win32_utils_to_utf8(abs, wabs, abs_size);
+    free(wabs);
+
+    return ret != NULL;
 #else
     return realpath(rel, abs) != NULL;
 #endif

--- a/news/5189.bootloader.rst
+++ b/news/5189.bootloader.rst
@@ -1,0 +1,1 @@
+(Windows) Use ``_wfullpath()`` instead of ``_fullpath()`` in ``pyi_path_fullpath`` to allow non-ASCII characters in the path.


### PR DESCRIPTION
Use `_wfullpath()` instead of `_fullpath()` in `pyi_path_fullpath` to allow non-ASCII characters in the path.

Fixes #5184.