### PR TITLE
build: Fix AppImage builds.

### DIFF
--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -233,7 +233,9 @@ class PKG(Target):
                 # file is contained within python egg, it is added with the egg
                 continue
             if typ in ('BINARY', 'EXTENSION', 'DEPENDENCY'):
-                if not self.exclude_binaries or typ == 'DEPENDENCY':
+                if self.exclude_binaries and typ == 'EXTENSION':
+                    self.dependencies.append((inm, fnm, typ))
+                elif not self.exclude_binaries or typ == 'DEPENDENCY':
                     if typ == 'BINARY':
                         # Avoid importing the same binary extension twice. This might
                         # happen if they come from different sources (eg. once from

--- a/news/4693.build.rst
+++ b/news/4693.build.rst
@@ -1,0 +1,1 @@
+Fix AppImage builds that were broken since PyInstaller 3.6.


### PR DESCRIPTION
AppImage builds were broken since the commit 392aba1.
The original behavior is now restored and more specific, it will hopefully introduce no regression on the MSYS2 side.

Fixes #4693.