### PR TITLE
compat: fix forced arch for helper-spawned python processes on macOS

### DIFF
--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -494,8 +494,15 @@ def __wrap_python(args, kwargs):
     # architecture as python executable.
     # It is necessary to run binaries with 'arch' command.
     if is_darwin:
-        mapping = {'32bit': '-i386', '64bit': '-x86_64'}
-        py_prefix = ['arch', mapping[architecture]]
+        if architecture == '64bit':
+            if machine == 'arm':
+                py_prefix = ['arch', '-arm64']  # Apple M1
+            else:
+                py_prefix = ['arch', '-x86_64']  # Intel
+        elif architecture == '32bit':
+            py_prefix = ['arch', '-i386']
+        else:
+            py_prefix = []
         # Since OS X 10.11 the environment variable DYLD_LIBRARY_PATH is no
         # more inherited by child processes, so we proactively propagate
         # the current value using the `-e` option of the `arch` command.

--- a/news/5640.bugfix.rst
+++ b/news/5640.bugfix.rst
@@ -1,0 +1,2 @@
+(macOS) Fix ``Bad CPU type in executable`` error in helper-spawned python
+processes when running under ``arm64``-only flavor of Python on Apple M1.


### PR DESCRIPTION
Extend the architecture setting in `__wrap_python()` on macOS to handle `arm64`. Fixes helper-spawned python sub-processes failing to start with `Bad CPU type in executable` when running under `arm64`-only version of Python on Apple M1.

Fixes #5640. 