### PR TITLE
tests: appimage: fix check for appimagetool

### DIFF
--- a/tests/functional/test_linux_appimage.py
+++ b/tests/functional/test_linux_appimage.py
@@ -27,7 +27,7 @@ import pytest
 def test_appimage_loading(tmp_path, pyi_builder_spec, arch):
     # Skip the test if appimagetool is not found
     appimagetool = pathlib.Path.home() / ('appimagetool-%s.AppImage' % arch)
-    if appimagetool.is_file():
+    if not appimagetool.is_file():
         pytest.skip('%s not found' % appimagetool)
 
     # Ensure appimagetool is executable


### PR DESCRIPTION
Fix the check for `appimagetool` in `test_appimage_loading`; due to missing negation, the test currently fails if `appimagetool`
is not installed, and is skipped if it is installed.