### PR TITLE
Analysis: ctypes: Guard against errors triggered by find_library(). (#5734)

### DIFF
--- a/PyInstaller/depend/utils.py
+++ b/PyInstaller/depend/utils.py
@@ -304,7 +304,13 @@ def _resolveCtypesImports(cbinaries):
     # local paths to library search paths, then replaces original values.
     old = _setPaths()
     for cbin in cbinaries:
-        cpath = find_library(os.path.splitext(cbin)[0])
+        try:
+            # There is an issue with find_library() where it can run into
+            # errors trying to locate the library. See #5734.
+            cpath = find_library(os.path.splitext(cbin)[0])
+        except FileNotFoundError:
+            # In these cases, find_library() should return None.
+            cpath = None
         if is_unix:
             # CAVEAT: find_library() is not the correct function. Ctype's
             # documentation says that it is meant to resolve only the filename

--- a/news/5734.bugfix.rst
+++ b/news/5734.bugfix.rst
@@ -1,0 +1,2 @@
+Fix a build error triggered by scanning ``ctypes.CDLL('libc.so')`` on certain
+Linux C compiler combinations.

--- a/tests/functional/test_regression.py
+++ b/tests/functional/test_regression.py
@@ -92,3 +92,13 @@ def test_issue_4141(pyi_builder):  #script_dir,
     pyi_builder.test_script('pyi_issue_4141.py',
                             app_name="main", run_from_path=True,
                             pyi_args=['--path', str(extra_path)])
+
+
+def test_5734():
+    """
+    In a regression this will raise a:
+        FileNotFoundError: [Errno 2] No such file or directory: b'liblibc.a'
+    on some Linux/gcc combinations.
+    """
+    from PyInstaller.depend.utils import _resolveCtypesImports
+    _resolveCtypesImports(["libc"])


### PR DESCRIPTION
On some Linux C compiler combinations:
```python
ctypes.util.find_library("libc.so")
```
Unintentionally trips a FileNotFoundError instead of simply returning None.

Fixes #5734.
