### PR TITLE
macOS: add Apple event processing for onedir .app bundles

### DIFF
--- a/bootloader/src/pyi_utils.h
+++ b/bootloader/src/pyi_utils.h
@@ -53,4 +53,9 @@ int pyi_utils_create_child(const char *thisfile, const ARCHIVE_STATUS *status,
                            const int argc, char *const argv[]);
 int pyi_utils_set_environment(const ARCHIVE_STATUS *status);
 
+/* Argument handling */
+int pyi_utils_initialize_args(const int argc, char *const argv[]);
+void pyi_utils_get_args(int *argc, char ***argv);
+void pyi_utils_free_args();
+
 #endif  /* HEADER_PY_UTILS_H */

--- a/bootloader/src/pyi_utils.h
+++ b/bootloader/src/pyi_utils.h
@@ -58,4 +58,16 @@ int pyi_utils_initialize_args(const int argc, char *const argv[]);
 void pyi_utils_get_args(int *argc, char ***argv);
 void pyi_utils_free_args();
 
+/* Apple event handling */
+#if defined(__APPLE__) && defined(WINDOWED)
+/*
+ * Watch for OpenDocument AppleEvents and add the files passed in to the
+ * sys.argv command line on the Python side.
+ *
+ * This allows on Mac OS X to open files when a file is dragged and dropped
+ * on the App icon in the OS X dock.
+ */
+void pyi_process_apple_events(bool short_timeout);
+#endif  /* defined(__APPLE__) && defined(WINDOWED) */
+
 #endif  /* HEADER_PY_UTILS_H */

--- a/news/5436.bugfix.rst
+++ b/news/5436.bugfix.rst
@@ -1,0 +1,2 @@
+(macOS) The drag & drop file paths passed to app bundles built in
+``onedir`` mode are now reflected in ``sys.argv``.

--- a/news/5908.bugfix.rst
+++ b/news/5908.bugfix.rst
@@ -1,0 +1,2 @@
+(macOS) The file paths passed from the UI (`Open with...`) to app bundles
+built in ``onedir`` mode are now reflected in ``sys.argv``.

