### PR TITLE
hookutils: is_module_satisfies: check if module can be imported

### DIFF
--- a/PyInstaller/utils/hooks/__init__.py
+++ b/PyInstaller/utils/hooks/__init__.py
@@ -529,7 +529,10 @@ def is_module_satisfies(requirements, version=None, version_attr='__version__'):
     # If no version was explicitly passed, query this module for it.
     if version is None:
         module_name = requirements_parsed.project_name
-        version = get_module_attribute(module_name, version_attr)
+        if can_import_module(module_name):
+            version = get_module_attribute(module_name, version_attr)
+        else:
+            version = None
 
     if not version:
         # Module does not exist in the system.


### PR DESCRIPTION
In `is_module_satisfies()`, before trying to query module's version via `get_module_attribute()` in the fallback path, check if the module can be imported at all via `can_import_module()`.

This prevents a `ModuleNotFoundError` from being dumped to stderr when calling `is_module_satisfies()` for package that is not
installed.