### PR TITLE
Revert "hooks: setuptools: Exclude outdated compat modules."

### DIFF
--- a/PyInstaller/hooks/hook-setuptools.py
+++ b/PyInstaller/hooks/hook-setuptools.py
@@ -13,8 +13,6 @@
 from PyInstaller.compat import is_unix, is_darwin
 from PyInstaller.utils.hooks import collect_submodules
 
-excludedimports = ["setuptools.py27compat", "setuptools.py33compat"]
-
 hiddenimports = [
     # Test case import/test_zipimport2 fails during importing
     # pkg_resources or setuptools when module not present.

--- a/news/5979.hooks.rst
+++ b/news/5979.hooks.rst
@@ -1,0 +1,2 @@
+Do not exclude ``setuptools.py27compat`` and ``setuptools.py33compat``
+as they are required by other ``setuptools`` modules.


### PR DESCRIPTION
This reverts commit 00dcae2a77ead2eed805bdc25eaff4927ecf2b46.

While the `setuptools.py27compat` and `setuptools.py33compat` are aimed at obsolete python versions, their exclusion and subsequent absence causes `ModuleNotFoundError` when `setuptools` tries to import them from its other modules (see #5973).

This affects older versions of `setuptools` (e.g., 40.x that comes with python 3.6). In newer versions, these modules are not present anymore (and them being in excludedimports probably generates "Import to be excluded not found" warnings during build process).