### PR TITLE
bootloader: on Windows, use user's SID to create directories

### DIFF
--- a/news/5216.bootloader.rst
+++ b/news/5216.bootloader.rst
@@ -1,0 +1,3 @@
+(Windows) Create temporary directories with user's SID instead of ``S-1-3-4``,
+to work around the lack of support for the latter in ``wine``.
+This enables ``onefile`` builds to run under ``wine`` again.


### PR DESCRIPTION
Retrieve and use current user's SID instead of using S-1-3-4, which is unsupported by wine. Fixes #4628.

----

This is a possible work-around on our side to address #4628. Instead of creating directory with permissions specified under SID "S-1-3-4" (which is unsupported by wine), we look up and use the user's SID.