### PR TITLE
Doc: Let there be cross references!

### DIFF
--- a/PyInstaller/__main__.py
+++ b/PyInstaller/__main__.py
@@ -70,6 +70,30 @@ def __add_options(parser):
                         version=__version__,
                         help='Show program version info and exit.')
 
+
+def generate_parser() -> argparse.ArgumentParser:
+    """Build an argparse parser for PyInstaller's main CLI."""
+
+    import PyInstaller.building.makespec
+    import PyInstaller.building.build_main
+    import PyInstaller.log
+
+    parser = argparse.ArgumentParser(formatter_class=_SmartFormatter)
+    parser.prog = "pyinstaller"
+    __add_options(parser)
+
+    PyInstaller.building.makespec.__add_options(parser)
+    PyInstaller.building.build_main.__add_options(parser)
+    PyInstaller.log.__add_options(parser)
+    parser.add_argument('filenames', metavar='scriptname', nargs='+',
+                        help=("name of scriptfiles to be processed or "
+                              "exactly one .spec-file. If a .spec-file is "
+                              "specified, most options are unnecessary "
+                              "and are ignored."))
+
+    return parser
+
+
 def run(pyi_args=None, pyi_config=None):
     """
     pyi_args     allows running PyInstaller programatically without a subprocess
@@ -77,22 +101,10 @@ def run(pyi_args=None, pyi_config=None):
     """
     check_requirements()
 
-    import PyInstaller.building.makespec
-    import PyInstaller.building.build_main
     import PyInstaller.log
 
     try:
-        parser = argparse.ArgumentParser(formatter_class=_SmartFormatter)
-        __add_options(parser)
-        PyInstaller.building.makespec.__add_options(parser)
-        PyInstaller.building.build_main.__add_options(parser)
-        PyInstaller.log.__add_options(parser)
-        parser.add_argument('filenames', metavar='scriptname', nargs='+',
-                            help=("name of scriptfiles to be processed or "
-                                  "exactly one .spec-file. If a .spec-file is "
-                                  "specified, most options are unnecessary "
-                                  "and are ignored."))
-
+        parser = generate_parser()
         args = parser.parse_args(pyi_args)
         PyInstaller.log.__process_options(parser, args)
 

--- a/PyInstaller/utils/cliutils/makespec.py
+++ b/PyInstaller/utils/cliutils/makespec.py
@@ -21,12 +21,16 @@ import PyInstaller.building.makespec
 import PyInstaller.log
 
 
-def run():
+def generate_parser():
     p = argparse.ArgumentParser()
     PyInstaller.building.makespec.__add_options(p)
     PyInstaller.log.__add_options(p)
     p.add_argument('scriptname', nargs='+')
+    return p
 
+
+def run():
+    p = generate_parser()
     args = p.parse_args()
     PyInstaller.log.__process_options(p, args)
 

--- a/doc/CHANGES-3.rst
+++ b/doc/CHANGES-3.rst
@@ -1224,7 +1224,7 @@ Fixed the following issues:
 - Solaris fixes.
 - Use library modulegraph for module dependency analysis.
 - Bootloader debug messages ``LOADER: ...`` printed to stderr.
-- PyInstaller no longer extends ``sys.path`` and bundled 3rd-party
+- PyInstaller no longer extends :data:`sys.path` and bundled 3rd-party
   libraries do not interfere with their other versions.
 - Enhancemants to ``Analysis()``:
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -15,7 +15,7 @@ endif
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
-ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
+ALLSPHINXOPTS   = -n -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 

--- a/doc/_static/css/pyinstaller.css
+++ b/doc/_static/css/pyinstaller.css
@@ -91,6 +91,7 @@ div.note p.admonition-title:after {
 }
 	
 /* --- Inline literals. --- */
+html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple).option > dt,
 .rst-content code.literal, .rst-content tt.literal {
   color: #034040;
   background: unset;
@@ -100,6 +101,7 @@ div.note p.admonition-title:after {
 }
 /* Inline literals with link targets
  * (usually generated with :func:`PyInstaller.foo.bar`). */
+html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple).option > dt,
 .rst-content a code.literal, .rst-content tt.literal {
   border-bottom: solid 1px #0001;
 }
@@ -120,7 +122,8 @@ div.note p.admonition-title:after {
 .wy-menu-vertical { padding-bottom: 1em; }
 
 /* Autodoc functions/classes */
-html.writer-html4 .rst-content dl:not(.docutils) > dt, html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple) > dt {
+html.writer-html4 .rst-content dl:not(.docutils) > dt,
+html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple):not(.option) > dt {
   /* This is a loose merge of the styles for inline literals and headings. */
   background-color: #EEEA;
   border: 2px outset #e1e4e520;

--- a/doc/_static/css/pyinstaller.css
+++ b/doc/_static/css/pyinstaller.css
@@ -118,3 +118,11 @@ div.note p.admonition-title:after {
    a little black stub poking out under the scrollbar. */
 .wy-nav-side { padding-bottom: unset; }
 .wy-menu-vertical { padding-bottom: 1em; }
+
+/* Autodoc functions/classes */
+html.writer-html4 .rst-content dl:not(.docutils) > dt, html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple) > dt {
+  /* This is a loose merge of the styles for inline literals and headings. */
+  background-color: #EEEA;
+  border: 2px outset #e1e4e520;
+  color: #034040;
+}

--- a/doc/advanced-topics.rst
+++ b/doc/advanced-topics.rst
@@ -78,7 +78,7 @@ Running Python code requires several steps:
    It sets up the Python import mechanism to load modules
    only from archives embedded in the executable.
    It also adds the attributes ``frozen``
-   and ``_MEIPASS`` to the ``sys`` built-in module.
+   and ``_MEIPASS`` to the :mod:`sys` built-in module.
 
 2. Execute any run-time hooks: first those specified by the
    user, then any standard ones.
@@ -86,9 +86,9 @@ Running Python code requires several steps:
 3. Install python "egg" files.
    When a module is part of a zip file (.egg),
    it has been bundled into the :file:`./eggs` directory.
-   Installing means appending .egg file names to ``sys.path``.
+   Installing means appending .egg file names to :data:`sys.path`.
    Python automatically detects whether an
-   item in ``sys.path`` is a zip file or a directory.
+   item in :data:`sys.path` is a zip file or a directory.
 
 4. Run the main script.
 
@@ -110,10 +110,10 @@ bundled with the app) and for C-extensions.
 The code can be read in :file:`./PyInstaller/loader/pyi_mod03_importers.py`.
 
 At runtime the PyInstaller :pep:`302` hooks are appended
-to the variable ``sys.meta_path``.
+to the variable :data:`sys.meta_path`.
 When trying to import modules the interpreter will
-first try PEP 302 hooks in ``sys.meta_path``
-before searching in ``sys.path``.
+first try PEP 302 hooks in :data:`sys.meta_path`
+before searching in :data:`sys.path`.
 As a result, the Python interpreter
 loads imported python modules from the archive embedded
 in the bundled executable.
@@ -123,7 +123,7 @@ in a bundled app:
 
 1. Is it a built-in module?
    A list of built-in modules is in variable
-   ``sys.builtin_module_names``.
+   :data:`sys.builtin_module_names`.
 
 2. Is it a module embedded in the executable?
    Then load it from embedded archive.
@@ -133,12 +133,12 @@ in a bundled app:
    :file:`{package.subpackage.module}.pyd` or
    :file:`{package.subpackage.module}.so`.
 
-4. Next examine paths in the ``sys.path``.
+4. Next examine paths in the :data:`sys.path`.
    There could be any additional location with python modules
    or ``.egg`` filenames.
 
 5. If the module was not found then
-   raise ``ImportError``.
+   raise :class:`ImportError`.
 
 Splash screen startup
 -------------------------------------
@@ -224,7 +224,7 @@ is not available at boot time, the module does not establish the connection
 until initialization.
 
 This module does not support reloads while the splash screen is displayed, i.e.
-it cannot be reloaded (such as by ``importlib.reload``), because the splash
+it cannot be reloaded (such as by :func:`importlib.reload`), because the splash
 screen closes automatically when the connection to this instance of the
 module is lost.
 
@@ -237,9 +237,9 @@ Functions
 .. Note::
     Note that if the ``_PYIBoot_SPLASH`` environment variable does not exist or an
     error occurs during the connection, the module will **not** raise an error, but simply
