### PR TITLE
building: macOS: strip the signature off the collected Python shared library

### DIFF
--- a/PyInstaller/building/utils.py
+++ b/PyInstaller/building/utils.py
@@ -219,9 +219,11 @@ def checkCache(fnm, strip=False, upx=False, upx_exclude=None, dist_nm=None):
             os.remove(cachedfile)
         else:
             # On Mac OS X we need relative paths to dll dependencies
-            # starting with @executable_path
+            # starting with @executable_path. We may also need to strip
+            # (invalidated) signature from collected shared libraries.
             if is_darwin:
                 dylib.mac_set_relative_dylib_deps(cachedfile, dist_nm)
+                dylib.mac_strip_signature(cachedfile, dist_nm)
             return cachedfile
 
 
@@ -353,9 +355,11 @@ def checkCache(fnm, strip=False, upx=False, upx_exclude=None, dist_nm=None):
     save_py_data_struct(cacheindexfn, cache_index)
 
     # On Mac OS X we need relative paths to dll dependencies
-    # starting with @executable_path
+    # starting with @executable_path. We may also need to strip
+    # (invalidated) signature from collected shared libraries.
     if is_darwin:
         dylib.mac_set_relative_dylib_deps(cachedfile, dist_nm)
+        dylib.mac_strip_signature(cachedfile, dist_nm)
     return cachedfile
 
 

--- a/PyInstaller/depend/dylib.py
+++ b/PyInstaller/depend/dylib.py
@@ -340,3 +340,59 @@ def mac_set_relative_dylib_deps(libname, distname):
             f.flush()
     except Exception:
         pass
+
+
+def mac_is_binary_signed(filename):
+    """
+    Check if the given macOS binary file is signed.
+    """
+    from macholib.MachO import MachO
+    from macholib import mach_o  # constants
+
+    # Open the file
+    try:
+        m = MachO(filename)
+    except Exception:
+        return False
+
+    # Walk over all headers and check if any contains LC_CODE_SIGNATURE
+    # load command
+    for header in m.headers:
+        for cmd in header.commands:
+            if cmd[0].cmd == mach_o.LC_CODE_SIGNATURE:
+                return True
+    return False
+
+
+def mac_strip_signature(libname, distname):
+    """
+    On macOS, strip away the signature from the binary file. As we may
+    not be collecting all components from a signed framework bundle, the
+    collection may invalidate the existing signature on a collected
+    shared library, which will prevent the latter from being loaded.
+    """
+    from ..compat import exec_command_rc
+
+    # For now, limit this only to Python shared library. Other shared
+    # library files from Python.framework bundle also seem to be signed,
+    # but their signature is not invalidated by partial collection like
+    # it is for Python library...
+    if os.path.basename(libname) != 'Python':
+        return
+    if not mac_is_binary_signed(libname):
+        return
+    # Run codesign --remove-signature libname
+    try:
+        logger.debug("Attempting to remove signature from %s", libname)
+        result = exec_command_rc('codesign', '--remove-signature', libname)
+    except Exception as e:
+        logger.warning(
+            "Failed to run 'codesign' to remove signature from %s: %r",
+            libname, e
+        )
+        return
+    if result != 0:
+        logger.warning(
+            "'codesign --remove-signature %s' returned non-zero status %d",
+            libname, result
+        )

--- a/PyInstaller/depend/dylib.py
+++ b/PyInstaller/depend/dylib.py
@@ -383,16 +383,14 @@ def mac_strip_signature(libname, distname):
         return
     # Run codesign --remove-signature libname
     try:
-        logger.debug("Attempting to remove signature from %s", libname)
+        logger.debug("Removing signature from %s", libname)
         result = exec_command_rc('codesign', '--remove-signature', libname)
     except Exception as e:
         logger.warning(
             "Failed to run 'codesign' to remove signature from %s: %r",
-            libname, e
-        )
+            libname, e)
         return
     if result != 0:
         logger.warning(
             "'codesign --remove-signature %s' returned non-zero status %d",
-            libname, result
-        )
+            libname, result)

--- a/news/5062.bugfix.rst
+++ b/news/5062.bugfix.rst
@@ -1,0 +1,2 @@
+(OSX) Fix the problem with ``Python`` shared library collected from
+recent python versions not being loaded due to invalidated signature.

--- a/news/5272.bugfix.rst
+++ b/news/5272.bugfix.rst
@@ -1,0 +1,2 @@
+(OSX) Fix the problem with ``Python`` shared library collected from
+recent python versions not being loaded due to invalidated signature.

--- a/news/5434.bugfix.rst
+++ b/news/5434.bugfix.rst
@@ -1,0 +1,2 @@
+(OSX) Fix the problem with ``Python`` shared library collected from
+recent python versions not being loaded due to invalidated signature.

--- a/news/5451.feature.rst
+++ b/news/5451.feature.rst
@@ -1,0 +1,5 @@
+(OSX) Automatically remove the signature from the collected copy of the
+``Python`` shared library, using ``codesign --remove-signature``. This
+accommodates both ``onedir`` and ``onefile`` builds with recent python
+versions for macOS, where invalidated signature on PyInstaller-collected
+copy of the ``Python`` library prevents the latter from being loaded.


### PR DESCRIPTION
Recent version of python on macOS have their `Python` shared library signed due to Gatekeeper requirements. Due to partial collection of content from the `Python.framework`, the copy of Python shared library that we bundle with frozen application ends up with its signature invalidated, and refuses to load regardless of Gatekeeper settings.

Manually stripping the (now invalid) signature using `codesign --remove-signature` fixes the problem, but can be performed
only with `onedir` builds. Therefore, we now attempt to detect the signature and automatically strip it away in order to accomodate
both `onefile` and `onedir` builds.

Fixes #5062.
Fixes #5272.
Fixes #5434.