### PR TITLE
 hooks: add a hook for win32ctypes.core

### DIFF
--- a/PyInstaller/hooks/hook-win32ctypes.core.py
+++ b/PyInstaller/hooks/hook-win32ctypes.core.py
@@ -1,0 +1,22 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2020, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+# TODO: remove this hook during PyInstaller 4.5 release cycle!
+
+from PyInstaller.utils.hooks import can_import_module, collect_submodules
+
+# We need to collect submodules from win32ctypes.core.cffi or
+# win32ctypes.core.ctypes for win32ctypes.core to work. The use of
+# the backend is determined by availability of cffi.
+if can_import_module('cffi'):
+    hiddenimports = collect_submodules('win32ctypes.core.cffi')
+else:
+    hiddenimports = collect_submodules('win32ctypes.core.ctypes')

--- a/news/5250.hooks.rst
+++ b/news/5250.hooks.rst
@@ -1,0 +1,1 @@
+(Windows) Add a hook for ``win32ctypes.core``.

--- a/tests/functional/test_libraries.py
+++ b/tests/functional/test_libraries.py
@@ -623,3 +623,12 @@ def test_pandas_extension(pyi_builder):
         assert is_float(1) == 0
         """)
 
+
+@importorskip('win32ctypes')
+@pytest.mark.skipif(not is_win,
+                    reason='pywin32-ctypes is supported only on Windows')
+@pytest.mark.parametrize('submodule', ['win32api', 'win32cred', 'pywintypes'])
+def test_pywin32ctypes(pyi_builder, submodule):
+    pyi_builder.test_source("""
+        from win32ctypes.pywin32 import {0}
+        """.format(submodule))


### PR DESCRIPTION
We need a hook to collect all submodules from `win32ctypes.core.cffi` or `win32ctypes.core.ctypes` (depending on availability of `cffi`) to avoid missing module errors when using `win32ctypes` pywin32 compatibility layer.