### PR TITLE
depend/utils: fix regression in ctypes.util.find_library scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Install apt packages
         if: startsWith(matrix.os, 'ubuntu')
         run: |
+          sudo apt-get update -qq
           sudo apt-get install -qq \
             libxml2-dev libxslt1-dev gfortran libatlas-base-dev \
             libespeak1 libxcb-image0 libxcb-keysyms1 libxcb-render-util0 \

--- a/tests/functional/test_import.py
+++ b/tests/functional/test_import.py
@@ -301,16 +301,15 @@ _template_ctypes_CDLL_find_library = """
         print('>>> file found')
     """
 
-# Ghostscript's libgs.so should be available in may Unix/Linux systems
-#
+
 # At least on Linux, we can not use our own `ctypes_dylib` because
 # `find_library` does not consult LD_LIBRARY_PATH and hence does not
-# find our lib. Anyway, this test tests the path of the loaded lib and
-# thus checks if libgs.so is included into the frozen exe.
+# find our lib. This tests verifies the path of the loaded library and
+# thus checks if the library is collected into the frozen application.
 # TODO: Check how this behaves on other platforms.
-@skip_if_lib_missing('gs', 'libgs.so (Ghostscript)')
-def test_ctypes_CDLL_find_library__gs(pyi_builder):
-    libname = 'gs'
+@skip_if_lib_missing('png', 'libpng.so (Ghostscript)')
+def test_ctypes_CDLL_find_library__png(pyi_builder):
+    libname = 'png'
     pyi_builder.test_source(_template_ctypes_CDLL_find_library % locals())
 
 


### PR DESCRIPTION
 Fix regression in names of binaries obtained from scanning for uses of `ctypes.util.find_library`, introduced by the `ctypes` scanning code refactoring (416f42b). 

The new code does not account for the fact that the input to `ctypes.util.find_library()` is library "base" name (i.e., without "lib" prefix and without suffix), and therefore obtained name needs to be resolved.