### PR TITLE
hookutils: collect_submodules: limit the impact of a failed subpackage import

### DIFF
--- a/PyInstaller/utils/hooks/__init__.py
+++ b/PyInstaller/utils/hooks/__init__.py
@@ -619,6 +619,7 @@ def collect_submodules(package, filter=lambda name: True):
     names = exec_statement("""
         import sys
         import pkgutil
+        import traceback
 
         # ``pkgutil.walk_packages`` doesn't walk subpackages of zipped files
         # per https://bugs.python.org/issue14209. This is a workaround.
@@ -643,7 +644,11 @@ def collect_submodules(package, filter=lambda name: True):
                         if onerror is not None:
                             onerror(name)
                         else:
-                            raise
+                            traceback.print_exc(file=sys.stderr)
+                            print(
+                                "collect_submodules: failed to import '{{}}'!"
+                                .format(name), file=sys.stderr
+                            )
                     else:
                         path = getattr(sys.modules[name], '__path__', None) or []
 

--- a/PyInstaller/utils/hooks/__init__.py
+++ b/PyInstaller/utils/hooks/__init__.py
@@ -645,10 +645,8 @@ def collect_submodules(package, filter=lambda name: True):
                             onerror(name)
                         else:
                             traceback.print_exc(file=sys.stderr)
-                            print(
-                                "collect_submodules: failed to import '{{}}'!"
-                                .format(name), file=sys.stderr
-                            )
+                            print("collect_submodules: failed to import %r!" %
+                                  name, file=sys.stderr)
                     else:
                         path = getattr(sys.modules[name], '__path__', None) or []
 

--- a/news/5426.hooks.rst
+++ b/news/5426.hooks.rst
@@ -1,0 +1,3 @@
+Limit the impact of a failed sub-package import on the result of 
+``collect_submodules()`` to ensure that modules from all other sub-packages
+are collected.


### PR DESCRIPTION
Fix the scenario where a single failed subpackage import during a package inspection by `collect_submodules()` prevents the remainder of the package from being inspected/collected.

Instead of re-raising the exception and aborting the package-walking, we now print a message to `stderr` and continue, in an attempt to salvage the situation based on the following rationale: if the problematic sub-package is required by the program, then the unfrozen version would have hit the same problem (and there's nothing we can do about it). On the other hand, if the problematic sub-package is not required by the program, we now properly collect all other sub-packages and allow the program to work, as opposed to breaking it by not collecting the remaining sub-packages at all.