### PR TITLE
building: ensure that onefile builds on Windows have manifest embedded

### DIFF
--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -531,8 +531,7 @@ class EXE(Target):
         if not os.path.exists(exe):
             raise SystemExit(_MISSING_BOOTLOADER_ERRORMSG)
 
-        if is_win and (self.icon != "NONE" or self.versrsrc or self.resources
-                       or self.uac_admin or self.uac_uiaccess or not is_64bits):
+        if is_win:
             fd, tmpnm = tempfile.mkstemp(prefix=os.path.basename(exe) + ".",
                                          dir=CONF['workpath'])
             # need to close the file, otherwise copying resources will fail
@@ -598,7 +597,7 @@ class EXE(Target):
                         logger.error("Error while updating resource %s %s in %s"
                                      " from data file %s",
                                      restype, resname, tmpnm, resfile, exc_info=1)
-            if is_win and self.manifest and not self.exclude_binaries:
+            if self.manifest and not self.exclude_binaries:
                 self.manifest.update_resources(tmpnm, [1])
             trash.append(tmpnm)
             exe = tmpnm

--- a/news/5625.bugfix.rst
+++ b/news/5625.bugfix.rst
@@ -1,0 +1,2 @@
+(Windows) Fix ``onefile`` builds not having manifest embedded when icon is 
+disabled via ``--icon NONE``.


### PR DESCRIPTION
... regardless of the icon setting.

The `onefile` builds on Windows may not have manifest embedded if icon was explicitly disabled via `--icon NONE`. This in turn causes subtle issues, such as #5624.

Fixes #5624.

Side note: with 3c3228d, the behavior of this issue became inverted; before it (i.e., PyInstaller 4.1 and older), the manifest would not be embedded if icon was not provided (i.e., `self.icon` was falsy), i.e., by default. So this may also explain some weird behavior of Windows `onefile` builds made with PyInstaller 4.1 and older (which mysteriously went away if --icon was specified).