### PR TITLE
Update Vagrant VMs

### DIFF
--- a/bootloader/Vagrantfile
+++ b/bootloader/Vagrantfile
@@ -358,53 +358,6 @@ Vagrant.configure(2) do |config|
         :keep_color => true
   end
 
-  #--- Mac OS X ---
-  config.vm.define "darwin64" do |b|
-    b.vm.box = "jhcook/yosemite-clitools"
-
-    # Guest additions are not available for OS X and thus no shared folders
-    b.vm.synced_folder "..", "/vagrant", :type => "rsync",
-      # Avoid rsyncing the huge SDKs not used here
-      :rsync__args => ["--verbose", "--archive", "--delete", "-z",
-                       "--include=bootloader", "--include=PyInstaller",
-                       "--exclude=/*", "--cvs-exclude", "--exclude=*.pyc",
-                       "--exclude=bootloader/build",
-                       "--exclude=bootloader/_sdks",
-                       "--exclude=bootloader/.lock-*",
-                       "--exclude=bootloader/.waf-*",
-                       "--exclude=bootloader/waf-*"],
-      # chown fails on the OS X box, since group 'vagrant' is missing
-      :rsync__chown => false
-
-    b.vm.provider :virtualbox do |v|
-      v.customize ['modifyvm', :id, '--ostype', 'MacOS1010_64']
-      v.customize ['modifyvm', :id, '--paravirtprovider', 'default']
-      # Adjust CPU settings according to
-      # https://github.com/geerlingguy/macos-virtualbox-vm
-      v.customize ['modifyvm', :id, '--cpuidset',
-                   # Leaf       EAX        EBX         ECX         EDX
-                   '00000001', '000306a9', '00020800', '80000201', '178bfbff']
-      # This should make make the box less choppy (source: geerlingguy)
-      #v.customize ["modifyvm", :id, '--audio', 'off']
-      # Disable USB variant requiring Virtualbox proprietary extension packs
-      v.customize ["modifyvm", :id, '--usbehci', 'off', '--usbxhci', 'off']
-      # Apple recommends 128MB (source: geerlingguy)
-      #v.customize ["modifyvm", :id, '--videocapmaxsize', '128MB']
-    end
-    b.vm.provision "fix permissions", :type => :shell, :privileged => true,
-        :inline => "chown -R vagrant: /vagrant"
-    ## install (security and other) updates
-    b.vm.provision "update software", :type => :shell, :privileged => true,
-        :inline => update_darwin
-    #b.vm.provision :reload  # for the case updates require reboot
-    # For this box we do not need any additional packages
-    #b.vm.provision "packages darwin", :type => :shell, :privileged => false,
-    #    :inline => packages_darwin
-    b.vm.provision "build bootloader", :type => :shell, :privileged => false,
-        :inline => build_bootloader("darwin64"),
-        :keep_color => true
-  end
-
   #--- Windows 64 bit
   #- This box requires interaction, automated build is not possible at
   #- the moment. Please see the README for more information.

--- a/bootloader/Vagrantfile
+++ b/bootloader/Vagrantfile
@@ -285,7 +285,7 @@ def build_bootloader_target_osx(boxname)
     PATH=~/osxcross/bin:$PATH
     echo $PATH
     export LD_LIBRARY_PATH=~/osxcross/lib:$LD_LIBRARY_PATH
-    export MACOSX_DEPLOYMENT_TARGET=10.11
+    export MACOSX_DEPLOYMENT_TARGET=10.13
     export CC=$(basename -a ~/osxcross/bin/x86_64-*-clang)
     python3 ./waf all --clang
   EOF

--- a/bootloader/Vagrantfile
+++ b/bootloader/Vagrantfile
@@ -102,7 +102,8 @@ def build_osxcross
     mkdir -p $SDK
     # Extract the SDK from Xcode.xip into MacOSX*.tar.*
     ./tools/gen_sdk_package_tools_dmg.sh $SDK/Xcode_tools.dmg || exit 1
