### PR TITLE
bootloader: archive: implement chunked i/o for file extraction

### DIFF
--- a/news/5551.bootloader.rst
+++ b/news/5551.bootloader.rst
@@ -1,0 +1,2 @@
+Perform file extraction from the embedded archive in a streaming manner
+in order to limit memory footprint when archive contains large files.


### PR DESCRIPTION
Perform file extraction and decompression in a streaming manner, using small data chunks (8 KiB) in order to reduce the memory footprint while unpacking a onefile build containing large data files.