### PR TITLE
CI/CD: Disable parallel testing.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,14 +86,14 @@ jobs:
         if: ${{ !startsWith(matrix.os, 'macos') }}
         uses: xoviat/actions-pytest@0.1-alpha2
         with:
-          args: -n 3 --maxfail 3 --durations 10 tests/unit tests/functional --force-flaky --no-flaky-report
+          args: --maxfail 3 --durations 10 tests/unit tests/functional --force-flaky --no-flaky-report
 
       - name: Run tests
         if: startsWith(matrix.os, 'macos')
         uses: xoviat/actions-pytest@0.1-alpha2
         with:
-          args: > 
-            -n 3 --maxfail 3 --durations 10 tests/unit tests/functional --ignore tests/functional/test_libraries.py 
+          args: >
+            --maxfail 3 --durations 10 tests/unit tests/functional --ignore tests/functional/test_libraries.py
             --force-flaky --no-flaky-report
 
       - name: Run hooksample tests

--- a/tests/requirements-tools.txt
+++ b/tests/requirements-tools.txt
@@ -18,9 +18,6 @@ execnet >= 1.5.0
 # Testing framework.
 pytest >= 2.7.3
 
-# Plugin allowing running tests in parallel.
-pytest-xdist
-
 # Plugin to abort hanging tests.
 pytest-timeout
 # allows specifying order without duplicates


### PR DESCRIPTION
For some reason that we can't work out, using pytest-xdist
on Windows Github Actions causes tests to fail.

For the record, we've also tried:
- reducing the maximum number of concurrent processes (#5741).
- greatly increasing timeout limits (again #5741)
- increasing flaky retry limit ([bwoodsend/super-flakey branch](https://github.com/bwoodsend/pyinstaller/runs/2375784301))
None of which made any noticeable difference.

The CI/CD for this PR should confirm that this works but [here](https://github.com/bwoodsend/pyinstaller/runs/2375768917) is a spotlessly working build log.