### PR TITLE
OSX: Add capability for already-running apps to accept URL & drag'n drop events via Apple Event forwarding

### DIFF
--- a/bootloader/src/pyi_utils.c
+++ b/bootloader/src/pyi_utils.c
@@ -1011,7 +1011,7 @@ pyi_utils_create_child(const char *thisfile, const ARCHIVE_STATUS* status,
         if (wait_rc == 0) {
             /* Child not done yet -- wait for and process AppleEvents with a
              * 1 second timeout, forwarding file-open events to the child. */
-            process_apple_events(false /* long timeout, 1 second */);
+            process_apple_events(false /* long timeout (1 sec) */);
         }
     } while (!wait_rc);
     #else

--- a/bootloader/src/pyi_utils.c
+++ b/bootloader/src/pyi_utils.c
@@ -1084,7 +1084,7 @@ static pascal OSErr handle_apple_event(const AppleEvent *theAppleEvent, AppleEve
     if (apple_event_is_open_doc || apple_event_is_open_uri) {
         const char *const descStr = apple_event_is_open_uri ? "GetURL" : "OpenDoc";
 
-        VS("LOADER [AppleEvent]: %s handler called.\n",descStr);
+        VS("LOADER [AppleEvent]: %s handler called.\n", descStr);
 
         if (!child_pid) {
             /* Child process is not up yet -- so we pick up kAEOpen and/or kAEGetURL events and append them to args. */

--- a/bootloader/src/pyi_utils.c
+++ b/bootloader/src/pyi_utils.c
@@ -1005,13 +1005,14 @@ pyi_utils_create_child(const char *thisfile, const ARCHIVE_STATUS* status,
     #if defined(__APPLE__) && defined(WINDOWED)
     /* MacOS code -- forward events to child! */
     do {
-        /* The below waitpid() call will run about once every second on Apple,
+        /* The below loop call will iterate about once every second on Apple,
          * waiting on the event queue most of that time. */
         wait_rc = waitpid(child_pid, &rc, WNOHANG);
-        if (wait_rc == 0)
-            /* Child not ready yet -- process apple events with 1 second
-             * timeout, forwarding them to child. */
+        if (wait_rc == 0) {
+            /* Child not done yet -- wait for and process AppleEvents with a
+             * 1 second timeout, forwarding file-open events to the child. */
             process_apple_events(false /* long timeout, 1 second */);
+        }
     } while (!wait_rc);
     #else
     wait_rc = waitpid(child_pid, &rc, 0);

--- a/bootloader/src/pyi_utils.c
+++ b/bootloader/src/pyi_utils.c
@@ -1076,9 +1076,9 @@ static const char *CC2Str(FourCharCode code) {
 
 /* Handles apple events 'odoc' and 'GURL', both before and after the child_pid is up, forwarding them to args if child
  * not up yet, or otherwise forwarding them to the child if the child is started. Other event types are ignored. */
-static pascal OSErr handle_apple_event(const AppleEvent *theAppleEvent, AppleEvent *reply, SRefCon handlerRefcon)
+static pascal OSErr handle_apple_event(const AppleEvent *theAppleEvent, AppleEvent *reply, SRefCon handlerRefCon)
 {
-    const FourCharCode evtCode = ((FourCharCode)handlerRefcon);
+    const FourCharCode evtCode = (FourCharCode)handlerRefCon;
     /* Note: the single-quoted 'odoc' & 'GURL' below are not a typo. They are the way
      * the Apple API encodes UInt32 in a "programmer-friendly" manner using the ISO-C
      * multi-character constant language feature. These evaluate to UInt32, which is

--- a/bootloader/src/pyi_utils.c
+++ b/bootloader/src/pyi_utils.c
@@ -1082,7 +1082,7 @@ static pascal OSErr handle_apple_event(const AppleEvent *theAppleEvent, AppleEve
                   apple_event_is_open_uri = ((FourCharCode)handlerRefcon) == 'GURL';
 
     if (apple_event_is_open_doc || apple_event_is_open_uri) {
-        const char * const descStr = apple_event_is_open_uri ? "GetURL" : "OpenDoc";
+        const char *const descStr = apple_event_is_open_uri ? "GetURL" : "OpenDoc";
 
         VS("LOADER [AppleEvent]: %s handler called.\n",descStr);
 
@@ -1110,7 +1110,7 @@ static pascal OSErr handle_apple_event(const AppleEvent *theAppleEvent, AppleEve
                 err = AEGetNthPtr(&docList, index, apple_event_is_open_doc ? typeFileURL : typeUTF8Text, &keywd,
                                   &returnedType, buf, sizeof(buf)-1, &actualSize);
                 if (err != noErr) {
-                    VS("LOADER [AppleEvent ARGV_EMU]: err[%d] = %d\n",(int)index-1, (int)err);
+                    VS("LOADER [AppleEvent ARGV_EMU]: err[%ld] = %d\n", index-1L, (int)err);
                 } else {
                     char *tmp_str = NULL, **tmp_argv = NULL;
 
@@ -1129,8 +1129,8 @@ static pascal OSErr handle_apple_event(const AppleEvent *theAppleEvent, AppleEve
                             CFRelease(url); /* free */
                             if (!ok) {
                                 VS("LOADER [AppleEvent ARGV_EMU]: "
-                                   "Failed to convert file:/// path to POSIX filesystem representation for arg %d!\n",
-                                   (int)index);
+                                   "Failed to convert file:/// path to POSIX filesystem representation for arg %ld!\n",
+                                   index);
                                 continue;
                             }
                         }

--- a/bootloader/src/pyi_utils.c
+++ b/bootloader/src/pyi_utils.c
@@ -1078,6 +1078,10 @@ static const char *CC2Str(FourCharCode code) {
  * not up yet, or otherwise forwarding them to the child if the child is started. Other event types are ignored. */
 static pascal OSErr handle_apple_event(const AppleEvent *theAppleEvent, AppleEvent *reply, SRefCon handlerRefcon)
 {
+    /* Note: the single-quoted 'odoc' & 'GRUL' below are not a typo. They are the way
+     * the Apple API encodes UInt32 in a "programmer-friendly" manner using the ISO-C
+     * multi-character constant language feature. These evaluate to UInt32, which is
+     * what the "FourCharCode" type is typedef'd as. */
     const Boolean apple_event_is_open_doc = ((FourCharCode)handlerRefcon) == 'odoc',
                   apple_event_is_open_uri = ((FourCharCode)handlerRefcon) == 'GURL';
 

--- a/bootloader/src/pyi_utils.c
+++ b/bootloader/src/pyi_utils.c
@@ -1005,7 +1005,7 @@ pyi_utils_create_child(const char *thisfile, const ARCHIVE_STATUS* status,
     #if defined(__APPLE__) && defined(WINDOWED)
     /* MacOS code -- forward events to child! */
     do {
-        /* The below loop call will iterate about once every second on Apple,
+        /* The below loop will iterate about once every second on Apple,
          * waiting on the event queue most of that time. */
         wait_rc = waitpid(child_pid, &rc, WNOHANG);
         if (wait_rc == 0) {

--- a/bootloader/src/pyi_utils.c
+++ b/bootloader/src/pyi_utils.c
@@ -1100,7 +1100,11 @@ static pascal OSErr handle_apple_event(const AppleEvent *theAppleEvent, AppleEve
             Size actualSize;
             DescType returnedType;
             AEKeyword keywd;
-            char buf[4*1024]; /* 4 KiB buffer is enough for any path data */
+            /* Note: In order to keep the below code sane, we will use a stack temporary buffer and we will assume
+             * a 64 KiB buffer is enough for each data item.  Since we are iterating over a potentially long list
+             * of URLs and/or files here, assuming each URL is < 64 KiB should be more than enough.
+             * Also note: MAX_PATH on MacOS is 1024 bytes. */
+            char buf[64*1024];
 
             VS("LOADER [AppleEvent ARGV_EMU]: Processing args for forward...\n");
 
@@ -1119,7 +1123,6 @@ static pascal OSErr handle_apple_event(const AppleEvent *theAppleEvent, AppleEve
                 } else if (actualSize > sizeof(buf)-1) {
                     VS("LOADER [AppleEvent ARGV_EMU]: err[%ld]: not enough space in buffer (%ld > %ld)\n",
                        index-1L, (long)actualSize, (long)(sizeof(buf)-1));
-                       // TODO: Fix this to use dynamic buffers
                 } else {
                     char *tmp_str = NULL, **tmp_argv = NULL;
 

--- a/bootloader/src/pyi_utils.c
+++ b/bootloader/src/pyi_utils.c
@@ -929,6 +929,10 @@ pyi_utils_create_child(const char *thisfile, const ARCHIVE_STATUS* status,
 
     argv_pyi = (char**)calloc(argc + 1, sizeof(char*));
     argc_pyi = 0;
+    if (!argv_pyi) {
+        VS("LOADER: failed to allocate argv_pyi: %s\n", strerror(errno));
+        goto cleanup;
+    }
 
     for (i = 0; i < argc; i++) {
     #if defined(__APPLE__) && defined(WINDOWED)
@@ -940,7 +944,14 @@ pyi_utils_create_child(const char *thisfile, const ARCHIVE_STATUS* status,
         else
     #endif
         {
-            argv_pyi[argc_pyi++] = strdup(argv[i]);
+            char *const tmp = strdup(argv[i]);
+            if (!tmp) {
+                VS("LOADER: failed to strdup argv[%d]: %s\n", i, strerror(errno));
+                /* If we can't allocate basic amounts of memory at this critical point,
+                 * we should probably just give up. */
+                goto cleanup;
+            }
+            argv_pyi[argc_pyi++] = tmp;
         }
     }
 

--- a/bootloader/src/pyi_utils.c
+++ b/bootloader/src/pyi_utils.c
@@ -1078,7 +1078,7 @@ static const char *CC2Str(FourCharCode code) {
  * not up yet, or otherwise forwarding them to the child if the child is started. Other event types are ignored. */
 static pascal OSErr handle_apple_event(const AppleEvent *theAppleEvent, AppleEvent *reply, SRefCon handlerRefcon)
 {
-    /* Note: the single-quoted 'odoc' & 'GRUL' below are not a typo. They are the way
+    /* Note: the single-quoted 'odoc' & 'GURL' below are not a typo. They are the way
      * the Apple API encodes UInt32 in a "programmer-friendly" manner using the ISO-C
      * multi-character constant language feature. These evaluate to UInt32, which is
      * what the "FourCharCode" type is typedef'd as. */

--- a/bootloader/src/pyi_utils.c
+++ b/bootloader/src/pyi_utils.c
@@ -1074,16 +1074,17 @@ static const char *CC2Str(FourCharCode code) {
     return buf;
 }
 
-/* Handles apple events 'odoc' and 'GRUL', both before and after the child_pid is up, forwarding them to args if child
+/* Handles apple events 'odoc' and 'GURL', both before and after the child_pid is up, forwarding them to args if child
  * not up yet, or otherwise forwarding them to the child if the child is started. Other event types are ignored. */
 static pascal OSErr handle_apple_event(const AppleEvent *theAppleEvent, AppleEvent *reply, SRefCon handlerRefcon)
 {
+    const FourCharCode evtCode = ((FourCharCode)handlerRefcon);
     /* Note: the single-quoted 'odoc' & 'GURL' below are not a typo. They are the way
      * the Apple API encodes UInt32 in a "programmer-friendly" manner using the ISO-C
      * multi-character constant language feature. These evaluate to UInt32, which is
      * what the "FourCharCode" type is typedef'd as. */
-    const Boolean apple_event_is_open_doc = ((FourCharCode)handlerRefcon) == 'odoc',
-                  apple_event_is_open_uri = ((FourCharCode)handlerRefcon) == 'GURL';
+    const Boolean apple_event_is_open_doc = evtCode == 'odoc',
+                  apple_event_is_open_uri = evtCode == 'GURL';
 
     if (apple_event_is_open_doc || apple_event_is_open_uri) {
         const char *const descStr = apple_event_is_open_uri ? "GetURL" : "OpenDoc";
@@ -1223,7 +1224,7 @@ static pascal OSErr handle_apple_event(const AppleEvent *theAppleEvent, AppleEve
         }
     } else {
         /* Not GetURL or OpenDoc, so just ignore */
-        VS("LOADER [AppleEvent]: Handler ignoring event.\n");
+        VS("LOADER [AppleEvent]: Handler ignoring event '%s'\n", CC2Str(evtCode));
     }
     return noErr;
 }

--- a/bootloader/src/pyi_utils.c
+++ b/bootloader/src/pyi_utils.c
@@ -1218,8 +1218,9 @@ static pascal OSErr handle_apple_event(const AppleEvent *theAppleEvent, AppleEve
             AEDisposeDesc(&evtCopy); /* dispose apple event copy */
         cleanup2:
             AEDisposeDesc(&target);
-            if (err)
+            if (err) {
                 VS("LOADER [AppleEvent EVT_FWD]: OpenDocument handler got error %d\n", (int)err);
+            }
             return (OSErr)err;
         }
     } else {
@@ -1250,12 +1251,14 @@ static OSStatus evt_handler_proc(EventHandlerCallRef href, EventRef eref, void *
     VS("LOADER [AppleEvent]: what=%hu message=%lx (%s) modifiers=%hu\n",
        eventRecord.what, eventRecord.message, CC2Str((FourCharCode)eventRecord.message), eventRecord.modifiers);
     OSStatus err = AEProcessAppleEvent(&eventRecord);
-    if (err == errAEEventNotHandled)
+    if (err == errAEEventNotHandled) {
         VS("LOADER [AppleEvent]: Ignored event.\n");
-    else if (err != noErr)
+    } else if (err != noErr) {
         VS("LOADER [AppleEvent]: Error processing event: %d\n", (int)err);
-    if (release)
+    }
+    if (release) {
         ReleaseEvent(eref);
+    }
     return noErr;
 }
 
@@ -1277,10 +1280,12 @@ static void process_apple_events(Boolean short_timeout)
         handler = NewEventHandlerUPP(evt_handler_proc);
         handler_ae = NewAEEventHandlerUPP(handle_apple_event);
         err = AEInstallEventHandler(kCoreEventClass, kAEOpenDocuments, handler_ae, (SRefCon)'odoc', false);
-        if (err == noErr)
+        if (err == noErr) {
             err = AEInstallEventHandler(kInternetEventClass, kAEGetURL, handler_ae, (SRefCon)'GURL', false);
-        if (err == noErr)
+        }
+        if (err == noErr) {
             err = InstallApplicationEventHandler(handler, 1, event_types, NULL, &handler_ref);
+        }
 
         if (err != noErr) {
             /* App-wide handler failed. Uninstall everything. */

--- a/news/5276.bootloader.rst
+++ b/news/5276.bootloader.rst
@@ -1,0 +1,1 @@
+(OSX) Apps now accept URL & drag'n drop events via Apple Event forwarding.

--- a/news/5276.bootloader.rst
+++ b/news/5276.bootloader.rst
@@ -1,1 +1,1 @@
-(OSX) Apps now accept URL & drag'n drop events via Apple Event forwarding.
+(OSX) Added capability for already-running apps to accept URL & drag'n drop events via Apple Event forwarding

--- a/tests/functional/scripts/pyi_pyqt5_log_events.py
+++ b/tests/functional/scripts/pyi_pyqt5_log_events.py
@@ -19,7 +19,8 @@ class EventHandler(QObject):
     logfile = None
 
     def eventFilter(self, obj, event):
-        """ This event filter just logs the URLs it receives as FileOpen events to self.logfile """
+        """ This event filter just logs the URLs it receives as FileOpen
+        events to self.logfile """
         assert self.logfile
         if event.type() == QEvent.FileOpen:
             try:
@@ -27,8 +28,8 @@ class EventHandler(QObject):
                     file.write(event.url().toString() + "\n")
                 return True
             except Exception as e:
-                print("Caught exception while attempting to write/open", self.logfile, "exception: " + repr(e),
-                      file=sys.stderr)
+                print("Caught exception while attempting to write/open",
+                      self.logfile, "exception: " + repr(e), file=sys.stderr)
             qApp.quit()  # Quit after receiving the event
         return False
 
@@ -38,8 +39,8 @@ class EventHandler(QObject):
             with open(self.logfile, 'wt') as file:
                 file.write("started\n")
         except Exception as e:
-            print("Caught exception while attempting to write/open", self.logfile, "exception: " + repr(e),
-                  file=sys.stderr)
+            print("Caught exception while attempting to write/open",
+                  self.logfile, "exception: " + repr(e), file=sys.stderr)
             qApp.quit()
 
 

--- a/tests/functional/scripts/pyi_pyqt5_log_events.py
+++ b/tests/functional/scripts/pyi_pyqt5_log_events.py
@@ -9,6 +9,7 @@
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
 
+import json
 import os
 import sys
 
@@ -38,7 +39,8 @@ class EventHandler(QObject):
         assert self.logfile
         try:
             with open(self.logfile, 'wt') as file:
-                file.write("started\n")
+                file.write("started {}\n"
+                           .format(json.dumps({"argv": sys.argv})))
         except Exception as e:
             print("Caught exception while attempting to write/open",
                   self.logfile, "exception: " + repr(e), file=sys.stderr)
@@ -54,7 +56,7 @@ def main():
 
     logfile = os.path.join(basedir, 'events.log')
 
-    app = QApplication(sys.argv)
+    app = QApplication(list(sys.argv))  # Copy args to prevent qApp modifying
     dummy = QWidget()
     dummy.hide()
     app.setQuitOnLastWindowClosed(False)

--- a/tests/functional/scripts/pyi_pyqt5_log_events.py
+++ b/tests/functional/scripts/pyi_pyqt5_log_events.py
@@ -15,6 +15,7 @@ import sys
 from PyQt5.QtCore import QObject, QEvent, QTimer
 from PyQt5.QtWidgets import QWidget, QApplication, qApp
 
+
 class EventHandler(QObject):
     logfile = None
 

--- a/tests/functional/scripts/pyi_pyqt5_log_events.py
+++ b/tests/functional/scripts/pyi_pyqt5_log_events.py
@@ -1,0 +1,76 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2019-2020, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+import os
+import sys
+
+from PyQt5.QtCore import QObject, QEvent, QTimer
+from PyQt5.QtWidgets import QWidget, QApplication, qApp
+
+class EventHandler(QObject):
+    logfile = None
+
+    def eventFilter(self, obj, event):
+        """ This event filter just logs the URLs it receives as FileOpen events to self.logfile """
+        assert self.logfile
+        if event.type() == QEvent.FileOpen:
+            try:
+                with open(self.logfile, 'at') as file:
+                    file.write(event.url().toString() + "\n")
+                return True
+            except Exception as e:
+                print("Caught exception while attempting to write/open", self.logfile, "exception: " + repr(e),
+                      file=sys.stderr)
+            qApp.quit()  # Quit after receiving the event
+        return False
+
+    def log_started(self):
+        assert self.logfile
+        try:
+            with open(self.logfile, 'wt') as file:
+                file.write("started\n")
+        except Exception as e:
+            print("Caught exception while attempting to write/open", self.logfile, "exception: " + repr(e),
+                  file=sys.stderr)
+            qApp.quit()
+
+
+def main():
+    basedir = os.path.dirname(sys.executable)
+    # if script is inside .app package
+    if os.path.basename(basedir) == 'MacOS':
+        basedir = os.path.abspath(
+            os.path.join(basedir, os.pardir, os.pardir, os.pardir))
+
+    logfile = os.path.join(basedir, 'events.log')
+
+    app = QApplication(sys.argv)
+    dummy = QWidget()
+    dummy.hide()
+    app.setQuitOnLastWindowClosed(False)
+    eh = EventHandler()
+    eh.logfile = logfile
+    app.installEventFilter(eh)
+    # Log that we did start so the calling app knows
+    QTimer.singleShot(0, eh.log_started)
+    timeout = 5000  # Default 5 seconds
+    try:
+        # Last arg is timeout (may be passed-in from test script)
+        timeout = int(1000 * float(sys.argv[-1]))
+    except (ValueError, IndexError):
+        """Arg was missing or bad arg, use default"""
+    # Quit the app after timeout milliseconds if we never get the event
+    QTimer.singleShot(timeout, app.quit)
+    app.exec_()
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/functional/scripts/pyi_pyqt5_log_events.py
+++ b/tests/functional/scripts/pyi_pyqt5_log_events.py
@@ -27,11 +27,11 @@ class EventHandler(QObject):
             try:
                 with open(self.logfile, 'at') as file:
                     file.write(event.url().toString() + "\n")
-                return True
             except Exception as e:
                 print("Caught exception while attempting to write/open",
                       self.logfile, "exception: " + repr(e), file=sys.stderr)
-            qApp.quit()  # Quit after receiving the event
+            qApp.quit()  # Tell app to quit after receiving the event
+            return True
         return False
 
     def log_started(self):

--- a/tests/functional/specs/pyi_osx_event_forwarding.spec
+++ b/tests/functional/specs/pyi_osx_event_forwarding.spec
@@ -16,7 +16,7 @@ app_name = 'pyi_osx_event_forwarding'
 custom_url_scheme = os.environ.get('PYI_CUSTOM_URL_SCHEME', 'pyi-test-app')
 custom_file_ext = os.environ.get('PYI_CUSTOM_FILE_EXT', 'pyi_test_ext')
 
-a = Analysis(['../scripts/pyi_pyqt5_log_events.py'])
+a = Analysis([os.path.join(os.path.dirname(SPECPATH), 'scripts/pyi_pyqt5_log_events.py')])
 pyz = PYZ(a.pure, a.zipped_data)
 exe = EXE(pyz,
           a.scripts,

--- a/tests/functional/specs/pyi_osx_event_forwarding.spec
+++ b/tests/functional/specs/pyi_osx_event_forwarding.spec
@@ -1,0 +1,40 @@
+# -*- mode: python -*-
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2020, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+import os
+
+app_name = 'pyi_osx_event_forwarding'
+custom_url_scheme = os.environ.get('PYI_CUSTOM_URL_SCHEME', 'pyi-test-app')
+
+a = Analysis(['../scripts/pyi_pyqt5_log_events.py'])
+pyz = PYZ(a.pure, a.zipped_data)
+exe = EXE(pyz,
+          a.scripts,
+          a.binaries,
+          a.zipfiles,
+          a.datas,
+          name=app_name,
+          debug=True,
+          bootloader_ignore_signals=False,
+          strip=False,
+          upx=False,
+          console=False )
+app = BUNDLE(exe,
+             name=app_name + '.app',
+             # Register custom protocol handler
+             info_plist={
+                'CFBundleURLTypes': [{
+                    'CFBundleURLName': 'PYITestApp',
+                    'CFBundleTypeRole': 'Viewer',
+                    'CFBundleURLSchemes': [custom_url_scheme]
+                }]
+             })

--- a/tests/functional/specs/pyi_osx_event_forwarding.spec
+++ b/tests/functional/specs/pyi_osx_event_forwarding.spec
@@ -14,6 +14,7 @@ import os
 
 app_name = 'pyi_osx_event_forwarding'
 custom_url_scheme = os.environ.get('PYI_CUSTOM_URL_SCHEME', 'pyi-test-app')
+custom_file_ext = os.environ.get('PYI_CUSTOM_FILE_EXT', 'pyi_test_ext')
 
 a = Analysis(['../scripts/pyi_pyqt5_log_events.py'])
 pyz = PYZ(a.pure, a.zipped_data)
@@ -30,11 +31,18 @@ exe = EXE(pyz,
           console=False )
 app = BUNDLE(exe,
              name=app_name + '.app',
-             # Register custom protocol handler
+             # Register custom protocol handler and custom file extension
              info_plist={
                 'CFBundleURLTypes': [{
-                    'CFBundleURLName': 'PYITestApp',
+                    'CFBundleURLName': 'PYITestApp' + custom_url_scheme,
                     'CFBundleTypeRole': 'Viewer',
-                    'CFBundleURLSchemes': [custom_url_scheme]
-                }]
+                    'CFBundleURLSchemes': [custom_url_scheme],
+                }],
+                'CFBundleDocumentTypes': [{
+                    'CFBundleTypeName': "PYITestApp_" + custom_file_ext,
+                    'CFBundleTypeExtensions': [
+                        custom_file_ext,
+                    ],
+                    'CFBundleTypeRole': "Viewer",
+                }],
              })

--- a/tests/functional/test_apple_events.py
+++ b/tests/functional/test_apple_events.py
@@ -64,7 +64,7 @@ def test_osx_event_forwarding(tmpdir, pyi_builder_spec):
 
     if os.path.exists(logfile_path):
         os.remove(logfile_path)
-    os.path.exists(logfile_path), 'Events logfile still exists!'
+    assert not os.path.exists(logfile_path), 'Events logfile still exists!'
 
     # Generate new URL scheme to avoid collisions
     custom_url_scheme = "pyi-test-%i" % time.time()

--- a/tests/functional/test_apple_events.py
+++ b/tests/functional/test_apple_events.py
@@ -21,7 +21,7 @@ import time
 
 # Local imports
 # -------------
-from PyInstaller.utils.tests import skipif_notosx
+from PyInstaller.utils.tests import importorskip, skipif_notosx
 
 
 @skipif_notosx
@@ -52,3 +52,71 @@ def test_osx_custom_protocol_handler(tmpdir, pyi_builder_spec):
     with open(logfile_path, 'r') as fh:
         log_lines = fh.readlines()
     assert log_lines and log_lines[-1] == url, 'Invalid arg appended'
+
+@skipif_notosx
+@importorskip('PyQt5')
+def test_osx_event_forwarding(tmpdir, pyi_builder_spec):
+    tmpdir = str(tmpdir)  # Fix for Python 3.5
+    app_path = os.path.join(tmpdir, 'dist',
+                            'pyi_osx_event_forwarding.app')
+
+    logfile_path = os.path.join(tmpdir, 'dist', 'events.log')
+
+    if os.path.exists(logfile_path):
+        os.remove(logfile_path)
+    os.path.exists(logfile_path), 'Events logfile still exists!'
+
+    # Generate new URL scheme to avoid collisions
+    custom_url_scheme = "pyi-test-%i" % time.time()
+    os.environ["PYI_CUSTOM_URL_SCHEME"] = custom_url_scheme
+
+    pyi_builder_spec.test_spec('pyi_osx_event_forwarding.spec')
+
+    timeout = 10.0  # Give up after 10 seconds
+    polltime = 0.25  # Poll events.log every 250ms
+
+    # Run using 'open', passing the timeout as an arg (side-effect: registers custom protocol handler)
+    subprocess.check_call(['open', app_path, '--args', str(timeout)])
+
+    def wait_for_started():
+        t0 = time.time()  # mark start time
+        # Poll logfile for app to be started (it writes "started" to the first log line)
+        while True:
+            elapsed = time.time() - t0
+            if elapsed > timeout:
+                return False
+            if os.path.exists(logfile_path):
+                with open(logfile_path, 'r') as fh:
+                    log_lines = fh.readlines()
+                    if log_lines:
+                        assert log_lines[0].startswith('started'), "Unexpected line in log file"
+                        return True  # it started ok, abort loop
+            else:
+                # Try again later
+                time.sleep(polltime)
+
+    assert wait_for_started(), 'App start timed out'
+
+    # At this point the app is running,
+    # Calling open again using the url should forward the Apple URL event to the already-running app.
+    url = custom_url_scheme + "://AnEvent"
+    subprocess.check_call(['open', url])
+
+    def wait_for_event_in_logfile():
+        t0 = time.time()  # mark start time
+        # Wait for the program to finish -- poll for expected line to appear in events.log
+        while True:
+            assert os.path.exists(logfile_path), 'Missing events logfile'
+            with open(logfile_path, 'rt') as fh:
+                log_lines = fh.readlines()
+            if len(log_lines) >= 2:
+                assert log_lines[-1].strip() == url, 'Logged url does not match expected'
+                return True
+            else:
+                # Try again later
+                time.sleep(polltime)
+            elapsed = time.time() - t0
+            if elapsed > timeout:
+                return False
+
+    assert wait_for_event_in_logfile(), 'Log to url timed out'

--- a/tests/functional/test_apple_events.py
+++ b/tests/functional/test_apple_events.py
@@ -53,6 +53,7 @@ def test_osx_custom_protocol_handler(tmpdir, pyi_builder_spec):
         log_lines = fh.readlines()
     assert log_lines and log_lines[-1] == url, 'Invalid arg appended'
 
+
 @skipif_notosx
 @importorskip('PyQt5')
 def test_osx_event_forwarding(tmpdir, pyi_builder_spec):

--- a/tests/functional/test_apple_events.py
+++ b/tests/functional/test_apple_events.py
@@ -65,7 +65,6 @@ def test_osx_event_forwarding(tmpdir, pyi_builder_spec):
 
     if os.path.exists(logfile_path):
         os.remove(logfile_path)
-    assert not os.path.exists(logfile_path), 'Events logfile still exists!'
 
     # Generate new URL scheme to avoid collisions
     custom_url_scheme = "pyi-test-%i" % time.time()

--- a/tests/functional/test_apple_events.py
+++ b/tests/functional/test_apple_events.py
@@ -75,12 +75,14 @@ def test_osx_event_forwarding(tmpdir, pyi_builder_spec):
     timeout = 10.0  # Give up after 10 seconds
     polltime = 0.25  # Poll events.log every 250ms
 
-    # Run using 'open', passing the timeout as an arg (side-effect: registers custom protocol handler)
+    # Run using 'open', passing the timeout as an arg (side-effect: registers
+    # custom protocol handler)
     subprocess.check_call(['open', app_path, '--args', str(timeout)])
 
     def wait_for_started():
         t0 = time.time()  # mark start time
-        # Poll logfile for app to be started (it writes "started" to the first log line)
+        # Poll logfile for app to be started (it writes "started" to the first
+        # log line)
         while True:
             elapsed = time.time() - t0
             if elapsed > timeout:
@@ -89,7 +91,8 @@ def test_osx_event_forwarding(tmpdir, pyi_builder_spec):
                 with open(logfile_path, 'r') as fh:
                     log_lines = fh.readlines()
                     if log_lines:
-                        assert log_lines[0].startswith('started'), "Unexpected line in log file"
+                        assert log_lines[0].startswith('started'), \
+                            "Unexpected line in log file"
                         return True  # it started ok, abort loop
             else:
                 # Try again later
@@ -98,19 +101,22 @@ def test_osx_event_forwarding(tmpdir, pyi_builder_spec):
     assert wait_for_started(), 'App start timed out'
 
     # At this point the app is running,
-    # Calling open again using the url should forward the Apple URL event to the already-running app.
+    # Calling open again using the url should forward the Apple URL event to
+    # the already-running app.
     url = custom_url_scheme + "://AnEvent"
     subprocess.check_call(['open', url])
 
     def wait_for_event_in_logfile():
         t0 = time.time()  # mark start time
-        # Wait for the program to finish -- poll for expected line to appear in events.log
+        # Wait for the program to finish -- poll for expected line to appear
+        # in events.log
         while True:
             assert os.path.exists(logfile_path), 'Missing events logfile'
             with open(logfile_path, 'rt') as fh:
                 log_lines = fh.readlines()
             if len(log_lines) >= 2:
-                assert log_lines[-1].strip() == url, 'Logged url does not match expected'
+                assert log_lines[-1].strip() == url, \
+                    'Logged url does not match expected'
                 return True
             else:
                 # Try again later
@@ -119,4 +125,5 @@ def test_osx_event_forwarding(tmpdir, pyi_builder_spec):
             if elapsed > timeout:
                 return False
 
-    assert wait_for_event_in_logfile(), 'URL event did not appear in log before timeout'
+    assert wait_for_event_in_logfile(), \
+        'URL event did not appear in log before timeout'

--- a/tests/functional/test_apple_events.py
+++ b/tests/functional/test_apple_events.py
@@ -89,7 +89,7 @@ def test_osx_event_forwarding(tmpdir, pyi_builder_spec):
             if elapsed > timeout:
                 return False
             if os.path.exists(logfile_path):
-                with open(logfile_path, 'r') as fh:
+                with open(logfile_path) as fh:
                     log_lines = fh.readlines()
                     if log_lines:
                         assert log_lines[0].startswith('started'), \

--- a/tests/functional/test_apple_events.py
+++ b/tests/functional/test_apple_events.py
@@ -119,4 +119,4 @@ def test_osx_event_forwarding(tmpdir, pyi_builder_spec):
             if elapsed > timeout:
                 return False
 
-    assert wait_for_event_in_logfile(), 'Log to url timed out'
+    assert wait_for_event_in_logfile(), 'URL event did not appear in log before timeout'


### PR DESCRIPTION
This is a resurrection of #3832 . 

It expands the already-existing "argv-emu" facility provided by the bootloader for macOS by adding additional capabilities to the bootloader.  To recap what the bootloader already could do previous to this PR:


- If a user drags/drops files onto the app icon in the GUI or clicks on a URL associated with the app, **and if the app was not already-running**, the bootloader was able to deal with this situation.
- The bootloader would, as part of the startup process, check the AppleEvents queue and translate all 'open doc' and 'open url' events into args that the subordinate program receives (as `sys.argv` in Python).
- **However**, once the app was started, clicking on URLs or dragging files to the app icon would *not* do anything.  This is because the AppleEvents queue was not polled after the subordinate app was started (bootloader would sit in `waitpid()` forever).

This PR fixes that last point, it:

1. Preserves existing argv-emu capabilities.
2. Expands on them by installing an apple events pump which periodically checks for open doc and open url events, forwarding them to the subordinate app.
3. This allows users to click on links or drag-drop files onto the app icon and the app will receive them as Apple Events, **even if it is already running**. (To really process these events in the Python subordinate app, one needs to use a GUI such as PyQt5, which hides the ugliness).

The polling is achieved by modifying the code that calls `waitpid()` to use `WNOHANG`, and then if that returns a result indicating the child process is still alive, then we service the AppleEvents queue for up to 1 second at a time, pushing events we see (if any) to the subordinate app (only 'odoc' and 'GURL' events are forwarded).

This PR also contains a new test (requires PyQt5) which exercises all the new code paths.  There are 3 major code paths:

1. Pre-startup: service apple event queue and translate URL events to sys.argv  (*existing functionality*)
2. If the URL event is a `file://` URL, translate that to a filesystem path (*existing functionality*)
3. While the app is running, forward all `'odoc'` and `'GURL'` events (open file, open url) to the subordinate app (**new** *functionality*)

Additionally this PR modernized (slightly) the API used for (1) and (2) above to not use deprecated calls.

---

This PR only affects bootloaders compiled with "windowed" mode for macOS.  Note that I did add an additional memory allocation failure check which would affect all `!WIN32` platforms -- but that check was needed for code correctness anyway to avoid a `SIGSEGV` in the unlikely case of out-of-memory at startup.

