### PR TITLE
bindepend: suppress missing library messages for macOS system libraries

### DIFF
--- a/PyInstaller/depend/bindepend.py
+++ b/PyInstaller/depend/bindepend.py
@@ -616,6 +616,7 @@ def _getImports_macholib(pth):
     from macholib.MachO import MachO
     from macholib.mach_o import LC_RPATH
     from macholib.dyld import dyld_find
+    from macholib.util import in_system_path
     rslt = set()
     seen = set()  # Libraries read from binary headers.
 
@@ -711,7 +712,12 @@ def _getImports_macholib(pth):
                 lib = dyld_find(lib, executable_path=exec_path)
                 rslt.add(lib)
             except ValueError:
-                logger.error('Can not find path %s (needed by %s)', lib, pth)
+                # Starting with Big Sur, system libraries are hidden. And
+                # we do not collect system libraries on any macOS version
+                # anyway, so suppress the corresponding error messages.
+                if not in_system_path(lib):
+                    logger.error('Can not find path %s (needed by %s)',
+                                 lib, pth)
 
     return rslt
 

--- a/news/5107.bugfix.rst
+++ b/news/5107.bugfix.rst
@@ -1,0 +1,3 @@
+(OSX) Suppress missing library error messages for system libraries as
+those are never collected by PyInstaller and starting with Big Sur,
+they are hidden by the OS.


### PR DESCRIPTION
Starting with macOS Big Sur, the system libraries are hidden. This results in a slew of error messages about missing libraries when
a shared library is scanned for imports. However, all these error messages are harmless, because we avoid collecting system libraries on macOS, nor do we need to further analyze them for dependencies (as they can depend only on other system libraries). Therefore, suppress the missing-library error messages for system libraries.

Closes #5107. 