### PR TITLE
setup: set has_ext_modules to True to build non-pure/binary wheels

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -203,4 +203,6 @@ setup(
                 'bdist_wheels': bdist_wheels,
                 },
     packages=find_packages(include=["PyInstaller", "PyInstaller.*"]),
+    # build a binary wheel that includes bootloader executable
+    has_ext_modules=lambda: True,
 )


### PR DESCRIPTION
Ensures that bootloader executable is collected and installed when installing from git checkout in non-editable mode (without -e argument given to pip) or when installing directly from github's repository zip archive.