### PR TITLE
refactor: Use absolute imports throughout.

### DIFF
--- a/PyInstaller/__init__.py
+++ b/PyInstaller/__init__.py
@@ -15,8 +15,8 @@ __all__ = ('HOMEPATH', 'PLATFORM', '__version__')
 import os
 import sys
 
-from . import compat
-from .utils.git import get_repo_revision
+from PyInstaller import compat
+from PyInstaller.utils.git import get_repo_revision
 
 
 # Note: Keep this variable as plain string so it could be updated automatically

--- a/PyInstaller/__main__.py
+++ b/PyInstaller/__main__.py
@@ -19,11 +19,11 @@ import argparse
 import platform
 
 
-from . import __version__
-from . import log as logging
+from PyInstaller import __version__
+from PyInstaller import log as logging
 
 # note: don't import anything else until this function is run!
-from .compat import check_requirements, is_conda
+from PyInstaller.compat import check_requirements, is_conda
 
 logger = logging.getLogger(__name__)
 
@@ -116,7 +116,7 @@ def run(pyi_args=None, pyi_config=None):
     except KeyboardInterrupt:
         raise SystemExit("Aborted by user request.")
     except RecursionError:
-        from . import _recursion_to_deep_message
+        from PyInstaller import _recursion_to_deep_message
         _recursion_to_deep_message.raise_with_msg()
 
 

--- a/PyInstaller/archive/writers.py
+++ b/PyInstaller/archive/writers.py
@@ -35,7 +35,7 @@ from PyInstaller.building.utils import get_code_object, strip_paths_in_code,\
     fake_pyc_timestamp
 from PyInstaller.loader.pyimod02_archive import PYZ_TYPE_MODULE, PYZ_TYPE_PKG, \
     PYZ_TYPE_DATA, PYZ_TYPE_NSPKG
-from ..compat import BYTECODE_MAGIC, is_py37, is_win
+from PyInstaller.compat import BYTECODE_MAGIC, is_py37, is_win
 
 
 class ArchiveWriter(object):

--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -34,7 +34,7 @@ from PyInstaller.depend.analysis import get_bootstrap_modules
 from PyInstaller.depend.utils import is_path_to_egg
 from PyInstaller.building.datastruct import TOC, Target, _check_guts_eq
 from PyInstaller.utils import misc
-from .. import log as logging
+from PyInstaller import log as logging
 
 logger = logging.getLogger(__name__)
 
@@ -69,7 +69,7 @@ class PYZ(Target):
 
         """
 
-        from ..config import CONF
+        from PyInstaller.config import CONF
         Target.__init__(self)
         name = kwargs.get('name', None)
         cipher = kwargs.get('cipher', None)
@@ -342,7 +342,7 @@ class EXE(Target):
                 Windows only. Setting to True allows an elevated application to
                 work with Remote Desktop
         """
-        from ..config import CONF
+        from PyInstaller.config import CONF
         Target.__init__(self)
 
         # Available options for EXE in .spec files.
@@ -520,7 +520,7 @@ class EXE(Target):
         return bootloader_file
 
     def assemble(self):
-        from ..config import CONF
+        from PyInstaller.config import CONF
         logger.info("Building EXE from %s", self.tocbasename)
         trash = []
         if os.path.exists(self.name):
@@ -673,7 +673,7 @@ class COLLECT(Target):
                 name
                     The name of the directory to be built.
         """
-        from ..config import CONF
+        from PyInstaller.config import CONF
         Target.__init__(self)
         self.strip_binaries = kws.get('strip', False)
         self.upx_exclude = kws.get("upx_exclude", [])

--- a/PyInstaller/building/build_main.py
+++ b/PyInstaller/building/build_main.py
@@ -27,24 +27,27 @@ import pkg_resources
 
 
 # Relative imports to PyInstaller modules.
-from .. import HOMEPATH, DEFAULT_DISTPATH, DEFAULT_WORKPATH
-from .. import compat
-from .. import log as logging
-from ..utils.misc import absnormpath, compile_py_files
-from ..compat import is_win, PYDYLIB_NAMES, open_file
-from ..depend import bindepend
-from ..depend.analysis import initialize_modgraph
-from .api import PYZ, EXE, COLLECT, MERGE
-from .datastruct import TOC, Target, Tree, _check_guts_eq
-from .osx import BUNDLE
-from .toc_conversion import DependencyProcessor
-from .utils import _check_guts_toc_mtime, format_binaries_and_datas
-from ..depend.utils import create_py3_base_library, scan_code_for_ctypes
-from ..archive import pyz_crypto
-from ..utils.misc import get_path_to_toplevel_modules, get_unicode_modules, mtime
+from PyInstaller import HOMEPATH, DEFAULT_DISTPATH, DEFAULT_WORKPATH
+from PyInstaller import compat
+from PyInstaller import log as logging
+from PyInstaller.utils.misc import absnormpath, compile_py_files
+from PyInstaller.compat import is_win, PYDYLIB_NAMES, open_file
+from PyInstaller.depend import bindepend
+from PyInstaller.depend.analysis import initialize_modgraph
+from PyInstaller.building.api import PYZ, EXE, COLLECT, MERGE
+from PyInstaller.building.datastruct import TOC, Target, Tree, _check_guts_eq
+from PyInstaller.building.osx import BUNDLE
+from PyInstaller.building.toc_conversion import DependencyProcessor
+from PyInstaller.building.utils import \
+    _check_guts_toc_mtime, format_binaries_and_datas
+from PyInstaller.depend.utils import \
+    create_py3_base_library, scan_code_for_ctypes
+from PyInstaller.archive import pyz_crypto
+from PyInstaller.utils.misc import \
+    get_path_to_toplevel_modules, get_unicode_modules, mtime
 
 if is_win:
-    from ..utils.win32 import winmanifest
+    from PyInstaller.utils.win32 import winmanifest
 
 logger = logging.getLogger(__name__)
 
@@ -164,7 +167,7 @@ class Analysis(Target):
                 individual files.
         """
         super(Analysis, self).__init__()