-    not initialize itself (i.e. ``pyi_splash.is_alive()`` will return ``False``). Before
+    not initialize itself (i.e. :func:`pyi_splash.is_alive` will return ``False``). Before
     sending commands to the splash screen, one should check if the module was initialized
-    correctly, otherwise a ``RuntimeError`` will be raised.
+    correctly, otherwise a :class:`RuntimeError` will be raised.
 
 .. py:function:: is_alive()
 
@@ -443,7 +443,7 @@ All parts of a ZlibArchive are stored in the
 
 A ZlibArchive is used at run-time to import bundled python modules.
 Even with maximum compression this works  faster than the normal import.
-Instead of searching ``sys.path``, there's a lookup in the dictionary.
+Instead of searching :data:`sys.path`, there's a lookup in the dictionary.
 There are no directory operations and no
 file to open (the file is already open).
 There's just a seek, a read and a decompress.
@@ -586,10 +586,10 @@ even when all the components of the application bundle are the same
 and the two applications execute in identical ways.
 
 You can assure that a build will produce the same bits
-by setting the ``PYTHONHASHSEED`` environment variable to a known
+by setting the :envvar:`PYTHONHASHSEED` environment variable to a known
 integer value before running |PyInstaller|.
 This forces Python to use the same random hash sequence until
-``PYTHONHASHSEED`` is unset or set to ``'random'``.
+:envvar:`PYTHONHASHSEED` is unset or set to ``'random'``.
 For example, execute |PyInstaller| in a script such as
 the following (for GNU/Linux and OS X)::
 

--- a/doc/bootloader-building.rst
+++ b/doc/bootloader-building.rst
@@ -33,7 +33,7 @@ This will produce the |bootloader| executables for your current platform
 * :file:`../PyInstaller/bootloader/{OS_ARCH}/runw_d` (OS X and Windows only).
 
 The bootloaders architecture defaults to the machine's one, but can be changed
-using the ``--target-arch=`` option – given the appropriate compiler and
+using the :option:`--target-arch` option – given the appropriate compiler and
 development files are installed. E.g. to build a 32-bit bootloader on a 64-bit
 machine, run::
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -74,6 +74,17 @@ intersphinx_mapping = {
     'python': ('http://docs.python.org/3', None),
 }
 
+# Autodoc cross references which don't exist and should not be warned about.
+nitpick_ignore = [
+    ("envvar", "CC"),
+    # Only applicable to AIX
+    ("envvar", "OBJECT_MODE"),
+    # TODO: Create autodoc-ed API references for these so that they can be
+    #       cross referenced properly.
+    ("py:mod", "Splash"),
+    ("py:class", "TOC"),
+]
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -15,7 +15,7 @@
 
 import sys
 import os
-import shlex
+from pathlib import Path
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -26,7 +26,9 @@ sys.path.insert(1, os.path.abspath('..'))
 sys.path.insert(3, os.path.abspath('./_extensions'))
 
 from PyInstaller import __version__
-import help2rst
+from help2rst import parser_to_rst  # noqa: E402
+from PyInstaller.__main__ import generate_parser  # noqa: E402
+from PyInstaller.utils.cliutils import makespec  # noqa: E402
 
 #--  PyInstaller HACK -----------------------------------------------
 
@@ -39,21 +41,26 @@ if on_rtd:
     if __version__.endswith('.mod'):
         __version__ = __version__[:-4]
 
-# FIXME: This should become something more sophisticated, e.g. a sphinx
-# extension
-for prog, outfile in (
-        ('../pyinstaller.py', 'man/_pyinstaller-options.tmp'),
-        ('../makespec.py', 'man/_pyi-makespec-options.tmp'),
-        ):
-    prog = os.path.abspath(os.path.join(os.path.dirname(__file__), prog))
-    help2rst.to_file(prog, True, '-', outfile)
-# Create a version with different labels to avoid warnings
-with open('man/_pyinstaller-options.tmp') as fh:
-    text = fh.read()
-text = text.replace('\n.. _pyinstaller ', '\n.. _options-group ')
-with open('_pyinstaller-options.tmp', 'w') as fh:
-    fh.write(text)
-del prog, outfile, fh, text
+# -- Generate CLI docs ----------------------------------------------------
+
+# Generate CLI references for ``pyinstaller`` and ``pyi-makespec``.
+# Only the first goes in the main docs with hyperref targets enabled.
+# Both references are copied into the man pages but without creating hyperref
+# targets (or we'd get 100s of duplicate reference errors).
+
+for (contents, path) in [
+    (parser_to_rst(generate_parser()),
+     "_pyinstaller-options.tmp"),
+    (parser_to_rst(generate_parser(), cross_references=False),
+     "man/_pyinstaller-options.tmp"),
+    (parser_to_rst(makespec.generate_parser(), cross_references=False),
+     "man/_pyi-makespec-options.tmp"),
+]:
+    # Avoid rewriting if no changes made. Otherwise sphinx mistakenly thinks
+    # its build cache needs refreshing.
+    path = Path(path)
+    if not path.exists() or path.read_text() != contents:
+        path.write_text(contents)
 
 # -- General configuration ------------------------------------------------
 

--- a/doc/feature-notes.rst
+++ b/doc/feature-notes.rst
@@ -70,7 +70,7 @@ We feel that it should be enough to cover most ctypes' usages, with little or
 no modification required in your code.
 
 If |PyInstaller| does not detect a library, you can add it to your
-bundle by passing the respective information to ``--add-binary`` option or
+bundle by passing the respective information to :option:`--add-binary` option or
 :ref:`listing it in the .spec-file <adding binary files>`. If your frozen
 application will be able to pick up the library at run-time can not be
 guaranteed as it depends on the detailed implementation.
@@ -132,7 +132,7 @@ These will typically show up as in a traceback like this
     ModuleNotFoundError: No module named 'csv'
 
 So if you are using a Cython C object module, which imports Python modules,
-you will have to list these as ``--hidden-import``.
+you will have to list these as :option:`--hidden-import`.
 
 
 macOS multi-arch support
@@ -171,7 +171,7 @@ of frozen application, or creating a non-native single-arch version using
 ``universal2`` environment, must therefore be explicitly enabled. This
 can be done either by specifying the target architecture in the ``.spec``
 file via the ``target_arch=`` argument to ``EXE()``, or on command-line
-via the ``--target-arch`` switch. Valid values are ``x86_64``, ``arm64``,
+via the :option:`--target-arch` switch. Valid values are ``x86_64``, ``arm64``,
 and ``universal2``.
 
 
@@ -217,7 +217,7 @@ a binary.
 the generated executable itself.** Instead of ad-hoc signing, it is also
 possible to use real code-signing identity. To do so, either specify your
 identity in the ``.spec`` file via ``codesign_identity=`` argument to
-``EXE()`` , or on command-line via the ``--codesign-identity`` switch.
+``EXE()`` , or on command-line via the :option:`--codesign-identity` switch.
 
 Being able to provide codesign identity allows user to ensure that all
 collected binaries in either ``onefile`` or ``onedir`` build are signed
@@ -240,14 +240,14 @@ signing of embedded binaries cannot be performed in a post-processing step.
 Furthermore, it is possible to specify entitlements file to be used
 when signing the collected binaries and the executable. This can be
 done in the ``.spec`` file via ``entitlements_file=`` argument to
-``EXE()``, or on command-line via the ``--osx-entitlements-file`` switch.
+``EXE()``, or on command-line via the :option:`--osx-entitlements-file` switch.
 
 App bundles
 ~~~~~~~~~~~
 
 |PyInstaller| also automatically attempts to sign `.app bundles`, either
 using ad-hoc identity or actual signing identity, if provided via
-``--codesign-identity`` switch. In addition to passing same options as
+:option:`--codesign-identity` switch. In addition to passing same options as
 when signing collected binaries (identity, hardened runtime, entitlement),
 deep signing is also enabled via by passing ``--deep`` option to the
 ``codesign`` utility.

--- a/doc/feature-notes.rst
+++ b/doc/feature-notes.rst
@@ -80,13 +80,13 @@ Gotchas
 ~~~~~~~~~~~~~~~
 
 The ctypes detection system at :ref:`Analysis time <spec-file operations>`
-is based on ``ctypes.util.find_library()``.
+is based on :func:`ctypes.util.find_library`.
 This means that you have to make sure
 that while performing ``Analysis`` and running frozen,
