### PR TITLE
loader: implement FrozenImporter source loading from .py files

### DIFF
--- a/PyInstaller/loader/pyimod03_importers.py
+++ b/PyInstaller/loader/pyimod03_importers.py
@@ -328,6 +328,15 @@ class FrozenImporter(object):
         Return None.
         """
         if fullname in self.toc:
+            # Try loading .py file from the filesystem
+            filename = pyi_os_path.os_path_join(
+                SYS_PREFIX,
+                fullname.replace('.', pyi_os_path.os_sep) + '.py')
+            try:
+                with open(filename, 'r') as fp:
+                    return fp.read()
+            except FileNotFoundError:
+                pass
             return None
         else:
             # ImportError should be raised if module not found.

--- a/news/5697.feature.rst
+++ b/news/5697.feature.rst
@@ -1,0 +1,3 @@
+Provide basic implementation for ``FrozenImporter.get_source()`` that
+allows reading source from ``.py`` files that are collected by hooks as
+data files.


### PR DESCRIPTION
Provide basic `FrozenImporter.get_source()` implementation that allows loading of source from `.py` files that have been collected by hooks as data files.

This is, for example, required by PyTorch's JIT compilation mechanism. 

The issue of missing source code inside frozen application, which is required by some packages, is tracked under #4764. However, it seems the primary solution discussed there is collecting `.py` files into PYZ archive. This PR instead adds support only for loading source from on-filesystem `.py` files that have been collected via `collect_data_files()` with `include_py_files=True`, which was also suggested by https://github.com/pyinstaller/pyinstaller/issues/4764#issuecomment-633777790. But in the end, the two approaches are complementary, and even if we really wanted to have `.py` files primarily collected into PYZ, we would still need an on-filesystem fallback (for `noarchive` option).

