### PR TITLE
winmanifest: enable longPathAware option in application's manifest

### DIFF
--- a/PyInstaller/utils/win32/winmanifest.py
+++ b/PyInstaller/utils/win32/winmanifest.py
@@ -896,6 +896,23 @@ class Manifest(object):
         cE.aChild(caE)
         docE.aChild(cE)
 
+        # Add application.windowsSettings section to enable longPathAware
+        # option (issue #5423).
+        if self.manifestType == "assembly":
+            aE = doc.cE("application")
+            aE.setAttribute("xmlns", "urn:schemas-microsoft-com:asm.v3")
+            wsE = doc.cE("windowsSettings")
+            lpaE = doc.cE("longPathAware")
+            lpaE.setAttribute(
+                "xmlns",
+                "http://schemas.microsoft.com/SMI/2016/WindowsSettings"
+            )
+            lpaT = doc.cT("true")
+            lpaE.aChild(lpaT)
+            wsE.aChild(lpaE)
+            aE.aChild(wsE)
+            docE.aChild(aE)
+
         return doc
 
     def toprettyxml(self, indent="  ", newl=os.linesep, encoding="UTF-8"):

--- a/news/5424.feature.rst
+++ b/news/5424.feature.rst
@@ -1,0 +1,2 @@
+(Windows) Enable ``longPathAware`` option in built application's manifest in
+order to support long file paths on Windows 10 v.1607 and later.


### PR DESCRIPTION
Enables long paths on Windows 10 v.1607 and later.
Fixes #5423.