### PR TITLE
bootloader: retrieve failed script error details before they are cleared

### DIFF
--- a/bootloader/src/pyi_python.c
+++ b/bootloader/src/pyi_python.c
@@ -58,6 +58,7 @@ DECLPROC(PyErr_Clear);
 DECLPROC(PyErr_Occurred);
 DECLPROC(PyErr_Print);
 DECLPROC(PyErr_Fetch);
+DECLPROC(PyErr_Restore);
 
 DECLPROC(PyImport_AddModule);
 DECLPROC(PyImport_ExecCodeModule);
@@ -123,6 +124,7 @@ pyi_python_map_names(HMODULE dll, int pyvers)
     GETPROC(dll, PyErr_Occurred);
     GETPROC(dll, PyErr_Print);
     GETPROC(dll, PyErr_Fetch);
+    GETPROC(dll, PyErr_Restore);
     GETPROC(dll, PyImport_AddModule);
     GETPROC(dll, PyImport_ExecCodeModule);
     GETPROC(dll, PyImport_ImportModule);

--- a/bootloader/src/pyi_python.h
+++ b/bootloader/src/pyi_python.h
@@ -155,6 +155,7 @@ EXTDECLPROC(PyObject *, PyMarshal_ReadObjectFromString, (const char *, size_t));
 
 /* Used to get traceback information while launching run scripts */
 EXTDECLPROC(void, PyErr_Fetch, (PyObject **, PyObject **, PyObject **));
+EXTDECLPROC(void, PyErr_Restore, (PyObject *, PyObject *, PyObject *));
 EXTDECLPROC(PyObject *, PyObject_Str, (PyObject *));
 EXTDECLPROC(PyObject *, PyObject_GetAttrString, (PyObject *, const char *));
 EXTDECLPROC(const char *, PyUnicode_AsUTF8, (PyObject *));

--- a/news/5446.bugfix.rst
+++ b/news/5446.bugfix.rst
@@ -1,0 +1,3 @@
+(Windows) The ``windowed``+``debug`` bootloader variant now properly
+displays the exception message and traceback information when the
+frozen script terminates due to uncaught exception.


### PR DESCRIPTION
The `windowed`+`debug` variant of the bootloader on Windows (`runw_d.exe`) [has the ability to display information about the uncaught exception that terminated the program execution](https://github.com/pyinstaller/pyinstaller/blob/b4ad0b0d905163cca42415d09ab32996a07ea5e7/bootloader/src/pyi_launch.c#L425-L469). I.e., after the `Failed to execute script <name>` dialog, it shows dialogs with `Error: <message>` and `Traceback: <traceback>`.

Unfortunately, at the moment, the extra dialogs always show `Error: NULL` and `Traceback: NULL`. This is because as per [docs](https://docs.python.org/3.9/c-api/exceptions.html#c.PyErr_PrintEx), the preceding `PyErr_Print()` call clears the error information, so `PyErr_Fetch()` comes up empty.

Therefore, we need to rearrange the calls so that exception information is retrieved before `PyErr_Print()` clears it.