-all the environment values ``find_library()`` uses to search libraries
+all the environment values :func:`~ctypes.util.find_library` uses to search libraries
 are aligned to those when running un-frozen.
 Examples include using ``LD_LIBRARY_PATH`` or ``DYLD_LIBRARY_PATH`` to
-widen ``find_library()`` scope.
+widen :func:`~ctypes.util.find_library` scope.
 
 
 SWIG support

--- a/doc/help2rst.py
+++ b/doc/help2rst.py
@@ -13,105 +13,124 @@
 """
 This script reformats the output of `myprog --help` to decent rst.
 
-Currently handles optparse and argparse output. Removes everything
-before "Options" resp. "optional arguments" and after "Obsolete
-options".
+There are two sphinx plugins which could replace this eventually:
+  - https://github.com/ashb/sphinx-argparse
+  - https://github.com/gaborbernat/sphinx-argparse-cli
+The former's output looks really nice but lacks support for cross referencing
+arguments. The latter supports cross referencing but its output looks hideous.
+Hopefully either one of them will evolve into something we can use eventually.
+
+The main functions here are parser_to_rst() and help_to_rst(). Throughout this
+code the **cross_references** option controls whether or not section headings
+and options should be given cross reference targets.
+
 """
-import argparse
-import subprocess
-import textwrap
+
+from textwrap import indent, wrap, dedent
 import re
-import sys
-import os
-
-__copyright__ = "Copyright (c) 2015-2021 PyInstaller Development Team, " \
-                "Copyright (c) 2015-2020 Hartmut Goebel"
-__author__ = "Hartmut Goebel <h.goebel@crazy-compilers.com>"
+from argparse import ArgumentParser
+from functools import partial
 
 
-def gen_headings(program, text, headings_character):
-    text = (t.rstrip() for t in text.splitlines())
-    new_text = []
-    dedent = 0
-    for line in text:
-        heading = line and not line.startswith((' ', '-'))
-        if heading:
-            # remove trailing colon
-            line = line.rstrip(':')
-            dedent = 0
-        elif dedent:
-            # dedent for this section already known
-            assert line[:dedent].strip() == '', line
-            line = line[dedent:]
-        else:
-            # dedent for this section not yet known
-            # check for next optional arguments (starting with a dash)
-            leading_whitespace = re.findall(r'^[ \t]*(?=-)', line)
-            if leading_whitespace:
-                dedent = len(leading_whitespace[0])
-                line = line[dedent:]
-        if heading:
-            # add a sphinx reference label
-            new_text.extend(('',
-                             '.. _%s %s:' % (program, line.lower()),
-                             ''))
-        new_text.append(line)
-        if heading:
-            # append underline
-            new_text.append(headings_character * len(line))
-            new_text.append('')  # empty line for readability only
-    return '\n'.join(new_text)
+def parser_to_rst(parser: ArgumentParser, cross_references=True):
+    """Extract the ``--help`` output from an argparse parser and convert it to
+    restructured text."""
+    help = parser.format_help()
+    return help_to_rst(help, cross_references)
 
 
-def process(program, generate_headings, headings_character):
-    help = subprocess.check_output([sys.executable, program, '--help'],
-                                   universal_newlines=True)
-    if '\nOptions:' in help:
-        # optparse style
-        help = help.split('\nOptions:', 1)[1]
-    elif '\noptional arguments:' in help:
-        # argparse style
-        help = help.split('\noptional arguments:', 1)[1]
-    else:
-        raise SystemError('unexpected format of output for --help')
-    # Remove any obsolete options
-    help = re.split(r'\n\s*Obsolete options', help)[0]
+# Matches headings followed by indented blocks.
+SECTION_REGEX = re.compile(
+    r"""
+    # A non-empty line with no indentation.
+    ^\S.*\n
 
-    help = help.strip('\n')
-    # escape stars prior to other processing
-    help = help.replace('*', r'\*')
-    # Change troublesome argparse text that the optparse-like docutils parser
-    # doesn't understand.
-    help = help.replace('{all,imports,bootloader,noarchive}',
-                        '<all,imports,bootloader,noarchive>')
-    if generate_headings:
-        program = os.path.splitext(os.path.basename(program))[0].lower()
-        help = textwrap.dedent(help)
-        help = gen_headings(program, help, headings_character)
-    return help
+    # Followed by a non-zero number of either blank lines or indented lines.
+    (?:(?:\ +.*)?\n)+
+
+""", re.MULTILINE | re.VERBOSE)
 
 
-def to_file(program, generate_headings, headings_character, outfile):
-    help = process(program, generate_headings, headings_character)
-    with open(outfile, 'w') as ofh:
-        print(help, file=ofh)
+def help_to_rst(help: str, cross_references=True):
+    """Convert the output of a ``cli --help`` call to rst."""
+    summary, *sections = SECTION_REGEX.findall(help)
+
+    # We could stick the summary (``usage: pyinstaller [-h] [--help] ...``)
+    # into a code block but it's pretty unhelpful so I'm choosing to omit it.
+    sections = "\n".join(section_to_rst(section, cross_references)
+                         for section in sections)
+
+    return sections
 
 
-def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument('--generate-headings',
-                        action='store_true', default=True,
-                        help=("Generate section headings from arumgent groups"
-                              " (this is the default)"))
-    parser.add_argument('--no-generate-headings',action='store_false',
-                        dest='generate_headings')
-    g = parser.add_argument_group('tst')
-    g.add_argument('--headings-character', default="-",
-                        help=("Character to use for underlining section headers"
-                              " (default: -)"))
-    parser.add_argument('program')
-    args = parser.parse_args()
-    print(process(**vars(args)))
+def section_to_rst(section: str, cross_references=True) -> str:
+    """Convert a single option group's ``--help`` output to rst.
 
-if __name__ == '__main__':
-    main()
+    This generates a heading for the option group followed by each option
+    within that group.
+
+    """
+    title, body = section.split("\n", maxsplit=1)
+
+    rst_title = rst_headerise(title, cross_references)
+    rst_body = OPTION_REGEX.sub(
+        partial(option_to_rst, cross_references=cross_references), body)
+
+    return rst_title + rst_body
+
+
+OPTION_REGEX = re.compile(
+    r"""
+    # Matches:
+    #   --name, --other-name, -n VALUE  Some description
+    #                                   and some more description.
+
+    # An option name prefixed with at least 1 space.
+    ^(\ +)(.*?)
+    # Optionally followed by at least 2 spaces and the start of the desciption.
+    (?:\ {2,}(.*))?\n
+
+    # More lines of description.
+    # Each line starts with more spaces than which prefixed the option name (so
+    # as to avoid picking up the next option).
+    # Blank lines are allowed.
+    (((?:\1\ +(.*))?\n)*)
+
+""", re.MULTILINE | re.VERBOSE)
+
+
+def option_to_rst(m: re.Match, cross_references=True) -> str:
+    """Convert a single option to rst.
+
+    The output should look like::
+
+        .. option:: --option-name -n
+
+            The help for that option nicely text-wrapped.
+
+    """
+    name = m.group(2)
+    assert name
+    body = " ".join(i for i in m.group(3, 4) if i)
+    # Escape characters which turn into invalid rst.
+    body = body.replace("*", r"\*")
+    # Re-wrap the help block.
+    body = "\n".join(
+        wrap(dedent(body),
+             width=75,
+             break_on_hyphens=False,
+             break_long_words=False))
+
+    template = ".. option:: {}\n\n{}\n\n" \
+        if cross_references else "{}\n\n{}\n\n"
+
+    return template.format(name, indent(body, "    "))
+
+
+def rst_headerise(title: str, cross_references=True) -> str:
+    """Create a title with the correct length '---' underline."""
+    title = title.strip(" \n:").title()
+    out = f"{title}\n{'-' * len(title)}\n\n"
+    if cross_references:
+        out = f".. _`{title}`:\n\n" + out
+    return out

--- a/doc/hooks.rst
+++ b/doc/hooks.rst
@@ -94,7 +94,7 @@ The names defined by these statements are visible to Analysis
 as attributes of the namespace.
 
 Thus a hook is a normal Python script and can use all normal Python facilities.
-For example it could test ``sys.version`` and adjust its
+For example it could test :data:`sys.version` and adjust its
 assignment to ``hiddenimports`` based on that.
 There are many hooks in the |PyInstaller| installation,
 but a much larger collection can be found in the
@@ -212,7 +212,7 @@ applies them to the bundle being created.
       datas = [ ('/usr/share/icons/education_*.png', 'icons') ]
 
    If you need to collect multiple directories or nested directories,