-        from ..config import CONF
+        from PyInstaller.config import CONF
 
         self.inputs = []
         spec_dir = os.path.dirname(CONF['spec'])
@@ -325,7 +328,7 @@ class Analysis(Target):
         self.datas = TOC(data['datas'])
 
         # Store previously found binding redirects in CONF for later use by PKG/COLLECT
-        from ..config import CONF
+        from PyInstaller.config import CONF
         self.binding_redirects = CONF['binding_redirects'] = data['binding_redirects']
 
         return False
@@ -334,7 +337,7 @@ class Analysis(Target):
         """
         This method is the MAIN method for finding all necessary files to be bundled.
         """
-        from ..config import CONF
+        from PyInstaller.config import CONF
 
         for m in self.excludes:
             logger.debug("Excluding module '%s'" % m)
@@ -535,7 +538,7 @@ class Analysis(Target):
                            + 4 * depInfo.tryexcept)
             return '%s (%s)' % (name, IMPORT_TYPES[imptype])
 
-        from ..config import CONF
+        from PyInstaller.config import CONF
         miss_toc = self.graph.make_missing_toc()
         with open_file(CONF['warnfile'], 'w', encoding='utf-8') as wf:
             wf.write(WARNFILE_HEADER)
@@ -551,7 +554,7 @@ class Analysis(Target):
         """Write a xref (in html) and with `--log-level DEBUG` a dot-drawing
         of the graph.
         """
-        from ..config import CONF
+        from PyInstaller.config import CONF
         with open_file(CONF['xref-file'], 'w', encoding='utf-8') as fh:
             self.graph.create_xref(fh)
             logger.info("Graph cross-reference written to %s", CONF['xref-file'])
@@ -595,7 +598,7 @@ def build(spec, distpath, workpath, clean_build):
     """
     Build the executable according to the created SPEC file.
     """
-    from ..config import CONF
+    from PyInstaller.config import CONF
 
     # Ensure starting tilde and environment variables get expanded in distpath / workpath.
     # '~/path/abc', '${env_var_name}/path/abc/def'
@@ -670,7 +673,7 @@ def build(spec, distpath, workpath, clean_build):
 
     # Set up module PyInstaller.config for passing some arguments to 'exec'
     # function.
-    from ..config import CONF
+    from PyInstaller.config import CONF
     CONF['workpath'] = workpath
 
     # Execute the specfile. Read it as a binary file...
@@ -709,7 +712,7 @@ def __add_options(parser):
 
 def main(pyi_config, specfile, noconfirm, ascii=False, **kw):
 
-    from ..config import CONF
+    from PyInstaller.config import CONF
     CONF['noconfirm'] = noconfirm
 
     # Some modules are included if they are detected at build-time or

--- a/PyInstaller/building/build_main.py
+++ b/PyInstaller/building/build_main.py
@@ -31,7 +31,7 @@ from PyInstaller import HOMEPATH, DEFAULT_DISTPATH, DEFAULT_WORKPATH
 from PyInstaller import compat
 from PyInstaller import log as logging
 from PyInstaller.utils.misc import absnormpath, compile_py_files
-from PyInstaller.compat import is_win, PYDYLIB_NAMES, open_file
+from PyInstaller.compat import is_win, PYDYLIB_NAMES
 from PyInstaller.depend import bindepend
 from PyInstaller.depend.analysis import initialize_modgraph
 from PyInstaller.building.api import PYZ, EXE, COLLECT, MERGE
@@ -223,7 +223,7 @@ class Analysis(Target):
             # Create a Python module which contains the decryption key which will
             # be used at runtime by pyi_crypto.PyiBlockCipher.
             pyi_crypto_key_path = os.path.join(CONF['workpath'], 'pyimod00_crypto_key.py')
-            with open_file(pyi_crypto_key_path, 'w', encoding='utf-8') as f:
+            with open(pyi_crypto_key_path, 'w', encoding='utf-8') as f:
                 f.write('# -*- coding: utf-8 -*-\n'
                         'key = %r\n' % cipher.key)
             self.hiddenimports.append('tinyaes')
@@ -540,7 +540,7 @@ class Analysis(Target):
 
         from PyInstaller.config import CONF
         miss_toc = self.graph.make_missing_toc()
-        with open_file(CONF['warnfile'], 'w', encoding='utf-8') as wf:
+        with open(CONF['warnfile'], 'w', encoding='utf-8') as wf:
             wf.write(WARNFILE_HEADER)
             for (n, p, status) in miss_toc:
                 importers = self.graph.get_importers(n)
