### PR TITLE
bootloader: waf: automatically enable/disable universal2 bootloader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
           pip install --progress-bar=off -U -r tests/requirements-tools.txt -r tests/requirements-libraries.txt
           # Compile bootloader
           cd bootloader
-          python waf all --no-universal2
+          python waf all
           cd ..
 
           # Install PyInstaller.

--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -187,14 +187,14 @@ def options(ctx):
                    action='store_true',
                    help='When building for 64-bit platform, build universal2 '
                         'fat binary (x86_64, arm64). (This is the default.).',
-                   default=True,
+                   default=None,
                    dest='macos_universal2')
     grp.add_option('--no-universal2',
                    action='store_false',
                    help='When building for 64-bit platform, build a thin '
                         'binary. Allows building with older toolchains that '
                         'do not support universal2 binaries.',
-                   default=True,
+                   default=None,
                    dest='macos_universal2')
 
 @conf
@@ -345,8 +345,20 @@ def set_arch_flags(ctx):
         if ctx.env.PYI_ARCH == '32bit':
             mac_arch = ['-arch', 'i386']
         else:
+            UNIVERSAL2_FLAGS = ['-arch', 'x86_64', '-arch', 'arm64']
+            if ctx.options.macos_universal2 in (None, True):
+                # Check for universal2 support if set to auto-detect
+                # (neither --universal2 nor --no-universal2 is provided),
+                # or if universal2 is explicitly enabled
+                supported = ctx.check_cc(
+                    cflags=UNIVERSAL2_FLAGS,
+                    linkflags=UNIVERSAL2_FLAGS,
+                    features='c cprogram',
+                    msg='Checking for universal2 support',
+                    mandatory=ctx.options.macos_universal2)
+                ctx.options.macos_universal2 = supported
             if ctx.options.macos_universal2:
-                mac_arch = ['-arch', 'x86_64', '-arch', 'arm64']
+                mac_arch = UNIVERSAL2_FLAGS
             else:
                 mac_arch = ['-arch', 'x86_64']
         ctx.env.append_value('CFLAGS', mac_arch)

--- a/doc/bootloader-building.rst
+++ b/doc/bootloader-building.rst
@@ -117,11 +117,15 @@ Instead of installing the full `Xcode` package, you can also install
 and use `Command Line Tools for Xcode <https://developer.apple.com/download/more/>`_.
 Installing either will provide the `clang` compiler.
 
-By default, 64-bit bootloaders are built as `universal2` fat binaries
-that support both `x86_64` and `arm64` architectures, which requires a
-recent version of `Xcode` (12.2 or later). If you wish to use an older
-version of `Xcode`, you can build the single-arch thin bootloader by
-passing ``--no-universal2`` flag to the ``waf`` build command.
+If the toolchain supports `universal2` binaries, the 64-bit bootloaders
+are by default built as `universal2` fat binaries that support both
+`x86_64` and `arm64` architectures. This requires a recent version
+of `Xcode` (12.2 or later). On older toolchains that lack support for
+`universal2` binaries, a single-arch `x86_64` thin bootloader is
+built. This behavior can be controlled by passing ``--universal2`` or
+``--no-universal2``  flags to the ``waf`` build command. Attempting to
+use ``--universal2`` flag and a toolchain that lacks support for
+`universal2` binaries will result in configuration error.
 
 Now you can build the bootloader as shown above.
 


### PR DESCRIPTION
Auto-detect whether the toolchain supports building `universal2` binaries, and enable/disable building of `universal2` bootloader
accordingly (unless `--universal2` or `--no-universal2` is explicitly passed on command-line).

Allows compiling bootloader on older toolchains without having to explicitly specify `--no-universal2`.