### PR TITLE
bootloader: obfuscate the CArchive MAGIC pattern stored in executable

### DIFF
--- a/news/5762.bugfix.rst
+++ b/news/5762.bugfix.rst
@@ -1,0 +1,3 @@
+Prevent a bootloader executable without an embedded CArchive from being
+misidentified as having one, which leads to undefined behavior in frozen
+applications with side-loaded CArchive packages.


### PR DESCRIPTION
The magic pattern buffer that we use for finding the `CArchive`'s `COOKIE` structure is itself stored in the executable as binary data, and can produce a match.

This is not a problem if `CArchive` is actually embedded in the executable, as it is matched first. However, for the builds with
side-loaded `CArchive` .pkg and "empty" bootloader executable, the full-file scan introduced in 698ad70 causes a spurious match in the executable, and leads to undefined behavior as we try to interpret the subsequent data as `CArchive`'s header and `TOC`.

Obfuscating the pattern by splitting it in two and separating it with unused data prevents the spurious match when scanning
an "empty" bootloader executable, i.e., one without appended `CArchive` package.

Fixes #5762.