@@ -555,7 +555,7 @@ class Analysis(Target):
         of the graph.
         """
         from PyInstaller.config import CONF
-        with open_file(CONF['xref-file'], 'w', encoding='utf-8') as fh:
+        with open(CONF['xref-file'], 'w', encoding='utf-8') as fh:
             self.graph.create_xref(fh)
             logger.info("Graph cross-reference written to %s", CONF['xref-file'])
         if logger.getEffectiveLevel() > logging.DEBUG:

--- a/PyInstaller/building/datastruct.py
+++ b/PyInstaller/building/datastruct.py
@@ -13,9 +13,8 @@
 import os
 
 from PyInstaller.utils import misc
-from PyInstaller.utils.misc import load_py_data_struct, save_py_data_struct
-from .. import log as logging
-from .utils import _check_guts_eq
+from PyInstaller import log as logging
+from PyInstaller.building.utils import _check_guts_eq
 
 logger = logging.getLogger(__name__)
 
@@ -122,7 +121,7 @@ class Target(object):
     invcnum = 0
 
     def __init__(self):
-        from ..config import CONF
+        from PyInstaller.config import CONF
         # Get a (per class) unique number to avoid conflicts between
         # toc objects
         self.invcnum = self.__class__.invcnum
@@ -149,7 +148,7 @@ class Target(object):
                         self.__class__.__name__, self.tocbasename)
         else:
             try:
-                data = load_py_data_struct(self.tocfilename)
+                data = misc.load_py_data_struct(self.tocfilename)
             except:
                 logger.info("Building because %s is bad", self.tocbasename)
             else:
@@ -183,7 +182,7 @@ class Target(object):
         maybe avoid regenerating it later.
         """
         data = tuple(getattr(self, g[0]) for g in self._GUTS)
-        save_py_data_struct(self.tocfilename, data)
+        misc.save_py_data_struct(self.tocfilename, data)
 
 
 class Tree(Target, TOC):

--- a/PyInstaller/building/makespec.py
+++ b/PyInstaller/building/makespec.py
@@ -18,11 +18,11 @@ import os
 import sys
 import argparse
 
-from .. import HOMEPATH, DEFAULT_SPECPATH
-from .. import log as logging
-from ..compat import expand_path, is_darwin, is_win, open_file
-from .templates import onefiletmplt, onedirtmplt, cipher_absent_template, \
-    cipher_init_template, bundleexetmplt, bundletmplt
+from PyInstaller import HOMEPATH, DEFAULT_SPECPATH
+from PyInstaller import log as logging
+from PyInstaller.compat import expand_path, is_darwin, is_win, open_file
+from PyInstaller.building.templates import onefiletmplt, onedirtmplt, \
+    cipher_absent_template, cipher_init_template, bundleexetmplt, bundletmplt
 
 logger = logging.getLogger(__name__)
 add_command_sep = os.pathsep

--- a/PyInstaller/building/makespec.py
+++ b/PyInstaller/building/makespec.py
@@ -20,7 +20,7 @@ import argparse
 
 from PyInstaller import HOMEPATH, DEFAULT_SPECPATH
 from PyInstaller import log as logging
-from PyInstaller.compat import expand_path, is_darwin, is_win, open_file
+from PyInstaller.compat import expand_path, is_darwin, is_win
 from PyInstaller.building.templates import onefiletmplt, onedirtmplt, \
     cipher_absent_template, cipher_init_template, bundleexetmplt, bundletmplt
 
