### PR TITLE
building: avoid using UPX with Windows DLLs that have CFG enabled

### DIFF
--- a/PyInstaller/utils/win32/versioninfo.py
+++ b/PyInstaller/utils/win32/versioninfo.py
@@ -20,6 +20,30 @@ from ...compat import text_read_mode, win32api
 import pefile
 
 
+def pefile_check_control_flow_guard(filename):
+    """
+    Checks if the specified PE file has CFG (Control Flow Guard) enabled.
+
+    Parameters
+    ----------
+    filename : str
+        Path to the PE file to inspect.
+
+    Returns
+    ----------
+    bool
+        True if file is a PE file with CFG enabled. False if CFG is not
+        enabled or if file could not be processed using pefile library.
+    """
+    try:
+        pe = pefile.PE(filename)
+        # https://docs.microsoft.com/en-us/windows/win32/debug/pe-format
+        # IMAGE_DLLCHARACTERISTICS_GUARD_CF = 0x4000
+        return bool(pe.OPTIONAL_HEADER.DllCharacteristics & 0x4000)
+    except Exception:
+        return False
+
+
 # TODO implement read/write version information with pefile library.
 # PE version info doc: http://msdn.microsoft.com/en-us/library/ms646981.aspx
 def pefile_read_version(filename):

--- a/news/5382.core.rst
+++ b/news/5382.core.rst
@@ -1,0 +1,1 @@
+(Windows) Avoid using UPX with DLLs that have control flow guard (CFG) enabled.


### PR DESCRIPTION
Compressing a DLL that has Control Flow Guard (CFG) enabled with UPX renders it unusable. The most common example of this is the `vcruntime140.dll`, but there could be others. So instead of having users to manually exclude such DLLs, we try to identify and skip them automatically.