### PR TITLE
Add support for pkgutil.iter_modules

### DIFF
--- a/PyInstaller/hooks/rthooks.dat
+++ b/PyInstaller/hooks/rthooks.dat
@@ -11,6 +11,7 @@
     'kivy':       ['pyi_rth_kivy.py'],
     'kivy.lib.gstplayer': ['pyi_rth_gstreamer.py'],
     'matplotlib': ['pyi_rth_mplconfig.py'],
+    'pkgutil': ['pyi_rth_pkgutil.py'],
     'pkg_resources':  ['pyi_rth_pkgres.py'],
     'PyQt5':      ['pyi_rth_pyqt5.py'],
     'PyQt5.QtWebEngineWidgets': ['pyi_rth_pyqt5webengine.py'],

--- a/PyInstaller/hooks/rthooks/pyi_rth_pkgutil.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_pkgutil.py
@@ -1,0 +1,91 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2021, PyInstaller Development Team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: Apache-2.0
+#-----------------------------------------------------------------------------
+#
+# This rthook overrides pkgutil.iter_modules with custom implementation
+# that uses PyInstaller's FrozenImporter to list sub-modules embedded
+# in the PYZ archive. The non-embedded modules (binary extensions, or
+# .pyc modules in noarchive build) are handled by original pkgutil
+# iter_modules implementation (and consequently, python's FileFinder).
+#
+# The preferred way of adding support for iter_modules would be adding
+# non-standard iter_modules() method to FrozenImporter itself. However,
+# that seems to work only for path entry finders (for use with sys.path_hooks),
+# while PyInstaller's FrozenImporter is registered as meta path finders
+# (for use with sys.meta_path). Turning FrozenImporter into path entry
+# finder, would seemingly require the latter to support on-filesystem
+# resources (e.g., extension modules) in addition to PYZ-embedded ones.
+#
+# Therefore, we instead opt for overriding pkgutil.iter_modules with
+# custom implementation that augments the output of original
+# implementation with contents of PYZ archive from FrozenImporter's TOC.
+
+
+import os
+import sys
+
+import pkgutil
+
+from pyimod03_importers import FrozenImporter
+
+
+SYS_PREFIX = sys._MEIPASS + os.path.sep
+SYS_PREFIXLEN = len(SYS_PREFIX)
+
+
+_orig_pkgutil_iter_modules = pkgutil.iter_modules
+
+
+def _pyi_pkgutil_iter_modules(path=None, prefix=''):
+    # Use original implementation to discover on-filesystem
+    # modules (binary extensions in regular builds, or both binary
+    # extensions and compiled pyc modules in noarchive debug builds)
+    yield from _orig_pkgutil_iter_modules(path, prefix)
+
+    # Find the instance of PyInstaller's FrozenImporter
+    for importer in pkgutil.iter_importers():
+        if isinstance(importer, FrozenImporter):
+            break
+    else:
+        return
+
+    if not path:
+        # Search for all top-level packages/modules. These will have
+        # no dots in their entry names
+        for entry in importer.toc:
+            if entry.count('.') != 0:
+                continue
+            is_pkg = importer.is_package(entry)
+            yield pkgutil.ModuleInfo(importer, prefix + entry, is_pkg)
+    else:
+        # Only single path is supported, and it must start with
+        # sys._MEIPASS
+        pkg_path = os.path.normpath(path[0])
+        assert pkg_path.startswith(SYS_PREFIX)
+        # Construct package prefix from path...
+        pkg_prefix = pkg_path[SYS_PREFIXLEN:]
+        pkg_prefix = pkg_prefix.replace(os.path.sep, '.')
+        # ... and ensure it ends with a dot (so we can directly filter
+        # out the package itself)
+        if not pkg_prefix.endswith('.'):
+            pkg_prefix += '.'
+        pkg_prefix_len = len(pkg_prefix)
+
+        for entry in importer.toc:
+            if not entry.startswith(pkg_prefix):
+                continue
+            name = entry[pkg_prefix_len:]
+            if name.count('.') != 0:
+                continue
+            is_pkg = importer.is_package(entry)
+            yield pkgutil.ModuleInfo(importer, prefix + name, is_pkg)
+
+
+pkgutil.iter_modules = _pyi_pkgutil_iter_modules

--- a/news/1905.feature.rst
+++ b/news/1905.feature.rst
@@ -1,0 +1,1 @@
+Implement support for :func:`pkgutil.iter_modules`.

