### PR TITLE
building: makespec: add new command-line switches for hookutils functions

### DIFF
--- a/PyInstaller/building/templates.py
+++ b/PyInstaller/building/templates.py
@@ -15,13 +15,14 @@ Templates to generate .spec files.
 """
 
 onefiletmplt = """# -*- mode: python ; coding: utf-8 -*-
+%(preamble)s
 %(cipher_init)s
 
 a = Analysis(%(scripts)s,
              pathex=%(pathex)s,
              binaries=%(binaries)s,
              datas=%(datas)s,
-             hiddenimports=%(hiddenimports)r,
+             hiddenimports=%(hiddenimports)s,
              hookspath=%(hookspath)r,
              runtime_hooks=%(runtime_hooks)r,
              excludes=%(excludes)s,
@@ -48,13 +49,14 @@ exe = EXE(pyz,
 """
 
 onedirtmplt = """# -*- mode: python ; coding: utf-8 -*-
+%(preamble)s
 %(cipher_init)s
 
 a = Analysis(%(scripts)s,
              pathex=%(pathex)s,
              binaries=%(binaries)s,
              datas=%(datas)s,
-             hiddenimports=%(hiddenimports)r,
+             hiddenimports=%(hiddenimports)s,
              hookspath=%(hookspath)r,
              runtime_hooks=%(runtime_hooks)r,
              excludes=%(excludes)s,

--- a/news/5391.feature.rst
+++ b/news/5391.feature.rst
@@ -1,0 +1,3 @@
+Add new command-line options that map to collect functions from hookutils:
+``-collect-submodules``, ``--collect-data``, ``--collect-binaries``,
+``--collect-all``, and ``--copy-metadata``.


### PR DESCRIPTION
Add new command-line options that map to the corresponding functions from the hookutils:
* --collect-submodules: collect_submodules()
* --collect-data: collect_data_files()
* --collect-binaries: collect_dynamic_libs()
* --collect-all: collect_all()
* --copy-metadata: copy_metadata()

The hookutils calls are added to the generated .spec files. They may be specified multiple times, and their results supplement
the entries that are manually passed via existing --add-data, --add-binary, and --hidden-import switches.

This allows hookutils calls to be added from command-line, without having to manually edit the .spec file.