### PR TITLE
setup: Collect all bootloaders for default bdist_wheel.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -203,4 +203,8 @@ setup(
                 'bdist_wheels': bdist_wheels,
                 },
     packages=find_packages(include=["PyInstaller", "PyInstaller.*"]),
+    # Include all bootloaders in wheels by default.
+    package_data = {
+        "PyInstaller": ["bootloader/*/*"],
+    },
 )


### PR DESCRIPTION
Amend #5787 (again). Fixes the issue highlighted in #5802 that `pip install .` doesn't take the bootloaders with it.