### PR TITLE
hooks: add hook for scipy.spatial.transform.rotation

### DIFF
--- a/PyInstaller/hooks/hook-scipy.spatial.transform.rotation.py
+++ b/PyInstaller/hooks/hook-scipy.spatial.transform.rotation.py
@@ -1,0 +1,17 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2021, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import is_module_satisfies
+
+# As of scipy 1.6.0, scipy.spatial.transform.rotation is cython-compiled,
+# so we fail to automatically pick up its imports
+if is_module_satisfies("scipy >= 1.6.0"):
+    hiddenimports = ['scipy.spatial.transform._rotation_groups']

--- a/news/5456.hooks.rst
+++ b/news/5456.hooks.rst
@@ -1,0 +1,1 @@
+Add hook for ``scipy.spatial.transform.rotation`` to fix compatibility with SciPy 1.6.0.


### PR DESCRIPTION
As of `scipy` 1.6.0, `scipy.spatial.transform.rotation` is cython compiled, so we fail to automatically pick up its imports. Therefore, `scipy.spatial.transform._rotation_groups` needs to be added to hidden imports.

Fixes #5440.
Fixes #5454.