### PR TITLE
Create stale.yml

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,28 @@
+n:
+  schedule:
+    - cron: "0 15 * * 1-5"
+name: Stale Bot
+jobs:
+  build:
+    name: stale
+    runs-on: ubuntu-latest
+    steps:
+      - name: stale
+        id: stale
+        uses: actions/stale@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-stale: 15
+          days-before-close: 30
+          stale-issue-message: |
+            Hi!
+            This issue has been left open with no activity for 15 days.
+            We get a lot of issues each dya so we currently close issues after 30 days of inactivity. It’s been at least 15 days since the last update here.
+            If we missed your issue, please reply to avoid closing it, If this issue have been fixed, You can close it
+          close-issue-message: |
+            Hi again!
+            This issue have been closed due to no activity for a month or more, even after marking it as stale, 
+            If your issue still persists, You can open a new issue
+          exempt-issue-labels: |
+            feature, @high, pull-request-wanted, not-stale, pinned
+            

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,7 +17,7 @@ jobs:
           stale-issue-message: |
             Hi!
             This issue has been left open with no activity for 15 days.
-            We get a lot of issues each dya so we currently close issues after 30 days of inactivity. It’s been at least 15 days since the last update here.
+            We get a lot of issues each day so we currently close issues after 30 days of inactivity. It’s been at least 15 days since the last update here.
             If we missed your issue, please reply to avoid closing it, If this issue have been fixed, You can close it
           close-issue-message: |
             Hi again!


### PR DESCRIPTION
This workflow is a simple bot which will result into more focus, How ? That's simple. It closes old issues, and avoids them to distract you from solving newer and more active issues,

It closes issues which are not active for a month, Will send something like a warning (friendly reminder) to stale issues (no activity for 15 days), Also has some exceptions, Every issue which got marked with `@high`, `pull-request-wanted`, `not-stale`, `pinned` will never get nor the warning nor closed. The last two doesn't exist, creating them helps to avoid closing some issues.

If you ask me before merging this PR (if you are going to), Add labels named `not-stale`, `pinned` and assign one to the fund request issue and some issues which you would want to keep open
