### PR TITLE
 tests: make test_pil_plugins compatible with pillow 8.0.0 and later

### DIFF
--- a/tests/functional/test_libraries.py
+++ b/tests/functional/test_libraries.py
@@ -596,8 +596,8 @@ def test_pil_plugins(pyi_builder):
         """
         # Verify packaging of PIL.Image. Specifically, the hidden import of FixTk
         # importing tkinter is causing some problems.
-        from PIL.Image import fromstring
-        print(fromstring)
+        from PIL.Image import frombytes
+        print(frombytes)
 
         # PIL import hook should bundle all available PIL plugins. Verify that plugins
         # are bundled.

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -29,7 +29,6 @@ keyring==19.2.0  # pyup: ignore
 babel==2.8.0
 future==0.18.2
 gevent==20.9.0
-Pillow==7.2.0
 pygments==2.7.1
 PySide2==5.14.0
 python-dateutil==2.8.1
@@ -62,6 +61,10 @@ numpy<=1.19.0; python_version == '3.5'  # pyup: ignore
 # And so did SciPy
 scipy==1.5.2; python_version > '3.5'
 scipy<=1.5.0; python_version == '3.5'  # pyup: ignore
+
+# Pillow 8.0 dropped support for python 3.5
+Pillow==8.0.0; python_version > '3.5'
+Pillow<8.0.0; python_version == '3.5' # pyup: ignore
 
 # Special cases
 # -------------


### PR DESCRIPTION
Pillow 8.0.0 removed `PIL.Image.fromstring`, which the test is trying to import. Instead, use `PIL.Image.frombytes` to verify the packaging.