### PR TITLE
hooks: PySide2/PyQt5: unify handling of relative Qt directory

### DIFF
--- a/PyInstaller/hooks/hook-PyQt5.QtQml.py
+++ b/PyInstaller/hooks/hook-PyQt5.QtQml.py
@@ -28,15 +28,12 @@ if pyqt5_library_info.version is not None:
     if not os.path.exists(qmldir):
         logger.warning('Unable to find Qt5 QML files. QML files not packaged.')
     else:
-        qml_rel_dir = ['PyQt5', 'Qt', 'qml']
-        datas += [(qmldir, os.path.join(*qml_rel_dir))]
+        qml_rel_dir = os.path.join(pyqt5_library_info.qt_rel_dir, 'qml')
+        datas += [(qmldir, qml_rel_dir)]
         binaries += [
             # Produce ``/path/to/Qt/Qml/path_to_qml_binary/qml_binary,
-            # PyQt5/Qt/Qml/path_to_qml_binary``. When Python 3.4 goes EOL (see
-            # PEP 448), this is better written as
-            # ``os.path.join(*qml_rel_dir,
-            # os.path.dirname(os.path.relpath(f, qmldir))))``.
-            (f, os.path.join(*(qml_rel_dir +
-                               [os.path.dirname(os.path.relpath(f, qmldir))])))
+            # PyQt5/Qt/Qml/path_to_qml_binary``.
+            (f, os.path.join(qml_rel_dir,
+                             os.path.dirname(os.path.relpath(f, qmldir))))
             for f in misc.dlls_in_subdirs(qmldir)
         ]

--- a/PyInstaller/hooks/hook-PyQt5.QtWebEngineWidgets.py
+++ b/PyInstaller/hooks/hook-PyQt5.QtWebEngineWidgets.py
@@ -22,7 +22,7 @@ if pyqt5_library_info.version is not None:
     hiddenimports, binaries, datas = add_qt5_dependencies(__file__)
 
     # Include the web engine process, translations, and resources.
-    rel_data_path = ['PyQt5', 'Qt']
+    rel_data_path = pyqt5_library_info.qt_rel_dir
     if compat.is_darwin:
         # This is based on the layout of the Mac wheel from PyPi.
         data_path = pyqt5_library_info.location['DataPath']
@@ -33,7 +33,7 @@ if pyqt5_library_info.version is not None:
             framework_dir = i + '.framework'
             datas += collect_system_data_files(
                 os.path.join(data_path, 'lib', framework_dir),
-                os.path.join(*rel_data_path, 'lib', framework_dir), True)
+                os.path.join(rel_data_path, 'lib', framework_dir), True)
         datas += [(os.path.join(data_path, 'lib', 'QtWebEngineCore.framework',
                                 'Resources'), os.curdir)]
     else:
@@ -43,24 +43,18 @@ if pyqt5_library_info.version is not None:
             # Gather translations needed by Chromium.
             (os.path.join(pyqt5_library_info.location['TranslationsPath'],
                           locales),
-             os.path.join('PyQt5', 'Qt', 'translations', locales)),
+             os.path.join(rel_data_path, 'translations', locales)),
             # Per the `docs <https://doc.qt.io/qt-5.10/qtwebengine-deploying.html#deploying-resources>`_,
             # ``DataPath`` is the base directory for ``resources``.
-            #
-            # When Python 3.4 goes EOL (see `PEP 448`_, this is better written as
-            # ``os.path.join(*rel_data_path, resources)``.
             (os.path.join(pyqt5_library_info.location['DataPath'], resources),
-             os.path.join(*(rel_data_path + [resources]))),
+             os.path.join(rel_data_path, resources)),
             # Include the webengine process. The ``LibraryExecutablesPath`` is only
             # valid on Windows and Linux.
-            #
-            # Again, rewrite when Python 3.4 is EOL to
-            # ``os.path.join(*rel_data_path, remove_prefix(...``.
             (os.path.join(pyqt5_library_info.location['LibraryExecutablesPath'],
                           'QtWebEngineProcess*'),
-             os.path.join(*(rel_data_path +
-                          [remove_prefix(pyqt5_library_info.location['LibraryExecutablesPath'],
-                                        pyqt5_library_info.location['PrefixPath'] + '/')])))
+             os.path.join(rel_data_path, remove_prefix(
+                pyqt5_library_info.location['LibraryExecutablesPath'],
+                pyqt5_library_info.location['PrefixPath'] + '/')))
         ]
 
     # Add Linux-specific libraries.

--- a/PyInstaller/hooks/hook-PyQt5.py
+++ b/PyInstaller/hooks/hook-PyQt5.py
@@ -25,7 +25,7 @@ if pyqt5_library_info.version is not None:
     # Collect the ``qt.conf`` file.
     datas = [x for x in
              collect_system_data_files(pyqt5_library_info.location['PrefixPath'],
-                                       os.path.join('PyQt5', 'Qt'))
+                                       pyqt5_library_info.qt_rel_dir)
              if os.path.basename(x[0]) == 'qt.conf']
 
     # Collect required Qt binaries.

