### PR TITLE
depend: prevent entry-point script(s) from affecting rt-hook inclusion

### DIFF
--- a/PyInstaller/depend/analysis.py
+++ b/PyInstaller/depend/analysis.py
@@ -685,6 +685,11 @@ class PyiModuleGraph(ModuleGraph):
         # so far. Assuming that runtime hooks apply only to modules and packages.
         temp_toc = self._make_toc(VALID_MODULE_TYPES)
         for (mod_name, path, typecode) in temp_toc:
+            # Explicitly ignore PYSOURCE to prevent unfortunately-named
+            # entry-point scripts from spuriously triggering inclusion
+            # of run-time hook
+            if typecode == 'PYSOURCE':
+                continue
             # Look if there is any run-time hook for given module.
             if mod_name in self._available_rthooks:
                 # There could be several run-time hooks for a module.


### PR DESCRIPTION
A poorly-named entry-point script (`usb.py`, `win32api.py`, etc.) triggers inclusion of the rt-hook for the corresponding package
even though the script does not make use of that package and the corresponding std-hook is not called.

So adjust `analyze_runtime_hooks()` to check the `typecode` and skip `PYSOURCE` entries to prevent entry-point script names from affecting the rt-hook selection process.

Fixes pyinstaller/pyinstaller-hooks-contrib#105.