### PR TITLE
Add hook for pandas.io.formats.style

### DIFF
--- a/PyInstaller/hooks/hook-pandas.io.formats.style.py
+++ b/PyInstaller/hooks/hook-pandas.io.formats.style.py
@@ -1,0 +1,18 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2021, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import collect_data_files
+
+# This module indirectly imports jinja2
+hiddenimports = ['jinja2']
+
+# It also requires template file stored in pandas/io/formats/templates
+datas = collect_data_files('pandas.io.formats')

--- a/news/6010.hooks.rst
+++ b/news/6010.hooks.rst
@@ -1,0 +1,2 @@
+Add a hook for ``pandas.io.formats.style`` to deal with indirect import of 
+``jinja2`` and the missing template file.

--- a/tests/functional/test_libraries.py
+++ b/tests/functional/test_libraries.py
@@ -391,6 +391,18 @@ def test_pandas_extension(pyi_builder):
         """)
 
 
+@importorskip('pandas')
+@importorskip('jinja2')
+def test_pandas_io_formats_style(pyi_builder):
+    # pandas.io.formats.style requires jinja2 as hiddenimport, as
+    # well as collected template file from pandas/io/formats/templates.
+    # See #6008 and #6009.
+    pyi_builder.test_source(
+        """
+        import pandas.io.formats.style
+        """)
+
+
 @importorskip('win32ctypes')
 @pytest.mark.skipif(not is_win,
                     reason='pywin32-ctypes is supported only on Windows')


### PR DESCRIPTION
Add `jinja2` to hiddenimports and collect data files from `pandas.io.formats` to include the missing template file (`pandas/io/formats/templates/html.tpl`).

Fixes #6008.
Fixes #6009.