### PR TITLE
[RFC] compat: ignore errors when decoding output from executed commands

### DIFF
--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -316,7 +316,7 @@ def exec_command(*cmdargs, **kwargs):
     # Thus we need to convert that to proper encoding.
     try:
         if encoding:
-            out = out.decode(encoding)
+            out = out.decode(encoding, errors='replace')
         else:
             # If no encoding is given, assume we're reading filenames from
             # stdout only because it's the common case.
@@ -416,7 +416,7 @@ def exec_command_stdout(*command_args, **kwargs):
     stdout = subprocess.check_output(command_args, **kwargs)
 
     # Return a Unicode string, decoded from this encoded byte array if needed.
-    return stdout if encoding is None else stdout.decode(encoding)
+    return stdout if encoding is None else stdout.decode(encoding, errors='replace')
 
 
 def exec_command_all(*cmdargs, **kwargs):
@@ -459,8 +459,8 @@ def exec_command_all(*cmdargs, **kwargs):
     # Thus we need to convert that to proper encoding.
     try:
         if encoding:
-            out = out.decode(encoding)
-            err = err.decode(encoding)
+            out = out.decode(encoding, errors='replace')
+            err = err.decode(encoding, errors='replace')
         else:
             # If no encoding is given, assume we're reading filenames from
             # stdout only because it's the common case.

--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -314,22 +314,13 @@ def exec_command(*cmdargs, **kwargs):
 
     # stdout/stderr are returned as a byte array NOT as string.
     # Thus we need to convert that to proper encoding.
-    try:
-        if encoding:
-            out = out.decode(encoding, errors='replace')
-        else:
-            # If no encoding is given, assume we're reading filenames from
-            # stdout only because it's the common case.
-            out = os.fsdecode(out)
-    except UnicodeDecodeError as e:
-        # The sub-process used a different encoding,
-        # provide more information to ease debugging.
-        print('--' * 20, file=sys.stderr)
-        print(str(e), file=sys.stderr)
-        print('These are the bytes around the offending byte:',
-              file=sys.stderr)
-        print('--' * 20, file=sys.stderr)
-        raise
+    if encoding:
+        out = out.decode(encoding, errors='replace')
+    else:
+        # If no encoding is given, assume we're reading filenames from
+        # stdout only because it's the common case.
+        out = os.fsdecode(out)
+
     return out
 
 
@@ -457,24 +448,14 @@ def exec_command_all(*cmdargs, **kwargs):
     out, err = proc.communicate()
     # stdout/stderr are returned as a byte array NOT as string.
     # Thus we need to convert that to proper encoding.
-    try:
-        if encoding:
-            out = out.decode(encoding, errors='replace')
-            err = err.decode(encoding, errors='replace')
-        else:
-            # If no encoding is given, assume we're reading filenames from
-            # stdout only because it's the common case.
-            out = os.fsdecode(out)
-            err = os.fsdecode(err)
-    except UnicodeDecodeError as e:
-        # The sub-process used a different encoding,
-        # provide more information to ease debugging.
-        print('--' * 20, file=sys.stderr)
-        print(str(e), file=sys.stderr)
-        print('These are the bytes around the offending byte:',
-              file=sys.stderr)
-        print('--' * 20, file=sys.stderr)
-        raise
+    if encoding:
+        out = out.decode(encoding, errors='replace')
+        err = err.decode(encoding, errors='replace')
+    else:
+        # If no encoding is given, assume we're reading filenames from
+        # stdout only because it's the common case.
+        out = os.fsdecode(out)
+        err = os.fsdecode(err)
 
     return proc.returncode, out, err
 

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -9,20 +9,20 @@
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
 
-from PyInstaller.utils.tests import skipif
-
-import pytest
-
 from PyInstaller import compat
 
 
-def test_exec_command_subprocess_wrong_encoding_reports_nicely(capsys):
-    # Ensure a nice error message is printed if decoding the output of the
-    # subprocess fails.
-    # Actually `exec_python()` is used for running the progam, so we can use a
+def test_exec_command_subprocess_wrong_encoding_stdout_salvageable():
+    # Ensure that even if the stdout of the executed command contains
+    # invalid characters (mismatched encoding or just garbage), the
+    # rest of the output is still salvageable and can be parsed.
+    # `exec_python()` is used for running the progam, so we can use a
     # small Python script.
-    prog = ("""import sys; sys.stdout.buffer.write(b'dfadfadf\\xa0:::::')""")
-    with pytest.raises(UnicodeDecodeError):
-        res = compat.exec_python('-c', prog)
-    out, err = capsys.readouterr()
-    assert 'bytes around the offending' in err
+    prog = (
+        "import sys; "
+        "sys.stdout.buffer.write(b'dfadfadf\\xa0:::::'); "
+        "sys.stdout.buffer.write(b'MessageOfInterest')"
+    )
+
+    out = compat.exec_python('-c', prog)
+    assert 'MessageOfInterest' in out


### PR DESCRIPTION
Use `decode(..., errors='replace')` when decoding `stdout` (and `stderr` if applicable) from the process executed in `exec_command()`, `exec_command_stdout()`, and `exec_command_all()`. This will replace any invalid characters with
? instead of raising `UnicodeDecodeError`.

The problem with the strict decoding is that we actually have no control over the encoding of the data in `stdout`. The process we
execute may directly or indirectly spawn another process with merged `stdout` (and perhaps even redirected `stderr`), and the data from that process may use arbitrary encoding that differs from the one that the original process is using. In such situations, strict decoding will lead to `UnicodeDecodeError` in places where this is difficult to handle (e.g., `collect_submodules()` call in a hook). Therefore, replacing offending characters with ? seems like a lesser evil.

An example of the above scenario is happening in #2258. The `collect_submodules()` call in the hook for `zmq` is triggering an
import for `zmq.backend.cffi`, which tries to compile a C extension module by invoking MSC `cl.exe`. The latter returns localized  error message encoded in the local codepage (different from utf-8 in default configurations), resulting in `UnicodeDecodeError` in
the hook.