### PR TITLE
Improvements for macOS CI

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -26,6 +26,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+      fail-fast: false
     steps:
       - uses: actions/checkout@v2
 

--- a/tests/functional/test_apple_events.py
+++ b/tests/functional/test_apple_events.py
@@ -46,13 +46,13 @@ def test_osx_custom_protocol_handler(tmpdir, pyi_builder_spec):
     subprocess.check_call(['open', app_path])
     # 'open' starts program in a different process
     #  so we need to wait for it to finish
-    time.sleep(2)
+    time.sleep(5)
 
     # Call custom protocol handler
     url = custom_url_scheme + "://url-args"
     subprocess.check_call(['open', url])
     # Wait for the program to finish
-    time.sleep(2)
+    time.sleep(5)
     assert os.path.exists(logfile_path), 'Missing args logfile'
     with open(logfile_path, 'r') as fh:
         log_lines = fh.readlines()


### PR DESCRIPTION
Based on the macOS CI failures I've seen recently, this PR:

* disables `fail-fast` strategy to allow all workflows to finish. This in turn allows us to see whether the failing test is affecting all python versions or not.

* increases the delay/wait time in `test_osx_custom_protocol_handler` in an attempt to prevent random failures on the CI. The situation w.r.t. this test has improved since the tests have been marked as flaky, but the occasional failure is still there...