### PR TITLE
Couple of fixes for test suite

### DIFF
--- a/PyInstaller/utils/conftest.py
+++ b/PyInstaller/utils/conftest.py
@@ -100,7 +100,7 @@ def pytest_runtest_setup(item):
         mark.name for mark in item.iter_markers())
     plat = sys.platform
     if supported_platforms and plat not in supported_platforms:
-        pytest.skip("only runs on %s" % plat)
+        pytest.skip("does not run on %s" % plat)
 
 
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)

--- a/tests/functional/test_hooks/test_six.py
+++ b/tests/functional/test_hooks/test_six.py
@@ -10,7 +10,10 @@
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
 
+from PyInstaller.utils.tests import importorskip
 
+
+@importorskip('six.moves')
 def test_six_moves(pyi_builder):
     pyi_builder.test_source(
         """
@@ -18,8 +21,10 @@ def test_six_moves(pyi_builder):
         UserList
         """)
 
+
 # Run the same test a second time to trigger errors like
 #   Target module "six.moves.urllib" already imported as "AliasNode(…)"
 # caused by PyiModuleGraph being cached in a insufficient way.
+@importorskip('six.moves')
 def test_six_moves_2nd_run(pyi_builder):
     return test_six_moves(pyi_builder)


### PR DESCRIPTION
Fix the test skip message due to unsupported platform - currently, running the test suite on linux produces `runs only on linux` skip messages for Windows-only test.

Add `@importorskip` decorators to `test_six_moves˙ and `test_six_moves_2nd_run` to prevent test failures when `six` is not installed.