### PR TITLE
Depend: Bytecode scanner: Skip false positive matches starting on odd bytes.

### DIFF
--- a/PyInstaller/building/build_main.py
+++ b/PyInstaller/building/build_main.py
@@ -450,8 +450,12 @@ class Analysis(Target):
         for name, co in ctypes_code_objs.items():
             # Get dlls that might be needed by ctypes.
             logger.debug('Scanning %s for shared libraries or dlls', name)
-            ctypes_binaries = scan_code_for_ctypes(co)
-            self.binaries.extend(set(ctypes_binaries))
+            try:
+                ctypes_binaries = scan_code_for_ctypes(co)
+                self.binaries.extend(set(ctypes_binaries))
+            except Exception as ex:
+                raise RuntimeError(f"Failed to scan the module '{name}'. "
+                                   f"This is a bug. Please report it.") from ex
 
         self.datas.extend(
             (dest, source, "DATA") for (dest, source) in

--- a/PyInstaller/depend/utils.py
+++ b/PyInstaller/depend/utils.py
@@ -219,7 +219,8 @@ def _scan_code_for_ctypes_getattr(code: CodeType):
 
     key_names = ("cdll", "oledll", "pydll", "windll")
 
-    for (name, attrs) in _ctypes_getattr_regex.findall(code.co_code):
+    for match in bytecode.finditer(_ctypes_getattr_regex, code.co_code):
+        name, attrs = match.groups()
         name = bytecode.load(name, code)
         attrs = bytecode.loads(attrs, code)
 

--- a/news/6007.bugfix.rst
+++ b/news/6007.bugfix.rst
@@ -1,0 +1,2 @@
+Fix a bytecode parsing bug which caused tuple index errors whilst scanning
+modules which use :mod:`ctypes`.


### PR DESCRIPTION
All bytecode instructions come in OPCODE, ARGUMENT pairs of bytes so that every even byte is an OPCODE and every odd one is an ARGUMENT.

Formally, this wasn't enforced by our bytecode scanner, leading to false positive matches when a sequence of pairs' ARGUMENTS just happens to be the sequence of bytes as the OPCODEs which the scanner is looking for. These false positive matches are likely to become invalid after further parsing which led to
index errors (such as in #6007).

The fix is simply to skip any `re.Match` found that does not satisfy `match.start() % 2 != 0`.

To streamline any other issues regarding bytecode scanning, the top level code which invokes the bytecode scanner now catches and reraises errors, adding exactly which module it failed to scan to the error message.

Fixes #6007.