--- a/PyInstaller/hooks/hook-PySide2.QtQml.py
+++ b/PyInstaller/hooks/hook-PySide2.QtQml.py
@@ -26,15 +26,12 @@ if pyside2_library_info.version is not None:
     if not os.path.exists(qmldir):
         logger.warning('Unable to find Qt5 QML files. QML files not packaged.')
     else:
-        qml_rel_dir = ['PySide2', 'qml']
-        datas += [(qmldir, os.path.join(*qml_rel_dir))]
+        qml_rel_dir = os.path.join(pyside2_library_info.qt_rel_dir, 'qml')
+        datas += [(qmldir, qml_rel_dir)]
         binaries += [
             # Produce ``/path/to/Qt/Qml/path_to_qml_binary/qml_binary,
-            # PyQt5/Qt/Qml/path_to_qml_binary``. When Python 3.4 goes EOL (see
-            # PEP 448), this is better written as
-            # ``os.path.join(*qml_rel_dir,
-            # os.path.dirname(os.path.relpath(f, qmldir))))``.
-            (f, os.path.join(*(qml_rel_dir +
-                               [os.path.dirname(os.path.relpath(f, qmldir))])))
+            # PyQt5/Qt/Qml/path_to_qml_binary``.
+            (f, os.path.join(qml_rel_dir,
+                             os.path.dirname(os.path.relpath(f, qmldir))))
             for f in misc.dlls_in_subdirs(qmldir)
         ]

--- a/PyInstaller/hooks/hook-PySide2.QtWebEngineWidgets.py
+++ b/PyInstaller/hooks/hook-PySide2.QtWebEngineWidgets.py
@@ -27,10 +27,6 @@ def get_relative_path_if_possible(actual, possible_prefix):
         return possible_relative_path
 
 
-def prefix_with_path(prefix_path, *paths):
-    return os.path.join(*prefix_path, *paths)  # noqa: E999
-
-
 # Ensure PySide2 is importable before adding info depending on it.
 if pyside2_library_info.version is not None:
     hiddenimports, binaries, datas = add_qt5_dependencies(__file__)
@@ -38,10 +34,7 @@ if pyside2_library_info.version is not None:
     # Include the web engine process, translations, and resources.
     # According to https://bugreports.qt.io/browse/PYSIDE-642
     # there's no subdir for windows
-    if compat.is_win:
-        rel_data_path = ['PySide2']
-    else:
-        rel_data_path = ['PySide2', 'Qt']
+    rel_data_path = pyside2_library_info.qt_rel_dir
 
     pyside2_locations = pyside2_library_info.location
     if compat.is_darwin:
@@ -54,7 +47,7 @@ if pyside2_library_info.version is not None:
             framework_dir = i + '.framework'
             datas += collect_system_data_files(
                 os.path.join(data_path, 'lib', framework_dir),
-                prefix_with_path(rel_data_path, 'lib', framework_dir), True)
+                os.path.join(rel_data_path, 'lib', framework_dir), True)
         datas += [(os.path.join(data_path, 'lib', 'QtWebEngineCore.framework',
                                 'Resources'), os.curdir)]
     else:
@@ -63,19 +56,19 @@ if pyside2_library_info.version is not None:
         datas += [
             # Gather translations needed by Chromium.
             (os.path.join(pyside2_locations['TranslationsPath'], locales),
-             prefix_with_path(rel_data_path, 'translations', locales)),
+             os.path.join(rel_data_path, 'translations', locales)),
             # Per the `docs
             # <https://doc.qt.io/qt-5.10/qtwebengine-deploying.html#deploying-resources>`_,
             # ``DataPath`` is the base directory for ``resources``.
             #
             (os.path.join(pyside2_locations['DataPath'], resources),
-             prefix_with_path(rel_data_path, resources)),
+             os.path.join(rel_data_path, resources)),
             # Include the webengine process. The ``LibraryExecutablesPath``
             # is only valid on Windows and Linux.
             #
             (os.path.join(pyside2_locations['LibraryExecutablesPath'],
                           'QtWebEngineProcess*'),
-             prefix_with_path(rel_data_path, get_relative_path_if_possible(
+             os.path.join(rel_data_path, get_relative_path_if_possible(
                  pyside2_locations['LibraryExecutablesPath'],
                  pyside2_locations['PrefixPath'] + '/')))
         ]

--- a/PyInstaller/hooks/hook-PySide2.py
+++ b/PyInstaller/hooks/hook-PySide2.py
@@ -12,22 +12,15 @@
 import os
 from PyInstaller.utils.hooks import collect_system_data_files
 from PyInstaller.utils.hooks.qt import pyside2_library_info, get_qt_binaries
-from PyInstaller.compat import is_win
 
 # Only proceed if PySide2 can be imported.
 if pyside2_library_info.version is not None:
-
     hiddenimports = ['shiboken2']
 
     # Collect the ``qt.conf`` file.
-    if is_win:
-        target_qt_conf_dir = ['PySide2']
-    else:
-        target_qt_conf_dir = ['PySide2', 'Qt']
-
     datas = [x for x in
              collect_system_data_files(pyside2_library_info.location['PrefixPath'],
-                                       os.path.join(*target_qt_conf_dir))
+                                       pyside2_library_info.qt_rel_dir)
              if os.path.basename(x[0]) == 'qt.conf']
 
     # Collect required Qt binaries.

