### PR TITLE
Hooks: Add hook-gi.repository.GtkosxApplication

### DIFF
--- a/PyInstaller/hooks/hook-gi.repository.GtkosxApplication.py
+++ b/PyInstaller/hooks/hook-gi.repository.GtkosxApplication.py
@@ -1,0 +1,18 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2020, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+"""
+Import hook for PyGObject https://wiki.gnome.org/PyGObject
+"""
+
+from PyInstaller.utils.hooks import get_gi_typelibs
+
+
+binaries, datas, hiddenimports = get_gi_typelibs('HarfBuzz', '0.0')

--- a/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GtkosxApplication.py
+++ b/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GtkosxApplication.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2020, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+def pre_safe_import_module(api):
+    # PyGObject modules loaded through the gi repository are marked as
+    # MissingModules by modulegraph so we convert them to
+    # RuntimeModules so their hooks are loaded and run.
+    api.add_runtime_module(api.module_name)

--- a/news/5385.hooks.rst
+++ b/news/5385.hooks.rst
@@ -1,0 +1,1 @@
+ Add hook-gi.repository.GtkosxApplication to fix TypeError with Gtk macOS apps.


### PR DESCRIPTION
Signed-off-by: Dan Yeaw <dan@yeaw.me>

This PR fixes issues when importing GtkosxApplication for use with GTK apps in macOS. For example, I was getting the following TypeError:

```
TypeError: <GtkosxApplication.Application object at 0x112573bc0 (GError at 0x7fa8061d7420)>: unknown signal name: NSApplicationOpenFile
```
