### PR TITLE
bootloader: return 1 if frozen python script exits due to exception

### DIFF
--- a/bootloader/src/pyi_launch.c
+++ b/bootloader/src/pyi_launch.c
@@ -516,7 +516,10 @@ pyi_launch_run_scripts(ARCHIVE_STATUS *status)
                     }
                 #endif /* if defined(WINDOWED) and defined(LAUNCH_DEBUG) */
 
-                return -1;
+                /* Be consistent with python interpreter, which returns
+                 * 1 if it exits due to unhandled exception.
+                 */
+                return 1;
             }
             free(data);
         }

--- a/news/5480.bugfix.rst
+++ b/news/5480.bugfix.rst
@@ -1,0 +1,3 @@
+Fix the return code if the frozen script fails due to unhandled exception.
+The return code 1 is used instead of -1, to keep the behavior consistent
+with that of the python interpreter.

--- a/tests/unit/test_systemexit.py
+++ b/tests/unit/test_systemexit.py
@@ -27,7 +27,8 @@ import pytest
         ('import sys; sys.exit()', 0),
         ('raise SystemExit(1)', 1),
         ('import sys; sys.exit(2)', 2),
-        ('raise SystemExit("Message to get printed to the console.")', 1)
+        ('raise SystemExit("Message to get printed to the console.")', 1),
+        ('raise Exception("Unhandled exception.")', 1)  # See issue #5480
     ]
 )
 def test_systemexit_is_handled_correctly(src, retcode, pyi_builder):


### PR DESCRIPTION
Keep the bootloader's return code consistent with that of python interpreter, which returns 1 if it exits due to exception in the python script.

Fixes #5480.