### PR TITLE
 hookutils: robustify the collect_submodules() function

### DIFF
--- a/news/5244.hooks.rst
+++ b/news/5244.hooks.rst
@@ -1,0 +1,1 @@
+Prevent output to ``stdout`` during module imports from ending up in the modules list collected by ``collect_submodules``.

--- a/tests/unit/hookutils_files2/foo/bar/__init__.py
+++ b/tests/unit/hookutils_files2/foo/bar/__init__.py
@@ -1,0 +1,2 @@
+# Print something to stdout
+print("Hello world!")

--- a/tests/unit/test_hookutils.py
+++ b/tests/unit/test_hookutils.py
@@ -183,20 +183,23 @@ class TestCollectSubmodules(object):
         ml = collect_submodules(TEST_MOD)
         self.test_collect_submod_all_included(ml)
 
-
     # Messages printed to stdout by modules during collect_submodules()
     # should not affect the collected modules list.
-    def test_collect_submod_stdout_interference (self, monkeypatch):
+    def test_collect_submod_stdout_interference(self, monkeypatch):
         TEST_MOD = 'foo'
-        TEST_MOD_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'hookutils_files2')
+        TEST_MOD_PATH = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            'hookutils_files2'
+        )
 
-        monkeypatch.setattr('PyInstaller.config.CONF', {'pathex': [TEST_MOD_PATH]})
+        monkeypatch.setattr('PyInstaller.config.CONF',
+                            {'pathex': [TEST_MOD_PATH]})
         monkeypatch.syspath_prepend(TEST_MOD_PATH)
 
         ml = collect_submodules(TEST_MOD)
         ml = sorted(ml)
 
-        assert ml == [ 'foo', 'foo.bar' ]
+        assert ml == ['foo', 'foo.bar']
 
 
 def test_is_module_or_submodule():

--- a/tests/unit/test_hookutils.py
+++ b/tests/unit/test_hookutils.py
@@ -184,6 +184,21 @@ class TestCollectSubmodules(object):
         self.test_collect_submod_all_included(ml)
 
 
+    # Messages printed to stdout by modules during collect_submodules()
+    # should not affect the collected modules list.
+    def test_collect_submod_stdout_interference (self, monkeypatch):
+        TEST_MOD = 'foo'
+        TEST_MOD_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'hookutils_files2')
+
+        monkeypatch.setattr('PyInstaller.config.CONF', {'pathex': [TEST_MOD_PATH]})
+        monkeypatch.syspath_prepend(TEST_MOD_PATH)
+
+        ml = collect_submodules(TEST_MOD)
+        ml = sorted(ml)
+
+        assert ml == [ 'foo', 'foo.bar' ]
+
+
 def test_is_module_or_submodule():
     assert is_module_or_submodule('foo.bar', 'foo.bar')
     assert is_module_or_submodule('foo.bar.baz', 'foo.bar')


### PR DESCRIPTION
Prevent the extra output to stdout during module import from showing up in the modules list collected by `collect_submodules()`.
The package-walking process now encloses the output module names with special prefix and suffix, which allows us to discard extra lines.

This fixes the issue with parts of error messages ending up in the hidden imports (and consequently in warnings about these
spurious modules not being found), as reported in #4813.

The PR also adds a new test, `test_collect_submod_stdout_interference` for testing the effect of extra output to stdout during module import process on the collected submodules list.