### PR TITLE
setup: collect all .py files from fake-modules using glob

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,6 +7,6 @@ recursive-include PyInstaller/bootloader/Windows-32bit *
 recursive-include PyInstaller/bootloader/Windows-64bit *
 include pyproject.toml
 # These files need to be explicitly included
-include PyInstaller/fake-modules/site.py
+include PyInstaller/fake-modules/*.py
 include PyInstaller/hooks/rthooks.dat
 include PyInstaller/lib/README.rst

--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,7 @@ class Wheel(bdist_wheel):
                 f"bootloader/{self.PYI_PLAT_NAME}/*",
                 "bootloader/images/*",
                 # These files need to be explictly included as well.
-                "fake-modules/site.py",
+                "fake-modules/*.py",
                 "hooks/rthooks.dat",
                 "lib/README.rst",
             ],
@@ -214,7 +214,7 @@ setup(
             # Include all bootloaders in wheels by default.
             "bootloader/*/*",
             # These files need to be explictly included as well.
-            "fake-modules/site.py",
+            "fake-modules/*.py",
             "hooks/rthooks.dat",
             "lib/README.rst",
         ],


### PR DESCRIPTION
Instead of collecting just `fake-modules/site.py`, collect all py files via `fake-modules/*.py` glob. This future-proofs the packaging
against new file additions.