### PR TITLE
archive: switch offsets and lengths to unsigned 32-bit integers

### DIFF
--- a/PyInstaller/archive/readers.py
+++ b/PyInstaller/archive/readers.py
@@ -33,7 +33,8 @@ class CTOCReader(object):
 
     When written to disk, it is easily read from C.
     """
-    ENTRYSTRUCT = '!iiiiBB'  # (structlen, dpos, dlen, ulen, flag, typcd) followed by name
+    # (structlen, dpos, dlen, ulen, flag, typcd) followed by name
+    ENTRYSTRUCT = '!iIIIBB'
     ENTRYLEN = struct.calcsize(ENTRYSTRUCT)
 
     def __init__(self):
@@ -104,14 +105,14 @@ class CArchiveReader(ArchiveReader):
     #
     #   typedef struct _cookie {
     #       char magic[8]; /* 'MEI\014\013\012\013\016' */
-    #       int  len;      /* len of entire package */
-    #       int  TOC;      /* pos (rel to start) of TableOfContents */
+    #       uint32_t len;  /* len of entire package */
+    #       uint32_t TOC;  /* pos (rel to start) of TableOfContents */
     #       int  TOClen;   /* length of TableOfContents */
     #       int  pyvers;   /* new in v4 */
     #       char pylibname[64];    /* Filename of Python dynamic library. */
     #   } COOKIE;
     #
-    _cookie_format = '!8siiii64s'
+    _cookie_format = '!8sIIii64s'
     _cookie_size = struct.calcsize(_cookie_format)
 
     def __init__(self, archive_path=None, start=0, length=0, pylib_name=''):

--- a/PyInstaller/archive/writers.py
+++ b/PyInstaller/archive/writers.py
@@ -234,7 +234,8 @@ class CTOC(object):
 
     When written to disk, it is easily read from C.
     """
-    ENTRYSTRUCT = '!iiiiBB'  # (structlen, dpos, dlen, ulen, flag, typcd) followed by name
+    # (structlen, dpos, dlen, ulen, flag, typcd) followed by name
+    ENTRYSTRUCT = '!iIIIBB'
     ENTRYLEN = struct.calcsize(ENTRYSTRUCT)
 
     def __init__(self):
@@ -312,14 +313,14 @@ class CArchiveWriter(ArchiveWriter):
     #
     #   typedef struct _cookie {
     #       char magic[8]; /* 'MEI\014\013\012\013\016' */
-    #       int  len;      /* len of entire package */
-    #       int  TOC;      /* pos (rel to start) of TableOfContents */
+    #       uint32_t len;  /* len of entire package */
+    #       uint32_t TOC;  /* pos (rel to start) of TableOfContents */
     #       int  TOClen;   /* length of TableOfContents */
     #       int  pyvers;   /* new in v4 */
     #       char pylibname[64];    /* Filename of Python dynamic library. */
     #   } COOKIE;
     #
-    _cookie_format = '!8siiii64s'
+    _cookie_format = '!8sIIii64s'
     _cookie_size = struct.calcsize(_cookie_format)
 
     def __init__(self, archive_path, logical_toc, pylib_name):

--- a/bootloader/src/pyi_archive.h
+++ b/bootloader/src/pyi_archive.h
@@ -36,9 +36,9 @@
 /* TOC entry for a CArchive */
 typedef struct _toc {
     int  structlen;  /*len of this one - including full len of name */
-    int  pos;        /* pos rel to start of concatenation */
-    int  len;        /* len of the data (compressed) */
-    int  ulen;       /* len of data (uncompressed) */
+    uint32_t pos;    /* pos rel to start of concatenation */
+    uint32_t len;    /* len of the data (compressed) */
+    uint32_t ulen;   /* len of data (uncompressed) */
     char cflag;      /* is it compressed (really a byte) */
     char typcd;      /* type code -'b' binary, 'z' zlib, 'm' module,
                       * 's' script (v3),'x' data, 'o' runtime option  */
@@ -49,8 +49,8 @@ typedef struct _toc {
 /* The CArchive Cookie, from end of the archive. */
 typedef struct _cookie {
     char magic[8];      /* 'MEI\014\013\012\013\016' */
-    int  len;           /* len of entire package */
-    int  TOC;           /* pos (rel to start) of TableOfContents */
+    uint32_t len;       /* len of entire package */
+    uint32_t TOC;       /* pos (rel to start) of TableOfContents */
     int  TOClen;        /* length of TableOfContents */
     int  pyvers;        /* new in v4 */
     char pylibname[64]; /* Filename of Python dynamic library e.g. python2.7.dll. */

--- a/news/3939.feature.rst
+++ b/news/3939.feature.rst
@@ -1,0 +1,2 @@
+Raise the maximum allowed size of ``CArchive`` (and consequently ``onefile``
+executables) from 2 GiB to 4 GiB.


### PR DESCRIPTION
Switch the offsets and lengths in `CTOC` and `CArchive` python data structures from signed 32-bit integers to unsigned 32-bit integers. Adjust the field definitions in bootloader's `CArchive` reader code accordingly.

Increases the maximum allowed CArchive size from 2 GiB to 4 GiB.

Fixes #3939.