### PR TITLE
utils/win32: Fix serializing VSVersionInfo.

### DIFF
--- a/PyInstaller/utils/misc.py
+++ b/PyInstaller/utils/misc.py
@@ -21,7 +21,7 @@ import py_compile
 import sys
 
 from PyInstaller import log as logging
-from PyInstaller.compat import BYTECODE_MAGIC, text_read_mode
+from PyInstaller.compat import BYTECODE_MAGIC, text_read_mode, is_win
 
 logger = logging.getLogger(__name__)
 
@@ -223,6 +223,10 @@ def load_py_data_struct(filename):
         # Binding redirects are stored as a named tuple, so bring the namedtuple
         # class into scope for parsing the TOC.
         from ..depend.bindepend import BindingRedirect
+
+        if is_win:
+            # import versioninfo so that VSVersionInfo can parse correctly
+            from .win32 import versioninfo  # noqa: F401
 
         return eval(f.read())
 

--- a/PyInstaller/utils/win32/versioninfo.py
+++ b/PyInstaller/utils/win32/versioninfo.py
@@ -210,6 +210,9 @@ class VSVersionInfo:
         return (struct.pack('hhh', sublen, vallen, typ)
                 + raw_name + b'\000\000' + pad + rawffi + pad2 + tmp)
 