-   you can use helper functions from the ``PyInstaller.utils.hooks`` module
+   you can use helper functions from the :mod:`PyInstaller.utils.hooks` module
    (see below) to create this list, for example::
 
       datas  = collect_data_files('submodule1')
@@ -388,14 +388,14 @@ which has the following immutable properties:
       * A non-package module or C extension, this is the absolute path of the
         corresponding file.
 
-``__path__``:
+:attr:`__path__`:
    A list of the absolute paths of all directories comprising the module
    if it is a package, or ``None``. Typically the list contains only the
    absolute path of the package's directory.
 
 ``co``:
     Code object compiled from the contents of ``__file__`` (e.g., via the
-    ``compile()`` builtin).
+    :func:`compile` builtin).
 
 ``analysis``:
     The ``Analysis`` object that loads the hook.
@@ -542,7 +542,7 @@ The ``psim_api`` object also offers the following methods:
    path that the imported module would add dynamically to
    the path if the module was executed normally.
    ``directory`` is a string, a pathname to add to the
-   ``__path__`` attribute.
+   :attr:`__path__` attribute.
 
 
 .. include:: _common_definitions.txt

--- a/doc/hooks.rst
+++ b/doc/hooks.rst
@@ -3,8 +3,6 @@
 Understanding PyInstaller Hooks
 ==================================
 
-.. py:currentmodule:: PyInstaller.utils.hooks
-
 .. note::
 
    We strongly encourage package developers
@@ -29,7 +27,7 @@ A hook can tell about additional source files or data files to import,
 or files not to import.
 
 A hook file is a Python script, and can use all Python features.
-It can also import helper methods from ``PyInstaller.utils.hooks``
+It can also import helper methods from :mod:`PyInstaller.utils.hooks`
 and useful variables from ``PyInstaller.compat``.
 These helpers are documented below.
 
@@ -247,240 +245,95 @@ applies them to the bundle being created.
 Useful Items in ``PyInstaller.compat``
 ----------------------------------------
 
-A hook may import the following names from ``PyInstaller.compat``,
+.. automodule:: PyInstaller.compat
+.. py:currentmodule:: PyInstaller.compat
+
+A hook may import the following names from :mod:`PyInstaller.compat`,
 for example::
 
    from PyInstaller.compat import base_prefix, is_win
 
-``is_py36``, ``is_py37``, ``is_py38``, ``is_py39``:
-   True when the current version of Python is at least 3.6, 3.7, 3.8 or 3.9 respectively.
+.. py:data:: is_py36, is_py37, is_py38, is_py39
 
-``is_win``:
+    True when the current version of Python is at least 3.6, 3.7, 3.8 or 3.9
+    respectively.
+
+.. py:data::  is_win
+
    True in a Windows system.
-``is_cygwin``:
-   True when ``sys.platform=='cygwin'``.
-``is_darwin``:
+
+.. py:data:: is_cygwin
+
+   True when ``sys.platform == 'cygwin'``.
+
+.. py:data:: is_darwin
+
    True in Mac OS X.
-``is_linux``:
-   True in any GNU/Linux system (``sys.platform.startswith('linux')``).
-``is_solar``:
+
+.. py:data:: is_linux
+
+   True in any GNU/Linux system.
+
+.. py:data:: is_solar
+
    True in Solaris.
-``is_aix``:
+
+.. py:data:: is_aix
+
    True in AIX.
-``is_freebsd``:
+
+.. py:data:: is_freebsd
+
    True in FreeBSD.
-``is_openbsd``:
+
+.. py:data:: is_openbsd
+
    True in OpenBSD.
 
-``is_venv``:
+.. py:data:: is_venv
+
    True in any virtual environment (either virtualenv or venv).
-``base_prefix``:
+
+.. py:data:: base_prefix
+
    String, the correct path to the base Python installation,
    whether the installation is native or a virtual environment.
 
-``EXTENSION_SUFFIXES``:
+.. py:data:: EXTENSION_SUFFIXES
+
    List of Python C-extension file suffixes. Used for finding all
-   binary dependencies in a folder; see file:`hook-cryptography.py`
+   binary dependencies in a folder; see :file:`hook-cryptography.py`
    for an example.
+
 
 Useful Items in ``PyInstaller.utils.hooks``
 --------------------------------------------
 
-A hook may import useful functions from ``PyInstaller.utils.hooks``.
+.. py:currentmodule:: PyInstaller.utils.hooks
+
+.. automodule:: PyInstaller.utils.hooks
+
+A hook may import useful functions from :mod:`PyInstaller.utils.hooks`.
 Use a fully-qualified import statement, for example::
 
    from PyInstaller.utils.hooks import collect_data_files, eval_statement
 
-The ``PyInstaller.utils.hooks`` functions listed here are generally useful
-and used in a number of existing hooks.
-There are several more functions besides these that serve the needs
-of specific hooks, such as hooks for PyQt5.
-You are welcome to read the ``PyInstaller.utils.hooks`` module
-(and read the existing hooks that import from it) to get code and ideas.
+The functions listed here are generally useful and used in a number of existing
+hooks.
 
