### PR TITLE
depend: work around the potential None referer in get_co_using_ctypes

### DIFF
--- a/PyInstaller/depend/analysis.py
+++ b/PyInstaller/depend/analysis.py
@@ -741,6 +741,11 @@ class PyiModuleGraph(ModuleGraph):
         if node:
             referers = self.getReferers(node)
             for r in referers:
+                # Under python 3.7 and earlier, if ctypes is added to
+                # hidden imports, one of referers ends up being None,
+                # causing #3825. Work around it.
+                if r is None:
+                    continue
                 r_ident =  r.identifier
                 # Ensure that modulegraph objects has attribute 'code'.
                 if type(r).__name__ in pure_python_module_types:

--- a/news/3825.bugfix.rst
+++ b/news/3825.bugfix.rst
@@ -1,0 +1,2 @@
+Fix the build-time error under python 3.7 and earlier when ``ctypes``
+is manually added to ``hiddenimports``.


### PR DESCRIPTION
If `ctypes` is (manually) added to hidden imports under python 3.7, one of `referers` entries processed in `get_co_using_ctypes()` method of `PyiModuleGraph` ends up being None. This in turn causes error when its `identifier` property is accessed, causing #3825.

Work around the problem by explicitly skipping `None` entries.

Fixes #3825.