### PR TITLE
breaking: drop python 3.5 support

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9]
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,11 +81,6 @@ jobs:
         - python -m PyInstaller.utils.run_tests -c PyInstaller/utils/pytest.ini --include_only=pyi_hooksample.
 
     - <<: *test-pyinstaller
-      python: 3.5
-    - <<: *test-libraries
-      python: 3.5
-
-    - <<: *test-pyinstaller
       python: 3.6
     - <<: *test-libraries
       python: 3.6

--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -713,5 +713,5 @@ def check_requirements():
     Fail hard if any requirement is not met.
     """
     # Fail hard if Python does not have minimum required version
-    if sys.version_info < (3, 5):
-        raise EnvironmentError('PyInstaller requires at Python 3.5 or newer.')
+    if sys.version_info < (3, 6):
+        raise EnvironmentError('PyInstaller requires at Python 3.6 or newer.')

--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ but is not tested against them as part of the continuous integration tests.
 Main Advantages
 ---------------
 
-- Works out-of-the-box with any Python version 3.5-3.9.
+- Works out-of-the-box with any Python version 3.6-3.9.
 - Fully multi-platform, and uses the OS support to load the dynamic libraries,
   thus ensuring full compatibility.
 - Correctly bundles the major Python packages such as numpy, PyQt5,
@@ -64,7 +64,7 @@ Requirements and Tested Platforms
 
 - Python: 
 
- - 3.5-3.9
+ - 3.6-3.9
  - tinyaes_ 1.0+ (only if using bytecode encryption).
    Instead of installing tinyaes, ``pip install pyinstaller[encryption]`` instead.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -94,16 +94,6 @@ environment:
       PYTHON_ARCH: 32
       TEST_PART: Base
 
-    - PYTHON: C:\Python35
-      PYTHON_VERSION: 3.5
-      PYTHON_ARCH: 32
-      TEST_PART: Libraries
-
-    - PYTHON: C:\Python35
-      PYTHON_VERSION: 3.5
-      PYTHON_ARCH: 32
-      TEST_PART: Base
-
 init:
   - ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%
   - ECHO \"%APPVEYOR_SCHEDULED_BUILD%\"

--- a/doc/hooks.rst
+++ b/doc/hooks.rst
@@ -250,8 +250,8 @@ for example::
 
    from PyInstaller.compat import modname_tkinter, is_win
 
-``is_py35``, ``is_py36``, ``is_py37``, ``is_py38``, ``is_py39``:
-   True when the current version of Python is at least 3.5, 3.6, 3.7, 3.8 or 3.9 respectively.
+``is_py36``, ``is_py37``, ``is_py38``, ``is_py39``:
+   True when the current version of Python is at least 3.6, 3.7, 3.8 or 3.9 respectively.
 
 ``is_win``:
    True in a Windows system.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -12,7 +12,7 @@ PyInstaller Manual
 |PyInstaller| bundles a Python application and all its dependencies into
 a single package.
 The user can run the packaged app without installing a Python interpreter or any modules.
-|PyInstaller| supports Python 3.5 or newer,
+|PyInstaller| supports Python 3.6 or newer,
 and correctly bundles the major Python packages
 such as numpy, PyQt, Django, wxPython, and others.
 
@@ -45,7 +45,7 @@ __ https://github.com/pyinstaller/pyinstaller-hooks-contrib
 
 Finally, this version drops support for Python 2.7,
 which is end-of-life since January 2020..
-The minimum required version is now Python 3.5.
+The minimum required version is now Python 3.6.
 The last version supporting Python 2.7 was PyInstaller 3.6.
 
 

--- a/doc/man/pyinstaller.rst
+++ b/doc/man/pyinstaller.rst
@@ -23,7 +23,7 @@ PyInstaller is a program that freezes (packages) Python programs into
 stand-alone executables, under Windows, GNU/Linux, Mac OS X,
 FreeBSD, OpenBSD, Solaris and AIX.
 Its main advantages over similar tools are that PyInstaller works with
-Python 3.5—3.7, it builds smaller executables thanks to transparent
+Python 3.6-3.9, it builds smaller executables thanks to transparent
 compression, it is fully multi-platform, and use the OS support to load the
 dynamic libraries, thus ensuring full compatibility.
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -464,9 +464,9 @@ You must make a unique version of the app for each word-length supported.
 Windows
 ---------------
 
-For **Python >= 3.5** targeting *Windows < 10*, the developer needs to take
+The developer needs to take
 special care to include the Visual C++ run-time .dlls:
-Python 3.5 uses Visual Studio 2015 run-time, which has been renamed into
+Python 3.5+ uses Visual Studio 2015 run-time, which has been renamed into
 `“Universal CRT“
 <https://blogs.msdn.microsoft.com/vcblog/2015/03/03/introducing-the-universal-crt/>`_
 and has become part of Windows 10.

--- a/doc/when-things-go-wrong.rst
+++ b/doc/when-things-go-wrong.rst
@@ -108,7 +108,7 @@ Build-Time Python Errors
 |PyInstaller| sometimes terminates by raising a Python exception.
 In most cases the reason is clear from the exception message,
 for example "Your system is not supported", or "Pyinstaller
-requires at least Python 3.5".
+requires at least Python 3.6".
 Others clearly indicate a bug that should be reported.
 
 One of these errors can be puzzling, however:

--- a/news/5439.core.rst
+++ b/news/5439.core.rst
@@ -1,0 +1,1 @@
+Drop support for python 3.5; EOL since September 2020.

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@
 
 setuptools<50.0.0   # 50.0.0 breaks a modulegraph regession test
 altgraph
-pyinstaller-hooks-contrib >= 2020.6
+pyinstaller-hooks-contrib >= 2020.11
 pefile; sys_platform == 'win32'
 pywin32-ctypes; sys_platform == 'win32'
 macholib; sys_platform == 'darwin'

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,6 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
@@ -55,7 +54,7 @@ classifiers =
 zip_safe = False
 packages = PyInstaller
 include_package_data = True
-python_requires = >=3.5
+python_requires = >=3.6
 ## IMPORTANT: Keep aligned with requirements.txt
 install_requires =
     setuptools

--- a/tests/functional/scripts/pyi_getfilesystemencoding.py
+++ b/tests/functional/scripts/pyi_getfilesystemencoding.py
@@ -17,12 +17,9 @@ frozen_encoding = str(sys.getfilesystemencoding())
 
 
 # For various OS is encoding different.
-# On Windows it should be still mbcs up to Python 3.5
 if sys.platform.startswith('win'):
-    encoding = 'mbcs'
-    if sys.version_info >= (3, 6):
-        # See PEP 529 for more information.
-        encoding = 'utf-8'
+    # See PEP 529 for more information.
+    encoding = 'utf-8'
 # On Mac OS X the value should be still the same.
 elif sys.platform.startswith('darwin'):
     encoding = 'utf-8'

--- a/tests/functional/test_apple_events.py
+++ b/tests/functional/test_apple_events.py
@@ -31,7 +31,6 @@ from PyInstaller.utils.tests import importorskip
 
 @pytest.mark.darwin
 def test_osx_custom_protocol_handler(tmpdir, pyi_builder_spec):
-    tmpdir = str(tmpdir)  # Fix for Python 3.5
     app_path = os.path.join(tmpdir, 'dist',
                             'pyi_osx_custom_protocol_handler.app')
     logfile_path = os.path.join(tmpdir, 'dist', 'args.log')
@@ -62,7 +61,6 @@ def test_osx_custom_protocol_handler(tmpdir, pyi_builder_spec):
 @pytest.mark.darwin
 @importorskip('PyQt5')
 def test_osx_event_forwarding(tmpdir, pyi_builder_spec):
-    tmpdir = str(tmpdir)  # Fix for Python 3.5
     app_path = os.path.join(tmpdir, 'dist',
                             'pyi_osx_event_forwarding.app')
 

--- a/tests/functional/test_django.py
+++ b/tests/functional/test_django.py
@@ -15,8 +15,7 @@ Functional tests for the Django content management system (CMS).
 
 import pytest
 
-from PyInstaller.utils.tests import importorskip, skipif
-from PyInstaller.compat import is_py36
+from PyInstaller.utils.tests import importorskip
 
 
 # In Django 2.1, ``django/contrib/auth/password_validation.py``, line 168, which
@@ -28,8 +27,6 @@ from PyInstaller.compat import is_py36
 # ``password_validation.pyc`` doesn't exist. Python 3.6 added the default
 # argument ``strict=False``, which ignores this exception. This file is in the
 # archive, but not the filesystem.
-@skipif(not is_py36,
-        reason='Call to resolve() raises an exception in Python 3.5.')
 @importorskip('django')
 # Django test might sometimes hang.
 @pytest.mark.timeout(timeout=7*60)

--- a/tests/functional/test_linux_appimage.py
+++ b/tests/functional/test_linux_appimage.py
@@ -21,25 +21,19 @@ import stat
 import subprocess
 import pytest
 
-from PyInstaller.compat import is_py36
-
 
 @pytest.mark.linux
 @pytest.mark.parametrize('arch', ['x86_64'])
 def test_appimage_loading(tmp_path, pyi_builder_spec, arch):
     # Skip the test if appimagetool is not found
     appimagetool = pathlib.Path.home() / ('appimagetool-%s.AppImage' % arch)
-    if not is_py36:
-        appimagetool = str(appimagetool)
-    if not os.path.isfile(appimagetool):
+    if appimagetool.is_file():
         pytest.skip('%s not found' % appimagetool)
 
     # Ensure appimagetool is executable
     if not os.access(appimagetool, os.X_OK):
-        st = os.stat(appimagetool)
-        os.chmod(appimagetool, st.st_mode | stat.S_IXUSR)
-
-    tmp_path = str(tmp_path)  # Fix for Python 3.5
+        st = appimagetool.stat()
+        appimagetool.chmod(st.st_mode | stat.S_IXUSR)
 
     app_name = 'apptest'
     app_path = os.path.join(tmp_path, '%s-%s.AppImage' % (app_name, arch))

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -17,8 +17,7 @@
 #
 # - v. 2.2 and above fails.
 Django==2.1.8  # pyup: ignore
-matplotlib==3.0.3; python_version <= '3.5'  # pyup: ignore
-matplotlib==3.2.2; python_version >= '3.6'  # pyup: ignore
+matplotlib==3.2.2 # pyup: ignore
 # - v 21.1.0 fails; earlier versions not tested.
 keyring==19.2.0  # pyup: ignore
 
@@ -42,28 +41,16 @@ sphinx==2.4.4 # pyup: ignore
 # Required for test_namespace_package
 sqlalchemy==1.3.22
 zope.interface==5.2.0
+pandas==1.1.5
+numpy==1.19.4
+scipy==1.5.4
+Pillow==8.0.1
 
 
-# Python 3.5 not supported / supported for older versions
+# Python versions not supported / supported for older package versions
 # -------------------------------------------------------
 
-# iPython 7.10.0 and higher dropped Python 3.5 support per https://ipython.readthedocs.io/en/stable/whatsnew/version7.html#stop-support-for-python-3-5-adopt-nep-29.
+# iPython 7.17 dropped support for python 3.6
+# https://ipython.readthedocs.io/en/stable/whatsnew/version7.html#ipython-7-17
 ipython==7.19.0; python_version > '3.6'
 ipython==7.16.1; python_version == '3.6'  # pyup: ignore
-ipython==7.9.0; python_version == '3.5'  # pyup: ignore
-
-# pandas 1.0.0 dropped Python 3.5 support.
-pandas==1.1.5; python_version > '3.5'
-pandas==0.25.3; python_version == '3.5'  # pyup: ignore
-
-# Numpy 1.19 dropped Python 3.5 support
-numpy==1.19.4; python_version > '3.5'
-numpy<=1.19.0; python_version == '3.5'  # pyup: ignore
-
-# And so did SciPy
-scipy==1.5.4; python_version > '3.5'
-scipy<=1.5.0; python_version == '3.5'  # pyup: ignore
-
-# Pillow 8.0 dropped support for python 3.5
-Pillow==8.0.1; python_version > '3.5'
-Pillow<8.0.0; python_version == '3.5' # pyup: ignore


### PR DESCRIPTION
* drop 3.5 from the CI matrices
* bump the check in compat.py so PyInstaller no longer runs on 3.5
* Remove/update most python 3.5 references in the docs
* update requirements.txt so that 3.5-specific dependencies are removed
* update setup.cfg so that PyInstaller won't install on python 3.5
* update the readme