### PR TITLE
loader: fix __main__ being recognized as built-in & allow retrieval of its code-object

### DIFF
--- a/PyInstaller/loader/pyimod03_importers.py
+++ b/PyInstaller/loader/pyimod03_importers.py
@@ -311,9 +311,15 @@ class FrozenImporter(object):
         ImportError should be raised if module not found.
         """
         try:
-            # extract() returns None if fullname not in the archive, thus the
-            # next line will raise an execpion which will be catched just
-            # below and raise the ImportError.
+            if fullname == '__main__':
+                # Special handling for __main__ module; the bootloader
+                # should store code object to _pyi_main_co attribute of
+                # the module.
+                return sys.modules['__main__']._pyi_main_co
+
+            # extract() returns None if fullname not in the archive, and the
+            # subsequent subscription attempt raises exception, which
+            # is turned into ImportError.
             return self._pyz_archive.extract(fullname)[1]
         except Exception as e:
             raise ImportError(

--- a/PyInstaller/loader/pyimod03_importers.py
+++ b/PyInstaller/loader/pyimod03_importers.py
@@ -584,3 +584,10 @@ def install():
                 pathFinders.append(item)
     sys.meta_path.extend(reversed(pathFinders))
     # TODO Do we need for Python 3 _frozen_importlib.FrozenImporter? Could it be also removed?
+
+    # Set the FrozenImporter as loader for __main__, in order for python
+    # to treat __main__ as a module instead of a built-in.
+    try:
+        sys.modules['__main__'].__loader__ = fimp
+    except Exception:
+        pass

--- a/bootloader/src/pyi_launch.c
+++ b/bootloader/src/pyi_launch.c
@@ -503,12 +503,17 @@ pyi_launch_run_scripts(ARCHIVE_STATUS *status)
 
             /* Unmarshall code object */
             code = PI_PyMarshal_ReadObjectFromString((const char *) data, ptoc->ulen);
-
             if (!code) {
                 FATALERROR("Failed to unmarshal code object for %s\n", ptoc->name);
                 PI_PyErr_Print();
                 return -1;
             }
+
+            /* Store the code object to __main__ module's _pyi_main_co
+             * attribute, so it can be retrieved by FrozenImporter,
+             * if necessary. */
+            PI_PyObject_SetAttrString(__main__, "_pyi_main_co", code);
+
             /* Run it */
             retval = PI_PyEval_EvalCode(code, main_dict, main_dict);
 

--- a/news/5897.bugfix.0.rst
+++ b/news/5897.bugfix.0.rst
@@ -1,0 +1,1 @@
+Fix ``__main__`` module being recognized as built-in instead of module.

--- a/news/5897.bugfix.1.rst
+++ b/news/5897.bugfix.1.rst
@@ -1,0 +1,2 @@
+Enable retrieval of code object for ``__main__`` module via its associated
+loader (i.e., ``FrozenImporter``).

--- a/tests/functional/test_misc.py
+++ b/tests/functional/test_misc.py
@@ -53,3 +53,14 @@ def test_inspect_getmodule_from_stackframes(pyi_builder):
         module_names = [module.__name__ for module in modules]
         assert module_names == expected_module_names
         """, pyi_args=['--paths', pathex], run_from_path=True)
+
+
+# Test whether dis can disassemble the __main__ module, as per #5897.
+def test_dis_main(pyi_builder):
+    pyi_builder.test_source(
+        """
+        import dis
+        import sys
+
+        print(dis.dis(sys.modules["__main__"].__loader__.get_code("__main__")))
+        """)


### PR DESCRIPTION
Make `__main__` module recognized as module instead of built-in, by setting its `__loader__` to `FrozenImporter` instance.

Enable retrieval of code object for `__main__` via `FrozenImporter.get_code` (by having bootloader store it in `_pyi_main_co` attribute of `__main__` module, as otherwise python code is unaware of frozen entry-point scripts).

Fixes #5897. Requires bootloader to be rebuilt.