### PR TITLE
hooks: hook-gevent no longer bundles unnecessary files.

### DIFF
--- a/PyInstaller/hooks/hook-gevent.py
+++ b/PyInstaller/hooks/hook-gevent.py
@@ -16,4 +16,6 @@ excludedimports = ["gevent.testing", "gevent.tests"]
 datas, binaries, hiddenimports = collect_all(
     'gevent',
     filter_submodules=lambda name: (
-        "gevent.testing" not in name or "gevent.tests" not in name))
+        "gevent.testing" not in name or "gevent.tests" not in name),
+    include_py_files=False,
+    exclude_datas=["**/tests"])

--- a/news/4857.hooks.rst
+++ b/news/4857.hooks.rst
@@ -1,0 +1,1 @@
+Gevent hook does not unnecessarily bundle HTML documentation, __pycache__ folders, tests nor generated .c and .h files


### PR DESCRIPTION
hook-gevent.py now passes False to the include_py_files argument and
["**/tests"] to the exclude_datas argument of collect_all() when
calling it.  This means that hook-gevent.py no longer bundles
__pycache__ folders, .c, .h files, tests nor HTML documentation.
Fixes #4857.