### PR TITLE
Bootloader: (OSX) Bump MACOSX_DEPLOYMENT_TARGET from 10.7 to 10.13.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,7 +90,7 @@ Requirements and Tested Platforms
 
 - Mac OS X (64bit):
 
- - Mac OS X 10.7 (Lion) or newer.
+ - Mac OS X 10.13 (High Sierra) or newer.
 
 
 Usage

--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -540,12 +540,11 @@ def configure(ctx):
 
 
     elif ctx.env.DEST_OS == 'darwin':
-        # OS X 10.7 might not understand some load commands.
-        # The following variable fixes 10.7 compatibility.
+        # macOS 10.13 is the oldest version supported by Apple.
         # According to OS X doc this variable is equivalent to gcc option:
-        #   -mmacosx-version-min=10.7
+        #   -mmacosx-version-min=10.13
         if not os.environ.get('MACOSX_DEPLOYMENT_TARGET'):
-            os.environ['MACOSX_DEPLOYMENT_TARGET'] = '10.7'
+            os.environ['MACOSX_DEPLOYMENT_TARGET'] = '10.13'
 
     ### Libraries
 

--- a/news/4627.bootloader.rst
+++ b/news/4627.bootloader.rst
@@ -1,0 +1,1 @@
+(OSX) Bump ``MACOSX_DEPLOYMENT_TARGET`` from 10.7 to 10.13.

--- a/news/4886.bootloader.rst
+++ b/news/4886.bootloader.rst
@@ -1,0 +1,1 @@
+(OSX) Bump ``MACOSX_DEPLOYMENT_TARGET`` from 10.7 to 10.13.


### PR DESCRIPTION
This will fix recent PyQt versions with the dark mode handling.

Note that bootloaders will need to be compiled against XCode 11 or newer to completely fix the linked issue.

Fixes #4627.
Fixes #4886.