### PR TITLE
tests/ci: use flake8 --extend-ignore instead of --ignore

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -173,4 +173,4 @@ exclude =
    bootloader
 show-source = True
 # E265 - block comment should start with '# '
-ignore = E265
+extend-ignore = E265


### PR DESCRIPTION
Using `--ignore` completely overrides the ignore list, while `--extend-ignore` (introduced in `flake8` v.3.6) extends the default settings.

Overriding the built-in defaults seems to enable both `W503` and `W504`, which are impossible to satisfy at the same time.