### PR TITLE
Declutter CI/CD logs.

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -60,4 +60,5 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest -n 3 --maxfail 3 --durations 10 tests/unit tests/functional --ignore tests/functional/test_libraries.py
+          pytest -n 3 --maxfail 3 --durations 10 tests/unit tests/functional --ignore tests/functional/test_libraries.py \
+            --force-flaky --no-flaky-report

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ jobs:
         #   Print the 10 longest tests; see
         #   https://docs.pytest.org/en/latest/usage.html#profiling-test-execution-duration
         - >
-          pytest -n 3 --maxfail 3 --durations 10
+          pytest -n 3 --maxfail 3 --durations 10 --force-flaky --no-flaky-report
           tests/unit tests/functional
           --ignore tests/functional/test_libraries.py
 

--- a/PyInstaller/depend/imphook.py
+++ b/PyInstaller/depend/imphook.py
@@ -591,7 +591,7 @@ class ModuleHook(object):
                 # "imports_to_remove".
                 for dest in imports_to_remove & references:
                     self.module_graph.removeReference(src, dest)
-                    logger.info(
+                    logger.debug(
                         "Excluding import of %s from module %s", dest, src)
 
 

--- a/PyInstaller/utils/conftest.py
+++ b/PyInstaller/utils/conftest.py
@@ -445,7 +445,7 @@ class AppBuilder(object):
                 '--distpath', self._distdir,
                 '--workpath', self._builddir,
                 '--path', _get_modules_dir(self._request),
-                '--log-level=DEBUG'
+                        '--log-level=INFO',
                 ]
 
         # Choose bundle mode.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -187,7 +187,7 @@ test_script:
   # statement.
   - if "%TEST_PART%" == "Libraries" (
       set PYTEST_CMD=%PYTEST% -k "test_noarchive[onefile]" ^&^&
-        %PYTEST% tests/functional/test_libraries.py
+        %PYTEST% tests/functional/test_libraries.py --no-flaky-report --force-flaky
         -k "not test_noarchive[onefile]" ^&^&
         python -m PyInstaller.utils.run_tests -c PyInstaller\utils\pytest.ini
                --include_only=pyi_hooksample.

--- a/setup.cfg
+++ b/setup.cfg
@@ -156,7 +156,7 @@ filterwarnings =
 #
 #   pytest -k test_name
 #
-addopts = "-v" "-rsxXfE" "--doctest-glob=" "--force-flaky" "--no-success-flaky-report"
+addopts = "-v" "-rsxXfE" "--doctest-glob="
 
 markers =
     darwin: only run on macOS


### PR DESCRIPTION
My war against noisy build logs:

- Move flaky testing to CI only. And disable flaky reporting which doesn't tell us anything we don't already know.
- Demote noisy logging of excluded imports to DEBUG.
- Drop pytest's log level to INFO.

I imagine we'll want to squash these but I've kept them separate in case anyone is particularly opposed to one of them.