### PR TITLE
archive_viewer: implement full front-to-back file scan & fix crash on exit

### DIFF
--- a/PyInstaller/utils/cliutils/archive_viewer.py
+++ b/PyInstaller/utils/cliutils/archive_viewer.py
@@ -65,7 +65,6 @@ def main(name, brief, debug, rec_debug, **unused_options):
         if cmd == 'U':
             if len(stack) > 1:
                 arch = stack[-1][1]
-                arch.lib.close()
                 del stack[-1]
             name, arch = stack[-1]
             show(name, arch)
@@ -106,8 +105,6 @@ def main(name, brief, debug, rec_debug, **unused_options):
 
 def do_cleanup():
     global stack, cleanup
-    for (name, arch) in stack:
-        arch.lib.close()
     stack = []
     for filename in cleanup:
         try:

--- a/news/2372.bugfix.rst
+++ b/news/2372.bugfix.rst
@@ -1,0 +1,3 @@
+``CArchiveReader`` now performs full back-to-front file search for
+``MAGIC``, allowing ``pyi-archive_viewer`` to open binaries with extra
+appended data after embedded package (e.g., digital signature).

--- a/news/5554.bugfix.rst
+++ b/news/5554.bugfix.rst
@@ -1,0 +1,2 @@
+Fix a crash in ``pyi-archive_viewer`` when quitting the application or
+moving up a level.


### PR DESCRIPTION
Implement full back-to-front file scan for the `MAGIC` pattern in the `CArchive` reader, as per discussion in #2372. This allows `archive_viewer` to find embedded package in binaries with additional appended data (e.g., digital signature). This also synchronizes the pattern search behavior in python-side `CArchive` implementation with bootloader-side changes proposed in #5511.

Fixes #2372.

The second commit fixes an assertion-related crash in `archive_viewer` that was uncovered during testing, and occurs when quitting the application or moving up a level.