### PR TITLE
Fix inspect.getmodule() failing to resolve module from stack-frame

### DIFF
--- a/PyInstaller/hooks/rthooks.dat
+++ b/PyInstaller/hooks/rthooks.dat
@@ -7,6 +7,7 @@
     'gi.repository.Gtk':    ['pyi_rth_gtk.py'],
     'gi.repository.Gst':    ['pyi_rth_gstreamer.py'],
     'gst':        ['pyi_rth_gstreamer.py'],
+    'inspect':    ['pyi_rth_inspect.py'],
     'kivy':       ['pyi_rth_kivy.py'],
     'kivy.lib.gstplayer': ['pyi_rth_gstreamer.py'],
     'matplotlib': ['pyi_rth_mplconfig.py'],

--- a/PyInstaller/hooks/rthooks/pyi_rth_inspect.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_inspect.py
@@ -1,0 +1,51 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2021, PyInstaller Development Team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: Apache-2.0
+#-----------------------------------------------------------------------------
+
+
+import sys
+import os
+import inspect
+
+
+_orig_inspect_getsourcefile = inspect.getsourcefile
+
+
+# Provide custom implementation of inspect.getsourcefile() for frozen
+# applications that properly resolves relative filenames obtained from
+# object (e.g., inspect stack-frames). See #5963.
+def _pyi_getsourcefile(object):
+    filename = inspect.getfile(object)
+    if not os.path.isabs(filename):
+        # Check if given filename matches the basename of __main__'s
+        # __file__
+        main_file = sys.modules['__main__'].__file__
+        if filename == os.path.basename(main_file):
+            return main_file
+
+        # If filename ends with .py suffix and does not correspond to
+        # frozen entry-point script, convert it to corresponding .pyc
+        # in sys._MEIPASS
+        if filename.endswith('.py'):
+            filename = os.path.normpath(
+                os.path.join(sys._MEIPASS, filename + 'c'))
+            # Ensure the relative path did not try to jump out of
+            # sys._MEIPASS, just in case...
+            if filename.startswith(sys._MEIPASS):
+                return filename
+    elif filename.startswith(sys._MEIPASS) and filename.endswith('.pyc'):
+        # If filename is already PyInstaller-compatible, prevent any
+        # further processing (i.e., with original implementation)
+        return filename
+    # Use original implementation as a fallback
+    return _orig_inspect_getsourcefile(object)
+
+
+inspect.getsourcefile = _pyi_getsourcefile

--- a/news/5963.bugfix.rst
+++ b/news/5963.bugfix.rst
@@ -1,0 +1,2 @@
+Fix :func:`inspect.getmodule` failing to resolve module from stack-frame
+obtained via :func:`inspect.stack`.

--- a/tests/functional/modules/pyi_inspect_getmodule_from_stackframes/helper_package/__init__.py
+++ b/tests/functional/modules/pyi_inspect_getmodule_from_stackframes/helper_package/__init__.py
@@ -1,0 +1,6 @@
+from . import helper_module
+
+
+def test_call_chain():
+    # Add another level of indirection...
+    return helper_module.test_call_chain()

--- a/tests/functional/modules/pyi_inspect_getmodule_from_stackframes/helper_package/helper_module.py
+++ b/tests/functional/modules/pyi_inspect_getmodule_from_stackframes/helper_package/helper_module.py
@@ -1,0 +1,11 @@
+import inspect
+
+
+def test_call_chain():
+    modules = []
+    for idx, frame_info in enumerate(inspect.stack()):
+        #print(frame_info)
+        module = inspect.getmodule(frame_info[0])
+        assert module, f"Failed to get module for frame #{idx}: {frame_info}"
+        modules.append(module)
+    return modules

--- a/tests/functional/test_misc.py
+++ b/tests/functional/test_misc.py
@@ -1,0 +1,55 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2021, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+
+import os
+
+
+# Directory with testing modules used in some tests.
+_MODULES_DIR = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    'modules'
+)
+
+
+# Test inspect.getmodule() on stack-frames obtained by inspect.stack().
+# Reproduces the issue reported by #5963 while expanding the test to
+# cover a package and its submodule in addition to the __main__ module.
+def test_inspect_getmodule_from_stackframes(pyi_builder):
+    pathex = os.path.join(_MODULES_DIR,
+                          'pyi_inspect_getmodule_from_stackframes')
+    # NOTE: run_from_path MUST be True, otherwise cwd + rel_path coincides
+    # with sys._MEIPASS + rel_path and masks the path resolving issue
+    # in onedir builds.
+    pyi_builder.test_source(
+        """
+        import helper_package
+
+        # helper_package.test_call_chain() calls eponymous function in
+        # helper_package.helper_module, which in turn uses inspect.stack()
+        # and inspect.getmodule() to obtain list of modules involved in
+        # the chain call.
+        modules = helper_package.test_call_chain()
+
+        # Expected call chain
+        expected_module_names = [
+            'helper_package.helper_module',
+            'helper_package',
+            '__main__'
+        ]
+
+        # All modules must have been resolved
+        assert not any(module is None for module in modules)
+
+        # Verify module names
+        module_names = [module.__name__ for module in modules]
+        assert module_names == expected_module_names
+        """, pyi_args=['--paths', pathex], run_from_path=True)


### PR DESCRIPTION
Add an rthook for `inspect` and override `inspect.getsourcefile` with our own implementation that handles module paths (especially relative ones, as obtained from `inspect`'s stack frames) in PyInstaller-compatible way. 

Fixes #5963.