### PR TITLE
depend: allow compiled modules to be collected into base_library.zip

### DIFF
--- a/PyInstaller/depend/utils.py
+++ b/PyInstaller/depend/utils.py
@@ -74,7 +74,9 @@ def create_py3_base_library(libzip_filename, graph):
             graph_nodes = list(graph.flatten())
             graph_nodes.sort(key=lambda item: item.identifier)
             for mod in graph_nodes:
-                if type(mod) in (modulegraph.SourceModule, modulegraph.Package):
+                if type(mod) in (modulegraph.SourceModule,
+                                 modulegraph.Package,
+                                 modulegraph.CompiledModule):
                     # Bundling just required modules.
                     if module_filter.match(mod.identifier):
                         st = os.stat(mod.filename)

--- a/news/5730.bugfix.rst
+++ b/news/5730.bugfix.rst
@@ -1,0 +1,1 @@
+Allow compiled modules to be collected into ``base_library.zip``.


### PR DESCRIPTION
This allows PyInstaller to work with embedded python on Windows, provided that the user worked around the lack of support for
collecting files from `python3X.zip` (i.e., by replacing the `python3X.zip` file with same-named folder that contains unpacked
contents of the zip).

In python 3.7 and later, the collected modules end up with hash that is derived from the raw contents of the original compiled
module (as opposed to source, which is unavailable). While this is technically incorrect, it should also be irrelevant in a
frozen application, and is therefore not explicitly addressed (e.g., by copying hash from the original compiled module).