### PR TITLE
hooks: matplotlib: assert that mpl_data_dir is not empty

### DIFF
--- a/PyInstaller/hooks/hook-matplotlib.py
+++ b/PyInstaller/hooks/hook-matplotlib.py
@@ -14,6 +14,7 @@ from PyInstaller.utils.hooks import exec_statement
 
 mpl_data_dir = exec_statement(
     "import matplotlib; print(matplotlib.get_data_path())")
+assert mpl_data_dir, "Failed to determine matplotlib's data directory!"
 
 datas = [
     (mpl_data_dir, "matplotlib/mpl-data"),

--- a/news/5629.hooks.rst
+++ b/news/5629.hooks.rst
@@ -1,0 +1,2 @@
+Prevent ``matplotlib`` hook from collecting current working directory when it 
+fails to determine the path to matplotlib's data directory.

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -17,7 +17,6 @@
 #
 # - v. 2.2 and above fails.
 Django==2.1.8  # pyup: ignore
-matplotlib==3.2.2 # pyup: ignore
 # - v 21.1.0 fails; earlier versions not tested.
 keyring==19.2.0  # pyup: ignore
 
@@ -45,6 +44,7 @@ pandas==1.1.5
 numpy==1.19.4
 scipy==1.5.4
 Pillow==8.0.1
+matplotlib==3.3.4
 
 
 # Python versions not supported / supported for older package versions


### PR DESCRIPTION
If the statement in `exec_statement()` fails for whatever reason, `mpl_data_dir` ends up empty, which in turn cases the current working directory being collected as `matplotlib/mpl-data`.

This leads to difficult-to-debug issues (see confusion around `.git` directory under #5504), so it's better to just signal the error.