-``exec_statement( 'statement' )``:
-   Execute a single Python statement in an externally-spawned interpreter
-   and return the standard output that results, as a string.
-   Examples::
-
-     tk_version = exec_statement(
-        "from _tkinter import TK_VERSION; print(TK_VERSION)"
-        )
-
-     mpl_data_dir = exec_statement(
-        "import matplotlib; print(matplotlib._get_data_path())"
-        )
-     datas = [ (mpl_data_dir, "") ]
-
-``eval_statement( 'statement' )``:
-   Execute a single Python statement in an externally-spawned interpreter.
-   If the resulting standard output text is not empty, apply
-   the ``eval()`` function to it; else return None. Example::
-
-      databases = eval_statement('''
-         import sqlalchemy.databases
-         print(sqlalchemy.databases.__all__)
-         ''')
-      for db in databases:
-         hiddenimports.append("sqlalchemy.databases." + db)
-
-``is_module_satisfies( requirements, version=None, version_attr='__version__' )``:
-   Check that the named module (fully-qualified) exists and satisfies the
-   given requirement. Example::
-
-       if is_module_satisfies('sqlalchemy >= 0.6'):
-
-   This function provides robust version checking based on the same low-level
-   algorithm used by ``easy_install`` and ``pip``, and should always be
-   used in preference to writing your own comparison code.
-   In particular, version strings should never be compared lexicographically
-   (except for exact equality).
-   For example ``'00.5' > '0.6'`` returns True, which is not the desired result.
-
-   The ``requirements`` argument uses the same syntax as supported by
-   the `Package resources`_ module of setup tools (follow the link to
-   see the supported syntax).
-
-   The optional ``version`` argument is is a PEP0440-compliant,
-   dot-delimited version specifier such as ``'3.14-rc5'``.
-
-   When the package being queried has been installed by ``easy_install``
-   or ``pip``, the existing setup tools machinery is used to perform the test
-   and the ``version`` and ``version_attr`` arguments are ignored.
-
-   When that is not the case, the ``version`` argument is taken as the
-   installed version of the package
-   (perhaps obtained by interrogating the package in some other way).
-   When ``version`` is ``None``, the named package is imported into a
-   subprocess, and the ``__version__`` value of that import is tested.
-   If the package uses some other name than ``__version__`` for its version
-   global, that name can be passed as the ``version_attr`` argument.
-
-   For more details and examples refer to the function's doc-string, found
-   in ``Pyinstaller/utils/hooks/__init__.py``.
-
-
-``collect_all( 'package-name', include_py_files=False )``:
-   Given a package name as a string, this function returns a tuple of ``datas, binaries,
-   hiddenimports`` containing all data files, binaries, and modules in the given
-   package, including any modules specified in the requirements for the
-   distribution of this module. The value of ``include_py_files`` is passed
-   directly to ``collect_data_files``.
-
-   Typical use: ``datas, binaries, hiddenimports = collect_all('my_module_name')``.
-   For example, ``hook-gevent.py`` invokes ``collect_all``, which gathers:
-
-   * All data files, such as ``__greenlet_primitives.pxd``, ``__hub_local.pxd``,
-     and many, many more.
-   * All binaries, such as ``__greenlet_primitives.cp37-win_amd64.pyd`` (on a
-     Windows 64-bit install) and many, many more.
-   * All modules in ``gevent``, such as ``gevent.threadpool``,
-     ``gevent._semaphore``, and many, many more.
-   * All requirements. ``pip show gevent`` gives ``Requires: cffi, greenlet``.
-     Therefore, the ``cffi`` and ``greenlet`` modules are included.
-
-``collect_submodules( 'package-name', pattern=None )``:
-   Returns a list of strings that specify all the modules in a package,
-   ready to be assigned to the ``hiddenimports`` global.
-   Returns an empty list when ``package`` does not name a package
-   (a package is defined as a module that contains a ``__path__`` attribute).
-
-   The ``pattern``, if given, is function to filter through the submodules
-   found, selecting which should be included in the returned list. It takes one
-   argument, a string, which gives the name of a submodule. Only if the
-   function returns true is the given submodule is added to the list of
-   returned modules. For example, ``filter=lambda name: 'test' not in
-   name`` will return modules that don't contain the word ``test``.
-
-``is_module_or_submodule( name, mod_or_submod )``:
-   This helper function is designed for use in the ``filter`` argument of
-   ``collect_submodules``, by returning ``True`` if the given ``name`` is
-   a module or a submodule of ``mod_or_submod``. For example:
-   ``collect_submodules('foo', lambda name: not is_module_or_submodule(name,
-   'foo.test'))`` excludes ``foo.test`` and ``foo.test.one`` but not
-   ``foo.testifier``.
-
-``collect_data_files( package, include_py_files=False, subdir=None, excludes=None, includes=None )``:
-    This routine produces a list of ``(source, dest)`` non-Python (i.e. data)
-    files which reside in ``package``. Its results can be directly assigned to
-    ``datas`` in a hook script; see, for example, ``hook-sphinx.py``.
-    Parameters:
-
-    -   The ``package`` parameter is a string which names the package.
-    -   By default, all Python executable files (those ending in ``.py``,
-        ``.pyc``, and so on) will NOT be collected; setting the
-        ``include_py_files`` argument to ``True`` collects these files as well.
-        This is typically used with Python routines (such as those in
-        ``pkgutil``) that search a given directory for Python executable files
-        then load them as extensions or plugins.
-    -   The ``subdir`` argument gives a subdirectory relative to ``package`` to
-        search, which is helpful when submodules are imported at run-time from a
-        directory lacking ``__init__.py``.
-    -   The ``excludes`` argument contains a sequence of strings or Paths. These
-        provide a list of `globs <https://docs.python.org/3/library/pathlib.html#pathlib.Path.glob>`_
-        to exclude from the collected data files; if a directory matches the
-        provided glob, all files it contains will be excluded as well. All
-        elements must be relative paths, which are relative to the provided
-        package's path (/ ``subdir`` if provided).
-
-        Therefore, ``*.txt`` will exclude only ``.txt`` files in ``package``\ 's
-        path, while ``**/*.txt`` will exclude all ``.txt`` files in
-        ``package``\ 's path and all its subdirectories. Likewise,
-        ``**/__pycache__`` will exclude all files contained in any subdirectory
-        named ``__pycache__``.
-    -   The ``includes`` function like ``excludes``, but only include matching
-        paths. ``excludes`` override ``includes``: a file or directory in both
-        lists will be excluded.
-
-    This function does not work on zipped Python eggs.
-
-``collect_dynamic_libs( 'module-name' )``:
-   Returns a list of (source, dest) tuples for all the dynamic libs
-   present in a module directory.
-   The list is ready to be assigned to the ``binaries`` global variable.
-   The function uses ``os.walk()`` to examine all files in the
-   module directory recursively.
-   The name of each file found is tested against the likely patterns for
-   a dynamic lib: ``*.dll``, ``*.dylib``, ``lib*.pyd``, and ``lib*.so``.
-   Example::
-
-      binaries = collect_dynamic_libs( 'enchant' )
-
-``get_module_file_attribute( 'module-name' )``:
-   Return the absolute path to *module-name*, a fully-qualified module name.
-   Example::
-
-      nacl_dir = os.path.dirname(get_module_file_attribute('nacl'))
-
-``get_package_paths( 'package-name' )``:
-   Given the name of a package, return a tuple.
-   The first element is the absolute path to the folder where the package is stored.
-   The second element is the absolute path to the named package.
-   For example, if ``pkg.subpkg`` is stored in ``/abs/Python/lib``
-   the result of::
-
-      get_package_paths( 'pkg.subpkg' )
-
-   is the tuple, ``( '/abs/Python/lib', '/abs/Python/lib/pkg/subpkg' )``
-
+.. autofunction:: exec_statement
+.. autofunction:: eval_statement
+.. autofunction:: is_module_satisfies
+.. autofunction:: collect_all
+.. autofunction:: collect_submodules
+.. autofunction:: is_module_or_submodule
+.. autofunction:: collect_data_files
+.. autofunction:: collect_dynamic_libs
+.. autofunction:: get_module_file_attribute
+.. autofunction:: get_package_paths
 .. autofunction:: copy_metadata
-
-.. autofunction:: PyInstaller.utils.hooks.collect_entry_point
-
-``get_homebrew_path( formula='' )``:
-   Return the homebrew path to the named formula, or to the
-   global prefix when formula is omitted. Returns None if
-   not found.
-
-
-``django_find_root_dir()``:
-   Return the path to the top-level Python package containing
-   the Django files, or None if nothing can be found.
-
-``django_dottedstring_imports( 'django-root-dir' )``:
-   Return a list of all necessary Django modules specified in
-   the Django settings.py file, such as the
-   ``Django.settings.INSTALLED_APPS`` list and many others.
+.. autofunction:: collect_entry_point
+.. autofunction:: get_homebrew_path
 
 
 Support for Conda
@@ -574,7 +427,8 @@ Or, it can simply set values in the four global variables, because
 these will be examined after ``hook()`` returns.
 
 Hooks may access the user parameters, given in the ``hooksconfig`` argument in
-the spec file, by calling :func:`get_hook_config()` inside a `hook()` function.
+the spec file, by calling :func:`~PyInstaller.utils.hooks.get_hook_config`
+inside a `hook()` function.
 
 .. autofunction:: PyInstaller.utils.hooks.get_hook_config
 

--- a/doc/hooks.rst
+++ b/doc/hooks.rst
@@ -67,7 +67,7 @@ Examples of these actions are shown below.
 When the module that needs these hidden imports is useful only to your project,
 store the hook file(s) somewhere near your source file.
 Then specify their location to the ``pyinstaller`` or ``pyi-makespec``
-command with the ``--additional-hooks-dir=`` option.
+command with the :option:`--additional-hooks-dir` option.
 If the hook file(s) are at the same level as the script,
 the command could be simply::
 
@@ -116,7 +116,7 @@ might catch up with these changes.
 If both PyInstaller and your package provide hooks for some module,
 your package's hooks take precedence,
 but can still be overridden by the command line option
-``--additional-hooks-dir``.
+:option:`--additional-hooks-dir`.
 
 
 You can tell PyInstaller about the additional hooks
@@ -139,7 +139,7 @@ This defines two entry-points:
    It must return a sequence of strings,
    each element of which provides an additional absolute path
    to search for hooks.
-   This is equivalent to passing the ``--additional-hooks-dir``
+   This is equivalent to passing the :option:`--additional-hooks-dir`
    command-line option to PyInstaller for each string in the sequence.
 
    In this example, the function is ``get_hook_dirs() -> List[str]``.
@@ -179,7 +179,7 @@ applies them to the bundle being created.
 ``hiddenimports``
     A list of module names (relative or absolute) that should
     be part of the bundled app.
-    This has the same effect as the ``--hidden-import`` command line option,
+    This has the same effect as the :option:`--hidden-import` command line option,
     but it can contain a list of names and is applied automatically
     only when the hooked module is imported.
     Example::
@@ -442,7 +442,7 @@ by Analysis, before it has located the path to that module or package
 
 Hooks of this type are only recognized if they are stored in
 a sub-folder named ``pre_find_module_path`` in a hooks folder,
-either in the distributed hooks folder or an ``--additional-hooks-dir`` folder.
+either in the distributed hooks folder or an :option:`--additional-hooks-dir` folder.
 You may have normal hooks as well as hooks of this type for the same module.
 For example |PyInstaller| includes both a ``hooks/hook-distutils.py``
 and also a ``hooks/pre_find_module_path/hook-distutils.py``.
