### PR TITLE
tests: test_time_module_localized: use cs_CZ.UTF-8 on all OSes

### DIFF
--- a/tests/functional/test_basic.py
+++ b/tests/functional/test_basic.py
@@ -402,8 +402,7 @@ def test_time_module_localized(pyi_builder, monkeypatch):
     # every function was using different locale:
     # time.ctime was using 'C'
     # time.strptime was using 'xx_YY' from the environment.
-    lang = 'cs_CZ' if is_darwin else 'cs_CZ.UTF-8'
-    monkeypatch.setenv('LC_ALL', lang)
+    monkeypatch.setenv('LC_ALL', 'cs_CZ.UTF-8')
     pyi_builder.test_source(
         """
         import time


### PR DESCRIPTION
Removed the macOS-specific `LC_ALL=cs_CZ` in the test; on all OSes we now use `cs_CZ.UTF-8`. Using `LC_ALL=cs_CZ` causes error on macOS when running under python 3.8, whereas `cs_CZ.UTF-8` seems to work just fine with python 3.5 - 3.8.