### PR TITLE
Add a warning in the docs that the -u option does not work on Windows.

### DIFF
--- a/doc/spec-files.rst
+++ b/doc/spec-files.rst
@@ -359,6 +359,8 @@ For example modify the spec file this way::
           exclude_binaries=...
           )
 
+.. Warning:: The ``u`` option does not work on Windows. See this `GitHub issue <https://github.com/pyinstaller/pyinstaller/issues/1441>`_ for more details.
+
 
 .. _spec file options for a mac os x bundle:
 


### PR DESCRIPTION
The relevant issue https://github.com/pyinstaller/pyinstaller/issues/1441 which will maybe provide a fix in the future is linked.