### PR TITLE
Ignore non-matching `ldconfig` lines without blowing up

### DIFF
--- a/PyInstaller/depend/utils.py
+++ b/PyInstaller/depend/utils.py
@@ -399,6 +399,12 @@ def load_ldconfig_cache():
     for line in text:
         # :fixme: this assumes libary names do not contain whitespace
         m = pattern.match(line)
+
+        if not m:
+            logger.warning("ldconfig output line does not appear to contain a"
+                           "library path: '%s'", line)
+            continue
+
         path = m.groups()[-1]
         if is_freebsd or is_openbsd:
             # Insert `.so` at the end of the lib's basename. soname


### PR DESCRIPTION
I am running on Linux, with `ldconfig --version`:

```
ldconfig (GNU libc) 2.33
Copyright (C) 2021 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
Written by Andreas Jaeger.
```

`ldconfig -p`, which is run to locate shared object files during the build process, adds a couple extra lines that aren't libraries.  I could not find a CLI arg to make it not print these.

```
5126 libs found in cache `/etc/ld.so.cache'
	p11-kit-trust.so (libc6,x86-64) => /usr/lib/p11-kit-trust.so
	p11-kit-trust.so (libc6) => /usr/lib32/p11-kit-trust.so
	pybullet.so.3.08 (libc6,x86-64) => /usr/lib/pybullet.so.3.08
	lib3MF.so.1 (libc6,x86-64) => /usr/lib/lib3MF.so.1
[...snip...]
Cache generated by: ldconfig (GNU libc) release release version 2.33
```

These were causing the build to blow up with the following error:

```
13664 INFO: Looking for ctypes DLLs
Traceback (most recent call last):
  File "/home/jeff/.cache/pypoetry/virtualenvs/deal-creator-dmBJBP2z-py3.8/bin/pyinstaller", line 8, in <module>
    sys.exit(run())
  File "/home/jeff/.cache/pypoetry/virtualenvs/deal-creator-dmBJBP2z-py3.8/lib/python3.8/site-packages/PyInstaller/__main__.py", line 114, in run
    run_build(pyi_config, spec_file, **vars(args))
  File "/home/jeff/.cache/pypoetry/virtualenvs/deal-creator-dmBJBP2z-py3.8/lib/python3.8/site-packages/PyInstaller/__main__.py", line 65, in run_build
    PyInstaller.building.build_main.main(pyi_config, spec_file, **kwargs)
  File "/home/jeff/.cache/pypoetry/virtualenvs/deal-creator-dmBJBP2z-py3.8/lib/python3.8/site-packages/PyInstaller/building/build_main.py", line 725, in main
    build(specfile, kw.get('distpath'), kw.get('workpath'), kw.get('clean_build'))
  File "/home/jeff/.cache/pypoetry/virtualenvs/deal-creator-dmBJBP2z-py3.8/lib/python3.8/site-packages/PyInstaller/building/build_main.py", line 672, in build
    exec(code, spec_namespace)
  File "build.spec", line 8, in <module>
    a = Analysis(
  File "/home/jeff/.cache/pypoetry/virtualenvs/deal-creator-dmBJBP2z-py3.8/lib/python3.8/site-packages/PyInstaller/building/build_main.py", line 242, in __init__
    self.__postinit__()
  File "/home/jeff/.cache/pypoetry/virtualenvs/deal-creator-dmBJBP2z-py3.8/lib/python3.8/site-packages/PyInstaller/building/datastruct.py", line 160, in __postinit__
    self.assemble()
  File "/home/jeff/.cache/pypoetry/virtualenvs/deal-creator-dmBJBP2z-py3.8/lib/python3.8/site-packages/PyInstaller/building/build_main.py", line 438, in assemble
    ctypes_binaries = scan_code_for_ctypes(co)
  File "/home/jeff/.cache/pypoetry/virtualenvs/deal-creator-dmBJBP2z-py3.8/lib/python3.8/site-packages/PyInstaller/depend/utils.py", line 145, in scan_code_for_ctypes
    binaries = _resolveCtypesImports(binaries)
  File "/home/jeff/.cache/pypoetry/virtualenvs/deal-creator-dmBJBP2z-py3.8/lib/python3.8/site-packages/PyInstaller/depend/utils.py", line 319, in _resolveCtypesImports
    load_ldconfig_cache()
  File "/home/jeff/.cache/pypoetry/virtualenvs/deal-creator-dmBJBP2z-py3.8/lib/python3.8/site-packages/PyInstaller/depend/utils.py", line 402, in load_ldconfig_cache
    path = m.groups()[-1]
AttributeError: 'NoneType' object has no attribute 'groups'
```

This PR makes `pyinstaller` ignore `ldconfig` output lines that don't match the regex that parses out the library paths.  I also added a log line to make it obvious when this is doing something unexpected (for example, this will make it obvious if the `fixme` comment about library names containing whitespace needs to be addressed).

```
13274 INFO: Loading module hook 'hook-setuptools.msvc.py' from '/home/jeff/.cache/pypoetry/virtualenvs/deal-creator-dmBJBP2z-py3.8/lib/python3.8/site-packages/PyInstaller/hooks'...
13276 INFO: Excluding import of numpy from module setuptools.msvc
13299 INFO: Looking for ctypes DLLs
13423 WARNING: ldconfig output line does not appear to contain a library path: 'Cache generated by: ldconfig (GNU libc) release release version 2.33'
13535 INFO: Analyzing run-time hooks ...
13542 INFO: Including run-time hook '/home/jeff/.cache/pypoetry/virtualenvs/deal-creator-dmBJBP2z-py3.8/lib/python3.8/site-packages/PyInstaller/hooks/rthooks/pyi_rth_multiprocessing.py'
13553 INFO: Looking for dynamic libraries
```