### PR TITLE
loader: ctypes: switch the search order for frozen libraries

### DIFF
--- a/PyInstaller/loader/pyimod04_ctypes.py
+++ b/PyInstaller/loader/pyimod04_ctypes.py
@@ -31,9 +31,12 @@ def install():
         return
 
     def _frozen_name(name):
-        if name:
+        # If the given (file)name does not exist, fall back to searching
+        # for its basename in sys._MEIPASS, where PyInstaller usually
+        # collects shared libraries.
+        if name and not os.path.isfile(name):
             frozen_name = os.path.join(sys._MEIPASS, os.path.basename(name))
-            if os.path.exists(frozen_name) and not os.path.isdir(frozen_name):
+            if os.path.isfile(frozen_name):
                 name = frozen_name
         return name
 

--- a/news/5907.hooks.rst
+++ b/news/5907.hooks.rst
@@ -1,0 +1,3 @@
+Switch the library search order in ``ctypes`` hooks: first check whether
+the given name exists as-is, before trying to search for its basename in
+``sys._MEIPASS`` (instead of the other way around).


### PR DESCRIPTION
Modify the `_frozen_name()` so that it first checks if the given (file)name exists, before falling back to searching `sys._MEIPASS`
for it.

This effectively switches the search order: whereas formerly we would first check `sys._MEIPASS` and use the given name as fallback, we now first check the given name and then search `sys._MEIPASS` as a fallback.