@@ -588,7 +588,7 @@ def main(scripts, name=None, onefile=None,
 
     # Write down .spec file to filesystem.
     specfnm = os.path.join(specpath, name + '.spec')
-    with open_file(specfnm, 'w', encoding='utf-8') as specfile:
+    with open(specfnm, 'w', encoding='utf-8') as specfile:
         if onefile:
             specfile.write(onefiletmplt % d)
             # For OSX create .app bundle.

--- a/PyInstaller/building/osx.py
+++ b/PyInstaller/building/osx.py
@@ -12,16 +12,16 @@
 import os
 import plistlib
 import shutil
-from ..compat import is_darwin
-from .api import EXE, COLLECT
-from .datastruct import Target, TOC, logger
-from .utils import _check_path_overlap, _rmtree, add_suffix_to_extensions, checkCache
-
+from PyInstaller.compat import is_darwin
+from PyInstaller.building.api import EXE, COLLECT
+from PyInstaller.building.datastruct import Target, TOC, logger
+from PyInstaller.building.utils import _check_path_overlap, _rmtree, \
+    add_suffix_to_extensions, checkCache
 
 
 class BUNDLE(Target):
     def __init__(self, *args, **kws):
-        from ..config import CONF
+        from PyInstaller.config import CONF
 
         # BUNDLE only has a sense under Mac OS X, it's a noop on other platforms
         if not is_darwin:

--- a/PyInstaller/building/toc_conversion.py
+++ b/PyInstaller/building/toc_conversion.py
@@ -12,10 +12,10 @@
 import os
 import zipfile
 import pkg_resources
-from ..depend.utils import get_path_to_egg
-from .datastruct import TOC, Tree
-from .. import log as logging
-from ..compat import ALL_SUFFIXES
+from PyInstaller.depend.utils import get_path_to_egg
+from PyInstaller.building.datastruct import TOC, Tree
+from PyInstaller import log as logging
+from PyInstaller.compat import ALL_SUFFIXES
 
 logger = logging.getLogger(__name__)
 
@@ -133,7 +133,7 @@ class DependencyProcessor(object):
     @staticmethod
     def __collect_data_files_from_zip(zipfilename):
         # 'PyInstaller.config' cannot be imported as other top-level modules.
-        from ..config import CONF
+        from PyInstaller.config import CONF
         workpath = os.path.join(CONF['workpath'], os.path.basename(zipfilename))
         try:
             os.makedirs(workpath)

--- a/PyInstaller/building/utils.py
+++ b/PyInstaller/building/utils.py
@@ -28,7 +28,7 @@ import struct
 from PyInstaller.config import CONF
 from PyInstaller import compat
 from PyInstaller.compat import is_darwin, is_win, EXTENSION_SUFFIXES, \
-    open_file, is_py37, is_cygwin
+    is_py37, is_cygwin
 from PyInstaller.depend import dylib
 from PyInstaller.depend.bindepend import match_binding_redirect
 from PyInstaller.utils import misc
@@ -600,7 +600,7 @@ def _load_code(modname, filename):
 
         # Open the source file in binary mode and allow the `compile()` call to
         # detect the source encoding.
-        with open_file(filename, 'rb') as f:
+        with open(filename, 'rb') as f:
             source = f.read()
         return compile(source, filename, 'exec')
 

--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -22,7 +22,7 @@ import subprocess
 import sys
 import errno
 import importlib.machinery
-from .exceptions import ExecCommandFailed
+from PyInstaller.exceptions import ExecCommandFailed
 
 # Copied from https://docs.python.org/3/library/platform.html#cross-platform.
 is_64bits = sys.maxsize > 2**32

--- a/PyInstaller/configure.py
+++ b/PyInstaller/configure.py
@@ -16,9 +16,9 @@ Configure PyInstaller for the current Python installation.
 
 import os
 
-from . import compat
-from . import log as logging
-from .compat import is_win, is_darwin
+from PyInstaller import compat
+from PyInstaller import log as logging
+from PyInstaller.compat import is_win, is_darwin
 
 logger = logging.getLogger(__name__)
 

--- a/PyInstaller/depend/analysis.py
+++ b/PyInstaller/depend/analysis.py
@@ -45,19 +45,20 @@ import ast
 from copy import deepcopy
 from collections import defaultdict
 
-from .. import compat
-from .. import HOMEPATH, PACKAGEPATH
-from .. import log as logging
-from ..log import INFO, DEBUG, TRACE
-from ..building.datastruct import TOC
-from .imphook import AdditionalFilesCache, ModuleHookCache
-from .imphookapi import PreSafeImportModuleAPI, PreFindModulePathAPI
-from ..compat import importlib_load_source, PY3_BASE_MODULES,\
-        PURE_PYTHON_MODULE_TYPES, BINARY_MODULE_TYPES, VALID_MODULE_TYPES, \
-        BAD_MODULE_TYPES, MODULE_TYPES_TO_TOC_DICT
-from ..lib.modulegraph.find_modules import get_implies
-from ..lib.modulegraph.modulegraph import ModuleGraph
-from ..utils.hooks import collect_submodules, is_package
+from PyInstaller import compat
+from PyInstaller import HOMEPATH, PACKAGEPATH
+from PyInstaller import log as logging
+from PyInstaller.log import INFO, DEBUG, TRACE
+from PyInstaller.building.datastruct import TOC
+from PyInstaller.depend.imphook import AdditionalFilesCache, ModuleHookCache
+from PyInstaller.depend.imphookapi import PreSafeImportModuleAPI,\
+    PreFindModulePathAPI
+from PyInstaller.compat import importlib_load_source, PY3_BASE_MODULES, \
+    PURE_PYTHON_MODULE_TYPES, BINARY_MODULE_TYPES, VALID_MODULE_TYPES, \
+    BAD_MODULE_TYPES, MODULE_TYPES_TO_TOC_DICT
+from PyInstaller.lib.modulegraph.find_modules import get_implies
+from PyInstaller.lib.modulegraph.modulegraph import ModuleGraph
+from PyInstaller.utils.hooks import collect_submodules, is_package
 
 
 logger = logging.getLogger(__name__)

--- a/PyInstaller/depend/analysis.py
+++ b/PyInstaller/depend/analysis.py
@@ -144,8 +144,7 @@ class PyiModuleGraph(ModuleGraph):
         for uhd in self._user_hook_dirs:
             uhd_path = os.path.abspath(os.path.join(uhd, 'rthooks.dat'))
             try:
-                with compat.open_file(uhd_path, compat.text_read_mode,
-                                      encoding='utf-8') as f:
+                with open(uhd_path, 'r', encoding='utf-8') as f:
                     rthooks = ast.literal_eval(f.read())
             except FileNotFoundError:
                 # Ignore if this hook path doesn't have run-time hooks.

--- a/PyInstaller/depend/dylib.py
+++ b/PyInstaller/depend/dylib.py
@@ -380,7 +380,7 @@ def mac_strip_signature(libname, distname):
     collection may invalidate the existing signature on a collected
     shared library, which will prevent the latter from being loaded.
     """
-    from ..compat import exec_command_rc
+    from PyInstaller.compat import exec_command_rc
 
     # For now, limit this only to Python shared library. Other shared
     # library files from Python.framework bundle also seem to be signed,

--- a/PyInstaller/depend/imphook.py
+++ b/PyInstaller/depend/imphook.py
@@ -17,11 +17,11 @@ Code related to processing of import hooks.
 import glob, sys, weakref
 import os.path
 
-from ..exceptions import ImportErrorWhenRunningHook
-from .. import log as logging
-from ..compat import expand_path, importlib_load_source
-from .imphookapi import PostGraphAPI
-from ..building.utils import format_binaries_and_datas
+from PyInstaller.exceptions import ImportErrorWhenRunningHook
+from PyInstaller import log as logging
+from PyInstaller.compat import expand_path, importlib_load_source
+from PyInstaller.depend.imphookapi import PostGraphAPI
+from PyInstaller.building.utils import format_binaries_and_datas
 
 logger = logging.getLogger(__name__)
 

--- a/PyInstaller/depend/imphookapi.py
+++ b/PyInstaller/depend/imphookapi.py
@@ -20,9 +20,10 @@ modifications into appropriate operations on the current `PyiModuleGraph`
 instance, thus modifying which modules will be frozen into the executable.
 """
 
-from ..lib.modulegraph.modulegraph import RuntimeModule, RuntimePackage
-from ..building.datastruct import TOC
-from ..building.utils import format_binaries_and_datas
+from PyInstaller.lib.modulegraph.modulegraph import RuntimeModule, \
+    RuntimePackage
+from PyInstaller.building.datastruct import TOC
+from PyInstaller.building.utils import format_binaries_and_datas
 
 
 class PreSafeImportModuleAPI(object):

--- a/PyInstaller/hooks/hook-_tkinter.py
+++ b/PyInstaller/hooks/hook-_tkinter.py
@@ -14,8 +14,7 @@ import os
 import sys
 import locale
 
-from PyInstaller.compat import is_win, is_darwin, is_unix, is_venv, \
-    base_prefix, open_file, text_read_mode
+from PyInstaller.compat import is_win, is_darwin, is_unix
 from PyInstaller.depend.bindepend import selectImports, getImports
 from PyInstaller.building.datastruct import Tree
 from PyInstaller.utils.hooks import exec_statement, logger
@@ -51,8 +50,8 @@ def _warn_if_activetcl_or_teapot_installed(tcl_root, tcltree):
     mentions_activetcl = False
     mentions_teapot = False
     # TCL/TK reads files using the `system encoding <https://www.tcl.tk/doc/howto/i18n.html#system_encoding>`_.
-    with open_file(init_resource, text_read_mode,
-                   encoding=locale.getpreferredencoding()) as init_file:
+    with open(init_resource, 'r',
+              encoding=locale.getpreferredencoding()) as init_file:
         for line in init_file.readlines():
             line = line.strip().lower()
             if line.startswith('#'):

--- a/PyInstaller/hooks/hook-gi.repository.GdkPixbuf.py
+++ b/PyInstaller/hooks/hook-gi.repository.GdkPixbuf.py
@@ -17,8 +17,7 @@ import os
 from shutil import which
 
 from PyInstaller.config import CONF
-from PyInstaller.compat import (
-    exec_command_stdout, is_darwin, is_win, is_linux, open_file)
+from PyInstaller.compat import exec_command_stdout, is_darwin, is_win, is_linux
 from PyInstaller.utils.hooks.gi import (
     collect_glib_translations, get_gi_typelibs, get_gi_libdir, logger)
 
@@ -148,7 +147,7 @@ if libdir:
             cachedata = '\n'.join(cd)
 
             # Write the updated loader cache to this file.
-            with open_file(cachefile, 'w') as fp:
+            with open(cachefile, 'w') as fp:
                 fp.write(cachedata)
 
             # Bundle this loader cache with this frozen application.

--- a/PyInstaller/hooks/hook-gi.repository.GdkPixbuf.py
+++ b/PyInstaller/hooks/hook-gi.repository.GdkPixbuf.py
@@ -19,7 +19,7 @@ from shutil import which
 from PyInstaller.config import CONF
 from PyInstaller.compat import (
     exec_command_stdout, is_darwin, is_win, is_linux, open_file)
-from PyInstaller.utils.hooks import (
+from PyInstaller.utils.hooks.gi import (
     collect_glib_translations, get_gi_typelibs, get_gi_libdir, logger)
 
 loaders_path = os.path.join('gdk-pixbuf-2.0', '2.10.0', 'loaders')

--- a/PyInstaller/hooks/hook-sqlalchemy.py
+++ b/PyInstaller/hooks/hook-sqlalchemy.py
@@ -12,7 +12,6 @@
 import re
 from PyInstaller.utils.hooks import (
     exec_statement, is_module_satisfies, logger)
-from PyInstaller.compat import open_file, text_read_mode
 from PyInstaller.lib.modulegraph.modulegraph import SourceModule
 from PyInstaller.lib.modulegraph.util import guess_encoding
 
@@ -67,11 +66,10 @@ def hook(hook_api):
                 node.identifier.startswith('sqlalchemy.'):
             known_imports.add(node.identifier)
             # Determine the encoding of the source file.
-            with open_file(node.filename, 'rb') as f:
+            with open(node.filename, 'rb') as f:
                 encoding = guess_encoding(f)
             # Use that to open the file.
-            with open_file(node.filename, text_read_mode,
-                           encoding=encoding) as f:
+            with open(node.filename, 'r', encoding=encoding) as f:
                 for match in depend_regex.findall(f.read()):
                     hidden_imports_set.add(match)
 

--- a/PyInstaller/utils/conftest.py
+++ b/PyInstaller/utils/conftest.py
@@ -52,7 +52,7 @@ from PyInstaller import __main__ as pyi_main
 from PyInstaller.utils.tests import gen_sourcefile
 from PyInstaller.utils.cliutils import archive_viewer
 from PyInstaller.compat import is_darwin, is_win, safe_repr, \
-    architecture, is_linux, text_read_mode
+    architecture, is_linux
 from PyInstaller.depend.analysis import initialize_modgraph
 from PyInstaller.utils.win32 import winutils
 from PyInstaller.utils.hooks.qt import pyqt5_library_info, pyside2_library_info
@@ -475,7 +475,7 @@ class AppBuilder(object):
         print('EXECUTING MATCHING:', toc_log)
         fname_list = archive_viewer.get_archive_content(exe)
         fname_list = [fn for fn in fname_list]
-        with open(toc_log, text_read_mode) as f:
+        with open(toc_log, 'r') as f:
             pattern_list = eval(f.read())
         # Alphabetical order of patterns.
         pattern_list.sort()

--- a/PyInstaller/utils/git.py
+++ b/PyInstaller/utils/git.py
@@ -15,7 +15,7 @@ This module contains various helper functions for git DVCS
 """
 
 import os
-from ..compat import exec_command, exec_command_rc
+from PyInstaller.compat import exec_command, exec_command_rc
 
 try:
     WindowsError
@@ -29,7 +29,7 @@ def get_repo_revision():
     cwd = os.path.dirname(gitdir)
     if not path.exists(gitdir):
         try:
-            from ._gitrevision import rev
+            from PyInstaller.utils._gitrevision import rev
             if not rev.startswith('$'):
                 # the format specifier has been substituted
                 return '+' + rev

--- a/PyInstaller/utils/hooks/__init__.py
+++ b/PyInstaller/utils/hooks/__init__.py
@@ -1021,7 +1021,7 @@ def get_installer(module):
     # which should be the program that installed the module.
     installer_file = os.path.join(metadata_dir, 'INSTALLER')
     if os.path.isdir(metadata_dir) and os.path.exists(installer_file):
-        with open_file(installer_file, 'r') as installer_file_object:
+        with open(installer_file, 'r') as installer_file_object:
             lines = installer_file_object.readlines()
             if lines[0] != '':
                 installer = lines[0].rstrip('\r\n')

--- a/PyInstaller/utils/hooks/django.py
+++ b/PyInstaller/utils/hooks/django.py
@@ -10,8 +10,8 @@
 # ----------------------------------------------------------------------------
 import os
 
-from ..hooks import eval_script
-from ...utils import misc
+from PyInstaller.utils.hooks import eval_script
+from PyInstaller.utils import misc
 
 
 __all__ = [
@@ -55,7 +55,7 @@ def django_find_root_dir():
     but usually one level up. We need to detect this special case too.
     """
     # 'PyInstaller.config' cannot be imported as other top-level modules.
-    from ...config import CONF
+    from PyInstaller.config import CONF
     # Get the directory with manage.py. Manage.py is supplied to PyInstaller as the
     # first main executable script.
     manage_py = CONF['main_script']

--- a/PyInstaller/utils/hooks/gi.py
+++ b/PyInstaller/utils/hooks/gi.py
@@ -11,11 +11,11 @@
 import os
 import re
 
-from ..hooks import collect_submodules, collect_system_data_files, eval_statement, exec_statement
-from ... import log as logging
-from ...compat import base_prefix, is_darwin, is_win, open_file, \
-    text_read_mode
-from ...depend.bindepend import findSystemLibrary
+from PyInstaller.utils.hooks import collect_submodules, \
+    collect_system_data_files, eval_statement, exec_statement
+from PyInstaller import log as logging
+from PyInstaller import compat
+from PyInstaller.depend.bindepend import findSystemLibrary
 
 logger = logging.getLogger(__name__)
 
@@ -111,17 +111,17 @@ def get_gi_typelibs(module, version):
 def gir_library_path_fix(path):
     import subprocess
     # 'PyInstaller.config' cannot be imported as other top-level modules.
-    from ...config import CONF
+    from PyInstaller.config import CONF
 
     path = os.path.abspath(path)
 
     # On OSX we need to recompile the GIR files to reference the loader path,
     # but this is not necessary on other platforms
-    if is_darwin:
+    if compat.is_darwin:
 
         # If using a virtualenv, the base prefix and the path of the typelib
         # have really nothing to do with each other, so try to detect that
-        common_path = os.path.commonprefix([base_prefix, path])
+        common_path = os.path.commonprefix([compat.base_prefix, path])
         if common_path == '/':
             logger.debug("virtualenv detected? fixing the gir path...")
             common_path = os.path.abspath(os.path.join(path, '..', '..', '..'))
@@ -144,12 +144,12 @@ def gir_library_path_fix(path):
                          'package.', gir_file)
             return None
 
-        with open_file(gir_file, text_read_mode, encoding='utf-8') as f:
+        with compat.open_file(gir_file, compat.text_read_mode, encoding='utf-8') as f:
             lines = f.readlines()
         # GIR files are `XML encoded <https://developer.gnome.org/gi/stable/gi-gir-reference.html>`_,
         # which means they are by definition encoded using UTF-8.
-        with open_file(os.path.join(CONF['workpath'], gir_name), 'w',
-                       encoding='utf-8') as f:
+        with compat.open_file(os.path.join(CONF['workpath'], gir_name), 'w',
+                              encoding='utf-8') as f:
             for line in lines:
                 if 'shared-library' in line:
                     split = re.split('(=)', line)
@@ -188,7 +188,7 @@ def get_glib_system_data_dirs():
 
 def get_glib_sysconf_dirs():
     """Try to return the sysconf directories, eg /etc."""
-    if is_win:
+    if compat.is_win:
         # On windows, if you look at gtkwin32.c, sysconfdir is actually
         # relative to the location of the GTK DLL. Since that's what
         # we're actually interested in (not the user path), we have to

--- a/PyInstaller/utils/hooks/gi.py
+++ b/PyInstaller/utils/hooks/gi.py
@@ -144,12 +144,12 @@ def gir_library_path_fix(path):
                          'package.', gir_file)
             return None
 
