### PR TITLE
Improve support for PEP-420 namespace packages

### DIFF
--- a/PyInstaller/archive/writers.py
+++ b/PyInstaller/archive/writers.py
@@ -34,7 +34,7 @@ import io
 from PyInstaller.building.utils import get_code_object, strip_paths_in_code,\
     fake_pyc_timestamp
 from PyInstaller.loader.pyimod02_archive import PYZ_TYPE_MODULE, PYZ_TYPE_PKG, \
-    PYZ_TYPE_DATA
+    PYZ_TYPE_DATA, PYZ_TYPE_NSPKG
 from ..compat import BYTECODE_MAGIC, is_py37
 
 
@@ -196,7 +196,7 @@ class ZlibArchiveWriter(ArchiveWriter):
                 # This is a NamespacePackage, modulegraph marks them
                 # by using the filename '-'. (But wants to use None,
                 # so check for None, too, to be forward-compatible.)
-                typ = PYZ_TYPE_PKG
+                typ = PYZ_TYPE_NSPKG
             else:
                 base, ext = os.path.splitext(os.path.basename(path))
                 if base == '__init__':

--- a/PyInstaller/lib/modulegraph/modulegraph.py
+++ b/PyInstaller/lib/modulegraph/modulegraph.py
@@ -2103,8 +2103,8 @@ class ModuleGraph(ObjectGraph):
             ns_pkgpath = _namespace_package_path(
                 fqname, pkgpath or [], self.path)
 
-            if ns_pkgpath or pkgpath:
-                # this is a namespace package
+            if (ns_pkgpath or pkgpath) and isinstance(loader, NAMESPACE_PACKAGE):
+                # this is a PEP-420 namespace package
                 m = self.createNode(NamespacePackage, fqname)
                 m.filename = '-'
                 m.packagepath = ns_pkgpath

--- a/PyInstaller/lib/modulegraph/modulegraph.py
+++ b/PyInstaller/lib/modulegraph/modulegraph.py
@@ -2092,7 +2092,8 @@ class ModuleGraph(ObjectGraph):
         partname = fqname.rpartition(".")[-1]
 
         if loader.is_package(partname):
-            if isinstance(loader, NAMESPACE_PACKAGE):
+            is_nspkg = isinstance(loader, NAMESPACE_PACKAGE)
+            if is_nspkg:
                 pkgpath = loader.namespace_dirs[:]  # copy for safety
             else:
                 pkgpath = []
@@ -2103,7 +2104,7 @@ class ModuleGraph(ObjectGraph):
             ns_pkgpath = _namespace_package_path(
                 fqname, pkgpath or [], self.path)
 
-            if (ns_pkgpath or pkgpath) and isinstance(loader, NAMESPACE_PACKAGE):
+            if (ns_pkgpath or pkgpath) and is_nspkg:
                 # this is a PEP-420 namespace package
                 m = self.createNode(NamespacePackage, fqname)
                 m.filename = '-'

--- a/PyInstaller/loader/pyimod02_archive.py
+++ b/PyInstaller/loader/pyimod02_archive.py
@@ -41,6 +41,7 @@ CRYPT_BLOCK_SIZE = 16
 PYZ_TYPE_MODULE = 0
 PYZ_TYPE_PKG = 1
 PYZ_TYPE_DATA = 2
