### PR TITLE
bootloader: replace stray MAX_PATH with PATH_MAX

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -124,6 +124,12 @@ cache:
 
 
 install:
+  # Enable long paths (needs reboot)
+  - ps: Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem' -Name 'LongPathsEnabled' -Value 1
+  - ps: Start-Sleep -s 10
+  - ps: Restart-Computer -Force
+  - ps: Start-Sleep -s 10
+
   - C:\cygwin\bin\du -hs "%LOCALAPPDATA%\pip\Cache"
   # Prepend newly installed Python to the PATH of this build (this cannot be
   # done from inside the powershell script as it would require to restart

--- a/bootloader/src/pyi_path.c
+++ b/bootloader/src/pyi_path.c
@@ -376,10 +376,10 @@ pyi_path_archivefile(char *archivefile, const char *thisfile)
 FILE*
 pyi_path_fopen(const char* filename, const char* mode)
 {
-    wchar_t wfilename[MAX_PATH];
+    wchar_t wfilename[PATH_MAX];
     wchar_t wmode[10];
 
-    pyi_win32_utils_from_utf8(wfilename, filename, MAX_PATH);
+    pyi_win32_utils_from_utf8(wfilename, filename, PATH_MAX);
     pyi_win32_utils_from_utf8(wmode, mode, 10);
     return _wfopen(wfilename, wmode);
 }

--- a/news/5617.bugfix.rst
+++ b/news/5617.bugfix.rst
@@ -1,0 +1,2 @@
+Fix ``onefile`` builds failing to extract files when the full target
+path exceeds 260 characters.

--- a/tests/functional/test_basic.py
+++ b/tests/functional/test_basic.py
@@ -606,3 +606,42 @@ def test_pe_checksum(pyi_builder):
             ctypes.byref(checksum)) == 0
 
         assert header_sum.value == checksum.value
+
+
+def test_onefile_longpath(pyi_builder, tmpdir):
+    """
+    Verify that files with paths longer than 260 characters are correctly
+    extracted from the onefile build. See issue #5615."
+    """
+    # The test is relevant only for onefile builds
+    if pyi_builder._mode != 'onefile':
+        pytest.skip('The test is relevant only to onefile builds.')
+    # Create data file with secret
+    _SECRET = 'LongDataPath'
+    src_filename = tmpdir / 'data.txt'
+    with open(src_filename, 'w') as fp:
+        fp.write(_SECRET)
+    # Generate long target filename/path; eight equivalents of SHA256
+    # strings plus data.txt should push just the _MEIPASS-relative path
+    # beyond 260 characters...
+    dst_filename = os.path.join(
+        *[32*chr(c) for c in range(ord('A'), ord('A')+8)], 'data.txt')
+    assert len(dst_filename) >= 260
+    # Name for --add-data
+    if is_win:
+        add_data_name = src_filename + ';' + os.path.dirname(dst_filename)
+    else:
+        add_data_name = src_filename + ':' + os.path.dirname(dst_filename)
+
+    pyi_builder.test_source(
+        """
+        import sys
+        import os
+
+        data_file = os.path.join(sys._MEIPASS, r'{data_file}')
+        print("Reading secret from %r" % (data_file))
+        with open(data_file, 'r') as fp:
+            secret = fp.read()
+        assert secret == r'{secret}'
+        """.format(data_file=dst_filename, secret=_SECRET),
+        ['--add-data', str(add_data_name)])


### PR DESCRIPTION
On Windows, `pyi_path_fopen()` erroneously uses `MAX_PATH` (260) instead of `PATH_MAX` (4096) to convert the filename to wide characters, which causes `MultiByteToWideChar()` call in `pyi_win32_utils_from_utf8()` to fail with
```
MultiByteToWideChar: The data area passed to a system call is too small.
```
when we try to open a file with a long filename (> 260).

Due to lack of error checking, the resulting `wfilename` array ends up with random content, and the `_wfopen()` call either fails
(in read-only mode) or creates a randomly-named file (in write mode).

Fixes #5615.