### PR TITLE
hooks: pandas: update for compatibility with pandas 1.2.0 and later

### DIFF
--- a/PyInstaller/hooks/hook-pandas.py
+++ b/PyInstaller/hooks/hook-pandas.py
@@ -9,7 +9,13 @@
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
 
-from PyInstaller.utils.hooks import collect_submodules
+from PyInstaller.utils.hooks import collect_submodules, is_module_satisfies
 
 # Pandas keeps Python extensions loaded with dynamic imports here.
 hiddenimports = collect_submodules('pandas._libs')
+
+# Pandas 1.2.0 and later require cmath hidden import on linux and macOS.
+# On Windows, this is not strictly required, but we add it anyway to keep
+# things simple (and future-proof).
+if is_module_satisfies('pandas >= 1.2.0'):
+    hiddenimports += ['cmath']

--- a/news/5630.hooks.rst
+++ b/news/5630.hooks.rst
@@ -1,0 +1,1 @@
+Update ``pandas`` hook for compatibility with version 1.2.0 and later.


### PR DESCRIPTION
`pandas` 1.2.0 and later require hidden import of `cmath` on linux and macOS.