### PR TITLE
archive: fix stored paths when building under MSYS

### DIFF
--- a/PyInstaller/archive/writers.py
+++ b/PyInstaller/archive/writers.py
@@ -35,7 +35,7 @@ from PyInstaller.building.utils import get_code_object, strip_paths_in_code,\
     fake_pyc_timestamp
 from PyInstaller.loader.pyimod02_archive import PYZ_TYPE_MODULE, PYZ_TYPE_PKG, \
     PYZ_TYPE_DATA, PYZ_TYPE_NSPKG
-from ..compat import BYTECODE_MAGIC, is_py37
+from ..compat import BYTECODE_MAGIC, is_py37, is_win
 
 
 class ArchiveWriter(object):
@@ -283,6 +283,10 @@ class CTOC(object):
         # slashes '\\' since on Windows the bootloader works only with back
         # slashes.
         nm = os.path.normpath(nm)
+        if is_win and os.path.sep == '/':
+            # When building under MSYS, the above path normalization
+            # uses Unix-style separators, so replace them manually.
+            nm = nm.replace(os.path.sep, '\\')
         self.data.append((dpos, dlen, ulen, flag, typcd, nm))
 
 

--- a/news/5569.bugfix.rst
+++ b/news/5569.bugfix.rst
@@ -1,0 +1,2 @@
+Fix extraction of nested files in ``onefile`` builds created in MSYS
+environments.


### PR DESCRIPTION
When building CArchive package under MSYS, `os.path.sep` is Unix-style forward clash separator that is incompatible with bootloader (which on Windows expects back slash separators). Therefore, if we are on Windows and `os.path.sep` is forward slash, `os.path.normpath()` in `CTOC.add()` needs to be followed by explicit replacement of forward slashes with back slashes.

Otherwise, bootloader fails to extract nested files from archive in onefile builds that are created in MSYS environment.

Fixes second part of the issue reported in #5560.