### PR TITLE
loader: remove deprecated PEP-302 functionality from FrozenImporter

### DIFF
--- a/PyInstaller/loader/pyimod03_importers.py
+++ b/PyInstaller/loader/pyimod03_importers.py
@@ -41,23 +41,6 @@ else:
     def trace(msg, *a):
         pass
 
-class FrozenPackageImporter(object):
-    """
-    Wrapper class for FrozenImporter that imports one specific fullname from
-    a module named by an alternate fullname. The alternate fullname is derived from the
-    __path__ of the package module containing that module.
-
-    This is called by FrozenImporter.find_module whenever a module is found as a result
-    of searching module.__path__
-    """
-    def __init__(self, importer, entry_name):
-        self._entry_name = entry_name
-        self._importer = importer
-
-    def load_module(self, fullname):
-        # Deprecated in Python 3.4, see PEP-451
-        return self._importer.load_module(fullname, self._entry_name)
-
 
 class FrozenImporter(object):
     """
@@ -71,14 +54,15 @@ class FrozenImporter(object):
     it doesn't work if the zip file is embedded into a PKG appended
     to an executable, like we create in one-file.
 
-    This is PEP-302 finder and loader class for the ``sys.meta_path`` hook.
-    A PEP-302 finder requires method find_module() to return loader
-    class with method load_module(). Both these methods are implemented
-    in one class.
+    This used to be PEP-302 finder and loader class for the ``sys.meta_path``
+    hook. A PEP-302 finder requires method find_module() to return loader class
+    with method load_module(). However, both of these methods were deprecated
+    in python 3.4 by PEP-451 (see below). Therefore, this class now provides
+    only optional extensions to the PEP-302 importer protocol.
 
     This is also a PEP-451 finder and loader class for the ModuleSpec type
     import system. A PEP-451 finder requires method find_spec(), a PEP-451
-    loader requires methods exec_module(), load_module(9 and (optionally)
+    loader requires methods exec_module(), load_module() and (optionally)
     create_module(). All these methods are implemented in this one class.
 
     To use this class just call
@@ -122,159 +106,6 @@ class FrozenImporter(object):
         # sys.path does not contain filename of executable with bundled zip archive.
         # Raise import error.
         raise ImportError("Can't load frozen modules.")
-
-
-    def find_module(self, fullname, path=None):
-        # Deprecated in Python 3.4, see PEP-451
-        """
-        PEP-302 finder.find_module() method for the ``sys.meta_path`` hook.
-
-        fullname     fully qualified name of the module
-        path         None for a top-level module, or package.__path__
-                     for submodules or subpackages.
-
-        Return a loader object if the module was found, or None if it wasn't.
-        If find_module() raises an exception, it will be propagated to the
-        caller, aborting the import.
-        """
-        module_loader = None  # None means - no module found in this importer.
-
-        if fullname in self.toc:
-            # Tell the import machinery to use self.load_module() to load the module.
-            module_loader = self
-            trace("import %s # PyInstaller PYZ", fullname)
-        elif path is not None:
-            # Try to handle module.__path__ modifications by the modules themselves
-            # Reverse the fake __path__ we added to the package module to a
-            # dotted module name and add the tail module from fullname onto that
-            # to synthesize a new fullname
-            modname = fullname.split('.')[-1]
-
-            for p in path:
-                p = p[SYS_PREFIXLEN+1:]
-                parts = p.split(pyi_os_path.os_sep)
-                if not parts: continue
-                if not parts[0]:
-                    parts = parts[1:]
-                parts.append(modname)
-                entry_name = ".".join(parts)
-                if entry_name in self.toc:
-                    module_loader = FrozenPackageImporter(self, entry_name)
-                    trace("import %s as %s # PyInstaller PYZ (__path__ override: %s)",
-                          entry_name, fullname, p)
-                    break
-        # Release the interpreter's import lock.
-        if module_loader is None:
-            trace("# %s not found in PYZ", fullname)
-        return module_loader
-
-    def load_module(self, fullname, entry_name=None):
-        # Deprecated in Python 3.4, see PEP-451
-        """
-        PEP-302 loader.load_module() method for the ``sys.meta_path`` hook.
-
-        Return the loaded module (instance of imp_new_module()) or raises
-        an exception, preferably ImportError if an existing exception
-        is not being propagated.
-
-        When called from FrozenPackageImporter, `entry_name` is the name of the
-        module as it is stored in the archive. This module will be loaded and installed
-        into sys.modules using `fullname` as its name
-        """
-        # Acquire the interpreter's import lock.
-        module = None
-        if entry_name is None:
-            entry_name = fullname
-        try:
-            # PEP302 If there is an existing module object named 'fullname'
-            # in sys.modules, the loader must use that existing module.
-            module = sys.modules.get(fullname)
-
-            # Module not in sys.modules - load it and it to sys.modules.
-            if module is None:
-                # Load code object from the bundled ZIP archive.
-                is_pkg, bytecode = self._pyz_archive.extract(entry_name)
-                # Create new empty 'module' object.
-                module = imp_new_module(fullname)
-
-                # TODO Replace bytecode.co_filename by something more meaningful:
-                # e.g. /absolute/path/frozen_executable/path/to/module/module_name.pyc
-                # Paths from developer machine are masked.
-
-                # Set __file__ attribute of a module relative to the
-                # executable so that data files can be found.
-                module.__file__ = self.get_filename(entry_name)
-
-                ### Set __path__  if 'fullname' is a package.
-                # Python has modules and packages. A Python package is container
-                # for several modules or packages.
-                if is_pkg:
-
-                    # If a module has a __path__ attribute, the import mechanism
-                    # will treat it as a package.
-                    #
-                    # Since PYTHONHOME is set in bootloader, 'sys.prefix' points to the
-                    # correct path where PyInstaller should find bundled dynamic
-                    # libraries. In one-file mode it points to the tmp directory where
-                    # bundled files are extracted at execution time.
-                    #
-                    # __path__ cannot be empty list because 'wx' module prepends something to it.
-                    # It cannot contain value 'sys.prefix' because 'xml.etree.cElementTree' fails
-                    # Otherwise.
-                    #
-                    # Set __path__ to point to 'sys.prefix/package/subpackage'.
-                    module.__path__ = [pyi_os_path.os_path_dirname(module.__file__)]
-
-                ### Set __loader__
-                # The attribute __loader__ improves support for module 'pkg_resources' and
-                # with the frozen apps the following functions are working:
-                # pkg_resources.resource_string(), pkg_resources.resource_stream().
-                module.__loader__ = self
-
-                ### Set __package__
-                # Accoring to PEP302 this attribute must be set.
-                # When it is present, relative imports will be based on this
-                # attribute rather than the module __name__ attribute.
-                # More details can be found in PEP366.
-                # For ordinary modules this is set like:
-                #     'aa.bb.cc.dd'  ->  'aa.bb.cc'
-                if is_pkg:
-                    module.__package__ = fullname
-                else:
-                    module.__package__ = fullname.rsplit('.', 1)[0]
-
-                ### Set __spec__
-                # In Python 3.4 was introduced module attribute __spec__ to
-                # consolidate all module attributes.
-                module.__spec__ = _frozen_importlib.ModuleSpec(
-                    entry_name, self, is_package=is_pkg)
-
-                ### Add module object to sys.modules dictionary.
-                # Module object must be in sys.modules before the loader
-                # executes the module code. This is crucial because the module
-                # code may (directly or indirectly) import itself; adding it
-                # to sys.modules beforehand prevents unbounded recursion in the
-                # worst case and multiple loading in the best.
-                sys.modules[fullname] = module
-
-                # Run the module code.
-                exec(bytecode, module.__dict__)
-                # Reread the module from sys.modules in case it's changed itself
-                module = sys.modules[fullname]
-
-        except Exception:
-            # Remove 'fullname' from sys.modules if it was appended there.
-            if fullname in sys.modules:
-                sys.modules.pop(fullname)
-            # TODO Do we need to raise different types of Exceptions for better debugging?
-            # PEP302 requires to raise ImportError exception.
-            #raise ImportError("Can't load frozen module: %s" % fullname)
-
-            raise
-
-
-        # Module returned only in case of no exception.
-        return module
 
     ### Optional Extensions to the PEP-302 Importer Protocol
 

--- a/news/5346.moduleloader.rst
+++ b/news/5346.moduleloader.rst
@@ -1,0 +1,3 @@
+Remove deprecated ``PEP-302`` functionality from ``FrozenImporter``.
+The ``find_module()`` and ``load_module()`` methods are deprecated 
+since python 3.4 in favor of ``PEP-451`` loader.


### PR DESCRIPTION
Remove `find_module()` and `load_module()` from `FrozenImporter`. As per comments in these two methods, they are deprecated since python 3.4 in favor of PEP-451 loader.

Also remove the `FrozenPackageImporter` class which was used only from `FrozenImporter.load_module()`.