### PR TITLE
Hook-utils: copy_metadata(): Preserve metadata folder name.

### DIFF
--- a/PyInstaller/hooks/hook-gevent.py
+++ b/PyInstaller/hooks/hook-gevent.py
@@ -9,7 +9,8 @@
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
 
-from PyInstaller.utils.hooks import collect_all
+from PyInstaller.utils.hooks import collect_all, copy_metadata
+from PyInstaller.compat import is_win
 
 excludedimports = ["gevent.testing", "gevent.tests"]
 
@@ -19,3 +20,12 @@ datas, binaries, hiddenimports = collect_all(
         "gevent.testing" not in name or "gevent.tests" not in name),
     include_py_files=False,
     exclude_datas=["**/tests"])
+
+datas += copy_metadata("zope.interface")
+datas += copy_metadata("greenlet")
+datas += copy_metadata("zope.event")
+datas += copy_metadata("setuptools")
+
+if is_win:
+    datas += copy_metadata("cffi")
+    datas += copy_metadata("pycparser")

--- a/PyInstaller/utils/hooks/__init__.py
+++ b/PyInstaller/utils/hooks/__init__.py
@@ -894,7 +894,9 @@ def collect_system_data_files(path, destdir=None, include_py_files=False):
 
 
 def copy_metadata(package_name):
-    """
+    """Collect distribution metadata so that
+    ``pkg_resources.get_distribution()`` can find it.
+
     This function returns a list to be assigned to the ``datas`` global
     variable. This list instructs PyInstaller to copy the metadata for the
     given package to PyInstaller's data directory.
@@ -905,61 +907,96 @@ def copy_metadata(package_name):
         Specifies the name of the package for which metadata should be copied.
 
     Returns
-    ----------
+    -------
     list
         This should be assigned to ``datas``.
 
     Examples
-    ----------
+    --------
         >>> from PyInstaller.utils.hooks import copy_metadata
         >>> copy_metadata('sphinx')
         [('c:\\python27\\lib\\site-packages\\Sphinx-1.3.2.dist-info',
           'Sphinx-1.3.2.dist-info')]
