### PR TITLE
Build: OSX: Fixed the ineffectiveness of the --distpath argument for t…

### DIFF
--- a/PyInstaller/building/osx.py
+++ b/PyInstaller/building/osx.py
@@ -89,11 +89,6 @@ class BUNDLE(Target):
         for inm, name, typ in self.toc:
             if typ == "EXECUTABLE":
                 self.exename = name
-                if self.name is None:
-                    self.appname = "Mac%s" % (os.path.splitext(inm)[0],)
-                    self.name = os.path.join(CONF['specpath'], self.appname + ".app")
-                else:
-                    self.name = os.path.join(CONF['specpath'], self.name)
                 break
         self.__postinit__()
 

--- a/news/4892.build.rst
+++ b/news/4892.build.rst
@@ -1,0 +1,1 @@
+OSX: Fixed the ineffectiveness of the ``--distpath`` argument for the ``BUNDLE`` step.


### PR DESCRIPTION
…he BUNDLE step.

I also cleaned up code that was never taken as `self.name` is never set to `None` else the entire process does not work and would fail before that code branch could be run.

Fixes #4892.