--- a/news/5920.bugfix.rst
+++ b/news/5920.bugfix.rst
@@ -1,0 +1,3 @@
+(macOS) App bundles built in ``onedir`` mode now filter out ``-psnxxx˙`
+command-line argument from ``sys.argv``, to keep behavior consistent
+with bundles built in ``onefile`` mode.

--- a/news/5920.feature.rst
+++ b/news/5920.feature.rst
@@ -1,0 +1,3 @@
+(macOS) In ``onedir`` ``windowed`` (.app bundle) mode, perform an
+interation of Apple event processing to convert ``odoc`` and ``GURL``
+events to ``sys.argv`` before entering frozen python script.

--- a/tests/functional/specs/pyi_osx_custom_protocol_handler.spec
+++ b/tests/functional/specs/pyi_osx_custom_protocol_handler.spec
@@ -14,21 +14,44 @@ import os
 
 app_name = 'pyi_osx_custom_protocol_handler'
 custom_url_scheme = os.environ.get('PYI_CUSTOM_URL_SCHEME', 'pyi-test-app')
+build_mode = os.environ.get('PYI_BUILD_MODE', 'onefile')
 
 a = Analysis(['../scripts/pyi_log_args.py'])
 pyz = PYZ(a.pure, a.zipped_data)
-exe = EXE(pyz,
-          a.scripts,
-          a.binaries,
-          a.zipfiles,
-          a.datas,
-          name=app_name,
-          debug=True,
-          bootloader_ignore_signals=False,
-          strip=False,
-          upx=False,
-          console=False )
-app = BUNDLE(exe,
+
+if build_mode == 'onefile':
+     exe = EXE(pyz,
+               a.scripts,
+               a.binaries,
+               a.zipfiles,
+               a.datas,
+               name=app_name,
+               debug=True,
+               bootloader_ignore_signals=False,
+               strip=False,
+               upx=False,
+               console=False )
+     bundle_arg = exe
+elif build_mode == 'onedir':
+     exe = EXE(pyz,
+               a.scripts,
+               exclude_binaries=True,
+               name=app_name,
+               debug=True,
+               bootloader_ignore_signals=False,
+               strip=False,
+               upx=False,
+               console=False )
+     coll = COLLECT(exe,
+                    a.binaries,
+                    a.zipfiles,
+                    a.datas,
+                    strip=False,
+                    upx=False,
+                    name=app_name)
+     bundle_arg = coll
+
+app = BUNDLE(bundle_arg,
              name=app_name + '.app',
              # Register custom protocol handler
              info_plist={

--- a/tests/functional/specs/pyi_osx_event_forwarding.spec
+++ b/tests/functional/specs/pyi_osx_event_forwarding.spec
@@ -15,21 +15,44 @@ import os
 app_name = 'pyi_osx_event_forwarding'
 custom_url_scheme = os.environ.get('PYI_CUSTOM_URL_SCHEME', 'pyi-test-app')
 custom_file_ext = os.environ.get('PYI_CUSTOM_FILE_EXT', 'pyi_test_ext')
+build_mode = os.environ.get('PYI_BUILD_MODE', 'onefile')
 
 a = Analysis([os.path.join(os.path.dirname(SPECPATH), 'scripts/pyi_pyqt5_log_events.py')])
 pyz = PYZ(a.pure, a.zipped_data)
-exe = EXE(pyz,
-          a.scripts,
-          a.binaries,
-          a.zipfiles,
-          a.datas,
-          name=app_name,
-          debug=True,
-          bootloader_ignore_signals=False,
-          strip=False,
-          upx=False,
-          console=False )
-app = BUNDLE(exe,
+
+if build_mode == 'onefile':
+     exe = EXE(pyz,
+               a.scripts,
+               a.binaries,
+               a.zipfiles,
+               a.datas,
+               name=app_name,
+               debug=True,
+               bootloader_ignore_signals=False,
+               strip=False,
+               upx=False,
+               console=False )
+     bundle_arg = exe
+elif build_mode == 'onedir':
+     exe = EXE(pyz,
+               a.scripts,
+               exclude_binaries=True,
+               name=app_name,
+               debug=True,
+               bootloader_ignore_signals=False,
+               strip=False,
+               upx=False,
+               console=False )
+     coll = COLLECT(exe,
+                    a.binaries,
+                    a.zipfiles,
+                    a.datas,
+                    strip=False,
+                    upx=False,
+                    name=app_name)
+     bundle_arg = coll
+
+app = BUNDLE(bundle_arg,
              name=app_name + '.app',
              # Register custom protocol handler and custom file extension
              info_plist={

--- a/tests/functional/test_apple_events.py
+++ b/tests/functional/test_apple_events.py
@@ -30,14 +30,17 @@ from PyInstaller.utils.tests import importorskip
 
 
 @pytest.mark.darwin
-def test_osx_custom_protocol_handler(tmpdir, pyi_builder_spec):
+@pytest.mark.parametrize("mode", ['onedir', 'onefile'])
+def test_osx_custom_protocol_handler(tmpdir, pyi_builder_spec, monkeypatch,
+                                     mode):
     app_path = os.path.join(tmpdir, 'dist',
                             'pyi_osx_custom_protocol_handler.app')
     logfile_path = os.path.join(tmpdir, 'dist', 'args.log')
 
     # Generate new URL scheme to avoid collisions
     custom_url_scheme = "pyi-test-%i" % time.time()
-    os.environ["PYI_CUSTOM_URL_SCHEME"] = custom_url_scheme
+    monkeypatch.setenv("PYI_CUSTOM_URL_SCHEME", custom_url_scheme)
+    monkeypatch.setenv("PYI_BUILD_MODE", mode)
 
     pyi_builder_spec.test_spec('pyi_osx_custom_protocol_handler.spec')
 
@@ -60,7 +63,8 @@ def test_osx_custom_protocol_handler(tmpdir, pyi_builder_spec):
 
 @pytest.mark.darwin
 @importorskip('PyQt5')
-def test_osx_event_forwarding(tmpdir, pyi_builder_spec):
+@pytest.mark.parametrize("mode", ['onedir', 'onefile'])
+def test_osx_event_forwarding(tmpdir, pyi_builder_spec, monkeypatch, mode):
     app_path = os.path.join(tmpdir, 'dist',
                             'pyi_osx_event_forwarding.app')
 
@@ -70,8 +74,9 @@ def test_osx_event_forwarding(tmpdir, pyi_builder_spec):
     unique_key = int(time.time())
     custom_url_scheme = "pyi-test-%i" % unique_key
     custom_file_ext = 'pyi_test_%i' % unique_key
-    os.environ["PYI_CUSTOM_URL_SCHEME"] = custom_url_scheme
-    os.environ["PYI_CUSTOM_FILE_EXT"] = custom_file_ext
+    monkeypatch.setenv("PYI_CUSTOM_URL_SCHEME", custom_url_scheme)
+    monkeypatch.setenv("PYI_CUSTOM_FILE_EXT", custom_file_ext)
+    monkeypatch.setenv("PYI_BUILD_MODE", mode)
 
     # test_script builds the app then implicitly runs the script, so we
     # pass arg "0" to tell the built script to exit right away here.


### PR DESCRIPTION
Have the `onedir` codepath in `windowed` mode (macOS app bundle) perform a single iteration of `apple_process_events()`, in order to process any `odoc` and `GURL` events that an .app bundle may have received. The events are converted into corresponding `sys.argv` arguments.

Fixes #5908. Fixes #5436.

The `test_osx_custom_protocol_handler` and `test_osx_event_forwarding` are now performed in both `onedir` and `onefile` mode, and all of them pass.

The core of the patch is the same as the proof-of-concept given in #5436 (i.e., running a single iteration of `apple_process_events()` and pass modified arguments to frozen python script), except we take additional care not to do this in a child process of `onefile` built (as it seems to upset `test_osx_event_forwarding[onefile]`, presumably because a forwarded activation event is swallowed).

As a side effect of argument processing, we now filter out `-psnxxx` argument from `sys.argv` in both `onedir` and `onefile` app bundles, which makes the behavior consistent between both modes (previously, `onedir` received original arguments). The meaning of the argument is now also documented/references, as suggested by #5442.