### PR TITLE
bootloader: assorted fixes and cleanup for building with MSC

### DIFF
--- a/bootloader/src/pyi_archive.c
+++ b/bootloader/src/pyi_archive.c
@@ -150,7 +150,7 @@ pyi_arch_extract(ARCHIVE_STATUS *status, TOC *ptoc)
         return NULL;
     }
 
-    fseek(status->fp, status->pkgstart + ntohl(ptoc->pos), SEEK_SET);
+    fseek(status->fp, (long)(status->pkgstart + ntohl(ptoc->pos)), SEEK_SET);
     data = (unsigned char *)malloc(ntohl(ptoc->len));
 
     if (data == NULL) {
@@ -418,7 +418,7 @@ pyi_arch_open(ARCHIVE_STATUS *status)
     pyvers = pyi_arch_get_pyversion(status);
 
     /* Read in in the table of contents */
-    fseek(status->fp, status->pkgstart + ntohl(status->cookie.TOC), SEEK_SET);
+    fseek(status->fp, (long)(status->pkgstart + ntohl(status->cookie.TOC)), SEEK_SET);
     status->tocbuff = (TOC *) malloc(ntohl(status->cookie.TOClen));
 
     if (status->tocbuff == NULL) {

--- a/bootloader/src/pyi_archive.c
+++ b/bootloader/src/pyi_archive.c
@@ -15,9 +15,6 @@
  * Fuctions related to PyInstaller archive embedded in executable.
  */
 
-/* TODO: use safe string functions */
-#define _CRT_SECURE_NO_WARNINGS 1
-
 #ifdef _WIN32
 /* TODO verify windows includes */
     #include <winsock.h>  /* ntohl */

--- a/bootloader/src/pyi_archive.h
+++ b/bootloader/src/pyi_archive.h
@@ -57,7 +57,7 @@ typedef struct _cookie {
 
 typedef struct _archive_status {
     FILE * fp;
-    int    pkgstart;
+    size_t pkgstart;
     TOC *  tocbuff;
     TOC *  tocend;
     COOKIE cookie;

--- a/bootloader/src/pyi_global.c
+++ b/bootloader/src/pyi_global.c
@@ -110,7 +110,7 @@ mbothererror(const char *fmt, ...)
     void mbfatal_winerror(const char * funcname, const char *fmt, ...)
     {
         char msg[MBTXTLEN];
-        int size = 0;
+        size_t size = 0;
         DWORD error_code = GetLastError();
         va_list args;
 
@@ -140,7 +140,7 @@ mbothererror(const char *fmt, ...)
     void mbfatal_perror(const char * funcname, const char *fmt, ...)
     {
         char msg[MBTXTLEN];
-        int size = 0;
+        size_t size = 0;
         va_list args;
 
         va_start(args, fmt);

--- a/bootloader/src/pyi_global.c
+++ b/bootloader/src/pyi_global.c
@@ -25,9 +25,6 @@
 /* #define STB_DEFINE  1/ * * / */
 /* #define STB_NO_REGISTRY 1 / * No need for Windows registry functions in stb.h. * / */
 
-/* TODO: use safe string functions */
-#define _CRT_SECURE_NO_WARNINGS 1
-
 #include <stdarg.h>  /* va_list, va_start(), va_end() */
 #include <stdio.h>
 

--- a/bootloader/src/pyi_global.h
+++ b/bootloader/src/pyi_global.h
@@ -158,22 +158,6 @@ void mbvs(const char *fmt, ...);
 /* Strings are usually terminated by this character. */
 #define PYI_NULLCHAR       '\0'
 
-/* Rewrite ANSI/POSIX functions to Win32 equivalents. */
-#if defined(_WIN32) && defined(_MSC_VER)
-    #define getpid           _getpid
-    #define mkdir            _mkdir
-    #define rmdir            _rmdir
-    #define stat             _stat
-    #define strdup           _strdup
-/*
- * Mingw on Windows contains the following functions.
- * Redefine them only if they are not available.
- */
-    #ifndef fileno
-        #define fileno           _fileno
-    #endif
-#endif
-
 /* Saved LC_CTYPE locale */
 extern char *saved_locale;
 

--- a/bootloader/src/pyi_global.h
+++ b/bootloader/src/pyi_global.h
@@ -163,10 +163,8 @@ void mbvs(const char *fmt, ...);
     #define getpid           _getpid
     #define mkdir            _mkdir
     #define rmdir            _rmdir
-    #define snprintf         _snprintf
     #define stat             _stat
     #define strdup           _strdup
-    #define vsnprintf        _vsnprintf
 /*
  * Mingw on Windows contains the following functions.
  * Redefine them only if they are not available.

--- a/bootloader/src/pyi_launch.c
+++ b/bootloader/src/pyi_launch.c
@@ -433,7 +433,7 @@ pyi_launch_run_scripts(ARCHIVE_STATUS *status)
                      * debug, print the traceback to a message box. */
 
                     const char *pvalue_cchar, *tb_cchar;
-                    char *char_pvalue, *char_tb, *module_name;
+                    char *module_name;
                     PyObject *ptype, *pvalue, *pvalue_str;
                     PyObject *ptraceback, *tb, *tb_str;
                     PyObject *module, *func;

--- a/bootloader/src/pyi_launch.c
+++ b/bootloader/src/pyi_launch.c
@@ -15,9 +15,6 @@
  * Launch a python module from an archive.
  */
 
-/* TODO: use safe string functions */
-#define _CRT_SECURE_NO_WARNINGS 1
-
 #if defined(__APPLE__) && defined(WINDOWED)
     #include <Carbon/Carbon.h>  /* TransformProcessType */
 #endif

--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -15,9 +15,6 @@
  * Bootloader for a packed executable.
  */
 
-/* TODO: use safe string functions */
-#define _CRT_SECURE_NO_WARNINGS 1
-
 #ifdef _WIN32
     #include <windows.h>
     #include <wchar.h>

--- a/bootloader/src/pyi_path.c
+++ b/bootloader/src/pyi_path.c
@@ -15,9 +15,6 @@
  * Path manipulation utilities.
  */
 
-/* TODO: use safe string functions */
-#define _CRT_SECURE_NO_WARNINGS 1
-
 #include <sys/types.h> /* struct stat, struct _stat */
 #include <sys/stat.h>  /* stat() */
 

--- a/bootloader/src/pyi_pythonlib.c
+++ b/bootloader/src/pyi_pythonlib.c
@@ -619,7 +619,7 @@ int
 pyi_pylib_install_zlib(ARCHIVE_STATUS *status, TOC *ptoc)
 {
     int rc = 0;
-    int zlibpos = status->pkgstart + ntohl(ptoc->pos);
+    size_t zlibpos = status->pkgstart + ntohl(ptoc->pos);
     PyObject * sys_path, *zlib_entry, *archivename_obj;
 
     /* Note that sys.path contains PyUnicode on py3. Ensure
@@ -637,7 +637,7 @@ pyi_pylib_install_zlib(ARCHIVE_STATUS *status, TOC *ptoc)
      */
     archivename_obj = PI_PyUnicode_DecodeFSDefault(status->archivename);
 #endif
-    zlib_entry = PI_PyUnicode_FromFormat("%U?%d", archivename_obj, zlibpos);
+    zlib_entry = PI_PyUnicode_FromFormat("%U?%zu", archivename_obj, zlibpos);
     PI_Py_DecRef(archivename_obj);
 
     sys_path = PI_PySys_GetObject("path");

--- a/bootloader/src/pyi_pythonlib.c
+++ b/bootloader/src/pyi_pythonlib.c
@@ -17,9 +17,6 @@
 /* size of buffer to store the name of the Python DLL library */
 #define DLLNAME_LEN (64)
 
-/* TODO: use safe string functions */
-#define _CRT_SECURE_NO_WARNINGS 1
-
 #ifdef _WIN32
     #include <windows.h> /* HMODULE */
     #include <fcntl.h>   /* O_BINARY */

--- a/bootloader/src/pyi_utils.c
+++ b/bootloader/src/pyi_utils.c
@@ -16,9 +16,6 @@
  * file path manipulation and other shared data types or functions.
  */
 
-/* TODO: use safe string functions */
-#define _CRT_SECURE_NO_WARNINGS 1
-
 #ifdef _WIN32
     #include <windows.h>
     #include <direct.h>  /* _rmdir */

--- a/bootloader/src/pyi_win32_utils.c
+++ b/bootloader/src/pyi_win32_utils.c
@@ -25,9 +25,6 @@
 /* windows.h will use API for WinServer 2003 with SP1 and WinXP with SP2 */
 #define _WIN32_WINNT 0x0502
 
-/* TODO: use safe string functions */
-#define _CRT_SECURE_NO_WARNINGS 1
-
 #include <windows.h>
 #include <commctrl.h> /* InitCommonControls */
 #include <stdio.h>    /* _fileno */

--- a/bootloader/tests/test_path.c
+++ b/bootloader/tests/test_path.c
@@ -9,9 +9,6 @@
 // SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 // -----------------------------------------------------------------------------
 
-/* TODO: use safe string functions */
-#define _CRT_SECURE_NO_WARNINGS 1
-
 #include <sys/types.h>
 #include <stdarg.h>
 #include <string.h>

--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -307,6 +307,8 @@ def set_arch_flags(ctx):
         ctx.env.append_value('CFLAGS', '/W3')
         # Disable warnings about deprecated POSIX function names
         ctx.env.append_value('CFLAGS', '/D_CRT_NONSTDC_NO_WARNINGS')
+        # Disable warnings about unsafe CRT functions
+        ctx.env.append_value('CFLAGS', '/D_CRT_SECURE_NO_WARNINGS')
         # We use SEH exceptions in winmain.c; make sure they are activated.
         ctx.env.append_value('CFLAGS', '/EHa')
 

--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -305,6 +305,8 @@ def set_arch_flags(ctx):
 
         # Enable 64bit porting warnings and other warnings too.
         ctx.env.append_value('CFLAGS', '/W3')
+        # Disable warnings about deprecated POSIX function names
+        ctx.env.append_value('CFLAGS', '/D_CRT_NONSTDC_NO_WARNINGS')
         # We use SEH exceptions in winmain.c; make sure they are activated.
         ctx.env.append_value('CFLAGS', '/EHa')
 

--- a/doc/bootloader-building.rst
+++ b/doc/bootloader-building.rst
@@ -46,7 +46,7 @@ then ask for technical help.
 Supported platforms are
 
 * GNU/Linux (using gcc)
-* Windows (using Visual C++ or MinGW's gcc)
+* Windows (using Visual C++ (VS2015 or later) or MinGW's gcc)
 * Mac OX X (using clang)
 
 Contributed platforms are
@@ -239,8 +239,7 @@ between three options:
    This is why the bootloaders delivered with PyInstaller are build using
    Visual Studio C++ compiler.
 
-   You can use any Visual Studio version that is convenient
-   (as long as it's supported by the waf build-tool).
+   Visual Studio 2015 or later is required.
 
 
 2. Using the `MinGW-w64`_ suite.

--- a/news/5320.bootloader.rst
+++ b/news/5320.bootloader.rst
@@ -1,0 +1,4 @@
+(Windows) Fix a bug in path-handling code with paths exceeding ``PATH_MAX``,
+which is caused by use of ``_snprintf`` instead of ``snprintf`` when
+building with MSC. Requires Visual Studio 2015 or later.
+Clean up the MSC codepath to address other compiler warnings.


### PR DESCRIPTION
This PR contains the following fixes and improvements for building with MSC (Visual Studio):

* remove the use of `_snprintf()` and `_vsnprintf()` as aliases for `snprintf()` and `vsnprintf()`. Visual Studio 2015 and later provide implementation of `snprintf()` and `vnsprintf()`, so use that instead. This implicitly assumes that VS2015 is minimum required version for building the bootloader, which I think is reasonable.

This fixes the bug that was revealed by bootloader's test suite - on overflow, `_snprintf()` does null-terminate the string, and returns -1 instead of number of characters that would be written. This affects our path-manipulation functions that make use of this function.

* drop the macro-based mapping of MSC-compatible function names to their POSIX equivalents. Instead, use the POSIX function names directly, and disable the deprecation warning for the whole project via CFLAGS.

* in a similar way, define _CRT_SECURE_NO_WARNINGS for the whole project via CFLAGS instead of on per-file level. This allows us to silence the those warnings in bundled zlib code as well.

* remove unused variables exposed by compiler warnings

* change the type from `int` to `size_t` where appropriate to address the compiler warnings. 

After this changeset, the whole bootloader's test suite passes on MSC builds, and building with MSC (tested with 2017 and 2019) produces no warnings anymore.