### PR TITLE
CI/CD: test libraries on macOS runners as well

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   tests:
-    runs-on: ${{ matrix.os }} 
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
@@ -49,7 +49,7 @@ jobs:
       - name: Set cache dir
         run: echo "pip_cache_dir=$(pip cache dir)" >> $GITHUB_ENV
         shell: bash
-        
+
       - name: Fetch cache
         id: cache-target
         uses: actions/cache@v2
@@ -83,23 +83,13 @@ jobs:
           echo "QT_DEBUG_PLUGINS=1" >> $GITHUB_ENV
 
       - name: Run tests
-        if: ${{ !startsWith(matrix.os, 'macos') }}
         uses: xoviat/actions-pytest@0.1-alpha2
         with:
-          args: > 
+          args: >
             -n 3 --maxfail 3 --durations 10 tests/unit tests/functional
             --force-flaky --no-flaky-report --reruns 3 --reruns-delay 10
 
-      - name: Run tests
-        if: startsWith(matrix.os, 'macos')
-        uses: xoviat/actions-pytest@0.1-alpha2
-        with:
-          args: > 
-            -n 3 --maxfail 3 --durations 10 tests/unit tests/functional --ignore tests/functional/test_libraries.py 
-            --force-flaky --no-flaky-report --reruns 3 --reruns-delay 10
-
       - name: Run hooksample tests
-        if: startsWith(matrix.os, 'macos')
         run: |
           # The ``run_tests`` script is invoked with the ``-c`` option to
           # specify a ``pytest.ini``, rather than allowing pytest to find


### PR DESCRIPTION
The macOS pipeline seems to have been ignoring `test_libraries.py` ever since it has been migrated from Travis. This looks like a mistake originating from tests being split between Base and Libraries on the Travis pipeline.