### PR TITLE
depend: expand _win_includes list with additiona DLLs from vcredist

### DIFF
--- a/PyInstaller/depend/dylib.py
+++ b/PyInstaller/depend/dylib.py
@@ -97,6 +97,14 @@ _win_includes = {
     r'ucrtbase\.dll',
     r'vcruntime140\.dll',
 
+    # Additional DLLs from VC 2015/2017/2019 runtime. Allow these to be
+    # collected to avoid missing-DLL errors when the target machine does
+    # not have the VC redistributable installed.
+    r'msvcp140\.dll',
+    r'msvcp140_1\.dll',
+    r'msvcp140_2\.dll',
+    r'vcruntime140_1\.dll',
+
     # Allow pythonNN.dll, pythoncomNN.dll, pywintypesNN.dll
     r'py(?:thon(?:com(?:loader)?)?|wintypes)\d+\.dll',
 }

--- a/news/5770.bugfix.rst
+++ b/news/5770.bugfix.rst
@@ -1,0 +1,4 @@
+(Windows) Enable collection of additional VC runtime DLLs (``msvcp140.dll``,
+``msvcp140_1.dll``, ``msvcp140_2.dll``, and ``vcruntime140_1.dll``), to
+allow frozen applications to run on Windows systems that do not have
+`Visual Studio 2015/2017/2019 Redistributable` installed.


### PR DESCRIPTION
Enable collection of `msvcp140{,_1,_2}.dll` and `vcruntime140_1.dll`. Collecting these DLLs should allow the frozen application to run on Windows systems that do not have *Visual Studio 205/2017/2019 Redistributable* installed.

Fixes #5768 (and likely other similar issues that we've seen in the past).