@@ -487,7 +487,7 @@ However, if there are normal hooks for these names, they will be called.
 
 Hooks of this type are only recognized if they are stored in a sub-folder
 named ``pre_safe_import_module`` in a hooks folder,
-either in the distributed hooks folder or an ``--additional-hooks-dir`` folder.
+either in the distributed hooks folder or an :option:`--additional-hooks-dir` folder.
 (See the distributed ``hooks/pre_safe_import_module`` folder for examples.)
 
 You may have normal hooks as well as hooks of this type for the same module.

--- a/doc/make.bat
+++ b/doc/make.bat
@@ -6,7 +6,7 @@ if "%SPHINXBUILD%" == "" (
 	set SPHINXBUILD=sphinx-build
 )
 set BUILDDIR=_build
-set ALLSPHINXOPTS=-d %BUILDDIR%/doctrees %SPHINXOPTS% .
+set ALLSPHINXOPTS=-n -d %BUILDDIR%/doctrees %SPHINXOPTS% .
 set I18NSPHINXOPTS=%SPHINXOPTS% .
 if NOT "%PAPER%" == "" (
 	set ALLSPHINXOPTS=-D latex_paper_size=%PAPER% %ALLSPHINXOPTS%

--- a/doc/man/pyi-makespec.rst
+++ b/doc/man/pyi-makespec.rst
@@ -25,7 +25,7 @@ files that cover basic usages::
 
 By default, ``pyi-makespec`` generates a spec file that tells
 |PyInstaller| to create a distribution directory contains the main
-executable and the dynamic libraries. The option ``--onefile``
+executable and the dynamic libraries. The option :option:`--onefile`
 specifies that you want PyInstaller to build a single file with
 everything inside.
 

--- a/doc/operating-mode.rst
+++ b/doc/operating-mode.rst
@@ -220,7 +220,7 @@ to mount the ``/tmp`` folder with a "no-execution" option.
 That option is not compatible with a |PyInstaller|
 one-file bundle. It needs to execute code out of :file:`/tmp`.
 If you know the target environment,
-``--runtime-tmpdir`` might be a workaround.)
+:option:`--runtime-tmpdir` might be a workaround.)
 
 Because the program makes a temporary folder with a unique name,
 you can run multiple copies of the app;
@@ -235,7 +235,7 @@ Thus if your app crashes frequently, your users will lose disk space to
 multiple :file:`_MEI{xxxxxx}` temporary folders.
 
 It is possible to control the location of the :file:`_MEI{xxxxxx}` folder by
-using the ``--runtime-tmpdir`` command line option. The specified path is
+using the :option:`--runtime-tmpdir` command line option. The specified path is
 stored in the executable, and the bootloader will create the
 :file:`_MEI{xxxxxx}` folder inside of the specified folder. Please see
 :ref:`defining the extraction location` for details.

--- a/doc/operating-mode.rst
+++ b/doc/operating-mode.rst
@@ -68,9 +68,9 @@ and other major packages.
 For a complete list, see `Supported Packages`_.
 
 Some Python scripts import modules in ways that |PyInstaller| cannot detect:
-for example, by using the ``__import__()`` function with variable data,
-using ``imp.find_module()``,
-or manipulating the ``sys.path`` value at run time.
+for example, by using the :func:`__import__` function with variable data,
+using :func:`importlib.import_module`,
+or manipulating the :data:`sys.path` value at run time.
 If your script requires files that |PyInstaller| does not know about,
 you must help it:
 

--- a/doc/runtime-information.rst
+++ b/doc/runtime-information.rst
@@ -122,7 +122,8 @@ If ``__file__`` is checked from inside a package or library (say
     PyInstaller --add-data=/path/to/my_library/file.dat:./my_library
 
 However, in this case it is much easier to switch to :ref:`the spec file
-<Using Spec Files>` and use the :meth:`collect_data_files` helper function::
+<Using Spec Files>` and use the
+:func:`PyInstaller.utils.hooks.collect_data_files` helper function::
 
     from PyInstaller.utils.hooks import collect_data_files
 

--- a/doc/runtime-information.rst
+++ b/doc/runtime-information.rst
@@ -93,7 +93,8 @@ Placing data files at expected locations inside the bundle
 
 To place the data-files where your code expects them to be (i.e., relative
 to the main script or bundle directory), you can use the **dest** parameter
-of the ``--add-data=source:dest`` command-line switches. Assuming you normally
+of the :option:`--add-data=source:dest <--add-data>` command-line switches.
+Assuming you normally
 use the following code in a file named ``my_script.py`` to locate a file
 ``file.dat`` in the same folder::
 
@@ -117,7 +118,7 @@ It will be found correctly at runtime without changing ``my_script.py``.
 
 If ``__file__`` is checked from inside a package or library (say
 ``my_library.data``) then ``__file__`` will be
-``[app root]/my_library/data.pyc`` and ``--add-data`` should mirror that::
+``[app root]/my_library/data.pyc`` and :option:`--add-data` should mirror that::
 
     PyInstaller --add-data=/path/to/my_library/file.dat:./my_library
 

--- a/doc/spec-files.rst
+++ b/doc/spec-files.rst
@@ -163,7 +163,7 @@ you could modify the spec file as follows::
              )
 
 And the command line equivalent (see
-:ref:`options-group What to bundle, where to search`
+:ref:`What To Bundle, Where To Search`
 for platform-specific details)::
 
 	pyinstaller --add-data 'src/README.txt:.' myscript.py
@@ -296,7 +296,7 @@ You could add it to the bundle this way::
              ...
 
 Or via the command line (again, see
-:ref:`options-group What to bundle, where to search`
+:ref:`What To Bundle, Where To Search`
 for platform-specific details)::
 
 	pyinstaller --add-binary '/usr/lib/libiodbc.2.dylib:.' myscript.py

--- a/doc/spec-files.rst
+++ b/doc/spec-files.rst
@@ -9,7 +9,7 @@ When you execute
 
 the first thing |PyInstaller| does is to build a spec (specification) file
 :file:`myscript.spec`.
-That file is stored in the ``--specpath=`` directory,
+That file is stored in the :option:`--specpath` directory,
 by default the current directory.
 
 The spec file tells |PyInstaller| how to process your script.
@@ -54,12 +54,12 @@ replaced by the options in the spec file.
 
 Only the following command-line options have an effect when building from a spec file:
 
-* ``--upx-dir=``
-* ``--distpath=``
-* ``--workpath=``
-* ``--noconfirm``
-* ``--ascii``
-* ``--clean``
+* :option:`--upx-dir`
+* :option:`--distpath`
+* :option:`--workpath`
+* :option:`--noconfirm`
+* :option:`--ascii`
+* :option:`--clean`
 
 .. _spec-file operations:
 
@@ -98,9 +98,9 @@ The statements in a spec file create instances of four classes,
   - ``scripts``: the python scripts named on the command line;
   - ``pure``: pure python modules needed by the scripts;
   - ``binaries``: non-python modules needed by the scripts, including names 
-    given by the ``--add-binary`` option;
+    given by the :option:`--add-binary` option;
   - ``datas``: non-binary files included in the app, including names given 
-    by the ``--add-data`` option.
+    by the :option:`--add-data` option.
 
 * An instance of class ``PYZ`` is a ``.pyz`` archive (described
   under :ref:`Inspecting Archives` below), which contains all the
@@ -141,7 +141,7 @@ In either case, to find the data files at run-time, see :ref:`Run-time Informati
 Adding Data Files
 ------------------
 
-You can add data files to the bundle by using the ``--add-data`` command option, or by 
+You can add data files to the bundle by using the :option:`--add-data` command option, or by
 adding them as a list to the spec file.
 
 When using the spec file, provide a list that
@@ -264,7 +264,7 @@ Adding Binary Files
    `binary` dependencies. Files like images and PDFs should go into the
    ``datas``.
 
-You can add binary files to the bundle by using the ``--add-binary`` command option, 
+You can add binary files to the bundle by using the :option:`--add-binary` command option,
 or by adding them as a list to the spec file.
 In the spec file, make a list of tuples that describe the files needed.
 Assign the list of tuples to the ``binaries=`` argument of Analysis.
@@ -280,7 +280,7 @@ Adding binary files works in a similar way as adding data files. As described in
 Normally |PyInstaller| learns about ``.so`` and ``.dll`` libraries by
 analyzing the imported modules.
 Sometimes it is not clear that a module is imported;
-in that case you use a ``--hidden-import=`` command option.
+in that case you use a :option:`--hidden-import` command option.
 But even that might not find all dependencies.
 
 Suppose you have a module ``special_ops.so`` that is written in C
@@ -370,7 +370,8 @@ Spec File Options for a Mac OS X Bundle
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When you build a windowed Mac OS X app
-(that is, running in Mac OS X, you specify the ``--onefile --windowed`` options),
+(that is, running in Mac OS X, you specify the :option:`--onefile`
+:option:`--windowed` options),
 the spec file contains an additional statement to
 create the Mac OS X application bundle, or app folder::
 
@@ -380,9 +381,9 @@ create the Mac OS X application bundle, or app folder::
              bundle_identifier=None)
 
 The ``icon=`` argument to ``BUNDLE`` will have the path to an icon file
