### PR TITLE
Implement support for Microsoft App Store Python

### DIFF
--- a/PyInstaller/building/build_main.py
+++ b/PyInstaller/building/build_main.py
@@ -360,7 +360,7 @@ class Analysis(Target):
 
         logger.info("running Analysis %s", self.tocbasename)
         # Get paths to Python and, in Windows, the manifest.
-        python = sys.executable
+        python = compat.python_executable
         if not is_win:
             # Linux/MacOS: get a real, non-link path to the running Python executable.
             while os.path.islink(python):

--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -165,6 +165,21 @@ is_conda = os.path.isdir(os.path.join(base_prefix, 'conda-meta'))
 # that the default non-conda behaviour is generally desired from PyInstaller.
 is_pure_conda = os.path.isdir(os.path.join(sys.prefix, 'conda-meta'))
 
+# Full path to python interpreter.
+python_executable = getattr(sys, '_base_executable', sys.executable)
+
+# Is this Python from Microsoft App Store (Windows only)?
+# Python from Microsoft App Store has executable pointing at empty shims.
+is_ms_app_store = is_win and os.path.getsize(python_executable) == 0
+
+if is_ms_app_store:
+    # Locate the actual executable inside base_prefix.
+    python_executable = os.path.join(
+        base_prefix, os.path.basename(python_executable))
+    if not os.path.exists(python_executable):
+        raise SystemExit('PyInstaller cannot locate real python executable '
+                         'belonging to Python from Microsoft App Store!')
+
 # In Python 3.4 module 'imp' is deprecated and there is another way how
 # to obtain magic value.
 import importlib.util

--- a/news/5816.feature.rst
+++ b/news/5816.feature.rst
@@ -1,0 +1,1 @@
+(Windows) Add support for Python from Microsoft App Store.


### PR DESCRIPTION
When running under Microsoft App Store Python, `sys.executable` and `sys._base_executable` point to an empty shim exe file, located inside `%LOCALAPPDATA%\Microsoft\WindowsApps\PythonSoftware[...]`.

The empty executable file causes errors when PyInstaller tries to analyze it to determine reference arch and obtain assembly
dependencies that need to be added to manifest. (This part actually uses only `sys.executable`, and can be worked around by using `venv`, which provides a non-empty copy of executable).

In addition, executable being empty causes failure to determine the name of the python library from the executable itself (as reported in #5815).

To fix these problems, we introduce new variables in `compat` module:
* `is_ms_app_store`: set to `True` when running under MS app store python
* `python_executable`: full path to python executable: defaults to `sys._base_executable` (if available) or `sys.executable`, except for MS app store python, where path to the actual executable is resolved.

In places where `sys._base_executable`/`sys.executable` were used, we now use `compat.python_executable`. And if  `is_ms_app_store` is set, we explicitly check for Python library in `compat.base_prefix`.

This seems to suffice to get Python 3.9 from MS app store work with pyinstaller, with and without virtual environment.

Fixes #5815.