+
+
+    Some packages rely on metadata files accessed through the
+    ``pkg_resources`` module. Normally |PyInstaller| does not include these
+    metadata files. If a package fails without them, you can use this
+    function in a hook file to easily add them to the bundle. The tuples in
+    the returned list have two strings. The first is the full pathname to a
+    folder in this system. The second is the folder name only. When these
+    tuples are added to ``datas``\\ , the folder will be bundled at the top
+    level.
+
+    .. versionchanged:: 4.3.1
+
+        Prevent ``dist-info`` metadata folders being renamed to ``egg-info``
+        which broke ``pkg_resources.require`` with *extras* (see
+        :issue:`#3033`).
+
     """
-
-    # Some notes: to look at the metadata locations for all installed
-    # packages::
-    #
-    #     for key, value in pkg_resources.working_set.by_key.iteritems():
-    #         print('{}: {}'.format(key, value.egg_info))
-    #
-    # Looking at this output, I see three general types of packages:
-    #
-    # 1. ``pypubsub: c:\python27\lib\site-packages\pypubsub-3.3.0-py2.7.egg\EGG-INFO``
-    # 2. ``codechat: c:\users\bjones\documents\documentation\CodeChat.egg-info``
-    # 3. ``zest.releaser: c:\python27\lib\site-packages\zest.releaser-6.2.dist-info``
-    # 4. ``pyserial: None``
-    #
-    # The first item shows that some metadata will be nested inside an egg. I
-    # assume we'll have to deal with zipped eggs, but I don't have any examples
-    # handy. The second and third items show different naming conventions for
-    # the metadata-containing directory. The fourth item shows a package with no
-    # metadata.
-    #
-    # So, in cases 1-3, copy the metadata directory. In case 4, emit an error
-    # -- there's no metadata to copy.
-    # See https://pythonhosted.org/setuptools/pkg_resources.html#getting-or-creating-distributions.
-    # Unfortunately, there's no documentation on the ``egg_info`` attribute; it
-    # was found through trial and error.
     dist = pkg_resources.get_distribution(package_name)
-    metadata_dir = dist.egg_info
-    # Determine a destination directory based on the standardized egg name for
-    # this distribution. This avoids some problems discussed in
-    # https://github.com/pyinstaller/pyinstaller/issues/1888.
-    dest_dir = '{}.egg-info'.format(dist.egg_name())
-    # Per https://github.com/pyinstaller/pyinstaller/issues/1888, ``egg_info``
-    # isn't always defined. Try a workaround based on a suggestion by
-    # @benoit-pierre in that issue.
-    if metadata_dir is None:
-        # We assume that this is an egg, so guess a name based on `egg_name()
-        # <https://pythonhosted.org/setuptools/pkg_resources.html#distribution-methods>`_.
-        metadata_dir = os.path.join(dist.location, dest_dir)
+    return [(dist.egg_info,
+             _copy_metadata_dest(dist.egg_info, dist.project_name))]
 
-    assert os.path.exists(metadata_dir)
-    logger.debug('Package {} metadata found in {} belongs in {}'.format(
-      package_name, metadata_dir, dest_dir))
 
-    return [(metadata_dir, dest_dir)]
+def _normalise_dist(name: str) -> str:
+    return name.lower().replace("_", "-")
+
+
+def _copy_metadata_dest(egg_path: str, project_name: str) -> str:
+    """Choose an appropriate destination path for a distribution's metadata.
+
+    Args:
+        egg_path:
+            The output of ``pkg_resources.get_distribution("xyz").egg_info``:
+            A full path to the source ``xyz-version.dist-info`` or
+            ``xyz-version.egg-info`` folder containing package metadata.
+        project_name:
+            The distribution name given
+    Returns:
+        The *dest* parameter: where in the bundle should this folder go.
+    Raises:
+        RuntimeError:
+            If **egg_path** is none. i.e. No metadata found.
+
+    """
+    if egg_path is None:
+        # According to older implementations of this function, packages may
+        # have no metadata. I have no idea when this can happen...
+        raise RuntimeError(
+            f"No metadata path found for distribution '{project_name}'.")
+
+    egg_path = Path(egg_path)
+    _project_name = _normalise_dist(project_name)
+
+    # There has been a fair amount of whack-a-mole fixing to this step.
+    # If new cases appear which this function can't handle, add them to the
+    # corresponding test:
+    #   tests/unit/test_hookutils.py::test_copy_metadata_dest()
+    # See there also for example input/outputs.
+
+    # The most obvious answer is that the metadata folder should have the same
+    # name in a PyInstaller build as it does normally::
+    if _normalise_dist(egg_path.name).startswith(_project_name):
+        # e.g. .../lib/site-packages/xyz-1.2.3.dist-info
+        return egg_path.name
+
+    # Using just the base-name breaks for an egg_path of the form:
+    #   '.../site-packages/xyz-version.win32.egg/EGG-INFO'
+    # because multiple collected metadata folders will be written to the same
+    # name 'EGG-INFO' and clobber each other (see #1888).
+    # In this case, the correct behaviour appears to be to use the last 2 parts
+    # of the path:
+    if len(egg_path.parts) >= 2:
+        if _normalise_dist(egg_path.parts[-2]).startswith(_project_name):
+            return os.path.join(*egg_path.parts[-2:])
+
+    # This is something unheard of.
+    raise RuntimeError(
+        f"Unknown metadata type '{egg_path}' from the '{project_name}' "
+        f"distribution. Please report this at "
+        f"https://github/pyinstaller/pyinstaller/issues.")
 
 
 def get_installer(module):

--- a/doc/hooks.rst
+++ b/doc/hooks.rst
@@ -3,6 +3,8 @@
 Understanding PyInstaller Hooks
 ==================================
 
+.. py:currentmodule:: PyInstaller.utils.hooks
+
 .. note::
 
    We strongly encourage package developers
@@ -468,23 +470,7 @@ You are welcome to read the ``PyInstaller.utils.hooks`` module
 
    is the tuple, ``( '/abs/Python/lib', '/abs/Python/lib/pkg/subpkg' )``
 
-``copy_metadata( 'package-name' )``:
-   Given the name of a package, return the name of its distribution
-   metadata folder as a list of tuples ready to be assigned
-   (or appended) to the ``datas`` global variable.
-
-   Some packages rely on metadata files accessed through the
-   ``pkg_resources`` module.
-   Normally |PyInstaller| does not include these metadata files.
-   If a package fails without them, you can use this
-   function in a hook file to easily add them to the bundle.
-   The tuples in the returned list have two strings.
-   The first is the full pathname to a folder in this system.
-   The second is the folder name only.
-   When these tuples are added to ``datas``\ ,
-   the folder will be bundled at the top level.
-   If *package-name* does not have metadata, an
-   AssertionError exception is raised.
+.. autofunction:: copy_metadata
 
 .. autofunction:: PyInstaller.utils.hooks.collect_entry_point
 

--- a/news/5774.bugfix.rst
+++ b/news/5774.bugfix.rst
@@ -1,0 +1,3 @@
+Prevent :func:`PyInstaller.utils.hooks.copy_metdata` from renaming
+``[...].dist-info`` metadata folders to ``[...].egg-info`` which breaks usage
+of ``pkg_resources.requires()`` with *extras*.

--- a/tests/unit/test_hookutils.py
+++ b/tests/unit/test_hookutils.py
@@ -343,8 +343,8 @@ def test_copy_metadata_dest(egg_path, name, target):
     """
     # Convert posix style filenames to native paths. i.e. replace '/' with '\'
     # on Windows.
-    egg_path = str(pathlib.Path(*pathlib.PurePosixPath(egg_path).parts))
-    target = str(pathlib.Path(*pathlib.PurePosixPath(target).parts))
+    egg_path = str(pathlib.PurePath(egg_path))
+    target = str(pathlib.PurePath(target))
 
     assert _copy_metadata_dest(egg_path, name) == target
 


### PR DESCRIPTION
Prevent metadata folders such as `foo-1.2.3.dist-info` from being renamed to `foo-1.2.3.egg-info` which breaks usage of:
```python
pkg_resources.get_distribution("foo").requires(extras=["..."])
```

This commit, in essence, reverts the patch applied to resolve #1888, which forcibly renamed everything to use `.egg-info` to avoid destination collisions caused by egg-info paths such as `site-packages/pyhook-1.5.1-py2.7-win32.egg/EGG-INFO` formally being copied into bundles as just `EGG-INFO`.

Now, in the above scenario, the destination folder is `pyhook-1.5.1-py2.7-win32.egg/EGG-INFO` which prevents both the naming collision and avoids renaming dist-infos to eggs.

Also merge the docstring documentation for copy_metdata() with the website version via sphinx.ext.autodoc.

Fixes #3033.