### PR TITLE
hookutils: fix argument order in `exec_script()` and `eval_script()`

### DIFF
--- a/PyInstaller/utils/hooks/__init__.py
+++ b/PyInstaller/utils/hooks/__init__.py
@@ -79,7 +79,7 @@ def exec_statement(statement):
     return __exec_python_cmd(cmd)
 
 
-def exec_script(script_filename, env=None, *args):
+def exec_script(script_filename, *args, env=None):
     """
     Executes a Python script in an externally spawned interpreter, and
     returns anything that was emitted in the standard output as a
@@ -108,7 +108,7 @@ def eval_statement(statement):
     return eval(txt)
 
 
-def eval_script(scriptfilename, env=None, *args):
+def eval_script(scriptfilename, *args, env=None):
     txt = exec_script(scriptfilename, *args, env=env).strip()
     if not txt:
         # return an empty string which is "not true" but iterable

--- a/news/5300.hooks.rst
+++ b/news/5300.hooks.rst
@@ -1,0 +1,1 @@
+Fix argument order in ``exec_script()`` and ``eval_script()``.


### PR DESCRIPTION
`*args` being placed after the `env` keyword argument means that the first argument intended to be passed to the script will actually end up overriding the `env`.