### PR TITLE
tests/ci: revert changes to xdist/rerunfailures

### DIFF
--- a/PyInstaller/utils/conftest.py
+++ b/PyInstaller/utils/conftest.py
@@ -63,7 +63,7 @@ from PyInstaller.utils.hooks.qt import pyqt5_library_info, pyside2_library_info
 # =======
 # Timeout for running the executable. If executable does not exit in this time
 # then it is interpreted as test failure.
-_EXE_TIMEOUT = 30  # In sec.
+_EXE_TIMEOUT = 60  # In sec.
 # Number of retries we should attempt if the executable times out.
 _MAX_RETRIES = 2
 # All currently supported platforms

--- a/tests/requirements-tools.txt
+++ b/tests/requirements-tools.txt
@@ -19,14 +19,14 @@ execnet >= 1.5.0
 pytest >= 2.7.3
 
 # Plugin allowing running tests in parallel.
-git+https://github.com/xoviat/pytest-xdist.git@crashitem
+pytest-xdist
 
 # Plugin to abort hanging tests.
 git+https://github.com/xoviat/pytest-timeout.git@thread-exception
 # allows specifying order without duplicates
 pytest-drop-dup-tests
 # reruns failed flaky tests
-git+https://github.com/xoviat/pytest-rerunfailures.git@crashitem
+pytest-rerunfailures
 
 # Better subprocess alternative with implemented timeout.
 psutil


### PR DESCRIPTION
#5765 may have eliminated the need for these patches.