-        with compat.open_file(gir_file, compat.text_read_mode, encoding='utf-8') as f:
+        with open(gir_file, 'r', encoding='utf-8') as f:
             lines = f.readlines()
         # GIR files are `XML encoded <https://developer.gnome.org/gi/stable/gi-gir-reference.html>`_,
         # which means they are by definition encoded using UTF-8.
-        with compat.open_file(os.path.join(CONF['workpath'], gir_name), 'w',
-                              encoding='utf-8') as f:
+        with open(os.path.join(CONF['workpath'], gir_name), 'w',
+                  encoding='utf-8') as f:
             for line in lines:
                 if 'shared-library' in line:
                     split = re.split('(=)', line)

--- a/PyInstaller/utils/hooks/win32.py
+++ b/PyInstaller/utils/hooks/win32.py
@@ -8,12 +8,6 @@
 #
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 # ----------------------------------------------------------------------------
-from ..hooks import exec_statement
-
-# NOTE: This function requires PyInstaller to be on the default "sys.path" for
-# the called Python process. Running py.test changes the working dir to a temp
-# dir, so PyInstaller should be installed via either "setup.py install" or
-# "setup.py develop" before running py.test.
 
 
 def get_pywin32_module_file_attribute(module_name):
@@ -46,6 +40,7 @@ def get_pywin32_module_file_attribute(module_name):
     `PyInstaller.utils.win32.winutils.import_pywin32_module()`
         For further details.
     """
+    from PyInstaller.utils.hooks import exec_statement
     statement = """
         from PyInstaller.utils.win32 import winutils
         module = winutils.import_pywin32_module('%s')

