### PR TITLE
Remove uuid from old requirements as it is unlicensed

### DIFF
--- a/tests/old_suite/test-requirements.txt
+++ b/tests/old_suite/test-requirements.txt
@@ -3,7 +3,6 @@ setuptools
 docutils
 jinja2
 sphinx
-uuid
 pyusb
 pytz
 pyenchant


### PR DESCRIPTION
`uuid` is an unlicensed [package](https://pypi.org/project/uuid/) making it incompatible with closed source projects. It seems that the python build-in [uuid](https://docs.python.org/3/library/uuid.html) exists on 2.7 and 3.5+. Furthermore, this package doesn't seem to be used anymore.