### PR TITLE
loader: disable import tracing if sys.stderr is unavailable

### DIFF
--- a/PyInstaller/loader/pyimod03_importers.py
+++ b/PyInstaller/loader/pyimod03_importers.py
@@ -33,7 +33,7 @@ SYS_PREFIXLEN = len(SYS_PREFIX)
 # with using type() function:
 imp_new_module = type(sys)
 
-if sys.flags.verbose:
+if sys.flags.verbose and sys.stderr:
     def trace(msg, *a):
         sys.stderr.write(msg % a)
         sys.stderr.write("\n")

--- a/news/4213.bugfix.rst
+++ b/news/4213.bugfix.rst
@@ -1,0 +1,4 @@
+(Windows) Fix the frozen program crashing immediately with
+``Failed to execute script pyiboot01_bootstrap`` message when built in
+``noconsole`` mode and with import logging enabled (either via
+``--debug imports`` or ``--debug all`` command-line switch).


### PR DESCRIPTION
The `FrozenImporter` in `pymod03_importers` uses `trace()` function if `sys.flags.verbose` is enabled to trace the imports to `sys.stderr`. This results in the following error:
  `Failed to execute script pyiboot01_bootstrap`
when `sys.stderr` is unavailable (is `None`), which happens on Windows when windowed bootloader is used in combination with
`sys.flags.verbose` enabled (i.e., `--debug imports` or `--debug all` is passed on the command-line).

The problem is that while `pyiboot01_bootstrap` does install its `NullWriter` for `sys.stderr` when the latter is unavailable, that
happens too late; there is an `import os` that happens between the end of bootstrap process (the `pyimod03_importers.install()` call) and monkey-patching `NullWriter()` into `sys.stderr`.

While the problem could also be fixed by moving the `NullWriter` initialization before the offending import, simply disabling the `trace()` function seems a better option.

Fixes #4213.