### PR TITLE
Hooks: Import correct typelib for GtkosxApplication

### DIFF
--- a/PyInstaller/hooks/hook-gi.repository.GtkosxApplication.py
+++ b/PyInstaller/hooks/hook-gi.repository.GtkosxApplication.py
@@ -12,7 +12,11 @@
 Import hook for PyGObject https://wiki.gnome.org/PyGObject
 """
 
+from PyInstaller.compat import is_darwin
 from PyInstaller.utils.hooks import get_gi_typelibs
 
 
-binaries, datas, hiddenimports = get_gi_typelibs('HarfBuzz', '0.0')
+if is_darwin:
+    binaries, datas, hiddenimports = get_gi_typelibs(
+        'GtkosxApplication', '1.0'
+    )

--- a/news/5475.hooks.rst
+++ b/news/5475.hooks.rst
@@ -1,0 +1,1 @@
+Hooks: Import correct typelib for GtkosxApplication.


### PR DESCRIPTION
This PR updates the hook to import the correct typelib instead of HarfBuzz.

Also puts a guard in place to only use the hook when in macOS to prevent a traceback caused by an import error in Linux and Windows:

```
10786 INFO: Loading module hook 'hook-gi.repository.GtkosxApplication.py' from '/home/dan/Projects/gaphor/packaging/hooks'...
Traceback (most recent call last):
  File "<string>", line 7, in <module>
gi.repository.GLib.Error: g-irepository-error-quark: Typelib file for namespace 'GtkosxApplication', version '1.0' not found (0)
```