### PR TITLE
Bootloader: waf: Support cross-compile for FreeBSD. [skip-ci]

### DIFF
--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -411,8 +411,8 @@ def configure(ctx):
         ctx.msg('System', 'Assuming cross-compilation for %s' %
                 DESTOS_TO_SYSTEM[ctx.env.DEST_OS])
 
-        if ctx.env.DEST_OS in ('freebsd', 'hpux', 'sunos'):
-            # For these FreeBSD and HP-UX we determine some settings from
+        if ctx.env.DEST_OS in ('hpux', 'sunos'):
+            # For SunOS and HP-UX we determine some settings from
             # Python's sysconfig. For cross-compiling somebody needs to
             # implement options to overwrite these values as they may be
             # wrong.

--- a/doc/bootloader-building.rst
+++ b/doc/bootloader-building.rst
@@ -409,6 +409,41 @@ The recommended value for :envvar:`CC` with the IBM compilers is
 `:command:xlc_r`.
 
 
+Building for FreeBSD
+====================
+
+A FreeBSD bootloader may be built with clang using :ref:`the usual steps
+<building the bootloader>` on a FreeBSD machine.
+Beware, however that any executable compiled natively on FreeBSD will only run
+on equal or newer versions of FreeBSD.
+In order to support older versions of FreeBSD, you must compile the oldest OS
+version you wish to support.
+
+Alternatively, the FreeBSD bootloaders may be cross compiled from Linux using
+Docker and a `FreeBSD cross compiler image
+<https://github.com/bwoodsend/freebsd-cross-build>`_.
+This image is kept in sync with the oldest non end of life FreeBSD release so
+that anything compiled on it will work on all active FreeBSD versions.
+
+In a random directory:
+
+* Start the docker daemon (usually with ``systemctl start docker`` - possibly
+  requiring ``sudo`` if you haven't setup rootless docker).
+* Download the latest cross compiler ``.tar.xz`` image from `here
+  <https://github.com/bwoodsend/freebsd-cross-build/releases>`_.
+* Import the image: ``docker image load -i freebsd-cross-build.tar.xz``.
+  The cross compiler image is now saved under the name ``freebsd-cross-build``.
+  You may discard the ``.tar.xz`` file if you wish.
+
+Then from the root of this repository:
+
+* Run:
+
+  .. code-block:: bash
+
+    docker run -v $(pwd):/io -it freebsd-cross-build bash -c "cd /io/bootloader; ./waf all"
+
+
 
 Vagrantfile Virtual Machines
 ================================

--- a/news/5733.bootloader.rst
+++ b/news/5733.bootloader.rst
@@ -1,0 +1,1 @@
+Enable cross compiling for FreeBSD from Linux.


### PR DESCRIPTION
- Fix the waf file to allow cross compiling for FreeBSD. It doesn't need any special handling. It just needs the 'this
is untested' check removed.
- Add developer docs explaining how to do it.