### PR TITLE
compat: fix python library lookup for recent versions of RHSCL python

### DIFF
--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -97,7 +97,8 @@ elif is_unix:
     PYDYLIB_NAMES = {'libpython%d.%d.so.1.0' % _pyver,
                      'libpython%d.%dm.so.1.0' % _pyver,
                      'libpython%d.%dmu.so.1.0' % _pyver,
-                     'libpython%d.%dm.so' % _pyver}
+                     'libpython%d.%dm.so' % _pyver,
+                     'libpython%d.%d.so' % _pyver}
 else:
     raise SystemExit('Your platform is not yet supported. '
                      'Please define constant PYDYLIB_NAMES for your platform.')

--- a/news/5749.bugfix.rst
+++ b/news/5749.bugfix.rst
@@ -1,0 +1,1 @@
+Fix python library lookup when building with RH SCL python 3.8 or later.


### PR DESCRIPTION
Fix python library lookup for recent versions of python packaged through RH SCL, which uses non-standard naming scheme:

```
lrwxrwxrwx  libpython3.8.so -> libpython3.8.so.rh-python38-1.0
-rwxr-xr-x  libpython3.8.so.rh-python38-1.0
-rwxr-xr-x  libpython3.so.rh-python38
```

This is an extension of b748881 that added support for earlier versions of RH SCL python.

Fixes #5749.