### PR TITLE
building: adjust macOS SDK version reported by frozen application

### DIFF
--- a/PyInstaller/utils/osx.py
+++ b/PyInstaller/utils/osx.py
@@ -19,6 +19,7 @@ import shutil
 
 from PyInstaller.compat import base_prefix
 from macholib.MachO import MachO
+from macholib.mach_o import LC_BUILD_VERSION, LC_VERSION_MIN_MACOSX
 
 
 def is_homebrew_env():
@@ -65,6 +66,65 @@ def get_macports_prefix():
     # Conversion:  /usr/local/bin/port -> /usr/local
     prefix = os.path.dirname(os.path.dirname(prefix))
     return prefix
+
+
+def _find_version_cmd(header):
+    """
+    Helper that finds the version command in the given MachO header.
+    """
+    # The SDK version is stored in LC_BUILD_VERSION command (used when
+    # targeting the latest versions of macOS) or in older LC_VERSION_MIN_MACOSX
+    # command. Check for presence of either.
+    version_cmd = [cmd for cmd in header.commands
+                   if cmd[0].cmd in {LC_BUILD_VERSION, LC_VERSION_MIN_MACOSX}]
+    assert len(version_cmd) == 1, \
+        "Expected exactly one LC_BUILD_VERSION or " \
+        "LC_VERSION_MIN_MACOSX command!"
+    return version_cmd[0]
+
+
+def get_macos_sdk_version(filename):
+    """
+    Obtain the version of macOS SDK against which the given binary
+    was built.
+
+    NOTE: currently, version is retrieved only from the first arch
+    slice in the binary.
+
+    :return: (major, minor, revision) tuple
+    """
+    binary = MachO(filename)
+    header = binary.headers[0]
+    # Find version command using helper
+    version_cmd = _find_version_cmd(header)
+    # Parse SDK version number
+    major = (version_cmd[1].sdk & 0xFF0000) >> 16
+    minor = (version_cmd[1].sdk & 0xFF00) >> 8
+    revision = (version_cmd[1].sdk & 0xFF)
+    return major, minor, revision
+
+
+def set_macos_sdk_version(filename, major, minor, revision):
+    """
+    Overwrite the macOS SDK version declared in the given binary with
+    the specified version.
+
+    NOTE: currently, only version in the first arch slice is modified.
+    """
+    # Validate values
+    assert major >= 0 and major <= 255, "Invalid major version value!"
+    assert minor >= 0 and minor <= 255, "Invalid minor version value!"
+    assert revision >= 0 and revision <= 255, "Invalid revision value!"
+    # Open binary
+    binary = MachO(filename)
+    header = binary.headers[0]
+    # Find version command using helper
+    version_cmd = _find_version_cmd(header)
+    # Write new SDK version number
+    version_cmd[1].sdk = major << 16 | minor << 8 | revision
+    # Write changes back.
+    with open(binary.filename, 'rb+') as fp:
+        binary.write(fp)
 
 
 def fix_exe_for_code_signing(filename):

--- a/news/5827.bugfix.rst
+++ b/news/5827.bugfix.rst
@@ -1,0 +1,4 @@
+(macOS) Work around the ``tkinter`` UI issues due to problems with
+dark mode activation: black ``Tk`` window with macOS Intel installers
+from ``python.org``, or white text on bright background with Anaconda
+python.

--- a/news/5839.bugfix.rst
+++ b/news/5839.bugfix.rst
@@ -1,0 +1,7 @@
+(macOS) Ensure that the macOS SDK version reported by the frozen application
+corresponds to the minimum of the SDK version used to build the bootloader
+and the SDK version used to build the Python library. Having the application
+report more recent version than Python library and other bundled libraries
+may result in macOS attempting to enable additional features that are not
+available in the Python library, which may in turn cause inconsistent behavior
+and UI issues with ``tkinter``.


### PR DESCRIPTION
Ensure that the macOS SDK version reported by the frozen application (`sdk` field of `LC_VERSION_MIN_MACOSX` load command in executable's headers) corresponds to the minimum of the SDK version used to build the bootloader and the SDK version used to build the Python library (and by extension, other python-bundled libraries, such as Tcl/Tk).

Having the application report more recent version that Python library may result in macOS attempting to enable additional features that are not available in the Python library, which may in turn case inconsistent behavior and UI issues with `tkinter`. Overall, matching the SDK version of Python library should ensure the most consistent behavior w.r.t. python interpreter executable, which reports that same version.

An example of SDK-version-based feature activation is macOS dark mode, which was introduced in macOS 10.14 Mojave. Python.org macOS Intel installers are still built against older 10.9 SDK, so their Tcl/Tk 8.6.8 libraries do not enable support for dark mode (and may be further lack support for it, anyway). This is not a problem when used with python interpreter, which also
reports 10.9 SDK and is in turn opted out from dark mode by the OS. However, when those Tcl/Tk libraries are used with PyInstaller bootloader that was built against macOS SDK 10.14 or newer, the OS activates dark mode, which results in black Tk windows (#5827).

A similar UI issue is present in Anaconda python, which is built against 10.10 SDK. While their python 3.9 uses Tcl/Tk 8.6.10,
the older SDK again precludes support for dark mode, and using those Tcl/Tk libraries with PyInstaller bootloader that was
built against macOS SDK 10.14 or newer, the UI ends up with white fonts on bright background.

In both cases, adjusting the reported SDK version back to 10.9 or 10.10, repsectively, disables the dark mode, and fixes the UI issues.

Fixes #5827.