### PR TITLE
CI: use two pytest-xdist workers on Windows and linux runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,14 +86,14 @@ jobs:
         if: ${{ !startsWith(matrix.os, 'macos') }}
         uses: xoviat/actions-pytest@0.1-alpha2
         with:
-          args: -n 2 --maxfail 3 --durations 10 tests/unit tests/functional --force-flaky --no-flaky-report
+          args: -n auto --maxfail 3 --durations 10 tests/unit tests/functional --force-flaky --no-flaky-report
 
       - name: Run tests
         if: startsWith(matrix.os, 'macos')
         uses: xoviat/actions-pytest@0.1-alpha2
         with:
           args: > 
-            -n 3 --maxfail 3 --durations 10 tests/unit tests/functional --ignore tests/functional/test_libraries.py 
+            -n auto --maxfail 3 --durations 10 tests/unit tests/functional --ignore tests/functional/test_libraries.py
             --force-flaky --no-flaky-report
 
       - name: Run hooksample tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
         if: ${{ !startsWith(matrix.os, 'macos') }}
         uses: xoviat/actions-pytest@0.1-alpha2
         with:
-          args: -n 3 --maxfail 3 --durations 10 tests/unit tests/functional --force-flaky --no-flaky-report
+          args: -n 2 --maxfail 3 --durations 10 tests/unit tests/functional --force-flaky --no-flaky-report
 
       - name: Run tests
         if: startsWith(matrix.os, 'macos')

--- a/setup.cfg
+++ b/setup.cfg
@@ -127,7 +127,7 @@ log_level = DEBUG
 # 'thread' timeout method adds more overhead but works in Travis containers.
 
 # Add a global timeout to prevent a hung CI
-timeout = 300
+timeout = 600
 
 # Look for tests only in tests directories.
 # Later we could change this to just "tests/**/test_*.py"


### PR DESCRIPTION
According to [specs](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources), Windows and linux runners have two cores (while macOS ones have three). Therefore, running three pytest-xdist workers is likely worsening the run-times of our tests, as one of those workers is always CPU-starved.

This is a sort of last-stop attempt at sorting out the sporadic timeout issues before opting to drop xdist-based parallelization altogether (in case the problems are caused by bincache interference).