+    def __eq__(self, other):
+        return self.toRaw() == other
+
     def __str__(self, indent=u''):
         indent = indent + u'  '
         tmp = [kid.__str__(indent+u'  ')
@@ -226,6 +229,10 @@ VSVersionInfo(
 %s]
 )
 """ % (indent, self.ffi.__str__(indent), indent, tmp, indent))
+
+    def __repr__(self):
+        return ("versioninfo.VSVersionInfo(ffi=%r, kids=%r)" %
+                (self.ffi, self.kids))
 
 
 def parseCommon(data, start=0):
@@ -317,6 +324,9 @@ class FixedFileInfo:
                              self.fileDateMS,
                              self.fileDateLS)
 
+    def __eq__(self, other):
+        return self.toRaw() == other
+
     def __str__(self, indent=u''):
         fv = (self.fileVersionMS >> 16, self.fileVersionMS & 0xffff,
               self.fileVersionLS >> 16, self.fileVersionLS & 0xFFFF)
@@ -346,6 +356,19 @@ class FixedFileInfo:
             u')'
         ]
         return (u'\n'+indent+u'  ').join(tmp)
+
+    def __repr__(self):
+        fv = (self.fileVersionMS >> 16, self.fileVersionMS & 0xffff,
+              self.fileVersionLS >> 16, self.fileVersionLS & 0xffff)
+        pv = (self.productVersionMS >> 16, self.productVersionMS & 0xffff,
+              self.productVersionLS >> 16, self.productVersionLS & 0xffff)
+        fd = (self.fileDateMS, self.fileDateLS)
+        return ('versioninfo.FixedFileInfo(filevers=%r, prodvers=%r, '
+                'mask=0x%x, flags=0x%x, OS=0x%x, '
+                'fileType=%r, subtype=0x%x, date=%r)' %
+                (fv, pv,
+                 self.fileFlagsMask, self.fileFlags, self.fileOS,
+                 self.fileType, self.fileSubtype, fd))
 
 
 class StringFileInfo(object):
@@ -384,6 +407,9 @@ class StringFileInfo(object):
         return (struct.pack('hhh', sublen, vallen, typ)
                 + raw_name + b'\000\000' + pad + tmp)
 
+    def __eq__(self, other):
+        return self.toRaw() == other
+
     def __str__(self, indent=u''):
         newindent = indent + u'  '
         tmp = [kid.__str__(newindent)
@@ -391,6 +417,9 @@ class StringFileInfo(object):
         tmp = u', \n'.join(tmp)
         return (u'%sStringFileInfo(\n%s[\n%s\n%s])'
                 % (indent, newindent, tmp, newindent))
+
+    def __repr__(self):
+        return 'versioninfo.StringFileInfo(%r)' % self.kids
 
 
 class StringTable:
@@ -432,11 +461,17 @@ class StringTable:
         return (struct.pack('hhh', sublen, vallen, typ)
                 + raw_name + b'\000\000' + tmp)
 
+    def __eq__(self, other):
+        return self.toRaw() == other
+
     def __str__(self, indent=u''):
         newindent = indent + u'  '
         tmp = (u',\n%s' % newindent).join(str(kid) for kid in self.kids)
         return (u"%sStringTable(\n%su'%s',\n%s[%s])"
                 % (indent, newindent, self.name, newindent, tmp))
+
+    def __repr__(self):
+        return 'versioninfo.StringTable(%r, %r)' % (self.name, self.kids)
 
 
 class StringStruct:
@@ -475,8 +510,14 @@ class StringStruct:
                 + raw_val + b'\000\000')
         return abcd
 
+    def __eq__(self, other):
+        return self.toRaw() == other
+
     def __str__(self, indent=''):
         return u"StringStruct(u'%s', u'%s')" % (self.name, self.val)
+
+    def __repr__(self):
+        return 'versioninfo.StringStruct(%r, %r)' % (self.name, self.val)
 
 
 def parseCodePage(data, i, limit):
@@ -523,9 +564,15 @@ class VarFileInfo:
         return (struct.pack('hhh', self.sublen, self.vallen, self.wType)
                 + raw_name + b'\000\000' + pad + tmp)
 
+    def __eq__(self, other):
+        return self.toRaw() == other
+
     def __str__(self, indent=''):
         return (indent + "VarFileInfo([%s])" %
                 ', '.join(str(kid) for kid in self.kids))
+
+    def __repr__(self):
+        return 'versioninfo.VarFileInfo(%r)' % self.kids
 
 
 class VarStruct:
@@ -566,8 +613,14 @@ class VarStruct:
         return (struct.pack('hhh', self.sublen, self.wValueLength, self.wType)
                 + raw_name + b'\000\000' + pad + tmp)
 
+    def __eq__(self, other):
+        return self.toRaw() == other
+
     def __str__(self, indent=u''):
         return u"VarStruct(u'%s', %r)" % (self.name, self.kids)
+
+    def __repr__(self):
+        return 'versioninfo.VarStruct(%r, %r)' % (self.name, self.kids)
 
 
 def SetVersion(exenm, versionfile):

--- a/news/5445.bugfix.rst
+++ b/news/5445.bugfix.rst
@@ -1,0 +1,4 @@
+(Windows) Fix "toc is bad" error messages
+when passing a ``VSVersionInfo``
+as the ``version`` parameter to ``EXE()``
+in a ``.spec`` file.

--- a/tests/unit/test_miscutils.py
+++ b/tests/unit/test_miscutils.py
@@ -1,0 +1,50 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2020, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+
+import pytest
+
+from PyInstaller.utils.misc import load_py_data_struct, save_py_data_struct
+
+
+@pytest.mark.win32
+def test_versioninfo(tmp_path):
+    from PyInstaller.utils.win32.versioninfo import VSVersionInfo, \
+        FixedFileInfo, StringFileInfo, StringTable, StringStruct, \
+        VarFileInfo, VarStruct
+
+    vsinfo = VSVersionInfo(
+        ffi=FixedFileInfo(
+            filevers=(1, 2, 3, 4),
+            prodvers=(5, 6, 7, 8),
+            mask=0x3f,
+            flags=0x1,
+            OS=0x40004,
+            fileType=0x42,
+            subtype=0x42,
+            date=(0, 0)
+        ),
+        kids=[
+            StringFileInfo(
+                [
+                    StringTable(
+                        '040904b0',
+                        [StringStruct('FileDescription',
+                                      'versioninfo test')])
+                ]),
+            VarFileInfo([VarStruct('Translation', [1033, 1200])])
+        ]
+    )
+
+    file = str(tmp_path / 'versioninfo')
+    save_py_data_struct(file, vsinfo)
+
+    assert vsinfo == load_py_data_struct(file)


### PR DESCRIPTION
This fixes "toc is bad" error messages if a VSVersionInfo is passed as 
the version parameter of the EXE function, which leads to spurious rebuids.