### PR TITLE
bootloader: Cygwin: set _MEIPASS as DLL search directory

### DIFF
--- a/news/6000.bugfix.rst
+++ b/news/6000.bugfix.rst
@@ -1,0 +1,2 @@
+(Cygwin) Add ``_MEIPASS`` to DLL search path to fix loading of python shared
+library in onefile builds made in cygwin environment and executed outside of it.


### PR DESCRIPTION
When processing dependencies of a DLL under Cygwin, the Windows' internal mechanism is used, which means that `LD_LIBRARY_PATH` has no effect, and the DLL search path needs to be established either via `PATH` or by calling `SetDllDirectory()`. The second option is already used in Windows codepath, so we extend it for Cygwin as well.

Failing to add _MEIPASS to DLL search path prevents python shared library from being loaded by a onefile build made under
cygwin when ran outside of cygwin environment, as it fails to resolve the dependent DLLs (see #6000). Onedir builds are unaffected because DLLs are located in the same directory as the executable. And both builds are unaffected when ran within cygwin environment, because the DLLs are in the `PATH`.

Fixes #6000.