### PR TITLE
 hooks: tkinter: avoid collecting data from system Tcl/Tk framework on macOS

### DIFF
--- a/PyInstaller/hooks/hook-_tkinter.py
+++ b/PyInstaller/hooks/hook-_tkinter.py
@@ -179,8 +179,8 @@ def _find_tcl_tk(hook_api):
                 # to
                 #     [('Tcl', '/path/to/Tcl'), ('Tk', '/path/to/Tk')]
                 mapping = {}
-                for l in bins:
-                    mapping[os.path.basename(l)] = l
+                for lib in bins:
+                    mapping[os.path.basename(lib)] = lib
                 bins = [
                     ('Tcl', mapping['Tcl']),
                     ('Tk', mapping['Tk']),

--- a/PyInstaller/hooks/rthooks/pyi_rth__tkinter.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth__tkinter.py
@@ -16,11 +16,18 @@ import sys
 tcldir = os.path.join(sys._MEIPASS, 'tcl')
 tkdir = os.path.join(sys._MEIPASS, 'tk')
 
-if not os.path.isdir(tcldir):
-    raise FileNotFoundError('Tcl data directory "%s" not found.' % (tcldir))
-if not os.path.isdir(tkdir):
-    raise FileNotFoundError('Tk data directory "%s" not found.' % (tkdir))
+# Notify "tkinter" of data directories.
+# On macOS, we do not collect data directories if system Tcl/Tk
+# framework is used. On other OSes, we always collect them, so their
+# absence is considered an error.
+is_darwin = sys.platform == 'darwin'
 
-# Notify "tkinter" of such directories.
-os.environ["TCL_LIBRARY"] = tcldir
-os.environ["TK_LIBRARY"] = tkdir
+if os.path.isdir(tcldir):
+    os.environ["TCL_LIBRARY"] = tcldir
+elif not is_darwin:
+    raise FileNotFoundError('Tcl data directory "%s" not found.' % (tcldir))
+
+if os.path.isdir(tkdir):
+    os.environ["TK_LIBRARY"] = tkdir
+elif not is_darwin:
+    raise FileNotFoundError('Tk data directory "%s" not found.' % (tkdir))

--- a/news/5217.hooks.rst
+++ b/news/5217.hooks.rst
@@ -1,0 +1,3 @@
+(OSX) Avoid collecting data from system Tcl/Tk framework in ``tkinter`` hook 
+as we do not collect their shared libraries, either.
+Affects only python versions that still use the system Tcl/Tk 8.5.


### PR DESCRIPTION
After a discussion with @bwoodsend, we reached conclusion that in the case of system Tcl/Tk framework on macOS, it makes no sense to collect data when we do not collect the shared library (which we do not; and is not needed anymore as #5172 ensures that the system libraries are used correctly). So this PR removes the collection of data from macOS' system Tcl/Tk. This affects only python builds that use system Tcl/Tk - older python.org builds (e.g., 32/64-bit 3.6.5) and apparently homebrew python.

As a bonus, this also takes care of the error in `tkinter` hook with homebrew python on macOS 11, which was reported in #5040.

-----

On macOS, we do not collect system libraries in general; if `tkinter` uses system Tcl/Tk 8.5 framework (older 32/64-bit
python.org builds, or brew python), we do not collect its Tk and Tcl shared library, either. Therefore, it makes little sense to
collect the data (scripts and modules) from the system framework, either.

This commit modifies the behavior of both `_tkinter` stdhook and rthook on macOS. The stdhook now treats `(None, None)` returned by `_find_tcl_tk()` as an indicator that the system framework is used and that data directories should not be collected. The rthook now sets `TCL_LIBRARY` and `TK_LIBRARY` environment variables if collected tcl and tk directories exist, but does not raise error anymore if they do not (under assumption that they have not been collected from the system framework).

The behavior under other OSes remains unchanged.