--- a/tests/functional/scripts/pyi_pkgutil_iter_modules.py
+++ b/tests/functional/scripts/pyi_pkgutil_iter_modules.py
@@ -1,0 +1,40 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2021, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+
+import sys
+import argparse
+import pkgutil
+import importlib
+
+# Argument parser
+parser = argparse.ArgumentParser(description="pkgutil iter_modules test")
+parser.add_argument('package', type=str, help="Package to test.")
+parser.add_argument('--prefix', type=str, default='',
+                    help="Optional prefix to pass to iter_modules.")
+parser.add_argument('--output-file', default=None, type=str,
+                    help="Output file.")
+args = parser.parse_args()
+
+# Output file (optional)
+if args.output_file:
+    fp = open(args.output_file, 'w')
+else:
+    fp = sys.stdout
+
+# Iterate over package's module
+package = importlib.import_module(args.package)
+for module in pkgutil.iter_modules(package.__path__, args.prefix):
+    print("%s;%d" % (module.name, module.ispkg), file=fp)
+
+# Cleanup
+if args.output_file:
+    fp.close()

--- a/tests/functional/test_pkgutil.py
+++ b/tests/functional/test_pkgutil.py
@@ -1,0 +1,93 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2021, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+#
+# Tests for pkgutil.iter_modules(). The test attempts to list contents
+# of a package in both unfrozen and frozen version, and compares the
+# obtained lists.
+#
+# We test two packages; altgraph (pure-python) and psutil (contains
+# binary extensions). The extensions are present on filesystem as-is,
+# and are therefore handled by python's FileFinder. The collected .pyc
+# modules, however, are embedded in PYZ archive, and are not visible
+# to standard python's finders/loaders. The exception to that is
+# noarchive mode, where .pyc modules are not collected into archive;
+# as they are present on filesystem as-is, they are again handled
+# directly by python's FileFinder. Therefore, the test is performed
+# both in archive and in noarchive mode, to cover both cases.
+
+
+import os
+
+import pytest
+
+from PyInstaller.compat import exec_python_rc
+
+
+# Read the output file produced by test script. Each line consists of
+# two elements separated by semi-colon: name;ispackage
+def _read_results_file(filename):
+    output = []
+    with open(filename, 'r') as fp:
+        for line in fp:
+            tokens = line.split(';')
+            assert len(tokens) == 2
+            output.append((tokens[0], int(tokens[1])))
+    # Sort the results, so we can compare them
+    return sorted(output)
+
+
+@pytest.mark.parametrize('package', [
+    'altgraph',  # pure python package
+    'psutil',  # package with extensions
+    'psutil.tests',  # sub-package
+])
+@pytest.mark.parametrize('archive', ['archive', 'noarchive'])
+def test_pkgutil_iter_modules(package, script_dir, tmpdir, pyi_builder,
+                              archive):
+    # Ensure package is available
+    pytest.importorskip(package)
+
+    # Full path to test script
+    test_script = 'pyi_pkgutil_iter_modules.py'
+    test_script = os.path.join(script_dir, test_script)
+
+    # Run unfrozen test script
+    out_unfrozen = os.path.join(tmpdir, 'output-unfrozen.txt')
+    rc = exec_python_rc(test_script, package, '--output-file', out_unfrozen)
+    assert rc == 0
+    # Read results
+    results_unfrozen = _read_results_file(out_unfrozen)
+
+    # Run frozen script
+    out_frozen = os.path.join(tmpdir, 'output-frozen.txt')
+    debug_args = ['--debug', 'noarchive'] if archive == 'noarchive' else []
+    pyi_builder.test_script(
+        test_script,
+        pyi_args=[
+            # ensure everything is collected
+            '--collect-submodules', package,
+            # however, psutil.tests pulls in pip and wheel, which in
+            # turn manage to pull in pyinstaller.exe/__main__ and break
+            # Windows noarchive build. So exclude those explicitly.
+            '--exclude', 'pip', '--exclude', 'wheel',
+            # enable/disable noarchive
+            *debug_args,
+        ],
+        app_args=[
+            package,
+            '--output-file', out_frozen,
+        ]
+    )
+    # Read results
+    results_frozen = _read_results_file(out_frozen)
+
+    # Compare
+    assert results_unfrozen == results_frozen


### PR DESCRIPTION
Implement support for `pkgutil.iter_modules`. 

This is done by an rthook that monkey-patches the function with our implementation, which extends the contents listed by original implementation (on-filesystem resources) with PYZ-embedded resources.

Closes #1905.
Fixes #5167 (the `iter_modules` not returning anything unless `noarchive` is used; however, the modules still need to be collected by `collect_submodules` in the first place).
Fixes #5799.
