### PR TITLE
Doc: add pathlib example for finding data files at runtime

### DIFF
--- a/doc/_common_definitions.txt
+++ b/doc/_common_definitions.txt
@@ -39,6 +39,7 @@
 .. _netpbm package: http://netpbm.sourceforge.net/
 .. _NextCloud: https://nextcloud.org
 .. _Parallels: http://www.parallels.com
+.. _pathlib: https://docs.python.org/3/library/pathlib.html
 .. _pefile: https://pypi.python.org/pypi/pefile/
 .. _PIL: http://www.pythonware.com/products/pil/
 .. _pip: http://www.pip-installer.org/

--- a/doc/runtime-information.rst
+++ b/doc/runtime-information.rst
@@ -59,6 +59,18 @@ bundled and in the bundle folder if it is bundled::
     bundle_dir = getattr(sys, '_MEIPASS', path.abspath(path.dirname(__file__)))
     path_to_dat = path.abspath(path.join(bundle_dir, 'other-file.dat'))
 
+Or, if you'd rather use pathlib_::
+
+    from pathlib import Path
+    import sys
+
+    if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
+        bundle_dir = Path(sys._MEIPASS)
+    else:
+        bundle_dir = Path(__file__).parent
+
+    path_to_dat = bundle_dir.absolute() / "other-file.dat"
+
 It is always best to use absolute paths, so
 ``path.abspath(path.join(bundle_dir, 'other-file.dat'))`` is preferred over
 ``path.join(bundle_dir, 'other-file.dat')``. Using absolute paths means that

--- a/doc/runtime-information.rst
+++ b/doc/runtime-information.rst
@@ -73,10 +73,14 @@ Or, if you'd rather use pathlib_::
 
 It is always best to use absolute paths, so
 ``path.abspath(path.join(bundle_dir, 'other-file.dat'))`` is preferred over
-``path.join(bundle_dir, 'other-file.dat')``. Using absolute paths means that
-you're less likely to encounter errors that can occur when using relative
-paths.
+``path.join(bundle_dir, 'other-file.dat')``. Using relative paths can lead to
+confusing errors should you attempt to find the parent of the current working
+directory. You'll get the incorrect value ``''`` instead of the expected
+``'..'``::
 
+    >>> from os import path
+    >>> path.dirname(".")
+    ''
 
 Using ``sys.executable`` and ``sys.argv[0]``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
I also threw in a little section to say that *if you can put the data files where they're expected to be then you can avoid this altogether*.