### PR TITLE
bootloader: assorted fixes for building with MinGW

### DIFF
--- a/bootloader/src/pyi_global.c
+++ b/bootloader/src/pyi_global.c
@@ -109,61 +109,29 @@ mbothererror(const char *fmt, ...)
 
     void mbfatal_winerror(const char * funcname, const char *fmt, ...)
     {
+        char fullmsg[MBTXTLEN];
         char msg[MBTXTLEN];
-        size_t size = 0;
         DWORD error_code = GetLastError();
         va_list args;
 
         va_start(args, fmt);
-            size = vsnprintf(msg, MBTXTLEN, fmt, args);
+            vsnprintf(msg, MBTXTLEN, fmt, args);
         va_end(args);
-
-        if(size < MBTXTLEN) {
-            strncpy(msg + size, funcname, MBTXTLEN - size - 1);
-            size += strlen(funcname);
-        }
-
-        if(size < MBTXTLEN) {
-            strncpy(msg + size, ": ", 2);
-            size += 2;
-        }
-
-        if(size < MBTXTLEN) {
-            strncpy(msg + size, GetWinErrorString(error_code), MBTXTLEN - size - 1);
-        }
-
-        msg[MBTXTLEN-1] = '\0';
-
-        show_message_box(msg, "Fatal error detected", MB_ICONEXCLAMATION);
+        snprintf(fullmsg, MBTXTLEN, "%s%s: %s", msg, funcname, GetWinErrorString(error_code));
+        show_message_box(fullmsg, "Fatal error detected", MB_ICONEXCLAMATION);
     }
 
     void mbfatal_perror(const char * funcname, const char *fmt, ...)
     {
+        char fullmsg[MBTXTLEN];
         char msg[MBTXTLEN];
-        size_t size = 0;
         va_list args;
 
         va_start(args, fmt);
-            size = vsnprintf(msg, MBTXTLEN, fmt, args);
+            vsnprintf(msg, MBTXTLEN, fmt, args);
         va_end(args);
-
-        if(size < MBTXTLEN) {
-            strncpy(msg + size, funcname, MBTXTLEN - size - 1);
-            size += strlen(funcname);
-        }
-
-        if(size < MBTXTLEN) {
-            strncpy(msg + size, ": ", 2);
-            size += 2;
-        }
-
-        if(size < MBTXTLEN) {
-            strncpy(msg + size, strerror(errno), MBTXTLEN - size - 1);
-        }
-
-        msg[MBTXTLEN-1] = '\0';
-
-        show_message_box(msg, "Fatal error detected", MB_ICONEXCLAMATION);
+        snprintf(fullmsg, MBTXTLEN, "%s%s: %s", msg, funcname, strerror(errno));
+        show_message_box(fullmsg, "Fatal error detected", MB_ICONEXCLAMATION);
     }
 #endif  /* _WIN32 and WINDOWED */
 

--- a/bootloader/src/pyi_global.h
+++ b/bootloader/src/pyi_global.h
@@ -126,7 +126,7 @@ void mbvs(const char *fmt, ...);
         #define VS pyi_global_printf
     #endif
 #else
-    #ifdef _WIN32
+    #if defined(_WIN32) && defined(_MSC_VER)
         #define VS
     #else
         #define VS(...)

--- a/bootloader/src/pyi_path.c
+++ b/bootloader/src/pyi_path.c
@@ -21,6 +21,9 @@
 #ifdef _WIN32
     #include <windows.h>  /* GetModuleFileNameW */
     #include <wchar.h>
+    #ifdef __GNUC__
+        #include <libgen.h> /* basename(), dirname() */
+    #endif
 #elif __APPLE__
     #include <libgen.h>      /* basename(), dirname() */
     #include <mach-o/dyld.h> /* _NSGetExecutablePath() */

--- a/bootloader/tests/test_launch.c
+++ b/bootloader/tests/test_launch.c
@@ -94,8 +94,12 @@ static void test_splitName(void **state) {
     assert_string_equal(path, "aaaaaaaaaa");
 }
 
