### PR TITLE
hooks: django multiple settings hook fix

### DIFF
--- a/PyInstaller/hooks/hook-django.py
+++ b/PyInstaller/hooks/hook-django.py
@@ -10,7 +10,7 @@
 #-----------------------------------------------------------------------------
 
 
-# Tested with django 1.8.
+# Tested with django 2.2
 
 
 import sys
@@ -40,10 +40,12 @@ if root_dir:
     # Include main django modules - settings.py, urls.py, wsgi.py.
     # Without them the django server won't run.
     package_name = os.path.basename(root_dir)
+    default_settings_module = f'{package_name}.settings'
+    settings_module = os.environ.get('DJANGO_SETTINGS_MODULE', default_settings_module)
     hiddenimports += [
             # TODO Consider including 'mysite.settings.py' in source code as a data files.
             #      Since users might need to edit this file.
-            package_name + '.settings',
+            settings_module,
             package_name + '.urls',
             package_name + '.wsgi',
     ]
@@ -67,7 +69,7 @@ if root_dir:
              'django.contrib.sites.migrations',
     ]
     # Include migration scripts of Django-based apps too.
-    installed_apps = eval(get_module_attribute(package_name + '.settings', 'INSTALLED_APPS'))
+    installed_apps = eval(get_module_attribute(settings_module, 'INSTALLED_APPS'))
     migration_modules.extend(set(app + '.migrations' for app in installed_apps))
     # Copy migration files.
     for mod in migration_modules:
@@ -80,7 +82,8 @@ if root_dir:
             datas.append((f, os.path.join(mod_name, bundle_dir)))
 
     # Include data files from your Django project found in your django root package.
-    datas += collect_data_files(package_name)
+    # excludes files from the project dir itself (changed behavior of collect_data_files)
+    datas += collect_data_files(package_name, excludes=os.listdir())
 
     # Include database file if using sqlite. The sqlite database is usually next to the manage.py script.
     root_dir_parent = os.path.dirname(root_dir)

--- a/PyInstaller/hooks/hook-django.py
+++ b/PyInstaller/hooks/hook-django.py
@@ -82,8 +82,7 @@ if root_dir:
             datas.append((f, os.path.join(mod_name, bundle_dir)))
 
     # Include data files from your Django project found in your django root package.
-    # excludes files from the project dir itself (changed behavior of collect_data_files)
-    datas += collect_data_files(package_name, excludes=os.listdir())
+    datas += collect_data_files(package_name)
 
     # Include database file if using sqlite. The sqlite database is usually next to the manage.py script.
     root_dir_parent = os.path.dirname(root_dir)

--- a/PyInstaller/utils/hooks/django.py
+++ b/PyInstaller/utils/hooks/django.py
@@ -34,8 +34,9 @@ def django_dottedstring_imports(django_root_dir):
     # module.
     pths.append(django_root_dir)
 
-    package_name = os.path.basename(django_root_dir) + '.settings'
-    env = {'DJANGO_SETTINGS_MODULE': package_name,
+    default_settings_module = os.path.basename(django_root_dir) + '.settings'
+    settings_module = os.environ.get('DJANGO_SETTINGS_MODULE', default_settings_module)
+    env = {'DJANGO_SETTINGS_MODULE': settings_module,
            'PYTHONPATH': os.pathsep.join(pths)}
     ret = eval_script('django_import_finder.py', env=env)
 

--- a/PyInstaller/utils/hooks/subproc/django_import_finder.py
+++ b/PyInstaller/utils/hooks/subproc/django_import_finder.py
@@ -16,7 +16,7 @@ This module parses all Django dependencies from the module mysite.settings.py.
 NOTE: With newer version of Django this is most likely the part of PyInstaller
       that will be broken.
 
-Tested with Django 1.8.
+Tested with Django 2.2
 """
 
 
@@ -34,10 +34,16 @@ from django.conf import settings
 from PyInstaller.utils.hooks import collect_submodules
 
 
-hiddenimports = list(settings.INSTALLED_APPS) + \
-                 list(settings.TEMPLATE_CONTEXT_PROCESSORS) + \
-                 list(settings.TEMPLATE_LOADERS) + \
-                 [settings.ROOT_URLCONF]
+hiddenimports = list(settings.INSTALLED_APPS)
+
+# do not fail script when settings does not have such attributes
+if hasattr(settings, 'TEMPLATE_CONTEXT_PROCESSORS'):
+    hiddenimports += list(settings.TEMPLATE_CONTEXT_PROCESSORS)
+
+if hasattr(settings, 'TEMPLATE_LOADERS'):
+    hiddenimports += list(settings.TEMPLATE_LOADERS)
+
+hiddenimports += [settings.ROOT_URLCONF]
 
 
 def _remove_class(class_name):
@@ -78,21 +84,6 @@ for v in settings.DATABASES.values():
     hiddenimports.append(v['ENGINE'])
 
 
-def find_url_callbacks(urls_module):
-    if isinstance(urls_module, list):
-        urlpatterns = urls_module
-        hid_list = []
-    else:
-        urlpatterns = urls_module.urlpatterns
-        hid_list = [urls_module.__name__]
-    for pattern in urlpatterns:
-        if isinstance(pattern, RegexURLPattern):
-            hid_list.append(pattern.callback.__module__)
-        elif isinstance(pattern, RegexURLResolver):
-            hid_list += find_url_callbacks(pattern.urlconf_module)
-    return hid_list
-
-
 # Add templatetags and context processors for each installed app.
 for app in settings.INSTALLED_APPS:
     app_templatetag_module = app + '.templatetags'
@@ -100,18 +91,6 @@ for app in settings.INSTALLED_APPS:
     hiddenimports.append(app_templatetag_module)
     hiddenimports += collect_submodules(app_templatetag_module)
     hiddenimports.append(app_ctx_proc_module)
-
-
-from django.core.urlresolvers import RegexURLPattern, RegexURLResolver
-
-
-# Construct base module name - without 'settings' suffix.
-base_module_name = '.'.join(os.environ['DJANGO_SETTINGS_MODULE'].split('.')[0:-1])
-base_module = __import__(base_module_name, {}, {}, ["urls"])
-urls = base_module.urls
-
-# Find url imports.
-hiddenimports += find_url_callbacks(urls)
 
 # Deduplicate imports.
 hiddenimports = list(set(hiddenimports))

--- a/news/5267.hooks.rst
+++ b/news/5267.hooks.rst
@@ -1,0 +1,1 @@
+Enable overriding Django settings path by `DJANGO_SETTINGS_MODULE` environment variable.


### PR DESCRIPTION
fixes https://github.com/pyinstaller/pyinstaller/issues/4830

Changes:
- settings - default or overriden by env variable `DJANGO_SETTINGS_MODULE`
- `find_url_callbacks` in `django_import_finder.py` was removed - has no impact in case of compiling my app, don't know whether it is needed in django 2.2+ and what problem it resolved
- ~~all files from directory are excluded (`datas += collect_data_files(package_name, excludes=os.listdir())`) - due to changed behavior of collect_data_files. Without this, I got all data copied into the result project (including development files, `.git` folder, etc.)~~ reverted after review

@Legorooj 