### PR TITLE
hooks: PySide2/PyQt5: fix the availability check for older Qt5 versions

### DIFF
--- a/PyInstaller/hooks/hook-PyQt5.QtNetwork.py
+++ b/PyInstaller/hooks/hook-PyQt5.QtNetwork.py
@@ -15,7 +15,7 @@ from PyInstaller.utils.hooks.qt import add_qt5_dependencies, pyqt5_library_info
 from PyInstaller.compat import is_win
 
 # Ensure PyQt5 is importable before adding info depending on it.
-if pyqt5_library_info.version:
+if pyqt5_library_info.version is not None:
     hiddenimports, binaries, datas = add_qt5_dependencies(__file__)
 
     # Add libraries needed for SSL if these are available. See issue #3520, #4048.

--- a/PyInstaller/hooks/hook-PyQt5.QtQml.py
+++ b/PyInstaller/hooks/hook-PyQt5.QtQml.py
@@ -15,7 +15,7 @@ from PyInstaller.utils.hooks.qt import pyqt5_library_info, add_qt5_dependencies
 from PyInstaller import log as logging
 
 # Ensure PyQt5 is importable before adding info depending on it.
-if pyqt5_library_info.version:
+if pyqt5_library_info.version is not None:
     logger = logging.getLogger(__name__)
 
     hiddenimports, binaries, datas = add_qt5_dependencies(__file__)

--- a/PyInstaller/hooks/hook-PyQt5.QtWebEngineWidgets.py
+++ b/PyInstaller/hooks/hook-PyQt5.QtWebEngineWidgets.py
@@ -18,7 +18,7 @@ from PyInstaller.depend.bindepend import getImports
 import PyInstaller.compat as compat
 
 # Ensure PyQt5 is importable before adding info depending on it.
-if pyqt5_library_info.version:
+if pyqt5_library_info.version is not None:
     hiddenimports, binaries, datas = add_qt5_dependencies(__file__)
 
     # Include the web engine process, translations, and resources.

--- a/PyInstaller/hooks/hook-PyQt5.py
+++ b/PyInstaller/hooks/hook-PyQt5.py
@@ -14,7 +14,7 @@ from PyInstaller.utils.hooks import collect_system_data_files
 from PyInstaller.utils.hooks.qt import pyqt5_library_info, get_qt_binaries
 
 # Ensure PyQt5 is importable before adding info depending on it.
-if pyqt5_library_info.version:
+if pyqt5_library_info.version is not None:
     hiddenimports = [
         # PyQt5.10 and earlier uses sip in an separate package;
         'sip',

--- a/PyInstaller/hooks/hook-PySide2.QtNetwork.py
+++ b/PyInstaller/hooks/hook-PySide2.QtNetwork.py
@@ -16,7 +16,7 @@ from PyInstaller.utils.hooks.qt import add_qt5_dependencies, \
 from PyInstaller.compat import is_win
 
 # Only proceed if PySide2 can be imported.
-if pyside2_library_info.version:
+if pyside2_library_info.version is not None:
     hiddenimports, binaries, datas = add_qt5_dependencies(__file__)
 
     # Add libraries needed for SSL if these are available. See issue #3520, #4048.

--- a/PyInstaller/hooks/hook-PySide2.QtQml.py
+++ b/PyInstaller/hooks/hook-PySide2.QtQml.py
@@ -15,7 +15,7 @@ from PyInstaller.utils.hooks.qt import pyside2_library_info, add_qt5_dependencie
 from PyInstaller import log as logging
 
 # Only proceed if PySide2 can be imported.
-if pyside2_library_info.version:
+if pyside2_library_info.version is not None:
     logger = logging.getLogger(__name__)
 
     hiddenimports, binaries, datas = add_qt5_dependencies(__file__)

--- a/PyInstaller/hooks/hook-PySide2.QtWebEngineWidgets.py
+++ b/PyInstaller/hooks/hook-PySide2.QtWebEngineWidgets.py
@@ -32,7 +32,7 @@ def prefix_with_path(prefix_path, *paths):
 
 
 # Ensure PySide2 is importable before adding info depending on it.
-if pyside2_library_info.version:
+if pyside2_library_info.version is not None:
     hiddenimports, binaries, datas = add_qt5_dependencies(__file__)
 
     # Include the web engine process, translations, and resources.

--- a/PyInstaller/hooks/hook-PySide2.py
+++ b/PyInstaller/hooks/hook-PySide2.py
@@ -15,7 +15,7 @@ from PyInstaller.utils.hooks.qt import pyside2_library_info, get_qt_binaries
 from PyInstaller.compat import is_win
 
 # Only proceed if PySide2 can be imported.
-if pyside2_library_info.version:
+if pyside2_library_info.version is not None:
 
     hiddenimports = ['shiboken2']
 

--- a/news/5425.hooks.rst
+++ b/news/5425.hooks.rst
@@ -1,0 +1,2 @@
+Fix the ``Qt5`` library availability check in ``PyQt5`` and ``PySide2`` hooks 
+to re-enable support for ``Qt5`` older than 5.8.


### PR DESCRIPTION
Replace the truthyness check of `{pyside2,pyqt5}_library_info.version` with explicit not-`None` check. The check is meant to ensure that the library is importable, however, the version information is not available in older Qt5 versions (`QLibraryInfo::version()` was added in Qt 5.8).

Therefore, an empty version array indicates that the library is available, but is too old to have the version information exposed. The library failing to import, however, should result in corresponding `library_info` structure to have version set to `None`.

Fixes #5381.