-
-int main(void) {
+#if defined(_WIN32)
+int wmain(void)
+#else
+int main(void)
+#endif
+{
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(test_checkFile),
         cmocka_unit_test(test_splitName),

--- a/bootloader/tests/test_path.c
+++ b/bootloader/tests/test_path.c
@@ -191,7 +191,12 @@ static void test_search_path(void **state) {
 }
 
 
-int main(void) {
+#if defined(_WIN32)
+int wmain(void)
+#else
+int main(void)
+#endif
+{
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(test_dirname),
         cmocka_unit_test(test_basename),

--- a/bootloader/zlib/unzip.c
+++ b/bootloader/zlib/unzip.c
@@ -607,11 +607,12 @@ local int unzlocal_GetCurrentFileInfoInternal (file,
 
 
     /* we check the magic */
-    if (err==UNZ_OK)
+    if (err==UNZ_OK) {
         if (unzlocal_getLong(&s->z_filefunc, s->filestream,&uMagic) != UNZ_OK)
             err=UNZ_ERRNO;
         else if (uMagic!=0x02014b50)
             err=UNZ_BADZIPFILE;
+    }
 
     if (unzlocal_getShort(&s->z_filefunc, s->filestream,&file_info.version) != UNZ_OK)
         err=UNZ_ERRNO;
@@ -687,11 +688,12 @@ local int unzlocal_GetCurrentFileInfoInternal (file,
         else
             uSizeRead = extraFieldBufferSize;
 
-        if (lSeek!=0)
+        if (lSeek!=0) {
             if (ZSEEK(s->z_filefunc, s->filestream,lSeek,ZLIB_FILEFUNC_SEEK_CUR)==0)
                 lSeek=0;
             else
                 err=UNZ_ERRNO;
+        }
         if ((file_info.size_file_extra>0) && (extraFieldBufferSize>0))
             if (ZREAD(s->z_filefunc, s->filestream,extraField,uSizeRead)!=uSizeRead)
                 err=UNZ_ERRNO;
@@ -712,11 +714,12 @@ local int unzlocal_GetCurrentFileInfoInternal (file,
         else
             uSizeRead = commentBufferSize;
 
-        if (lSeek!=0)
+        if (lSeek!=0) {
             if (ZSEEK(s->z_filefunc, s->filestream,lSeek,ZLIB_FILEFUNC_SEEK_CUR)==0)
                 lSeek=0;
             else
                 err=UNZ_ERRNO;
+        }
         if ((file_info.size_file_comment>0) && (commentBufferSize>0))
             if (ZREAD(s->z_filefunc, s->filestream,szComment,uSizeRead)!=uSizeRead)
                 err=UNZ_ERRNO;
@@ -976,11 +979,12 @@ local int unzlocal_CheckCurrentFileCoherencyHeader (s,piSizeVar,
         return UNZ_ERRNO;
 
 
-    if (err==UNZ_OK)
+    if (err==UNZ_OK) {
         if (unzlocal_getLong(&s->z_filefunc, s->filestream,&uMagic) != UNZ_OK)
             err=UNZ_ERRNO;
         else if (uMagic!=0x04034b50)
             err=UNZ_BADZIPFILE;
+    }
 
     if (unzlocal_getShort(&s->z_filefunc, s->filestream,&uData) != UNZ_OK)
         err=UNZ_ERRNO;

--- a/news/5322.bootloader.rst
+++ b/news/5322.bootloader.rst
@@ -1,0 +1,2 @@
+(Windows) Fix compiler warnings produced by MinGW 10.2 in order to allow
+building the bootloader without having to suppress the warnings.


### PR DESCRIPTION
This PR fixes building of the bootloader under MinGW, mainly by addressing the warnings produced by the compiler.

As part of addressing the compiler warnings, it also fixes a potential bug in `mbfatal_winerror()` and `mbfatal_perror()`: the `strncpy()` call that appends `": "` and its preceding `size` check do not actually ensure that the buffer fits two more characters - just one. On the whole, it seems better idea to simply use an additional `snprintf()` call to format the whole message instead of those partial `strncpy()` calls.

After this changeset, the bootloader and its tests build under MinGW (tested under msys2, with `mingw-w64-x86_64-gcc` and  `mingw-w64-i686-gcc` at `10.2.0-5`)