### PR TITLE
Tests/functional: Pillow test fixed and requirements updated for PIL 8.0.0

### DIFF
--- a/tests/functional/test_libraries.py
+++ b/tests/functional/test_libraries.py
@@ -596,8 +596,8 @@ def test_pil_plugins(pyi_builder):
         """
         # Verify packaging of PIL.Image. Specifically, the hidden import of FixTk
         # importing tkinter is causing some problems.
-        from PIL.Image import fromstring
-        print(fromstring)
+        from PIL.Image import frombytes
+        print(frombytes)
 
         # PIL import hook should bundle all available PIL plugins. Verify that plugins
         # are bundled.

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -29,7 +29,6 @@ keyring==19.2.0  # pyup: ignore
 babel==2.8.0
 future==0.18.2
 gevent==20.9.0
-Pillow==7.2.0
 pygments==2.7.1
 PySide2==5.14.0
 python-dateutil==2.8.1
@@ -62,6 +61,10 @@ numpy<=1.19.0; python_version == '3.5'  # pyup: ignore
 # And so did SciPy
 scipy==1.5.3; python_version > '3.5'
 scipy<=1.5.0; python_version == '3.5'  # pyup: ignore
+
+# Pillow 8.0 dropped support for python 3.5
+Pillow==8.0.0; python_version > '3.5'
+Pillow<8.0.0; python version == '3.5' # pyup: ignore
 
 # Special cases
 # -------------

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -64,7 +64,7 @@ scipy<=1.5.0; python_version == '3.5'  # pyup: ignore
 
 # Pillow 8.0 dropped support for python 3.5
 Pillow==8.0.0; python_version > '3.5'
-Pillow<8.0.0; python version == '3.5' # pyup: ignore
+Pillow<8.0.0; python_version == '3.5' # pyup: ignore
 
 # Special cases
 # -------------


### PR DESCRIPTION
Pillow tests were breaking after update to version 8.0.0. This required changing the  /tests/functional/test_libraries.py to import "frombytes" instead of "fromstring" in test_pil_plugins . This makes it compatible with PIL 8.0.0 as well as earlier PIL. Also, the changeset from an earlier commit was applied to requirements-libraries.txt to implement Pillow support based on Python version. 