### PR TITLE
 loader: ensure that packages have submodule_search_locations set

### DIFF
--- a/PyInstaller/loader/pyimod03_importers.py
+++ b/PyInstaller/loader/pyimod03_importers.py
@@ -288,6 +288,14 @@ class FrozenImporter(object):
         # (e.g. zipimport), that information may be stored in
         # spec.loader_state.
         spec.has_location = True
+
+        # Set submodule_search_locations for packages. Seems to be
+        # required for importlib_resources from 3.2.0 - see issue #5395.
+        if is_pkg:
+            spec.submodule_search_locations = [
+                pyi_os_path.os_path_dirname(self.get_filename(entry_name))
+            ]
+
         return spec
 
     def create_module(self, spec):

--- a/news/5396.bugfix.rst
+++ b/news/5396.bugfix.rst
@@ -1,0 +1,2 @@
+Ensure that spec for frozen packages has ``submodule_search_locations`` set
+in order to fix compatibility  with ``importlib_resources`` 3.2.0 and later.


### PR DESCRIPTION
Returning empty list for `submodule_search_locations` for frozen packages seems to break `importlib_resources` from `3.2.0` on (used by older python versions that don't have standard `importlib`).

Fixes #5395.