### PR TITLE
archive: CArchiveWriter: strip the path from .pyc modules

### DIFF
--- a/PyInstaller/archive/writers.py
+++ b/PyInstaller/archive/writers.py
@@ -383,13 +383,24 @@ class CArchiveWriter(ArchiveWriter):
                 header = fh.read(4)
                 fh.seek(0)
                 if header == BYTECODE_MAGIC:
-                    # Read whole header and load code
+                    # Read whole header and load code.
+                    # According to PEP-552, in python versions prior to
+                    # 3.7, the PYC header consists of three 32-bit words
+                    # (magic, timestamp, and source file size).
+                    # From python 3.7 on, the PYC header was extended to
+                    # four 32-bit words (magic, flags, and, depending on
+                    # the flags, either timestamp and source file size,
+                    # or a 64-bit hash).
                     if is_py37:
                         header = fh.read(16)
                     else:
                         header = fh.read(12)
                     code = marshal.load(fh)
                     # Strip paths from code, marshal back into module form.
+                    # The header fields (timestamp, size, hash, etc.) are
+                    # all referring to the source file, so our modification
+                    # of the code object does not affect them, and we can
+                    # re-use the original header.
                     code = strip_paths_in_code(code)
                     data = header + marshal.dumps(code)
                     # Create file-like object for timestamp re-write

--- a/news/5380.core.rst
+++ b/news/5380.core.rst
@@ -1,0 +1,3 @@
+Strip absolute paths from ``.pyc`` modules collected in the CArchive (PKG).
+This enables build reproducibility without having to match the location of
+the build environment.


### PR DESCRIPTION
This makes the .pyc modules in the PKG archive invariant to the build-environment location, and in turn enables reproducible
builds without having to match the location of the build environment.

Fixes #5377.