### PR TITLE
bootloader: on linux, fully resolve the executable name while preserving process name

### DIFF
--- a/bootloader/src/pyi_path.c
+++ b/bootloader/src/pyi_path.c
@@ -290,23 +290,21 @@ pyi_path_executable(char *execfile, const char *appname)
 #else /* ifdef _WIN32 */
     /* On Linux, FreeBSD, and Solaris, we try these /proc paths first
      */
-    size_t result = -1;
+    size_t name_len = -1;
 
     #if defined(__linux__)
-    result = readlink("/proc/self/exe", execfile, PATH_MAX);  /* Linux */
+    name_len = readlink("/proc/self/exe", execfile, PATH_MAX-1);  /* Linux */
     #elif defined(__FreeBSD__)
-    result = readlink("/proc/curproc/file", execfile, PATH_MAX);  /* FreeBSD */
+    name_len = readlink("/proc/curproc/file", execfile, PATH_MAX-1);  /* FreeBSD */
     #elif defined(__sun)
-    result = readlink("/proc/self/path/a.out", execfile, PATH_MAX);  /* Solaris */
+    name_len = readlink("/proc/self/path/a.out", execfile, PATH_MAX-1);  /* Solaris */
     #endif
 
-    if (-1 != result) {
+    if (name_len != -1) {
         /* execfile is not yet zero-terminated. result is the byte count. */
-        *(execfile + result) = '\0';
+        *(execfile + name_len) = '\0';
     } else {
-        char buffer[PATH_MAX];
-
-        if (appname[0] == PYI_SEP || strchr(appname, PYI_SEP)) {
+        if (strchr(appname, PYI_SEP)) {
             /* Absolute or relative path: Canonicalize directory path,
              * but keep original basename.
              */
@@ -318,11 +316,12 @@ pyi_path_executable(char *execfile, const char *appname)
         else {
             /* No absolute or relative path, just program name: search $PATH.
              */
+            char buffer[PATH_MAX];
             if (! pyi_search_path(buffer, appname)) {
                 /* Searching $PATH failed, user is crazy. */
                 VS("LOADER: Searching $PATH failed for %s", appname);
                 if (snprintf(buffer, PATH_MAX, "%s", appname) >= PATH_MAX) {
-                    VS("LOADER: Appname too large %s\n", appname);
+                    VS("LOADER: Full path to application exceeds PATH_MAX: %s\n", appname);
                     return false;
                 }
             }

--- a/news/5232.bootloader.rst
+++ b/news/5232.bootloader.rst
@@ -1,0 +1,1 @@
+(GNU/Linux) Reintroduce executable resolution via ``readlink()`` on ``/proc/self/exe`` and preserve the process name using ``prctl()`` with ``PR_GET_NAME`` and ``PR_SET_NAME``.


### PR DESCRIPTION
This is a proof-of-concept fix for #4674, #4693, and #5179. It effectively reverts ebcd49c to bring back full executable name resolution via `readlink()` on the corresponding `/proc` entry - failing to do so seems to be the cause of #4674 and #4693. The second part of PR addresses the process name issue by using `prctl()` and an environment variable to pass the process name from parent to child launcher process.

With the modified bootloader, the existing `test_symlink_basename_is_kept` tests keep passing, and the `test_appimage_loading` added by #5229 also passes now.