### PR TITLE
bootloader: set __file__ in __main__ module to full path

### DIFF
--- a/bootloader/src/pyi_launch.c
+++ b/bootloader/src/pyi_launch.c
@@ -443,11 +443,11 @@ pyi_launch_run_scripts(ARCHIVE_STATUS *status)
             data = pyi_arch_extract(status, ptoc);
             /* Set the __file__ attribute within the __main__ module,
              *  for full compatibility with normal execution. */
-            if (snprintf(buf, PATH_MAX, "%s.py", ptoc->name) >= PATH_MAX) {
-                FATALERROR("Name exceeds PATH_MAX\n");
+            if (snprintf(buf, PATH_MAX, "%s%c%s.py", status->mainpath, PYI_SEP, ptoc->name) >= PATH_MAX) {
+                FATALERROR("Absolute path to script exceeds PATH_MAX\n");
                 return -1;
             }
-            VS("LOADER: Running %s\n", buf);
+            VS("LOADER: Running %s.py\n", ptoc->name);
             __file__ = PI_PyUnicode_FromString(buf);
             PI_PyObject_SetAttrString(__main__, "__file__", __file__);
             Py_DECREF(__file__);

--- a/news/5649.bootloader.rst
+++ b/news/5649.bootloader.rst
@@ -1,0 +1,2 @@
+Set the ``__file__`` attribute in the ``__main__`` module (entry-point
+script) to the absolute file name inside the ``_MEIPASS``.

--- a/news/5649.break.rst
+++ b/news/5649.break.rst
@@ -1,0 +1,6 @@
+The ``__file__`` attribute in the ``__main__`` module (entry-point
+script) is now set to the absolute file name inside the ``_MEIPASS``
+(as if script file existed there) instead of just script filename.
+This better matches the behavior of ``__file__`` in the unfrozen script,
+but might break the existing code that explicitly relies on the old
+frozen behavior.

--- a/news/5649.doc.rst
+++ b/news/5649.doc.rst
@@ -1,0 +1,2 @@
+Update the ``Run-time Information`` section to reflect the changes in
+behavior of ``__file__`` inside the ``__main__`` module.

--- a/tests/functional/scripts/pyi_filename.py
+++ b/tests/functional/scripts/pyi_filename.py
@@ -10,5 +10,8 @@
 #-----------------------------------------------------------------------------
 
 
-if __file__ != 'pyi_filename.py':
-   raise ValueError(__file__)
+import sys
+import os
+
+assert os.path.dirname(__file__) == sys._MEIPASS
+assert os.path.basename(__file__) == 'pyi_filename.py'


### PR DESCRIPTION
Set `__file__` attribute in `__main__` module to full path (i.e., including absolute path to `_MEIPASS`) instead of just entry-point
script  name. This ensures consistent behavior with that of `__file__` attributes in packages/modules, where the full path to
file is returned, as if it existed inside the `_MEIPASS`.

Fixes #5626.