--- a/PyInstaller/utils/misc.py
+++ b/PyInstaller/utils/misc.py
@@ -21,7 +21,7 @@ import py_compile
 import sys
 
 from PyInstaller import log as logging
-from PyInstaller.compat import BYTECODE_MAGIC, text_read_mode, is_win
+from PyInstaller.compat import BYTECODE_MAGIC, is_win
 
 logger = logging.getLogger(__name__)
 
@@ -219,7 +219,7 @@ def load_py_data_struct(filename):
     :param filename:
     :return:
     """
-    with open(filename, text_read_mode, encoding='utf-8') as f:
+    with open(filename, 'r', encoding='utf-8') as f:
         # Binding redirects are stored as a named tuple, so bring the namedtuple
         # class into scope for parsing the TOC.
         from PyInstaller.depend.bindepend import BindingRedirect  # noqa: F401

--- a/PyInstaller/utils/misc.py
+++ b/PyInstaller/utils/misc.py
@@ -222,11 +222,11 @@ def load_py_data_struct(filename):
     with open(filename, text_read_mode, encoding='utf-8') as f:
         # Binding redirects are stored as a named tuple, so bring the namedtuple
         # class into scope for parsing the TOC.
-        from ..depend.bindepend import BindingRedirect
+        from PyInstaller.depend.bindepend import BindingRedirect  # noqa: F401
 
         if is_win:
             # import versioninfo so that VSVersionInfo can parse correctly
-            from .win32 import versioninfo  # noqa: F401
+            from PyInstaller.utils.win32 import versioninfo  # noqa: F401
 
         return eval(f.read())
 

--- a/PyInstaller/utils/osx.py
+++ b/PyInstaller/utils/osx.py
@@ -17,7 +17,7 @@ Utils for Mac OS X platform.
 import os
 import shutil
 
-from ..compat import base_prefix
+from PyInstaller.compat import base_prefix
 from macholib.MachO import MachO
 
 

--- a/PyInstaller/utils/release.py
+++ b/PyInstaller/utils/release.py
@@ -22,7 +22,7 @@ https://zestreleaser.readthedocs.org/en/latest/entrypoints.html
 """
 
 import os
