### PR TITLE
bootloader: On Unix fix path lookup of archive

### DIFF
--- a/bootloader/src/pyi_path.c
+++ b/bootloader/src/pyi_path.c
@@ -293,7 +293,7 @@ pyi_path_executable(char *execfile, const char *appname)
         if (! pyi_search_path(buffer, appname)) {
             /* Searching $PATH failed, user is crazy. */
             VS("LOADER: Searching $PATH failed for %s", appname);
-            if (snprintf(buffer, PATH_MAX, "%s", "appname") >= PATH_MAX) {
+            if (snprintf(buffer, PATH_MAX, "%s", appname) >= PATH_MAX) {
                 VS("LOADER: Appname too large %s\n", appname);
                 return false;
             }


### PR DESCRIPTION
Fixes #5257
Fixed path resolution of the archive, for the case the archive is not directory not listed in `PATH` environment variable.
Error message caused by this issue looked like:
"Cannot open self /some_path/appname or archive /some_path/appname.pkg"