### PR TITLE
setup: Put Windows bootloaders back in the sdist.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,8 @@
 recursive-include bootloader *.c *.h wscript waf strip.py
 recursive-exclude PyInstaller/bootloader *
 recursive-include PyInstaller/bootloader/images *
+# Keep the Windows bootloaders so that MSYS2 users aren't required to build
+# from source. (Wheels don't work on MSYS2.)
+recursive-include PyInstaller/bootloader/Windows-32bit *
+recursive-include PyInstaller/bootloader/Windows-64bit *
 include pyproject.toml


### PR DESCRIPTION
Without them MSYS2 users are forced to build from source because wheels don't work on MSYS2 and pip won't simply use the Windows wheel - even though it would be compatible.
