### PR TITLE
Setup: Fix unicode path related installation errors (#5678).

### DIFF
--- a/news/5678.bugfix.rst
+++ b/news/5678.bugfix.rst
@@ -1,0 +1,2 @@
+Fix installation issues stemming from unicode characters in
+file paths.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,3 +64,13 @@
 		directory = "build"
 		name = "Bootloader build"
 		showcontent = true
+
+[build-system]
+# Tells pip to install wheel before trying to install PyInstaller
+# from an sdist or from Github.
+# Installing without wheel uses legacy `python setup.py install`
+# which has issues with unicode paths.
+requires = [
+	"wheel",
+	"setuptools",
+]


### PR DESCRIPTION
Pip prefers to install sdists by building a .whl then installing that. If the `wheel` package is not installed then it defaults to the older `python setup.py install`method. This older method breaks if it encounters unicode paths so ideally we want to `wheel` installed before attempting to install PyInstaller itself. PEP517's build-system.requires adds this option.

One downside of this is that it makes source installations slower because it creates a full blown virtual environment to build this wheel in - even if you already have wheel installed. Another interesting caveat is that it doesn't change `pip install -e .`.