### PR TITLE
building: automatically exclude Qt plugins from upx processing

### DIFF
--- a/PyInstaller/building/utils.py
+++ b/PyInstaller/building/utils.py
@@ -275,6 +275,9 @@ def checkCache(fnm, strip=False, upx=False, upx_exclude=None, dist_nm=None,
         # Flow Guard enabled, as it breaks them.
         if is_win and versioninfo.pefile_check_control_flow_guard(fnm):
             logger.info('Disabling UPX for %s due to CFG!', fnm)
+        elif misc.is_file_qt_plugin(fnm):
+            logger.info('Disabling UPX for %s due to it being a Qt plugin!',
+                        fnm)
         else:
             bestopt = "--best"
             # FIXME: Linux builds of UPX do not seem to contain LZMA

--- a/news/4178.feature.rst
+++ b/news/4178.feature.rst
@@ -1,0 +1,1 @@
+Automatically exclude Qt plugins from UPX processing.


### PR DESCRIPTION
UPX is known to "corrupt" Qt plugins (it removes the `.qtmetad` section and `QTMETADATA` magic string - see upx/upx#107).

Instead of requiring users to manually exclude Qt plugins from UPX processing, do it automatically based on the file analysis, i.e.,
full back-to-front scan for the `QTMETADATA` magic string.

Fixes #4178.