-from ..compat import exec_command, getenv
+from PyInstaller.compat import exec_command, getenv
 
 
 def sign_source_distribution(data):

--- a/PyInstaller/utils/run_tests.py
+++ b/PyInstaller/utils/run_tests.py
@@ -15,7 +15,7 @@ import argparse
 import pytest
 import pkg_resources
 
-from .. import compat
+from PyInstaller import compat
 
 
 def paths_to_test(include_only=None):

--- a/PyInstaller/utils/win32/icon.py
+++ b/PyInstaller/utils/win32/icon.py
@@ -19,23 +19,19 @@ support the operation of CopyIcons_FromIco(). None of these classes
 and globals are referenced outside this module.
 '''
 
+import os.path
+import struct
+
+from PyInstaller.compat import win32api, pywintypes
+from PyInstaller import config
+
+import PyInstaller.log as logging
+logger = logging.getLogger(__name__)
+
 RT_ICON = 3
 RT_GROUP_ICON = 14
 LOAD_LIBRARY_AS_DATAFILE = 2
 
-import os.path
-import struct
-import types
-try:
-    StringTypes = types.StringTypes
-except AttributeError:
-    StringTypes = [ type("") ]
-
-from ...compat import win32api, pywintypes
-from ... import config
-
-import PyInstaller.log as logging
-logger = logging.getLogger(__name__)
 
 class Structure:
     def __init__(self):
@@ -174,7 +170,7 @@ def CopyIcons(dstpath, srcpath):
     relative or absolute.
     '''
 
