### PR TITLE
build: OSX: Improve codesigning and notarization robustness.

### DIFF
--- a/PyInstaller/building/osx.py
+++ b/PyInstaller/building/osx.py
@@ -174,7 +174,7 @@ class BUNDLE(Target):
                 fnm = checkCache(fnm, strip=self.strip, upx=self.upx,
                                  upx_exclude=self.upx_exclude, dist_nm=inm)
             # Add most data files to a list for symlinking later.
-            if typ == 'DATA' and base_path not in ('base_library.zip', 'PySide2', 'PyQt5'):
+            if typ == 'DATA' and base_path not in ('PySide2', 'PyQt5'):
                 links.append((inm, fnm))
             else:
                 tofnm = os.path.join(self.name, "Contents", "MacOS", inm)

--- a/news/3550.build.rst
+++ b/news/3550.build.rst
@@ -1,0 +1,1 @@
+OSX: Improve codesigning and notarization robustness.


### PR DESCRIPTION
Move the `base_library.zip` file to the `Resources` folder of the app and link it to the `MacOS` folder.

Fixes #3550.
Fixes #5112.