### PR TITLE
bootloader: replace strncpy() with snprintf()

### DIFF
--- a/bootloader/src/pyi_path.c
+++ b/bootloader/src/pyi_path.c
@@ -83,7 +83,9 @@ pyi_path_dirname(char *result, const char *path)
         return false;
     }
     dirpart = (char *) dirname((char *) tmp);  /* _XOPEN_SOURCE - no 'const'. */
-    strncpy(result, dirpart, PATH_MAX);
+    if (snprintf(result, PATH_MAX, "%s", dirpart) >= PATH_MAX) {
+        return false;
+    }
 #endif /* ifndef HAVE_DIRNAME */
     return true;
 }

--- a/news/5212.bootloader.rst
+++ b/news/5212.bootloader.rst
@@ -1,0 +1,1 @@
+(GNU/Linux) Replace a ``strncpy()`` call in ``pyi_path_dirname()`` with ``snprintf()`` to ensure that the resulting string is always null-terminated.


### PR DESCRIPTION
Replace a `strncpy()` call in `pyi_path_dirname()` with `snprintf()` to ensure that the resulting string is always null-terminated.
    
Fixes potential issue that is detected and warned against by newer versions of `gcc`, e.g. `gcc` 10 on Fedora 32:
```
In file included from /usr/include/string.h:495,
                 from ../../src/pyi_path.c:37:
In function ‘strncpy’,
    inlined from ‘pyi_path_dirname’ at ../../src/pyi_path.c:86:5,
    inlined from ‘pyi_path_fullpath_keep_basename’ at ../../src/pyi_path.c:174:5:
/usr/include/bits/string_fortified.h:106:10: error: ‘__builtin_strncpy’ specified bound 4096 equals destination size [-Werror=stringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
         |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```