### PR TITLE
bootloader: minor cleanup

### DIFF
--- a/bootloader/src/pyi_launch.c
+++ b/bootloader/src/pyi_launch.c
@@ -474,14 +474,14 @@ pyi_launch_run_scripts(ARCHIVE_STATUS *status)
     __main__ = PI_PyImport_AddModule("__main__");
 
     if (!__main__) {
-        FATALERROR("Could not get __main__ module.");
+        FATALERROR("Could not get __main__ module.\n");
         return -1;
     }
 
     main_dict = PI_PyModule_GetDict(__main__);
 
     if (!main_dict) {
-        FATALERROR("Could not get __main__ module's dict.");
+        FATALERROR("Could not get __main__ module's dict.\n");
         return -1;
     }
 

--- a/bootloader/src/pyi_launch.h
+++ b/bootloader/src/pyi_launch.h
@@ -70,21 +70,5 @@ int pyi_launch_execute(ARCHIVE_STATUS *status);
  */
 void pyi_parent_to_background();
 
-/*
- * Call a simple "int func(void)" entry point.  Assumes such a function
- * exists in the main namespace.
- * Return non zero on failure, with -2 if the specific error is
- * that the function does not exist in the namespace.
- *
- * @param name		Name of the function to execute.
- * @param presult	Integer return value.
- */
-int callSimpleEntryPoint(char *name, int *presult);
-
-/**
- * Clean up extracted binaries
- */
-void cleanUp(ARCHIVE_STATUS *status);
-
 #endif  /* PYI_LAUNCH_H */
 

--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -155,7 +155,7 @@ pyi_main(int argc, char * argv[])
 #else
         /* Windows */
         if (pyi_win32_utils_from_utf8(dllpath_w, extractionpath, PATH_MAX) == NULL) {
-            FATALERROR("Failed to convert DLL search path!");
+            FATALERROR("Failed to convert DLL search path!\n");
             return -1;
         }
 #endif  /* defined(__CYGWIN__) */

--- a/bootloader/src/pyi_path.c
+++ b/bootloader/src/pyi_path.c
@@ -263,12 +263,12 @@ pyi_path_executable(char *execfile, const char *appname)
     /* GetModuleFileNameW returns an absolute, fully qualified path
      */
     if (!GetModuleFileNameW(NULL, modulename_w, PATH_MAX)) {
-        FATAL_WINERROR("GetModuleFileNameW", "Failed to get executable path.");
+        FATAL_WINERROR("GetModuleFileNameW", "Failed to get executable path.\n");
         return false;
     }
 
     if (!pyi_win32_utils_to_utf8(execfile, modulename_w, PATH_MAX)) {
-        FATALERROR("Failed to convert executable path to UTF-8.");
+        FATALERROR("Failed to convert executable path to UTF-8.\n");
         return false;
     }
 
@@ -321,7 +321,7 @@ pyi_path_executable(char *execfile, const char *appname)
             char buffer[PATH_MAX];
             if (! pyi_search_path(buffer, appname)) {
                 /* Searching $PATH failed, user is crazy. */
-                VS("LOADER: Searching $PATH failed for %s", appname);
+                VS("LOADER: Searching $PATH failed for %s\n", appname);
                 if (snprintf(buffer, PATH_MAX, "%s", appname) >= PATH_MAX) {
                     VS("LOADER: Full path to application exceeds PATH_MAX: %s\n", appname);
                     return false;

--- a/bootloader/src/pyi_pythonlib.c
+++ b/bootloader/src/pyi_pythonlib.c
@@ -498,7 +498,7 @@ pyi_pylib_start_python(ARCHIVE_STATUS *status)
 
     /* Check for a python error */
     if (PI_PyErr_Occurred()) {
-        FATALERROR("Error detected starting Python VM.");
+        FATALERROR("Error detected starting Python VM.\n");
         return -1;
     }
 
@@ -675,7 +675,7 @@ pyi_pylib_finalize(ARCHIVE_STATUS *status)
      */
     if (status->is_pylib_loaded == true) {
         #ifndef WINDOWED
-            /* 
+            /*
              * We need to manually flush the buffers because otherwise there can be errors.
              * The native python interpreter flushes buffers before calling Py_Finalize,
              * so we need to manually do the same. See isse #4908.

--- a/bootloader/src/pyi_utils.c
+++ b/bootloader/src/pyi_utils.c
@@ -1479,7 +1479,7 @@ static pascal OSErr handle_apple_event(const AppleEvent *theAppleEvent, AppleEve
     default:
         /* Not 'GURL', 'odoc', 'rapp', or 'actv'  -- this is not reached unless there is a
          * programming error in the code that sets up the handler(s) in pyi_process_apple_events. */
-        OTHERERROR("LOADER [AppleEvent]: %s called with unexpected event type '%s'!",
+        OTHERERROR("LOADER [AppleEvent]: %s called with unexpected event type '%s'!\n",
                    __FUNCTION__, CC2Str(evtCode));
         return errAEEventNotHandled;
     }

--- a/bootloader/src/pyi_utils.c
+++ b/bootloader/src/pyi_utils.c
@@ -576,19 +576,6 @@ pyi_remove_temp_path(const char *dir)
 }
 #endif /* ifdef _WIN32 */
 
-/* TODO is this function still used? Could it be removed? */
-/*
- * If binaries were extracted, this should be called
- * to remove them
- */
-void
-cleanUp(ARCHIVE_STATUS *status)
-{
-    if (status->temppath[0]) {
-        pyi_remove_temp_path(status->temppath);
-    }
-}
-
 /*
  * helper for extract2fs
  * which may try multiple places

--- a/bootloader/src/pyi_win32_utils.c
+++ b/bootloader/src/pyi_win32_utils.c
@@ -175,7 +175,7 @@ pyi_win32_wcs_to_mbs(const wchar_t *wstr)
 
     str = (char *)calloc(len + 1, sizeof(char));
     if (str == NULL) {
-        FATAL_WINERROR("win32_wcs_to_mbs", "Out of memory.");
+        FATAL_WINERROR("win32_wcs_to_mbs", "Out of memory.\n");
         return NULL;
     };
 
@@ -310,7 +310,7 @@ pyi_win32_utils_to_utf8(char *str, const wchar_t *wstr, size_t len)
 
         output = (char *)calloc(len + 1, sizeof(char));
         if (output == NULL) {
-            FATAL_WINERROR("win32_utils_to_utf8", "Out of memory.");
+            FATAL_WINERROR("win32_utils_to_utf8", "Out of memory.\n");
             return NULL;
         };
     }
@@ -374,7 +374,7 @@ pyi_win32_utils_from_utf8(wchar_t *wstr, const char *str, size_t wlen)
 
         output = (wchar_t *)calloc(wlen + 1, sizeof(wchar_t));
         if (output == NULL) {
-            FATAL_WINERROR("win32_utils_from_utf8", "Out of memory.");
+            FATAL_WINERROR("win32_utils_from_utf8", "Out of memory.\n");
             return NULL;
         };
     }


### PR DESCRIPTION
Minor cleanup in bootloader's code:
* ensure all `VS()` and `*ERROR()` messages end with newline (`\n`)
* remove two unused functions, `callSimpleEntryPoint` and `cleanUp`