### PR TITLE
Avoid segfault when temp path is missing

### DIFF
--- a/bootloader/src/pyi_utils.c
+++ b/bootloader/src/pyi_utils.c
@@ -513,6 +513,9 @@ pyi_remove_temp_path(const char *dir)
         dirnmlen++;
     }
     ds = opendir(dir);
+    if (!ds) {
+        return;
+    }
     finfo = readdir(ds);
 
     while (finfo) {

--- a/news/5255.bootloader.rst
+++ b/news/5255.bootloader.rst
@@ -1,0 +1,1 @@
+(GNU/Linux) Avoid segfault when temp path is missing.


### PR DESCRIPTION
If the temp path is removed during application runtime (by a /tmp
cleaning script for example), the application will segfault on exit due
to calling readdir on a NULL pointer. Fix this issue by returning
immediately if the opendir fails.