+PYZ_TYPE_NSPKG = 3  # PEP-420 namespace package
 
 class FilePos(object):
     """
@@ -310,7 +311,7 @@ class ZlibArchiveReader(ArchiveReader):
         (typ, pos, length) = self.toc.get(name, (0, None, 0))
         if pos is None:
             return None
-        return typ == PYZ_TYPE_PKG
+        return typ in (PYZ_TYPE_PKG, PYZ_TYPE_NSPKG)
 
     def extract(self, name):
         (typ, pos, length) = self.toc.get(name, (0, None, 0))
@@ -323,7 +324,7 @@ class ZlibArchiveReader(ArchiveReader):
             if self.cipher:
                 obj = self.cipher.decrypt(obj)
             obj = zlib.decompress(obj)
-            if typ in (PYZ_TYPE_MODULE, PYZ_TYPE_PKG):
+            if typ in (PYZ_TYPE_MODULE, PYZ_TYPE_PKG, PYZ_TYPE_NSPKG):
                 obj = marshal.loads(obj)
         except EOFError as e:
             raise ImportError("PYZ entry '%s' failed to unmarshal" %

--- a/PyInstaller/loader/pyimod02_archive.py
+++ b/PyInstaller/loader/pyimod02_archive.py
@@ -313,6 +313,12 @@ class ZlibArchiveReader(ArchiveReader):
             return None
         return typ in (PYZ_TYPE_PKG, PYZ_TYPE_NSPKG)
 
+    def is_pep420_namespace_package(self, name):
+        (typ, pos, length) = self.toc.get(name, (0, None, 0))
+        if pos is None:
+            return None
+        return typ == PYZ_TYPE_NSPKG
+
     def extract(self, name):
         (typ, pos, length) = self.toc.get(name, (0, None, 0))
         if pos is None:

--- a/PyInstaller/loader/pyimod03_importers.py
+++ b/PyInstaller/loader/pyimod03_importers.py
@@ -262,6 +262,11 @@ class FrozenImporter(object):
             spec = _frozen_importlib.ModuleSpec(
                 fullname, None,
                 is_package=True)
+            # Set submodule_search_locations, which seems to fill the
+            # __path__ attribute.
+            spec.submodule_search_locations = [
+                pyi_os_path.os_path_dirname(self.get_filename(entry_name))
+            ]
             return spec
 
         # origin has to be the filename

--- a/PyInstaller/loader/pyimod03_importers.py
+++ b/PyInstaller/loader/pyimod03_importers.py
@@ -107,6 +107,18 @@ class FrozenImporter(object):
         # Raise import error.
         raise ImportError("Can't load frozen modules.")
 
+    # Private helper
+    def _is_pep420_namespace_package(self, fullname):
+        if fullname in self.toc:
+            try:
+                return self._pyz_archive.is_pep420_namespace_package(fullname)
+            except Exception as e:
+                raise ImportError(
+                    'Loader FrozenImporter cannot handle module ' + fullname
+                ) from e
+        else:
+            raise ImportError('Loader FrozenImporter cannot handle module ' + fullname)
+
     ### Optional Extensions to the PEP-302 Importer Protocol
 
     def is_package(self, fullname):
@@ -243,6 +255,14 @@ class FrozenImporter(object):
         if entry_name is None:
             trace("# %s not found in PYZ", fullname)
             return None
+
+        if self._is_pep420_namespace_package(entry_name):
+            # PEP-420 namespace package; as per PEP 451, we need to
+            # return a spec with "loader" set to None (a.k.a. not set)
+            spec = _frozen_importlib.ModuleSpec(
+                fullname, None,
+                is_package=True)
+            return spec
 
         # origin has to be the filename
         origin = self.get_filename(entry_name)

--- a/PyInstaller/loader/pyimod03_importers.py
+++ b/PyInstaller/loader/pyimod03_importers.py
@@ -117,7 +117,9 @@ class FrozenImporter(object):
                     'Loader FrozenImporter cannot handle module ' + fullname
                 ) from e
         else:
-            raise ImportError('Loader FrozenImporter cannot handle module ' + fullname)
+            raise ImportError(
+                'Loader FrozenImporter cannot handle module ' + fullname
+            )
 
     ### Optional Extensions to the PEP-302 Importer Protocol
 

--- a/news/5354.core.rst
+++ b/news/5354.core.rst
@@ -1,0 +1,1 @@
+Improve support for ``PEP-420`` namespace packages.

--- a/tests/functional/test_import.py
+++ b/tests/functional/test_import.py
@@ -546,6 +546,7 @@ def test_nspkg_pep420(pyi_builder):
         pyi_args=['--paths', os.pathsep.join(pathex)],
     )
 
+
 def test_nspkg_attributes(pyi_builder):
     # Test that non-PEP-420 namespace packages (e.g., the ones using
     # pkg_resources.declare_namespace) have proper attributes:
@@ -573,6 +574,7 @@ def test_nspkg_attributes(pyi_builder):
         """,
         pyi_args=['--paths', os.pathsep.join(pathex)],
     )
+
 
 def test_nspkg_attributes_pep420(pyi_builder):
     # Test that PEP-420 namespace packages have proper attributes:


### PR DESCRIPTION
In PEP-420 namespace packages, the `__file__` attribute should be either unset (python 3.6 and earlier) or set to None (python 3.7 and later). This results in a different `repr()`, i.e.
```
<module 'package' (namespace)>
```
instead of
```
<module 'package' from '[...]/package/__init__.pyc'>
```

This PR adds tests and implements support for proper behavior and distinction between PEP-420 and non-PEP-420 namespace packages.

In the `modulegraph`, the `NamespacePackage` node is now used only for PEP-420 namespace packages, and their identification is now based on the loader type. This fixes #5338, which is caused by a spurious namespace declaration that shadows the actual package.