### PR TITLE
Hooks: Include library Info.plist for Qt libraries.

### DIFF
--- a/PyInstaller/utils/hooks/qt.py
+++ b/PyInstaller/utils/hooks/qt.py
@@ -499,6 +499,7 @@ def add_qt5_dependencies(hook_file):
     logger.debug('add_qt5_dependencies: Examining %s, based on hook of %s.',
                  module, hook_file)
 
+    datas = []
     # Walk through all the static dependencies of a dynamically-linked library
     # (``.so``/``.dll``/``.dylib``).
     imports = set(getImports(module))
@@ -527,6 +528,17 @@ def add_qt5_dependencies(hook_file):
         # Mac: rename from ``qt`` to ``qt5`` to match names in Windows/Linux.
         if compat.is_darwin and lib_name.startswith('qt'):
             lib_name = 'qt5' + lib_name[2:]
+        # Mac: Include each library's Info.plist if it exists.
+        if compat.is_darwin:
+            path_components = os.path.normpath(
+                os.path.abspath(imp)).split(os.path.sep)[:-3]
+            info_plist = os.path.join(
+                os.path.sep, *path_components, 'Resources', 'Info.plist')
+            if os.path.exists(info_plist):
+                datas.append((
+                    info_plist,
+                    os.path.join(namespace, *path_components[-3:],
+                                 'Resources')))
 
         # match libs with QT_LIBINFIX set to '_conda', i.e. conda-forge builds
         if lib_name.endswith('_conda'):
@@ -565,7 +577,6 @@ def add_qt5_dependencies(hook_file):
         pyqt5_library_info.qt_rel_dir if is_PyQt5
         else pyside2_library_info.qt_rel_dir
     )
-    datas = []
     for tb in translations_base:
         src = os.path.join(tp, tb + '_*.qm')
         # Not all PyQt5 installations include translations. See

--- a/news/5861.bugfix.rst
+++ b/news/5861.bugfix.rst
@@ -1,0 +1,1 @@
+(macOS) Fix segfaults when freezing an app with PyQt5 version 5.15.4


### PR DESCRIPTION
Freezing an application on OSX Big Sur was causing segfaults with Qt
5.15.4. The core lib is trying to load up the plugins, but fails when it
can't find the corresponding Info.plist (See a sample stacktrace in
https://stackoverflow.com/questions/66848968 that is likely this same
issue). By including the Info.plist files as resources, the app freezes
correctly and can run.