### PR TITLE
Add hook utility for collecting setuptools entrypoints.

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -65,6 +65,8 @@ del prog, outfile, fh, text
 # ones.
 extensions = ['sphinx.ext.intersphinx',
               'sphinx.ext.autodoc',
+              'sphinx.ext.napoleon',
+              'sphinx_autodoc_typehints',
               'pyi_sphinx_roles']
 
 intersphinx_mapping = {

--- a/doc/hooks.rst
+++ b/doc/hooks.rst
@@ -486,6 +486,7 @@ You are welcome to read the ``PyInstaller.utils.hooks`` module
    If *package-name* does not have metadata, an
    AssertionError exception is raised.
 
+.. autofunction:: PyInstaller.utils.hooks.collect_entry_point
 
 ``get_homebrew_path( formula='' )``:
    Return the homebrew path to the named formula, or to the

--- a/news/5734.feature.rst
+++ b/news/5734.feature.rst
@@ -1,0 +1,2 @@
+Add new hook utility :func:`~PyInstaller.utils.hooks.collect_entry_point` for
+collecting plugins defined through setuptools entry points.

--- a/tests/functional/scripts/list_pytest11_entry_point.py
+++ b/tests/functional/scripts/list_pytest11_entry_point.py
@@ -1,0 +1,19 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2021, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+"""Print all modules exporting the entry point 'pytest11'."""
+
+import pkg_resources
+
+plugins = sorted(
+    i.module_name for i in pkg_resources.iter_entry_points("pytest11"))
+
+print("\n".join(plugins))

--- a/tests/functional/specs/list_pytest11_entry_point.spec
+++ b/tests/functional/specs/list_pytest11_entry_point.spec
@@ -1,0 +1,35 @@
+# -*- mode: python -*-
+#-----------------------------------------------------------------------------
+# Copyright (c) 2021, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+from pathlib import Path
+from PyInstaller.utils.hooks import collect_entry_point
+
+app_name = 'list_pytest11_entry_point'
+
+datas, hidden = collect_entry_point("pytest11")
+
+a = Analysis([str(Path(SPECPATH).parent / 'scripts' / 'list_pytest11_entry_point.py')],
+             datas=datas,
+             hiddenimports=hidden)
+pyz = PYZ(a.pure, a.zipped_data)
+exe = EXE(pyz,
+          a.scripts,
+          [('u', None, 'OPTION'), ],
+          exclude_binaries=True,
+          name=app_name,
+          debug=False,
+          console=True)
+coll = COLLECT(exe,
+               a.binaries,
+               a.zipfiles,
+               a.datas,
+               name=app_name)

--- a/tests/functional/test_hook_utilities.py
+++ b/tests/functional/test_hook_utilities.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+"""
+"""
+
+from subprocess import run, PIPE
+from os.path import join
+
+
+def test_collect_entry_point(pyi_builder_spec, script_dir, tmpdir):
+    """Test PyInstaller.utils.hooks.collect_entry_point().
+
+    On adding ``collect_entry_point('pytest11')`` to the spec file, the list
+    of modules exporting the 'pytest11' entry point should be same after
+    freezing.
+
+    """
+    import pkg_resources
+    plugins = sorted(
+        i.module_name for i in pkg_resources.iter_entry_points("pytest11"))
+
+    assert len(plugins), "The pytest11 entry point appears to have moved."
+
+    pyi_builder_spec.test_spec('list_pytest11_entry_point.spec')
+    exe = join(tmpdir, "dist", "list_pytest11_entry_point",
+               "list_pytest11_entry_point")
+
+    p = run([exe], stdout=PIPE, check=True, universal_newlines=True)
+    collected_plugins = p.stdout.strip("\n").split("\n")
+
+    assert collected_plugins == plugins


### PR DESCRIPTION
For cases where *collect all backends/plugins* really is what you want. My main motivation for this is collecting pytest plugins but it could also mop up the mess that is our keyring support or possibly be used to allow 3<sup>rd</sup> party matplotlib backends.

Provides an easy fix to #5016 and #1188.