### PR TITLE
Enable building universal2 wheels for macOS

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,6 +5,10 @@ recursive-include PyInstaller/bootloader/images *
 # from source. (Wheels don't work on MSYS2.)
 recursive-include PyInstaller/bootloader/Windows-32bit *
 recursive-include PyInstaller/bootloader/Windows-64bit *
+# Until pip 20.1.2 is considered old, keep the macOS bootloaders
+# in here too so that older pips which don't recognise the universal2
+# wheel tag can still use the sdist.
+recursive-include PyInstaller/bootloader/Darwin-64bit *
 include pyproject.toml
 # These files need to be explicitly included
 include PyInstaller/fake-modules/*.py


### PR DESCRIPTION
Implements the changes from #5879.

This turned out to be much simpler than I expected. All it takes is replacing `x86_64` in the wheel platform tag to `universal2`. But because the macOS bootloaders can now be compiled in 3 different ways (`x86_64`, `arm64` or both), I've made the wheel tag automatically determinant on what bootloaders. And to reduce the number of places we have to hardcode it, I've done the same with the macOS deployment target - i.e. the minimum required macOS version in the wheel tag is derived from that of the bootloaders.

This makes macholib (irregardless of platform) and PyInstaller itself a build dependency of `setup.py wheel_darwin_64bit` but neither *should* be a problem.