### PR TITLE
bootloader: wscript: fix setting of MACOSX_DEPLOYMENT_TARGET

### DIFF
--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -446,6 +446,22 @@ def configure(ctx):
                       'If you want this feature, please help implementing. '
                       'See the wscript file for details.' % ctx.env.DEST_OS)
 
+    if ctx.env.DEST_OS == 'darwin':
+        # macOS 10.13 is the oldest version supported by Apple.
+        # According to OS X doc this variable is equivalent to gcc option:
+        #   -mmacosx-version-min=10.13
+        #
+        # MACOSX_DEPLOYMENT_TARGET must be set before the compiler toolchain
+        # is used for the first time (i.e., check_sizeof_pointer() call
+        # made by detect_arch() call below), otherwise it will be
+        # automatically set to the toolchain's default value.
+        if not os.environ.get('MACOSX_DEPLOYMENT_TARGET'):
+            ctx.msg('MacOS deployment target', 'Setting to 10.13')
+            os.environ['MACOSX_DEPLOYMENT_TARGET'] = '10.13'
+        else:
+            ctx.msg('MacOS deployment target', 'Already set - %s' % (
+                    os.environ.get('MACOSX_DEPLOYMENT_TARGET')))
+
     # Detect architecture after completing compiler search
     ctx.detect_arch()
 
@@ -574,13 +590,6 @@ def configure(ctx):
                 ctx.env.append_value('STATICLIBPATH', '/usr/local/lib/hpux64')
 
 
-    elif ctx.env.DEST_OS == 'darwin':
-        # macOS 10.13 is the oldest version supported by Apple.
-        # According to OS X doc this variable is equivalent to gcc option:
-        #   -mmacosx-version-min=10.13
-        if not os.environ.get('MACOSX_DEPLOYMENT_TARGET'):
-            os.environ['MACOSX_DEPLOYMENT_TARGET'] = '10.13'
-
     ### Libraries
 
     if ctx.env.DEST_OS == 'win32':
@@ -667,14 +676,6 @@ def configure(ctx):
 
             # Use Unicode entry point wmain/wWinMain
             ctx.env.append_value('LINKFLAGS', '-municode')
-
-    if ctx.env.DEST_OS == 'darwin':
-        if not any(x for x in ctx.env.CPPFLAGS + ctx.env.CFLAGS
-                   if x.startswith('-mmacosx-version-min=')):
-            ctx.env.append_value('CFLAGS', '-mmacosx-version-min=10.7')
-        if not any(x for x in ctx.env.LDFLAGS + ctx.env.LINKFLAGS
-                   if x.startswith('-mmacosx-version-min=')):
-            ctx.env.append_value('LINKFLAGS', '-mmacosx-version-min=10.7')
 
     # On linux link only with needed libraries.
     # -Wl,--as-needed is on some platforms detected during configure but


### PR DESCRIPTION
Remove the low-level setting of macOS deployment target via `-mmacosx-version-min` switch in `CFLAGS` and `LDFLAGS`. Instead, use only `MACOSX_DEPLOYMENT_TARGET` environment variable.

Move setting the default `MACOSX_DEPLOYMENT_TARGET` for bootloader (if the variable is not defined in the environment already) before first test/check that requires compiler. Otherwise, the environment variable is automatically set to the toolchain's default.

We should now be targeting 10.13 by default, but the target can be changed by setting `MACOSX_DEPLOYMENT_TARGET` in environment before calling `waf`.