### PR TITLE
hookutils: tcl/tk: clean up Tcl/Tk library search on macOS

### DIFF
--- a/PyInstaller/building/splash.py
+++ b/PyInstaller/building/splash.py
@@ -211,6 +211,15 @@ class Splash(Target):
         self.uses_tkinter = self._uses_tkinter(binaries)
         self.script = self.generate_script()
         self.tcl_lib, self.tk_lib = find_tcl_tk_shared_libs(self._tkinter_file)
+        if is_darwin:
+            # Outdated Tcl/Tk 8.5 system framework is not supported.
+            # Depending on macOS version, the library path will come
+            # up empty (hidden system libraries on Big Sur), or will
+            # be [/System]/Library/Frameworks/Tcl.framework/Tcl
+            if self.tcl_lib[1] is None or 'Library/Frameworks/Tcl.framework' \
+                                          in self.tcl_lib[1]:
+                raise SystemExit("The splash screen feature does not support"
+                                 " macOS system framework version of Tcl/Tk.")
         # Check if tcl/tk was found
         assert all(self.tcl_lib)
         assert all(self.tk_lib)


### PR DESCRIPTION
Currently, the Tcl/Tk library search on macOS first calls `bindepend.selectImports()` and then as fallback `bindepend.getImports()`.

`bindepend.selectImports()` ignores the imports that were encountered during previous invocation. This means that if the
search was ran twice (e.g., once when trying to locate data directories for `_tkinter` hook and once for splash screen), the second run might behave differently than the first one. And since `selectImports()` coming up empty is interpreted in certain way, this may lead to errors.

So instead, reimplement the library search function using only `bindepend.getImports()`, based on implementation of similar
functionality in `Splash._get_dlls()`. Then, replace the use of `Splash._get_dlls()` with the new reimplemented function.