--- a/PyInstaller/hooks/rthooks/pyi_rth_pyqt5.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_pyqt5.py
@@ -15,7 +15,12 @@ import sys
 # The path to Qt's components may not default to the wheel layout for
 # self-compiled PyQt5 installations. Mandate the wheel layout. See
 # ``utils/hooks/qt.py`` for more details.
-pyqt_path = os.path.join(sys._MEIPASS, 'PyQt5', 'Qt')
+#
+# Try PyQt5 5.15.4-style path first...
+pyqt_path = os.path.join(sys._MEIPASS, 'PyQt5', 'Qt5')
+if not os.path.isdir(pyqt_path):
+    # ... and fall back to the older version
+    pyqt_path = os.path.join(sys._MEIPASS, 'PyQt5', 'Qt')
 os.environ['QT_PLUGIN_PATH'] = os.path.join(pyqt_path, 'plugins')
 os.environ['QML2_IMPORT_PATH'] = os.path.join(pyqt_path, 'qml')
 # This is required starting in PyQt5 5.12.3. See discussion in #4293.

--- a/PyInstaller/hooks/rthooks/pyi_rth_pyqt5webengine.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_pyqt5webengine.py
@@ -14,8 +14,11 @@ import sys
 
 # See ``pyi_rth_qt5.py`: use a "standard" PyQt5 layout.
 if sys.platform == 'darwin':
+    # Try PyQt5 5.15.4-style path first...
+    pyqt_path = os.path.join(sys._MEIPASS, 'PyQt5', 'Qt5')
+    if not os.path.isdir(pyqt_path):
+        # ... and fall back to the older version
+        pyqt_path = os.path.join(sys._MEIPASS, 'PyQt5', 'Qt')
     os.environ['QTWEBENGINEPROCESS_PATH'] = os.path.normpath(os.path.join(
-        sys._MEIPASS, 'PyQt5', 'Qt', 'lib',
-        'QtWebEngineCore.framework', 'Helpers', 'QtWebEngineProcess.app',
-        'Contents', 'MacOS', 'QtWebEngineProcess'
-    ))
+        pyqt_path, 'lib', 'QtWebEngineCore.framework', 'Helpers',
+        'QtWebEngineProcess.app', 'Contents', 'MacOS', 'QtWebEngineProcess'))

--- a/PyInstaller/hooks/rthooks/pyi_rth_pyside2.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_pyside2.py
@@ -15,6 +15,9 @@ import sys
 # The path to Qt's components may not default to the wheel layout for
 # self-compiled PySide2 installations. Mandate the wheel layout. See
 # ``utils/hooks/qt.py`` for more details.
-pyqt_path = os.path.join(sys._MEIPASS, 'PySide2')
+if sys.platform.startswith('win'):
+    pyqt_path = os.path.join(sys._MEIPASS, 'PySide2')
+else:
+    pyqt_path = os.path.join(sys._MEIPASS, 'Qt', 'PySide2')
 os.environ['QT_PLUGIN_PATH'] = os.path.join(pyqt_path, 'plugins')
 os.environ['QML2_IMPORT_PATH'] = os.path.join(pyqt_path, 'qml')

--- a/news/5631.hooks.rst
+++ b/news/5631.hooks.rst
@@ -1,0 +1,1 @@
+Add support for ``PyQt5`` 5.15.4.

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -28,9 +28,9 @@ babel==2.9.1
 future==0.18.2
 gevent==21.1.2
 pygments==2.9.0
-pyside2==5.15.1
-pyqt5==5.15.1
-pyqtwebengine==5.15.1
+pyside2==5.15.2
+pyqt5==5.15.4
+pyqtwebengine==5.15.4
 python-dateutil==2.8.1
 pytz==2021.1
 requests==2.25.1


### PR DESCRIPTION
Extend `Qt5LibraryInfo` with new property, `qt_rel_dir`, which denotes the relative Qt data path in the frozen application. Its value
varies between `PyQt5` and `PySide2`, their versions, and platforms:
* `PyQt5/Qt` for `PyQt5 <= 5.15.3` on all platforms
* `PyQt5/Qt5` for `PyQt5 >= 5.15.4` on all platforms
* `PySide2/Qt` for `PySide2` on Linux and macOS
* `PySide` for `PySide2` on Windows

This way, we now have a unified, central location when this path is determined, instead of the corresponding functionality being scattered across the hooks.

Adds support for `PyQt5 5.15.4`, and fixes #5631.

The paths used by rthooks also need to be adjusted to handle `PyQt5/Qt` vs `PyQt5/Qt5` switch, and to handle the difference between `PySide2` on Windows and `PySide2/Qt` on other platforms (as we now make distinction between the two).