-that you specify using the ``--icon=`` option.
+that you specify using the :option:`--icon` option.
 The ``bundle_identifier`` will have the value you specify with the
-``--osx-bundle-identifier=`` option.
+:option:`--osx-bundle-identifier` option.
 
 An :file:`Info.plist` file is an important part of a Mac OS X app bundle.
 (See the `Apple bundle overview`_ for a discussion of the contents
@@ -437,7 +438,8 @@ The :mod:`Splash` Target
 
 For a splash screen to be displayed by the bootloader, the :mod:`Splash` target must be called
 at build time. This class can be added when the spec file is created with the command-line
-option ``--splash IMAGE_FILE``. By default, the option to display the optional text is disabled
+option :option:`--splash IMAGE_FILE <--splash>`. By default, the option to
+display the optional text is disabled
 (``text_pos=None``). For more information about the splash screen, see :ref:`splash screen`
 section. The :mod:`Splash` Target looks like this::
 
@@ -649,7 +651,7 @@ Other globals contain information about the build environment:
 	The relative path to the :file:`dist` folder where
 	the application will be stored.
 	The default path is relative to the current directory.
-	If the ``--distpath=`` option is used, ``DISTPATH`` contains that value.
+	If the :option:`--distpath` option is used, ``DISTPATH`` contains that value.
 
 ``HOMEPATH``
 	The absolute path to the |PyInstaller|

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -652,7 +652,7 @@ before your code has started executing.
 The |bootloader| gets the names of opened documents from
 the OpenDocument event and encodes them into the ``argv``
 string before starting your code.
-Thus your code can query ``sys.argv`` to get the names
+Thus your code can query :data:`sys.argv` to get the names
 of documents that should be opened at startup.
 
 OpenDocument is the only AppleEvent the |bootloader| handles.

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -187,9 +187,9 @@ been UPX-compressed, the full execution sequence is:
 * The Python interpreter executes your script.
 
 |PyInstaller| looks for UPX on the execution path
-or the path specified with the ``--upx-dir`` option.
+or the path specified with the :option:`--upx-dir` option.
 If UPX exists, |PyInstaller| applies it to the final executable,
-unless the ``--noupx`` option was given.
+unless the :option:`--noupx` option was given.
 UPX has been used with |PyInstaller| output often, usually with no problems.
 
 
@@ -199,7 +199,7 @@ Encrypting Python Bytecode
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To encrypt the Python bytecode modules stored in the bundle,
-pass the ``--key=``\ *key-string*  argument on
+pass the :option:`--key`\ =\ *key-string*  argument on
 the command line.
 
 For this to work, you need to run::
@@ -287,7 +287,7 @@ Defining the Extraction Location
 In rare cases, when you bundle to a single executable
 (see :ref:`Bundling to One File` and :ref:`how the one-file program works`),
 you may want to control the location of the temporary directory at compile
-time. This can be done using the ``--runtime-tmpdir`` option. If this option is
+time. This can be done using the :option:`--runtime-tmpdir` option. If this option is
 given, the bootloader will ignore any temp-folder location defined by the
 run-time OS. Please use this option only if you know what you are doing.
 
@@ -413,7 +413,7 @@ The version text file is encoded UTF-8 and may contain non-ASCII characters.
 Be sure to edit and save the text file in UTF-8 unless you are
 certain it contains only ASCII string values.
 
-Your edited version text file can be given with the ``--version-file=``
+Your edited version text file can be given with the :option:`--version-file`
 option to ``pyinstaller`` or ``pyi-makespec``.
 The text data is converted to a Version resource and
 installed in the bundled app.
@@ -459,14 +459,14 @@ Building Mac OS X App Bundles
 
 Under Mac OS X, |PyInstaller| always builds a UNIX executable in
 :file:`dist`.
-If you specify ``--onedir``, the output is a folder named :file:`myscript`
+If you specify :option:`--onedir`, the output is a folder named :file:`myscript`
 containing supporting files and an executable named :file:`myscript`.
-If you specify ``--onefile``, the output is a single UNIX executable
+If you specify :option:`--onefile`, the output is a single UNIX executable
 named :file:`myscript`.
 Either executable can be started from a Terminal command line.
 Standard input and output work as normal through that Terminal window.
 
-If you specify ``--windowed`` with either option, the ``dist`` folder
+If you specify :option:`--windowed` with either option, the ``dist`` folder
 also contains an OS X application named :file:`myscript.app`.
 
 As you probably know, an application is a special type of folder.
@@ -477,14 +477,14 @@ The one built by |PyInstaller| contains a folder always named
   + A folder :file:`Resources` that contains an icon file.
   + A file :file:`Info.plist` that describes the app.
   + A folder :file:`MacOS` that contains the the executable and
-    supporting files, just as in the ``--onedir`` folder.
+    supporting files, just as in the :option:`--onedir` folder.
 
-Use the ``icon=`` argument to specify a custom icon for the application.
+Use the :option:`--icon` argument to specify a custom icon for the application.
 It will be copied into the :file:`Resources` folder.
 (If you do not specify an icon file, |PyInstaller| supplies a
 file :file:`icon-windowed.icns` with the |PyInstaller| logo.)
 
-Use the ``osx-bundle-identifier=`` argument to add a bundle identifier.
+Use the :option:`--osx-bundle-identifier` argument to add a bundle identifier.
 This becomes the ``CFBundleIdentifier`` used in code-signing
 (see the `PyInstaller code signing recipe`_
 and for more detail, the `Apple code signing overview`_ technical note).

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -58,11 +58,9 @@ or, on Windows,
 Options
 ~~~~~~~~~~~~~~~
 
-General Options
-------------------
+A full list of the ``pyinstaller`` command's options are as follows:
 
 .. include:: _pyinstaller-options.tmp
-
 
 
 Shortening the Command

--- a/doc/when-things-go-wrong.rst
+++ b/doc/when-things-go-wrong.rst
@@ -45,7 +45,7 @@ Build-time Messages
 --------------------
 
 When the ``Analysis`` step runs, it produces error and warning messages.
-These display after the command line if the ``--log-level`` option allows it.
+These display after the command line if the :option:`--log-level` option allows it.
 Analysis also puts messages in a warnings file
 named :file:`build/{name}/warn-{name}.txt` in the
 ``work-path=`` directory.
@@ -87,7 +87,7 @@ You can open it in any web browser.
 Find a module name, then keep clicking the "imported by" links
 until you find the top-level import that causes that module to be included.
 
-If you specify ``--log-level=DEBUG`` to the ``pyinstaller`` command,
+If you specify :option:`--log-level=DEBUG <--log-level>` to the ``pyinstaller`` command,
 |PyInstaller| additionally generates a GraphViz_ input file representing the
 dependency graph.
 The file is :file:`build/{name}/graph-{name}.dot` in the
@@ -134,14 +134,14 @@ try setting the correct path in the environment variable
 Getting Debug Messages
 ----------------------
 
-The ``--debug=all`` option (and its :ref:`choices <What To Generate>`) provides a
-signficiant amount of diagnostic information.
+The :option:`--debug=all <--debug>` option (and its :ref:`choices <What To
+Generate>`) provides a significant amount of diagnostic information.
 This can be useful during development of a complex package,
 or when your app doesn't seem to be starting,
 or just to learn how the runtime works.
 
 Normally the debug progress messages go to standard output.
-If the ``--windowed`` option is used when bundling a Windows app,
+If the :option:`--windowed` option is used when bundling a Windows app,
 they are sent to any attached debugger. If you are not using a debugger
 (or don't have one), the DebugView_ the free (beer) tool can be used to
 display such messages. It has to be started before running the bundled
@@ -149,9 +149,9 @@ application.
 
 .. _DebugView: https://docs.microsoft.com/en-us/sysinternals/downloads/debugview
 
-For a ``--windowed`` Mac OS app they are not displayed.
+For a :option:`--windowed` Mac OS app they are not displayed.
 
-Consider bundling without ``--debug`` for your production version.
+Consider bundling without :option:`--debug` for your production version.
 Debugging messages require system calls and have an impact on performance.
 
 
@@ -160,9 +160,9 @@ Debugging messages require system calls and have an impact on performance.
 Getting Python's Verbose Imports
 --------------------------------
 
-You can build the app with the ``--debug=imports`` option
+You can build the app with the :option:`--debug=imports<--debug>` option
 (see `Getting Debug Messages`_ above),
-which will pass the ``-v`` (verbose imports) flag
+which will pass the :option:`-v` (verbose imports) flag
 to the embedded Python interpreter.
 This can be extremely useful.
 It can be informative even with apps that are apparently working,
@@ -170,14 +170,14 @@ to make sure that they are getting all imports from the bundle,
 and not leaking out to the local installed Python.
 
 Python verbose and warning messages always go to standard output
-and are not visible when the ``--windowed`` option is used.
+and are not visible when the :option:`--windowed` option is used.
 Remember to not use this for your production version.
 
 
 Figuring Out Why Your GUI Application Won't Start
 ---------------------------------------------------
 
-If you are using the ``--windowed`` option,
+If you are using the :option:`--windowed` option,
 your bundled application may fail to start with an error message like
 ``Failed to execute script my_gui``.
 In this case, you will want to get more verbose output to find out
@@ -188,11 +188,11 @@ what is going on.
   in `Terminal` instead of clicking on ``my_gui.app``.
 
 * For Windows, you will need to re-bundle your application without the
-  ``--windowed`` option.
+  :option:`--windowed` option.
   Then you can run the resulting executable from the command line,
   i.e.: ``my_gui.exe``.
 
-* For Unix and GNU/Linux there in no ``--windowed`` option.
+* For Unix and GNU/Linux there in no :option:`--windowed` option.
   Anyway, if a your GUI application fails,
   you can run your application on the command line,
   i.e. ``./dist/my_gui``.
@@ -229,7 +229,7 @@ Extending the Path
 
 If Analysis recognizes that a module is needed, but cannot find that module,
 it is often because the script is manipulating :data:`sys.path`.
-The easiest thing to do in this case is to use the ``--paths=`` option
+The easiest thing to do in this case is to use the :option:`--paths` option
 to list all the other places that the script might be searching for imports::
 
        pyi-makespec --paths=/path/to/thisdir \
@@ -256,12 +256,12 @@ When this occurs, Analysis can detect nothing.
 There will be no warnings, only an ImportError at run-time.
 
 To find these hidden imports,
-build the app with the ``--debug=imports`` flag
+build the app with the :option:`--debug=imports<--debug>` flag
 (see :ref:`Getting Python's Verbose Imports` above)
 and run it.
 
 Once you know what modules are needed, you add the needed modules
-to the bundle using the ``--hidden-import=`` command option,
+to the bundle using the :option:`--hidden-import` command option,
 or by editing the spec file,
 or with a hook file (see :ref:`Understanding PyInstaller Hooks` below).
 
@@ -304,7 +304,7 @@ These are small scripts that manipulate the environment before your main script 
 effectively providing additional top-level code to your script.
 
 There are two ways of providing runtime hooks.
-You can name them with the option ``--runtime-hook=``\ *path-to-script*.
+You can name them with the option :option:`--runtime-hook`\ =\ *path-to-script*.
 
 Second, some runtime hooks are provided.
 At the end of an analysis,
@@ -318,8 +318,8 @@ and will be called before your main script starts.
 
 Hooks you name with the option are executed
 in the order given, and before any installed runtime hooks.
-If you specify  ``--runtime-hook=file1.py --runtime-hook=file2.py``
-then the execution order at runtime will be:
+If you specify  :option:`--runtime-hook=file1.py --runtime-hook=file2.py
+<--runtime-hook>` then the execution order at runtime will be:
 
 1. Code of :file:`file1.py`.
 2. Code of :file:`file2.py`.

--- a/doc/when-things-go-wrong.rst
+++ b/doc/when-things-go-wrong.rst
@@ -134,7 +134,7 @@ try setting the correct path in the environment variable
 Getting Debug Messages
 ----------------------
 
-The ``--debug=all`` option (and its :ref:`choices <pyinstaller how to generate>`) provides a
+The ``--debug=all`` option (and its :ref:`choices <What To Generate>`) provides a
 signficiant amount of diagnostic information.
 This can be useful during development of a complex package,
 or when your app doesn't seem to be starting,

--- a/doc/when-things-go-wrong.rst
+++ b/doc/when-things-go-wrong.rst
@@ -228,7 +228,7 @@ Extending the Path
 ------------------
 
 If Analysis recognizes that a module is needed, but cannot find that module,
-it is often because the script is manipulating ``sys.path``.
+it is often because the script is manipulating :data:`sys.path`.
 The easiest thing to do in this case is to use the ``--paths=`` option
 to list all the other places that the script might be searching for imports::
 
@@ -236,7 +236,7 @@ to list all the other places that the script might be searching for imports::
                     --paths=/path/to/otherdir myscript.py
 
 These paths will be noted in the spec file.
-They will be added to the current ``sys.path`` during analysis.
+They will be added to the current :data:`sys.path` during analysis.
 
 
 Listing Hidden Imports
@@ -247,9 +247,9 @@ but the app fails with an import error,
 the problem is a hidden import; that is, an import that is not
 visible to the analysis phase.
 
-Hidden imports can occur when the code is using ``__import__``,
-``imp.find_module()``
-or perhaps ``exec`` or ``eval``.
+Hidden imports can occur when the code is using :func:`__import__`,
+:func:`importlib.import_module`
+or perhaps :func:`exec` or :func:`eval`.
 Hidden imports can also occur when an extension module uses the
 Python/C API to do an import.
 When this occurs, Analysis can detect nothing.
@@ -266,21 +266,21 @@ or by editing the spec file,
 or with a hook file (see :ref:`Understanding PyInstaller Hooks` below).
 
 
-Extending a Package's ``__path__``
-----------------------------------
+Extending a Package's :attr:`__path__`
+----------------------------------------------
 
 Python allows a script to extend the search path used for imports
-through the ``__path__`` mechanism.
-Normally, the ``__path__`` of an imported module has only one entry,
+through the :attr:`__path__` mechanism.
+Normally, the :attr:`__path__` of an imported module has only one entry,
 the directory in which the ``__init__.py`` was found.
-But ``__init__.py`` is free to extend its ``__path__`` to include other directories.
+But ``__init__.py`` is free to extend its :attr:`__path__` to include other directories.
 For example, the ``win32com.shell.shell`` module actually resolves to
 ``win32com/win32comext/shell/shell.pyd``.
-This is because ``win32com/__init__.py`` appends ``../win32comext`` to its ``__path__``.
+This is because ``win32com/__init__.py`` appends ``../win32comext`` to its :attr:`__path__`.
 
 Because the ``__init__.py`` of an imported module
 is not actually executed during analysis,
-changes it makes to ``__path__`` are not seen by |PyInstaller|.
+changes it makes to :attr:`__path__` are not seen by |PyInstaller|.
 We fix the problem with the same hook mechanism we use for hidden imports,
 with some additional logic; see :ref:`Understanding PyInstaller Hooks` below.
 


### PR DESCRIPTION
An assortment of doc refactorings to better leverage `sphinx.ext.autodoc` and `sphinx.ext.intersphinx`.

- Use autodoc throughout `PyInstaller.utils.hooks`and `PyInstaller.compat` so that:
  - We don't have to maintain doctrings and website docs.
  - Each function/class/variable has a both a unique url target such as [hooks.html#PyInstaller.utils.hooks.collect_submodules](http://pyinstaller.readthedocs.io/hooks.html#PyInstaller.utils.hooks.collect_submodules) and a unique rst target ``:func:`PyInstaller.utils,hooks.collect_submodules` ``.
- Replace ``` ``xyz()`` ``` with ``:func:`xyz` `` for standard library functions where possible. This turns them into links to Python's own documentation.
- Make each CLI option a reference-able and promote plain literal options ``` ``--hiddenimport`` ``` to fancy hyperlinked ones.

I'd also quite do something similar to hook globals but that can wait for another PR (and another dose of motivation).

Closes #5459.