### PR TITLE
bootloader: fix cross-compilation detection, improve Cygwin handling

### DIFF
--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -219,7 +219,14 @@ if is_win:
 architecture = '64bit' if sys.maxsize > 2**32 and is_darwin else \
     '32bit' if is_darwin else platform.architecture()[0]
 
-system = platform.system()
+# Cygwin needs special handling, because platform.system() contains
+# identifiers such as MSYS_NT-10.0-19042 and CYGWIN_NT-10.0-19042 that
+# do not fit PyInstaller's OS naming scheme. Explicitly set `system` to
+# 'Cygwin'.
+if is_cygwin:
+    system = 'Cygwin'
+else:
+    system = platform.system()
 
 # Machine suffix for bootloader.
 # PyInstaller is reported to work on ARM architecture, so for that

--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -54,7 +54,7 @@ DESTOS_TO_SYSTEM = {
     'sunos': platform.system(),  ## FIXME: inhibits cross-compile
     'hpux': 'HP-UX',
     'aix': 'AIX',
-    'cygwin': platform.system(), ## FIXME: inhibits cross-compile
+    'cygwin': 'Cygwin',
 }
 
 # Map from platform.system() to waf's DEST_OS
@@ -67,11 +67,18 @@ SYSTEM_TO_BUILDOS = {
     'SunOS': 'sunos',
     'HP-UX': 'hpux',
     'AIX': 'aix',
-    DESTOS_TO_SYSTEM['cygwin']: 'cygwin',
+    'Cygwin': 'cygwin',
 }
 
 # waf's name of the system we are building on
-BUILD_OS = SYSTEM_TO_BUILDOS.get(platform.system(), platform.system())
+if sys.platform == 'cygwin':
+    # Cygwin needs special handling, because platform.system() contains
+    # identifiers such as MSYS_NT-10.0-19042 and CYGWIN_NT-10.0-19042 that
+    # do not fit PyInstaller's OS naming scheme, nor waf's DEST_OS, which is
+    # 'cygwin'.
+    BUILD_OS = SYSTEM_TO_BUILDOS.get('Cygwin')
+else:
+    BUILD_OS = SYSTEM_TO_BUILDOS.get(platform.system(), platform.system())
 
 is_cross = None
 


### PR DESCRIPTION
The addition of support for compiling bootloader under Cygwin (bc0354278f31a796566f51d5509beb8820d3d1a3) introduced a cosmetic regression where compiling on any other platform is detected as cross-compiling. This is because the addition of `DESTOS_TO_SYSTEM['cygwin']: 'cygwin'` entry to `SYSTEM_TO_BUILDOS` and `'cygwin': platform.system()˙ entry to `DESTOS_TO_SYSTEM` causes `BUILD_OS˙ to always become `cygwin`.

To fix that, modify the `wscript` to explicitly check for `sys.platform == 'cygwin'` and in that case ignore `platform.system()`, which on Cygwin contains an identifier that does not fit the PyInstaller's OS naming scheme (i.e., `MSYS_NT-10.0-19042`, `CYGWIN_NT-10.0-19042`). Instead, manually force the system name to `'Cygwin'`.

Similarly, manually override `compat.system` to `'Cygwin'`, to allow bootloaders to be found in the new location, i.e., `Cygwin-{arch}` instead of `CYGWIN_NT-10.0-19042-{arch}` or `MSYS_NT-10.0-19042-{arch}`.