-    mv MacOSX11*.tar.* tarballs/
+    # Take the SDK with highest version
+    mv $(ls MacOSX*.sdk.tar.* | sort -V | tail -n1) tarballs/
     # Build the build-tools into directory `target/`
     UNATTENDED=1 ./build.sh
 

--- a/bootloader/Vagrantfile
+++ b/bootloader/Vagrantfile
@@ -458,7 +458,7 @@ Vagrant.configure(2) do |config|
         :inline => packages_chocolatey()
       b.vm.provision "install packages",
         :type => :shell, :privileged => false, :keep_color => true,
-        :inline => choco_install("python3 vcbuildtools")
+        :inline => choco_install("python3 visualstudio2019-workload-vctools")
       b.vm.provision "build bootloader",
         :type => :shell, :privileged => false, :keep_color => true,
         :inline => build_bootloader_on_windows("windows10")

--- a/doc/bootloader-building.rst
+++ b/doc/bootloader-building.rst
@@ -125,10 +125,7 @@ passing ``--no-universal2`` flag to the ``waf`` build command.
 
 Now you can build the bootloader as shown above.
 
-Alternatively you may want to use the `darwin64` build-guest
-provided by the Vagrantfile (see below).
-
-By default, the build script targets Mac OSX 10.7, which can be overridden by
+By default, the build script targets Mac OSX 10.13, which can be overridden by
 exporting the MACOSX_DEPLOYMENT_TARGET environment variable.
 
 .. _cross-building for mac os x:
@@ -462,7 +459,7 @@ All guests [#]_ will automatically build the bootloader when running
 .. [#] Except of guest `osxcross`, which will build the OS X SDK and cctools
        as described in section :ref:`cross-building for mac os x`.
 
-All guests (except of `darwin64`), when building the bootloaders, are sharing
+When building the bootloaders, the guests are sharing
 the PyInstaller distribution folder and will put the built executables onto
 the build-host (into :file:`../PyInstaller/bootloader/`).
 
@@ -483,7 +480,7 @@ Example usage::
 You can pass some parameters for configuring the Vagrantfile by setting
 environment variables, like this::
 
-    GUI=1 TARGET=OSX vagrant up darwin64
+    GUI=1 TARGET=OSX vagrant up linux64
 
 or like this::
 
@@ -496,7 +493,7 @@ We currently provide this guests:
 :linux64:  GNU/Linux (some recent version) used to build the GNU/Linux
            bootloaders.
 
-           * If ``TARGET=OS`` is set, cross-builds the bootloaders for OS X
+           * If ``TARGET=OSX`` is set, cross-builds the bootloaders for OS X
              (see :ref:`cross-building for mac os x`).
 
            * If ``TARGET=WINDOWS`` is set, cross-builds the bootloaders
@@ -505,21 +502,6 @@ We currently provide this guests:
 
            * Otherwise (which is the default) bootloaders for GNU/Linux are
              build.
-
-:darwin64:  Mac OS X 'Yosemite' – not actually used by the PyInstaller team,
-            but provided for testing.
-
-            This guest, when building the bootloaders, does *not* put the
-            built executables onto the build-host. You need to fetch them
-            using::
-
-             vagrant plugin install vagrant-scp vagrant-reload # required only once
-             vagrant scp -a darwin64:/vagrant/PyInstaller/bootloader/Darwin-* \
-                            ../PyInstaller/bootloader/
-
-            This is due the fact that this machine doesn't include the
-            Virtualbox guest additions and thus doesn't support shared
-            folders.
 
 :windows10: Windows 10, used for building the Windows bootloaders
             using Visual  C++.


### PR DESCRIPTION
Update MACOSX_DEPLOYMENT_TARGET from 10.11 to 10.13 when cross-compiling macOS bootloaders in `linux64` VM.

Improve selection of macOS SDK in `build-osxcross` VM - always select the latest available version of the SDK. Fixes building with SDKs extracted from Xcode command line tools 12.5, which provide two variants of SDK with major version 11 - "11" and "11.3".

Upgrade VS toolchain in `windows10` VM from VS2015 to VS2019.