### PR TITLE
simplify LD_LIBRARY_PATH_ORIG processing, fixes #2892

### DIFF
--- a/bootloader/src/pyi_utils.c
+++ b/bootloader/src/pyi_utils.c
@@ -851,11 +851,15 @@ set_dynamic_library_path(const char* path)
      * that we have bundled.
      */
     orig_path = pyi_getenv(env_var);
-    if (orig_path) {
-        pyi_setenv(env_var_orig, orig_path);
-        VS("LOADER: %s=%s\n", env_var_orig, orig_path);
-    }
-    /* prepend our path to the original path, pyi_strjoin can deal with orig_path being NULL or empty string */
+    /* it is important that we ALWAYS set env_var_orig to simplify restoring env_var.
+     * empty string in env_var_orig means env_var was either not present or empty [=invalid].
+     */
+    if (!orig_path)
+        orig_path = "";
+    pyi_setenv(env_var_orig, orig_path);
+    VS("LOADER: %s=%s\n", env_var_orig, orig_path);
+
+    /* prepend our path to the original path, pyi_strjoin can deal with orig_path being empty */
     new_path = pyi_strjoin(path, ":", orig_path);
     rc = pyi_setenv(env_var, new_path);
     VS("LOADER: %s=%s\n", env_var, new_path);

--- a/doc/advanced-topics.rst
+++ b/doc/advanced-topics.rst
@@ -41,8 +41,8 @@ A. First process: bootloader starts.
 
     2. Modify various environment variables:
 
-       - GNU/Linux: If set, save the original value of LD_LIBRARY_PATH
-         into LD_LIBRARY_PATH_ORIG.
+       - GNU/Linux: Save the original value of LD_LIBRARY_PATH (or an
+         empty string, if not set) into LD_LIBRARY_PATH_ORIG.
          Prepend our path to LD_LIBRARY_PATH.
 
        - AIX: same thing, but using LIBPATH and LIBPATH_ORIG.


### PR DESCRIPTION
if _ORIG is always there, users can easily restore LDLP to its original
value before forking a process. it must be always there so users can
easily differentiate whether their code is running from a pyinstaller
bundle (no matter whether it is single-file or single-directory) or not.

e.g. when forking to the system ssh, it is important that ssh loads the
system openssl lib (not the openssl lib inside the pyinstaller bundle).