### PR TITLE
Tests: Fix test_osx_custom_protocol_handler() on Python 3.5

### DIFF
--- a/tests/functional/test_apple_events.py
+++ b/tests/functional/test_apple_events.py
@@ -26,6 +26,7 @@ from PyInstaller.utils.tests import skipif_notosx
 
 @skipif_notosx
 def test_osx_custom_protocol_handler(tmpdir, pyi_builder_spec):
+    tmpdir = str(tmpdir)  # Fix for Python 3.5
     app_path = os.path.join(tmpdir, 'dist',
                             'pyi_osx_custom_protocol_handler.app')
     logfile_path = os.path.join(tmpdir, 'dist', 'args.log')


### PR DESCRIPTION
Fix this error on Python 3.5:
```
test_osx_custom_protocol_handler failed (1 runs remaining out of 2).
	<class 'TypeError'>
	join() argument must be str or bytes, not 'LocalPath'
	[<TracebackEntry /Users/runner/work/pyinstaller/pyinstaller/tests/functional/test_apple_events.py:30>, 
```

I kept the change very simple to ease its deletion when 3.5 will be out of support.