### PR TITLE
bootloader: fix bootloader tests under Windows/MSC

### DIFF
--- a/bootloader/tests/test_path.c
+++ b/bootloader/tests/test_path.c
@@ -9,6 +9,9 @@
 // SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 // -----------------------------------------------------------------------------
 
+/* TODO: use safe string functions */
+#define _CRT_SECURE_NO_WARNINGS 1
+
 #include <sys/types.h>
 #include <stdarg.h>
 #include <string.h>
@@ -21,25 +24,33 @@
 #include <setjmp.h> // required fo cmocka :-(
 #include <cmocka.h>
 
+// NOTE: path separator is platform dependent, hence the use of PYI_SEPSTR
+// and string concatenation...
 
 static void test_dirname(void **state) {
     char result[PATH_MAX];
 
-    assert_true(pyi_path_dirname(result, "/a1/bb/cc/dd"));
-    assert_string_equal(result, "/a1/bb/cc");
+    // pyi_path_dirname("/a1/bb/cc/dd") -> "/a1/bb/cc"
+    assert_true(pyi_path_dirname(result, PYI_SEPSTR "a1" PYI_SEPSTR "bb" PYI_SEPSTR "cc" PYI_SEPSTR "dd"));
+    assert_string_equal(result, PYI_SEPSTR "a1" PYI_SEPSTR "bb" PYI_SEPSTR "cc");
 
-    assert_true(pyi_path_dirname(result, "/a2/bb/cc/dd/"));
-    assert_string_equal(result, "/a2/bb/cc");
+    // pyi_path_dirname("/a2/bb/cc/dd/") -> "/a2/bb/cc"
+    assert_true(pyi_path_dirname(result, PYI_SEPSTR "a2" PYI_SEPSTR "bb" PYI_SEPSTR "cc" PYI_SEPSTR "dd" PYI_SEPSTR));
+    assert_string_equal(result, PYI_SEPSTR "a2" PYI_SEPSTR "bb" PYI_SEPSTR "cc");
 
+    // pyi_path_dirname("d3d") -> "."
     assert_true(pyi_path_dirname(result, "d3d"));
     assert_string_equal(result, PYI_CURDIRSTR);
 
-    assert_true(pyi_path_dirname(result, "d5d/"));
+    // pyi_path_dirname("d5d/") -> "."
+    assert_true(pyi_path_dirname(result, "d5d" PYI_SEPSTR));
     assert_string_equal(result, PYI_CURDIRSTR);
 
+    // pyi_path_dirname("") -> "."
     assert_true(pyi_path_dirname(result, ""));
     assert_string_equal(result, PYI_CURDIRSTR);
 
+    // Test correct handling of paths that exceed PATH_MAX
     char *path2 = (char *) malloc(PATH_MAX+10);
     memset(path2, 'a', PATH_MAX+8);
     // a few bytes more
@@ -60,10 +71,12 @@ static void test_basename(void **state) {
     // basename()'s second argument is not `const`, thus using a constant
     // string yields to segementation fault.
 
-    strcpy(input, "/aa/bb/cc/d1d");
+    // pyi_path_basename("/aa/bb/cc/d1d") -> "d1d"
+    strcpy(input, PYI_SEPSTR "aa" PYI_SEPSTR "bb" PYI_SEPSTR "cc" PYI_SEPSTR "d1d");
     pyi_path_basename(result, input);
     assert_string_equal(result, "d1d");
 
+    // pyi_path_basename("d3dd") -> "d3dd"
     strcpy(input, "d3dd");
     pyi_path_basename(result, input);
     assert_string_equal(result, "d3dd");
@@ -71,19 +84,23 @@ static void test_basename(void **state) {
     /* These cases are not correctly handled by our implementation of
      * basename(). But this is okay, since we use basename() only to determine
      * the application path based on argv[0].
-     *
-    strcpy(input, "/aa/bb/cc/d2d/");
+     */
+#if 0
+    // pyi_path_basename("/aa/bb/cc/d2d/") -> "d2d"
+    strcpy(input, PYI_SEPSTR "aa" PYI_SEPSTR "bb" PYI_SEPSTR "cc" PYI_SEPSTR "d2d" PYI_SEPSTR);
     pyi_path_basename(result, input);
     assert_string_equal(result, "d2d");
 
-    strcpy(input, "d4dd/");
+    // pyi_path_basename("d4dd/") -> "d4dd"
+    strcpy(input, "d4dd" PYI_SEPSTR);
     pyi_path_basename(result, input);
     assert_string_equal(result, "d4dd");
 
+    // pyi_path_basename("") -> "."
     strcpy(input, "");
     pyi_path_basename(result, input);
     assert_string_equal(result, PYI_CURDIRSTR);
-    */
+#endif
 }
 
 
@@ -93,30 +110,36 @@ static void test_join(void **state) {
     char result[PATH_MAX];
     char *r;
 
+    // pyi_path_join("lalala", "mememe") -> "lalala/mememe"
     r = pyi_path_join((char *)result, "lalala", "mememe");
     assert_ptr_equal(r, &result);
-    assert_string_equal(result, "lalala/mememe");
+    assert_string_equal(result, "lalala" PYI_SEPSTR "mememe");
 
-    r = pyi_path_join((char *)result, "lalala/", "mememe");
+    // pyi_path_join("lalala/", "mememe") -> "lalala/mememe"
+    r = pyi_path_join((char *)result, "lalala" PYI_SEPSTR, "mememe");
     assert_ptr_equal(r, &result);
-    assert_string_equal(result, "lalala/mememe");
+    assert_string_equal(result, "lalala" PYI_SEPSTR "mememe");
 
-    r = pyi_path_join((char *)result, "lalala/", "mememe/");
+    // pyi_path_join("lalala/", "mememe/") -> "lalala/mememe"
+    r = pyi_path_join((char *)result, "lalala" PYI_SEPSTR, "mememe" PYI_SEPSTR);
     assert_ptr_equal(r, &result);
-    assert_string_equal(result, "lalala/mememe");
+    assert_string_equal(result, "lalala" PYI_SEPSTR "mememe");
 
-    r = pyi_path_join((char *)result, "lalala", "mememe/");
+    // pyi_path_join("lalala", "mememe/") -> "lalala/mememe"
+    r = pyi_path_join((char *)result, "lalala", "mememe" PYI_SEPSTR);
     assert_ptr_equal(r, &result);
-    assert_string_equal(result, "lalala/mememe");
+    assert_string_equal(result, "lalala" PYI_SEPSTR "mememe");
 
-    r = pyi_path_join((char *)result, "lal/ala/", "mem/eme/");
+    // pyi_path_join("lal/ala", "mem/eme/") -> "lal/ala/meme/me"
+    r = pyi_path_join((char *)result, "lal" PYI_SEPSTR "ala" PYI_SEPSTR, "mem" PYI_SEPSTR "eme" PYI_SEPSTR);
     assert_ptr_equal(r, &result);
-    assert_string_equal(result, "lal/ala/mem/eme");
+    assert_string_equal(result, "lal" PYI_SEPSTR "ala" PYI_SEPSTR "mem" PYI_SEPSTR "eme");
 
-    // First string empty is not handled
+    // First string empty is not handled:
+    //  pyi_path_join("", "mememe") -> "/mememe"
     r = pyi_path_join((char *)result, "", "mememe");
     assert_ptr_equal(r, &result);
-    assert_string_equal(result, "/mememe");
+    assert_string_equal(result, PYI_SEPSTR "mememe");
 
     memset(path1, 'a', PATH_MAX); path1[PATH_MAX-1] = '\0';
     memset(path2, 'b', PATH_MAX); path2[PATH_MAX-1] = '\0';
@@ -124,7 +147,7 @@ static void test_join(void **state) {
     assert_int_equal(strlen(path2), PATH_MAX-1);
     assert_ptr_equal(NULL, pyi_path_join(result, path1, path2));
 
-    // tests near max lenght of path1
+    // tests near max length of path1
     assert_ptr_equal(NULL, pyi_path_join(result, path1, ""));
     path1[PATH_MAX-2] = '\0';
     assert_ptr_equal(NULL, pyi_path_join(result, path1, ""));
@@ -137,7 +160,7 @@ static void test_join(void **state) {
     assert_int_equal(strlen(result), PATH_MAX-2); // -2 no trailing slash in path1
     assert_ptr_equal(NULL, pyi_path_join(result, path1, "xx"));
 
-    // tests near max lenght of path2
+    // tests near max length of path2
     assert_ptr_equal(NULL, pyi_path_join(result, "", path2));
     assert_ptr_equal(NULL, pyi_path_join(result, "x", path2));
     path2[PATH_MAX-2] = '\0';
@@ -149,14 +172,14 @@ static void test_join(void **state) {
     path2[PATH_MAX-4] = '\0';
     assert_ptr_equal(r, pyi_path_join(result, "", path2));
     assert_ptr_equal(r, pyi_path_join(result, "x", path2));
-    // we don't count exaclty if slashes are contained
+    // we don't count exactly if slashes are contained
     assert_int_equal(strlen(result), PATH_MAX-2);
     assert_ptr_equal(NULL, pyi_path_join(result, "xx", path2));
-    path2[PATH_MAX-4] = '/';
+    path2[PATH_MAX-4] = PYI_SEP;
     assert_int_equal(path2[strlen(path2)], 0);
-    assert_int_equal(path2[strlen(path2)-1], '/');
+    assert_int_equal(path2[strlen(path2)-1], PYI_SEP);
     assert_ptr_equal(r, pyi_path_join(result, "", path2));
-    // we don't count exaclty if slashes are contained
+    // we don't count exactly if slashes are contained
     assert_int_equal(strlen(result), PATH_MAX-3);
     assert_int_equal(result[strlen(result)-1], 'b'); // trailing slash removed
     assert_ptr_equal(NULL, pyi_path_join(result, "x", path2));

--- a/bootloader/tests/test_path.c
+++ b/bootloader/tests/test_path.c
@@ -13,6 +13,7 @@
 #include <stdarg.h>
 #include <string.h>
 #include <stdlib.h>
+#include <stdio.h>
 
 #include "pyi_global.h"
 #include "pyi_path.h"

--- a/bootloader/tests/wscript
+++ b/bootloader/tests/wscript
@@ -16,14 +16,27 @@ def configure(ctx):
 def build(ctx):
 
     def test_program(name):
+        if ctx.env.DEST_OS == 'win32':
+            # WS2_32: ntohl()
+            # Z: inflate*()
+            # ADVAPI32: ConvertStringSecurityDescriptorToSecurityDescriptorW()
+            extra_libs=['ADVAPI32', 'WS2_32', 'Z']
+        else:
+            extra_libs=[]
         ctx.program(
             source= ["test_%s.c" % name],
             target="test_%s" % name,
             includes='../src',
-            use=ctx.env.link_with_dynlibs + ["CMOCKA", "OBJECTS"],
+            use=ctx.env.link_with_dynlibs + ["CMOCKA", "OBJECTS"] + extra_libs,
             stlib=ctx.env.link_with_staticlibs,
             install_path=None,
         )
+
+    if ctx.env.DEST_OS == 'win32' and ctx.variant.endswith('w'):
+        # Skip building tests on Windows with windowed variants. In addition to
+        # requiring additional libraries, these also expect the entry point to
+        # be WinMain() instead of main().
+        return
 
     if "LIB_CMOCKA" in ctx.env:
         test_program("path")

--- a/news/5318.bootloader.rst
+++ b/news/5318.bootloader.rst
@@ -1,0 +1,2 @@
+(Windows) Fix building of bootloader's test suite under Windows with Visual Studio.
+This fixes build errors when ``cmocka`` is present in the build environment.


### PR DESCRIPTION
Fix compilation of bootloader tests when compiling under Windows with Visual Studio and `cmocka` is available. Attempting to build the bootloader itself in such an environment would fail due to tests failing to build, as reported in #5314.

Fix the `test_path` battery of tests for Windows compatibility, by using `PYI_SEPSTR` and string concatenation instead of full-path string literals.

The remaining failing tests are the ones that check for behavior with paths larger than `PATH_MAX`, which trigger a bug that is caused by our use of `_snprintf()` as `snprintf()` replacement under MSC.

Fixes #5314.