### PR TITLE
Fix tests on macOS 11

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -60,4 +60,4 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest -n 3 --maxfail 3 --durations 10 tests/unit tests/functional --ignore tests/functional/test_libraries.py
+          pytest -n 3 --maxfail 3 --durations 10 tests/unit tests/functional --ignore tests/functional/test_libraries.py --basetemp ~/pytest-temp

--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -41,6 +41,11 @@ is_win_10 = is_win and (platform.win32_ver()[0] == '10')
 is_cygwin = sys.platform == 'cygwin'
 is_darwin = sys.platform == 'darwin'  # Mac OS X
 
+# On macOS 11 (Big Sur), platform.mac_ver() reports either 10.16 or 11.x,
+# depending on version of macOS for which the python interpreter was
+# compiled and the setting of SYSTEM_VERSION_COMPAT environment variable.
+is_macos_11 = is_darwin and platform.mac_ver()[0].startswith(('10.16', '11'))
+
 # Unix platforms
 is_linux = sys.platform.startswith('linux')
 is_solar = sys.platform.startswith('sun')  # Solaris

--- a/tests/unit/test_depend_utils.py
+++ b/tests/unit/test_depend_utils.py
@@ -15,7 +15,7 @@ import pytest
 import textwrap
 
 from PyInstaller.depend import utils
-from PyInstaller.compat import is_unix, is_win
+from PyInstaller.compat import is_win, is_macos_11
 
 
 CTYPES_CLASSNAMES = (
@@ -58,6 +58,8 @@ def test_ctypes_LibraryLoader_LoadLibrary(monkeypatch, classname):
     assert res == set(['somelib.xxx'])
 
 
+@pytest.mark.skipif(is_macos_11,
+                    reason='System libraries are hidden on macOS 11.')
 def test_ctypes_util_find_library(monkeypatch):
     # for lind_library() we need a lib actually existing on the system
     if is_win:


### PR DESCRIPTION
This is a follow-up to discussion in #5464. There are three problematic tests that are failing on macOS Big Sur:
* test_depend_utils.py::test_ctypes_util_find_library
* test_apple_events.py::test_osx_custom_protocol_handler
* test_apple_events.py::test_osx_event_forwarding

The first one is failing because it tries to find system `c` library via `ctypes.util.find_library()`. As system libraries are hidden on Big Sur, this does not work - we now skip the test.

The other two tests use custom URL schema, and on Big Sur, this does not seem to work if the .app bundle is in the temporary directory (`/priv/var/...` or its symlink `/var/...`). Therefore, we now check the `tmpdir` prefix and xfail the test accordingly. 

For our macOS CI, we force `pytest` to use `basetemp` in user's home directory, so that those tests succeed.

The very first commit introduces `compat.is_macos_11`, which is used to identify Big Sur in the tests.

With these changes, we could switch/extend our macOS CI to Big Sur.