### PR TITLE
Building: Windows: Set EXE checksums (#5579).

### DIFF
--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -640,6 +640,10 @@ class EXE(Target):
             logger.info("Fixing EXE for code signing %s", self.name)
             import PyInstaller.utils.osx as osxutils
             osxutils.fix_exe_for_code_signing(self.name)
+        if is_win:
+            # Set checksum to appease antiviral software.
+            from PyInstaller.utils.win32.winutils import set_exe_checksum
+            set_exe_checksum(self.name)
 
         os.chmod(self.name, 0o755)
         # get mtime for storing into the guts

--- a/PyInstaller/utils/win32/winutils.py
+++ b/PyInstaller/utils/win32/winutils.py
@@ -155,3 +155,17 @@ def convert_dll_name_to_str(dll_name):
         return str(dll_name, encoding='UTF-8')
     else:
         return dll_name
+
+
+def set_exe_checksum(exe_path):
+    """Set executable's checksum in its metadata.
+
+    This optional checksum is supposed to protect the executable against
+    corruption but some anti-viral software have taken to flagging anything
+    without it set correctly as malware. See issue #5579.
+    """
+    import pefile
+    pe = pefile.PE(exe_path)
+    pe.OPTIONAL_HEADER.CheckSum = pe.generate_checksum()
+    pe.close()
+    pe.write(exe_path)

--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -311,6 +311,8 @@ def set_arch_flags(ctx):
         ctx.env.append_value('CFLAGS', '/D_CRT_SECURE_NO_WARNINGS')
         # We use SEH exceptions in winmain.c; make sure they are activated.
         ctx.env.append_value('CFLAGS', '/EHa')
+        # Set the PE checksum on resulting binary
+        ctx.env.append_value('LINKFLAGS', '/RELEASE')
 
     # Ensure proper architecture flags on Mac OS X.
     elif ctx.env.DEST_OS == 'darwin':

--- a/news/5579.feature.rst
+++ b/news/5579.feature.rst
@@ -1,0 +1,1 @@
+Windows: Set EXE checksums. Reduces false-positive detection from antiviral software.


### PR DESCRIPTION
#5579 explains the what/why for this PR well.

Windows executables contain an optional checksum to protect against corruption. It turns out that several of antiviral programs
raise false positives if this checksum is missing or wrong. Setting this checksum appeases McAfee and inconsistently fixes
MS Defender which are probably the most common (and also dumbest) AVs for Windows. 

Sod's law says that in a few months the AV programs will notice that we've rumbled their *I am not a virus* metadata tag and come up with something even less effective to waste our time with but in the meantime we get to enjoy a little ironical break from the constant false-positive reports.

This PR sets the checksum for built executables. We probably should apply this directly to the bootloaders too but I can't do anything to that wafscript. I've spent several hours trying to work out how to get waf to run 3 lines of code in the right place. 

Closes #5579 .

