### PR TITLE
hooks: changed PY_DYLIB_PATTERNS to contain *.so

### DIFF
--- a/PyInstaller/utils/hooks/__init__.py
+++ b/PyInstaller/utils/hooks/__init__.py
@@ -700,7 +700,7 @@ def is_module_or_submodule(name, mod_or_submod):
 PY_DYLIB_PATTERNS = [
     '*.dll',
     '*.dylib',
-    'lib*.so',
+    '*.so',
 ]
 
 

--- a/news/5561.hooks.rst
+++ b/news/5561.hooks.rst
@@ -1,0 +1,2 @@
+The ``collect_data_files()`` method now no longer requires .so files
+to have a lib prefix.


### PR DESCRIPTION
This was done because .so files aren't just used by Python. Some
exectuables need to be bundled with .so files too.