### PR TITLE
Use public get_data_path for matplotlib hook

### DIFF
--- a/PyInstaller/hooks/hook-matplotlib.py
+++ b/PyInstaller/hooks/hook-matplotlib.py
@@ -13,7 +13,7 @@
 from PyInstaller.utils.hooks import exec_statement
 
 mpl_data_dir = exec_statement(
-    "import matplotlib; print(matplotlib._get_data_path())")
+    "import matplotlib; print(matplotlib.get_data_path())")
 
 datas = [
     (mpl_data_dir, "matplotlib/mpl-data"),

--- a/news/5568.bugfix.rst
+++ b/news/5568.bugfix.rst
@@ -1,0 +1,3 @@
+Remove dependence on a `private function
+<https://github.com/matplotlib/matplotlib/commit/e1352c71f07aee7eab004b73dd9bda2a260ab31b>`_
+removed in ``matplotlib`` 3.4.0rc1.


### PR DESCRIPTION
Fixes #5567. The bigger question is if this breaks earlier versions of matplotlib and how to deal with that if so.