### PR TITLE
building: avoid using .pyo module suffix in noarchive mode

### DIFF
--- a/PyInstaller/building/build_main.py
+++ b/PyInstaller/building/build_main.py
@@ -491,7 +491,11 @@ class Analysis(Target):
                 if os.path.splitext(os.path.basename(path))[0] == '__init__':
                     name += os.sep + '__init__'
                 # Append the extension for the compiled result.
-                name += '.py' + ('o' if sys.flags.optimize else 'c')
+                # In python 3.5 (PEP-488) .pyo files were replaced by
+                # .opt-1.pyc and .opt-2.pyc. However, it seems that for
+                # bytecode-only module distribution, we always need to
+                # use the .pyc extension.
+                name += '.pyc'
                 new_toc.append((name, path, typecode))
             # Put the result of byte-compiling this TOC in datas. Mark all entries as data.
             for name, path, typecode in compile_py_files(new_toc, CONF['workpath']):

--- a/news/5383.core.rst
+++ b/news/5383.core.rst
@@ -1,0 +1,1 @@
+Avoid using ``.pyo`` module file suffix (removed since PEP-488) in ``noarchive`` mode.


### PR DESCRIPTION
The `.pyo` file suffix is gone since python 3.5 (PEP-488), and using it when storing bytecode-optimized module files outside the PYZ archive (i.e., `noarchive` mode) will lead to module-not-found errors.

The PEP-488 replaced the .pyo suffix with `.opt-1.pyc` and `.opt-2.pyc`, but for bytecode-only module distribution, it seems that we need to use the plain `.pyc` - same as for non-optimized case.