### PR TITLE
hooks: Add `exclude_datas` to utils.hooks.collect_all().

### DIFF
--- a/PyInstaller/hooks/hook-gevent.py
+++ b/PyInstaller/hooks/hook-gevent.py
@@ -13,4 +13,7 @@ from PyInstaller.utils.hooks import collect_all
 
 excludedimports = ["gevent.testing", "gevent.tests"]
 
-datas, binaries, hiddenimports = collect_all('gevent')
+datas, binaries, hiddenimports = collect_all(
+    'gevent',
+    filter_submodules=lambda name: (
+        "gevent.testing" not in name or "gevent.tests" not in name))

--- a/PyInstaller/utils/hooks/__init__.py
+++ b/PyInstaller/utils/hooks/__init__.py
@@ -1032,15 +1032,22 @@ def requirements_for_package(package_name):
 # ``collect_data_files``.
 #
 # Typical use: ``datas, binaries, hiddenimports = collect_all('my_module_name')``.
-def collect_all(package_name, include_py_files=True):
+def collect_all(
+        package_name, include_py_files=True, filter_submodules=None,
+        exclude_datas=None, include_datas=None):
     datas = []
     try:
         datas += copy_metadata(package_name)
     except Exception as e:
         logger.warning('Unable to copy metadata for %s: %s', package_name, e)
-    datas += collect_data_files(package_name, include_py_files)
+    datas += collect_data_files(package_name, include_py_files,
+                                excludes=exclude_datas, includes=include_datas)
     binaries = collect_dynamic_libs(package_name)
-    hiddenimports = collect_submodules(package_name)
+    if filter_submodules:
+        hiddenimports = collect_submodules(package_name,
+                                           filter=filter_submodules)
+    else:
+        hiddenimports = collect_submodules(package_name)
     try:
         hiddenimports += requirements_for_package(package_name)
     except Exception as e:

--- a/news/5113.hooks.rst
+++ b/news/5113.hooks.rst
@@ -1,1 +1,1 @@
-Add `exclude_datas` to utils.hooks.collect_all() to allow caller to exclude datafiles.
+Add ``exclude_datas``, ``include_datas``, and ``filter_submodules`` to ``collect_all()``. These arguments map to the ``excludes`` and ``includes`` arguments of ``collect_data_files``, and to the `filter` argument of ``collect_submodules``.

--- a/news/5113.hooks.rst
+++ b/news/5113.hooks.rst
@@ -1,0 +1,1 @@
+Add `exclude_datas` to utils.hooks.collect_all() to allow caller to exclude datafiles.

--- a/news/5201.hooks.rst
+++ b/news/5201.hooks.rst
@@ -1,0 +1,1 @@
+Modify hook for ``gevent`` to exclude test submodules.


### PR DESCRIPTION
utils.hooks.collect_all() now contains an `exclude_datas` parameter
that is passed to util.hooks.collect_data_files(). This means that
when calling utils.hooks.collect_all() the caller can exclude
datafiles they select. Fixes #5113