### PR TITLE
building: osx: remove spurious MacOS/ prefix from CFBundleExecutable

### DIFF
--- a/PyInstaller/building/osx.py
+++ b/PyInstaller/building/osx.py
@@ -150,8 +150,8 @@ class BUNDLE(Target):
                            # Cli option --osx-bundle-identifier sets this value.
                            "CFBundleIdentifier": self.bundle_identifier,
 
-                           # Fix for #156 - 'MacOS' must be in the name - not sure why
-                           "CFBundleExecutable": 'MacOS/%s' % os.path.basename(self.exename),
+                           "CFBundleExecutable":
+                               os.path.basename(self.exename),
                            "CFBundleIconFile": os.path.basename(self.icon),
                            "CFBundleInfoDictionaryVersion": "6.0",
                            "CFBundlePackageType": "APPL",

--- a/news/4413.bugfix.rst
+++ b/news/4413.bugfix.rst
@@ -1,0 +1,2 @@
+(macOS) Remove spurious ``MacOS/`` prefix from ``CFBundleExecutable`` property
+in the generated ``Info.plist`` when building an app bundle.

--- a/news/5442.bugfix.rst
+++ b/news/5442.bugfix.rst
@@ -1,0 +1,2 @@
+(macOS) Remove spurious ``MacOS/`` prefix from ``CFBundleExecutable`` property
+in the generated ``Info.plist`` when building an app bundle.


### PR DESCRIPTION
Remove spurious `MacOS/` prefix from `CFBundleExecutable` in the generated `Info.plist` when building an app bundle. As discussed in #4413 and #5442, the `CFBundleExecutable` should contain only executable name.

Having the `MacOS/` prefix causes the following warning to be shown in macOS Console.app when the bundle is launched on macOS 10.14 Mojave (the later versions of macOS seem unaffected):

```
com.apple.xpc.launchd.domain.pid.<Application Name>.<PID>): Could not resolve origin of domain. XPC services in this domain's bundle will not be bootstrapped: error = 107: Malformed bundle, taint = missing executable
```

Effectively reverts 6b99e01.

Fixes #5442.
Fixes #4413.