-    if type(srcpath) in StringTypes:
+    if isinstance(srcpath, str):
         # just a single string, make it a one-element list
         srcpath = [ srcpath ]
 

--- a/PyInstaller/utils/win32/versioninfo.py
+++ b/PyInstaller/utils/win32/versioninfo.py
@@ -14,7 +14,7 @@
 import codecs
 import struct
 
-from ...compat import text_read_mode, win32api
+from PyInstaller.compat import text_read_mode, win32api
 
 # ::TODO:: #1920 revert to using pypi version
 import pefile

--- a/PyInstaller/utils/win32/versioninfo.py
+++ b/PyInstaller/utils/win32/versioninfo.py
@@ -14,7 +14,7 @@
 import codecs
 import struct
 
-from PyInstaller.compat import text_read_mode, win32api
+from PyInstaller.compat import win32api
 
 # ::TODO:: #1920 revert to using pypi version
 import pefile
@@ -627,7 +627,7 @@ def SetVersion(exenm, versionfile):
     if isinstance(versionfile, VSVersionInfo):
         vs = versionfile
     else:
-        with codecs.open(versionfile, text_read_mode, 'utf-8') as fp:
+        with codecs.open(versionfile, 'r', 'utf-8') as fp:
             txt = fp.read()
         vs = eval(txt)
 

--- a/PyInstaller/utils/win32/winresource.py
+++ b/PyInstaller/utils/win32/winresource.py
@@ -18,7 +18,7 @@ winresource.py <dstpath> <srcpath>
 Updates or adds resources from file <srcpath> in file <dstpath>.
 """
 
-from ...compat import pywintypes, win32api
+from PyInstaller.compat import pywintypes, win32api
 
 import PyInstaller.log as logging
 logger = logging.getLogger(__name__)

--- a/PyInstaller/utils/win32/winutils.py
+++ b/PyInstaller/utils/win32/winutils.py
@@ -19,7 +19,7 @@ __all__ = ['get_windows_dir']
 import os
 import sys
 
-from ... import compat
+from PyInstaller import compat
 
 import PyInstaller.log as logging
 logger = logging.getLogger(__name__)
@@ -30,7 +30,7 @@ def get_windows_dir():
     Return the Windows directory e.g. C:\\Windows.
     """
     # imported here to avoid circular import
-    from ... import compat
+    from PyInstaller import compat
     windir = compat.win32api.GetWindowsDirectory()
     if not windir:
         raise SystemExit("Error: Can not determine your Windows directory")
@@ -42,7 +42,7 @@ def get_system_path():
     Return the required Windows system paths.
     """
     # imported here to avoid circular import
-    from ... import compat
+    from PyInstaller import compat
     _bpath = []
     sys_dir = compat.win32api.GetSystemDirectory()
     # Ensure C:\Windows\system32  and C:\Windows directories are
@@ -61,7 +61,7 @@ def extend_system_path(paths):
     Some hooks might extend PATH where PyInstaller should look for dlls.
     """
     # imported here to avoid circular import
-    from ... import compat
+    from PyInstaller import compat
     old_PATH = compat.getenv('PATH', '')
     paths.append(old_PATH)
     new_PATH = os.pathsep.join(paths)

--- a/tests/old_suite/runtests.py
+++ b/tests/old_suite/runtests.py
@@ -24,28 +24,10 @@ import subprocess
 import sys
 import unittest
 
-# ignore some warnings which only confuse when running tests
-import warnings
-
-warnings.filterwarnings('ignore',
-    "Parent module '.*' not found while handling absolute import")
-
-
-# Expand PYTHONPATH with PyInstaller package to support running without
-# installation -- only if not running in a virtualenv.
-#if not (hasattr(sys, 'real_prefix') or sys.prefix != sys.base_prefix):
-pyi_home = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..')
-sys.path.insert(0, pyi_home)
-
-# Unbuffered sys.stdout, so we can follow stdout continuously when
-# running the test-cases, esp. the generated executables.
-#sys.stdout = os.fdopen(sys.stdout.fileno(), 'w', 0)
-
-
 import PyInstaller
 from PyInstaller import compat, configure
 from PyInstaller import __main__ as pyi_main
-from PyInstaller.compat import is_win, is_darwin, modname_tkinter, text_read_mode
+from PyInstaller.compat import is_win, is_darwin, modname_tkinter
 from PyInstaller.utils import misc
 import PyInstaller.utils.hooks as hookutils
 from PyInstaller.utils.win32 import winutils
@@ -421,7 +403,7 @@ class BuildTestRunner(object):
                 return False, 'Executable for %s missing' % logfn
             fname_list = archive_viewer.get_archive_content(prog)
             fname_list = [fn for fn in fname_list]
-            with open(logfn, text_read_mode) as fp:
+            with open(logfn, 'r') as fp:
                 pattern_list = eval(fp.read())
             # Alphabetical order of patterns.
             pattern_list.sort()


### PR DESCRIPTION
Replace all `from . import xyz` with fully qualified `from PyInstaller import xyz`.

Doing so makes it far easier to load a file's namespace (and thereby debug its contents) into any IDE which *runs* a script by calling runpy in an interactive console (PyCharm's console, Pyzo, Spyder, ...). Similarly, when stuck without an IDE (e.g. using Docker), any namespace can be quickly entered using `python -i PyInstaller/subpackage/module.py`.

Unfortunately, this PR will be a merge-conflict magnet but...