### PR TITLE
setup: fix missing files in sdist and wheels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
           cd ..
 
           # Install PyInstaller.
-          pip install --progress-bar=off -e .
+          pip install --progress-bar=off .
 
           # Make sure the help options print.
           python -m pyinstaller -h

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,3 +6,7 @@ recursive-include PyInstaller/bootloader/images *
 recursive-include PyInstaller/bootloader/Windows-32bit *
 recursive-include PyInstaller/bootloader/Windows-64bit *
 include pyproject.toml
+# These files need to be explicitly included
+include PyInstaller/fake-modules/site.py
+include PyInstaller/hooks/rthooks.dat
+include PyInstaller/lib/README.rst

--- a/setup.py
+++ b/setup.py
@@ -105,10 +105,16 @@ class Wheel(bdist_wheel):
                 f"https://pyinstaller.readthedocs.io/en/stable/"
                 f"bootloader-building.html for how to compile them.")
 
-        # And add the correct bootloaders as data files.
         self.distribution.package_data = {
-            "PyInstaller": [f"bootloader/{self.PYI_PLAT_NAME}/*",
-                            "bootloader/images/*"],
+            "PyInstaller": [
+                # And add the correct bootloaders as data files.
+                f"bootloader/{self.PYI_PLAT_NAME}/*",
+                "bootloader/images/*",
+                # These files need to be explictly included as well.
+                "fake-modules/site.py",
+                "hooks/rthooks.dat",
+                "lib/README.rst",
+            ],
         }
         super().finalize_options()
 
@@ -203,8 +209,14 @@ setup(
                 'bdist_wheels': bdist_wheels,
                 },
     packages=find_packages(include=["PyInstaller", "PyInstaller.*"]),
-    # Include all bootloaders in wheels by default.
     package_data = {
-        "PyInstaller": ["bootloader/*/*"],
+        "PyInstaller": [
+            # Include all bootloaders in wheels by default.
+            "bootloader/*/*",
+            # These files need to be explictly included as well.
+            "fake-modules/site.py",
+            "hooks/rthooks.dat",
+            "lib/README.rst",
+        ],
     },
 )


### PR DESCRIPTION
Ensure that the following files are collected into sdist and wheels (it seems we need to collect them explicitly):
* PyInstaller/fake-modules/site.py
* PyInstaller/hooks/rthooks.dat
* PyInstaller/lib/README.rst