### PR TITLE
bootloader: clean up endianess conversion

### DIFF
--- a/bootloader/src/pyi_global.h
+++ b/bootloader/src/pyi_global.h
@@ -51,6 +51,7 @@ typedef int bool;
 
 /* Type for dynamic library. */
 #ifdef _WIN32
+    #include <windows.h>  /* HINSTANCE */
     #define dylib_t   HINSTANCE
 #else
     #define dylib_t   void *

--- a/bootloader/src/pyi_launch.c
+++ b/bootloader/src/pyi_launch.c
@@ -21,14 +21,7 @@
 
 #ifdef _WIN32
     #include <windows.h>
-    #include <winsock.h>  /* ntohl */
 #else
-    #ifdef __FreeBSD__
-/* freebsd issue #188316 */
-        #include <arpa/inet.h>  /* ntohl */
-    #else
-        #include <netinet/in.h>  /* ntohl */
-    #endif
     #include <langinfo.h> /* CODESET, nl_langinfo */
     #include <stdlib.h>   /* malloc */
 #endif
@@ -460,7 +453,7 @@ pyi_launch_run_scripts(ARCHIVE_STATUS *status)
             Py_DECREF(__file__);
 
             /* Unmarshall code object */
-            code = PI_PyMarshal_ReadObjectFromString((const char *) data, ntohl(ptoc->ulen));
+            code = PI_PyMarshal_ReadObjectFromString((const char *) data, ptoc->ulen);
 
             if (!code) {
                 FATALERROR("Failed to unmarshal code object for %s\n", ptoc->name);

--- a/bootloader/src/pyi_python.c
+++ b/bootloader/src/pyi_python.c
@@ -17,7 +17,6 @@
 
 #ifdef _WIN32
     #include <windows.h>  /* HMODULE */
-    #include <winsock.h>  /* ntohl */
 #else
     #include <dlfcn.h>  /* dlsym */
 #endif

--- a/bootloader/src/pyi_pythonlib.c
+++ b/bootloader/src/pyi_pythonlib.c
@@ -21,15 +21,8 @@
     #include <windows.h> /* HMODULE */
     #include <fcntl.h>   /* O_BINARY */
     #include <io.h>      /* _setmode */
-    #include <winsock.h> /* ntohl */
 #else
     #include <dlfcn.h>  /* dlerror */
-    #ifdef __FreeBSD__
-/* freebsd issue #188316 */
-        #include <arpa/inet.h>  /* ntohl */
-    #else
-        #include <netinet/in.h>  /* ntohl */
-    #endif
     #include <stdlib.h>  /* mbstowcs */
 #endif /* ifdef _WIN32 */
 #include <stddef.h>  /* ptrdiff_t */
@@ -565,14 +558,14 @@ pyi_pylib_import_modules(ARCHIVE_STATUS *status)
             if (pyvers >= 37) {
                 /* Python >= 3.7 the header: size was changed to 16 bytes. */
                 co = PI_PyObject_CallFunction(loadfunc, "y#", modbuf + 16,
-                                              ntohl(ptoc->ulen) - 16);
+                                              ptoc->ulen - 16);
             }
             else {
                 /* It looks like from python 3.3 the header */
                 /* size was changed to 12 bytes. */
                 co =
-                    PI_PyObject_CallFunction(loadfunc, "y#", modbuf + 12, ntohl(
-                                                 ptoc->ulen) - 12);
+                    PI_PyObject_CallFunction(loadfunc, "y#", modbuf + 12,
+                                                 ptoc->ulen - 12);
             };
 
             if (co != NULL) {
@@ -619,7 +612,7 @@ int
 pyi_pylib_install_zlib(ARCHIVE_STATUS *status, TOC *ptoc)
 {
     int rc = 0;
-    size_t zlibpos = status->pkgstart + ntohl(ptoc->pos);
+    size_t zlibpos = status->pkgstart + ptoc->pos;
     PyObject * sys_path, *zlib_entry, *archivename_obj;
 
     /* Note that sys.path contains PyUnicode on py3. Ensure

--- a/bootloader/tests/wscript
+++ b/bootloader/tests/wscript
@@ -17,10 +17,9 @@ def build(ctx):
 
     def test_program(name):
         if ctx.env.DEST_OS == 'win32':
-            # WS2_32: ntohl()
             # Z: inflate*()
             # ADVAPI32: ConvertStringSecurityDescriptorToSecurityDescriptorW()
-            extra_libs=['ADVAPI32', 'WS2_32', 'Z']
+            extra_libs=['ADVAPI32', 'Z']
         else:
             extra_libs=[]
         ctx.program(

--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -556,14 +556,13 @@ def configure(ctx):
 
     if ctx.env.DEST_OS == 'win32':
         if ctx.env.CC_NAME == 'msvc':
-            ctx.check_libs_msvc('user32 comctl32 kernel32 advapi32 ws2_32',
+            ctx.check_libs_msvc('user32 comctl32 kernel32 advapi32',
                                 mandatory=True)
         else:
             ctx.check_cc(lib='user32', mandatory=True)
             ctx.check_cc(lib='comctl32', mandatory=True)
             ctx.check_cc(lib='kernel32', mandatory=True)
             ctx.check_cc(lib='advapi32', mandatory=True)
-            ctx.check_cc(lib='ws2_32', mandatory=True)
     else:
         # Mac OS X and FreeBSD do not need libdl.
         # https://stackoverflow.com/questions/20169660/where-is-libdl-so-on-mac-os-x
@@ -750,7 +749,7 @@ def build(ctx):
             source=['src/main.c', icon_rc],
             target=exe_name,
             install_path=install_path,
-            use='OBJECTS USER32 COMCTL32 KERNEL32 ADVAPI32 WS2_32 Z',
+            use='OBJECTS USER32 COMCTL32 KERNEL32 ADVAPI32 Z',
             includes='src windows zlib',
             features=features,
         )


### PR DESCRIPTION
This PR places the endianess conversion for multi-byte integer fields in COOKIE and TOC structures in a single place, i.e., after the data is read from the file (as opposed to performing it on every field access). The main motivation is to simplify the eventual transition from 32-bit integers to 64-bit ones to increase maximum archive file size.

On Windows, replace the use of `ntohl()` from `ws2_32` library with compiler-provided byte-swap functions. This allows us to drop otherwise unneccessary dependency on `ws2_32` in bootloader executables.