### PR TITLE
Changed the default cache directory on Windows.

### DIFF
--- a/PyInstaller/configure.py
+++ b/PyInstaller/configure.py
@@ -65,7 +65,7 @@ def _get_pyinst_cache_dir():
     if compat.getenv('PYINSTALLER_CONFIG_DIR'):
         cache_dir = compat.getenv('PYINSTALLER_CONFIG_DIR')
     elif is_win:
-        cache_dir = compat.getenv('APPDATA')
+        cache_dir = compat.getenv('LOCALAPPDATA')
         if not cache_dir:
             cache_dir = os.path.expanduser('~\\Application Data')
     elif is_darwin:

--- a/news/5537.bugfix.rst
+++ b/news/5537.bugfix.rst
@@ -1,0 +1,6 @@
+(Windows) Change default cache directory to ``LOCALAPPDATA``
+(from the original ``APPDATA``).
+This is to make sure that cached data
+doesn't get synced with the roaming profile.
+For this and future versions ``AppData\Roaming\pyinstaller``
+might be safely deleted.


### PR DESCRIPTION
I recently used pyinstaller on Windows and later noticed that there were about 200MB of files syncing into my corporate Roaming Profile.

I think that the default cache directory should not be in the Roaming profile (`%APPDATA%` i.e. `C:\Users\<UserName>\AppData\Roaming\pyinstaller`) but much rather in the Local profile (`%LOCALAPPDATA%` i.e. `C:\Users\<UserName>\AppData\Local\pyinstaller`) by default, since there is no need to synchronize them between computers.

I know that I can change the behavior by setting the `PYINSTALLER_CONFIG_DIR` or disable syncing that folder, but I think that it would be better to adhere to Microsofts recommendation in terms of what to use the Roaming profile for. Also please note that this is of course opinionated/controversial as there is a lot of other (commercial) software that is doing it wrong too...

As a reference please see this similar case where I contributed in the same manner to the Jedi project https://github.com/davidhalter/jedi/pull/1575