### PR TITLE
 bootloader: implement full back-to-front scan for embedded archive

### DIFF
--- a/news/5330.bugfix.rst
+++ b/news/5330.bugfix.rst
@@ -1,0 +1,2 @@
+PyInstaller-frozen onefile programs are now compatible with ``staticx``
+even if the bootloader is built as position-independent executable (PIE).

--- a/news/5511.bootloader.rst
+++ b/news/5511.bootloader.rst
@@ -1,0 +1,1 @@
+Implement full back-to-front file search for the embedded archive.


### PR DESCRIPTION
Implement full back-to-front file scan for finding the embedded archive's cookie. This saves us from having to make assumptions
about the cookie's positon, which both simplifies the search and makes it more robust.

Currently, we are searching within fixed-sized search window either from the end of file or from end of file's digital signature (if
present; on Windows and macOS only).

This breaks when a 3rd party tool appends extra data at the end of executable; for example, with PIE bootloader executable,
`staticx` tool on linux will append extra sections at the end of file, which is perfectly valid behavior, but it breaks our fixed-size
search window assumptions. Therefore, full back-to-front search fixes #5330 and JonathonReinhart/staticx#71.

Another motivation for brute-force search is macOS 11, as we will sooner or later want to support universal2 fat binary bootloaders in addition to single-arch thin ones. Full-file search allows us to do so without having to search for digital signature and in turn parsing the headers of each binary format.