### PR TITLE
hooks: update keyring hook

### DIFF
--- a/PyInstaller/hooks/hook-keyring.py
+++ b/PyInstaller/hooks/hook-keyring.py
@@ -9,8 +9,12 @@
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
 
-# Tested with keyring 3.7 on MacOS.
+from PyInstaller.utils.hooks import collect_submodules, copy_metadata
 
-from PyInstaller.utils.hooks import collect_submodules
-
+# Collect backends
 hiddenimports = collect_submodules('keyring.backends')
+
+# Keyring performs backend plugin discovery using setuptools entry points,
+# which are listed in the metadata. Therefore, we need to copy the
+# metadata, otherwise no backends will be found at run-time.
+datas = copy_metadata('keyring')

--- a/news/5245.hooks.rst
+++ b/news/5245.hooks.rst
@@ -1,0 +1,1 @@
+Update ``keyring`` hook to collect metadata, which is required for backend discovery.

--- a/tests/functional/test_libraries.py
+++ b/tests/functional/test_libraries.py
@@ -362,7 +362,11 @@ def test_idlelib(pyi_builder):
 
 @importorskip('keyring')
 def test_keyring(pyi_builder):
-    pyi_builder.test_source("import keyring")
+    pyi_builder.test_source(
+        """
+        import keyring
+        keyring.get_password("test", "test")
+        """)
 
 
 @importorskip('numpy')

--- a/tests/functional/test_libraries.py
+++ b/tests/functional/test_libraries.py
@@ -361,6 +361,9 @@ def test_idlelib(pyi_builder):
 
 
 @importorskip('keyring')
+@skipif(is_linux, reason="SecretStorage backend on linux requires active "
+                         "D-BUS session and initialized keyring, and may "
+                         "need to unlock the keyring via UI prompt.")
 def test_keyring(pyi_builder):
     pyi_builder.test_source(
         """


### PR DESCRIPTION
Update `keyring` hook for compatibility with recent versions of `keyring` work. Tested on linux, Windows and macOS.

Fixes #4569.