### PR TITLE
Improve missing linked library warnings

### DIFF
--- a/PyInstaller/depend/bindepend.py
+++ b/PyInstaller/depend/bindepend.py
@@ -602,8 +602,8 @@ def _getImports_ldd(pth):
                 if lib not in rslt:
                     rslt.add(lib)
             else:
-                logger.error('Can not find %s in path %s (needed by %s)',
-                             name, lib, pth)
+                logger.warning('Cannot find %s in path %s (needed by %s)',
+                               name, lib, pth)
     return rslt
 
 
@@ -699,7 +699,7 @@ def _getImports_macholib(pth):
                     break
             # Log error if no existing file found.
             if not final_lib:
-                logger.error('Can not find path %s (needed by %s)', lib, pth)
+                logger.warning('Cannot find path %s (needed by %s)', lib, pth)
 
         # Macholib has to be used to get absolute path to libraries.
         else:
@@ -716,8 +716,8 @@ def _getImports_macholib(pth):
                 # we do not collect system libraries on any macOS version
                 # anyway, so suppress the corresponding error messages.
                 if not in_system_path(lib):
-                    logger.error('Can not find path %s (needed by %s)',
-                                 lib, pth)
+                    logger.warning('Cannot find path %s (needed by %s)',
+                                   lib, pth)
 
     return rslt
 

--- a/PyInstaller/depend/bindepend.py
+++ b/PyInstaller/depend/bindepend.py
@@ -604,6 +604,14 @@ def _getImports_ldd(pth):
             else:
                 logger.warning('Cannot find %s in path %s (needed by %s)',
                                name, lib, pth)
+        elif line.endswith("not found"):
+            # On glibc-based linux distributions, missing libraries
+            # are marked with name.so => not found
+            tokens = line.split('=>')
+            if len(tokens) != 2:
+                continue
+            name = tokens[0].strip()
+            logger.warning('Cannot find %s (needed by %s)', name, pth)
     return rslt
 
 

--- a/PyInstaller/depend/bindepend.py
+++ b/PyInstaller/depend/bindepend.py
@@ -527,11 +527,8 @@ def selectImports(pth, xtrapath=None):
                 logger.debug("Adding %s dependency of %s from %s",
                              lib, os.path.basename(pth), npth)
                 rv.append((lib, npth))
-        else:
-            # Don't spew out false warnings on win 10 and UCRT (see issue
-            # #1566).
-            if not (compat.is_win_10 and lib.startswith("api-ms-win-crt")):
-                logger.warning("lib not found: %s dependency of %s", lib, pth)
+        elif dylib.warn_missing_lib(lib):
+            logger.warning("lib not found: %s dependency of %s", lib, pth)
 
     return rv
 
@@ -601,7 +598,7 @@ def _getImports_ldd(pth):
                 # Add lib if it is not already found.
                 if lib not in rslt:
                     rslt.add(lib)
-            else:
+            elif dylib.warn_missing_lib(name):
                 logger.warning('Cannot find %s in path %s (needed by %s)',
                                name, lib, pth)
         elif line.endswith("not found"):
@@ -611,7 +608,8 @@ def _getImports_ldd(pth):
             if len(tokens) != 2:
                 continue
             name = tokens[0].strip()
-            logger.warning('Cannot find %s (needed by %s)', name, pth)
+            if dylib.warn_missing_lib(name):
+                logger.warning('Cannot find %s (needed by %s)', name, pth)
     return rslt
 
 
@@ -705,8 +703,8 @@ def _getImports_macholib(pth):
                     final_lib = os.path.abspath(os.path.join(run_path, lib))
                     rslt.add(final_lib)
                     break
-            # Log error if no existing file found.
-            if not final_lib:
+            # Log warning if no existing file found.
+            if not final_lib and dylib.warn_missing_lib(lib):
                 logger.warning('Cannot find path %s (needed by %s)', lib, pth)
 
         # Macholib has to be used to get absolute path to libraries.
@@ -723,7 +721,7 @@ def _getImports_macholib(pth):
                 # Starting with Big Sur, system libraries are hidden. And
                 # we do not collect system libraries on any macOS version
                 # anyway, so suppress the corresponding error messages.
-                if not in_system_path(lib):
+                if not in_system_path(lib) and dylib.warn_missing_lib(lib):
                     logger.warning('Cannot find path %s (needed by %s)',
                                    lib, pth)
 

--- a/PyInstaller/depend/dylib.py
+++ b/PyInstaller/depend/dylib.py
@@ -26,8 +26,7 @@ import os
 import re
 
 
-from PyInstaller.compat import is_win, is_win_10, is_unix, is_aix, is_darwin, \
-    is_linux
+from PyInstaller import compat
 
 
 import PyInstaller.log as logging
@@ -168,13 +167,13 @@ _aix_excludes = {
 }
 
 
-if is_win:
+if compat.is_win:
     _includes |= _win_includes
     _excludes |= _win_excludes
-elif is_aix:
+elif compat.is_aix:
     # The exclude list for AIX differs from other *nix platforms.
     _excludes |= _aix_excludes
-elif is_unix:
+elif compat.is_unix:
     # Common excludes for *nix platforms -- except AIX.
     _excludes |= _unix_excludes
 
@@ -207,7 +206,7 @@ exclude_list = ExcludeList()
 include_list = IncludeList()
 
 
-if is_darwin:
+if compat.is_darwin:
     # On Mac use macholib to decide if a binary is a system one.
     from macholib import util
 
@@ -228,7 +227,7 @@ if is_darwin:
 
     exclude_list = MacExcludeList(exclude_list)
 
-elif is_win:
+elif compat.is_win:
     class WinExcludeList(object):
         def __init__(self, global_exclude_list):
             self._exclude_list = global_exclude_list
@@ -283,11 +282,11 @@ _warning_suppressions = [
 
 # On some systems (e.g., openwrt), libc.so might point to ldd. Suppress
 # warnings about it.
-if is_linux:
+if compat.is_linux:
     _warning_suppressions.append(r'ldd')
 
 # Suppress false warnings on win 10 and UCRT (see issue #1566).
-if is_win_10:
+if compat.is_win_10:
     _warning_suppressions.append(r'api-ms-win-crt.*')
 
 

--- a/PyInstaller/depend/dylib.py
+++ b/PyInstaller/depend/dylib.py
@@ -26,7 +26,8 @@ import os
 import re
 
 
-from PyInstaller.compat import is_win, is_win_10, is_unix, is_aix, is_darwin
+from PyInstaller.compat import is_win, is_win_10, is_unix, is_aix, is_darwin, \
+    is_linux
 
 
 import PyInstaller.log as logging
@@ -274,6 +275,11 @@ def include_library(libname):
 # libraries
 _warning_suppressions = [
 ]
+
+# On some systems (e.g., openwrt), libc.so might point to ldd. Suppress
+# warnings about it.
+if is_linux:
+    _warning_suppressions.append(r'ldd')
 
 # Suppress false warnings on win 10 and UCRT (see issue #1566).
 if is_win_10:

--- a/PyInstaller/depend/dylib.py
+++ b/PyInstaller/depend/dylib.py
@@ -274,6 +274,11 @@ def include_library(libname):
 # Patterns for suppressing warnings about missing dynamically linked
 # libraries
 _warning_suppressions = [
+    # We fail to discover shiboken2 (PySide2) and shiboken6 (PySide6)
+    # shared libraries due to the way the packages set up the search
+    # path to the library, which is located in a separate package.
+    # Suppress the harmless warnings to avoid confusion.
+    r'(lib)?shiboken.*',
 ]
 
 # On some systems (e.g., openwrt), libc.so might point to ldd. Suppress

--- a/news/6015.bugfix.0.rst
+++ b/news/6015.bugfix.0.rst
@@ -1,0 +1,1 @@
+Downgrade messages about missing dynamic link libraries from ERROR to WARNING.

--- a/news/6015.bugfix.1.rst
+++ b/news/6015.bugfix.1.rst
@@ -1,0 +1,3 @@
+(Linux) Display missing library warnings for "not found" lines in ``ldd`` 
+output (i.e., ``libsomething.so => not found``) instead of quietly 
+ignoring them.

--- a/news/6015.bugfix.2.rst
+++ b/news/6015.bugfix.2.rst
@@ -1,0 +1,1 @@
+(Linux) Fix spurious missing library warning when ``libc.so`` points to ``ldd``.

--- a/news/6015.bugfix.3.rst
+++ b/news/6015.bugfix.3.rst
@@ -1,0 +1,2 @@
+Suppress missing library warning for ``shiboken2`` (``PySide2``) and
+``shiboken6`` (``PySide6``) shared library. 


### PR DESCRIPTION
This PR is a collection of changes that aim to improve missing-library messages generated during binary dependency scanning.

First, downgrade messages from ERROR to WARNING, because it is a pain having to explain to users that the build process did finish nevertheless and that they should try running the generated binary. (It is actually quite reasonable to assume that something has gone terribly wrong when you see that message, unless you've worked with PyInstaller before).

Display warnings for missing libraries on linux systems (i.e., `libsomething.so => not found` lines in `ldd` output). Currently, we are quietly swallowing those, which leads to issues like #5863 that would have been otherwise easy to figure out. This probably captures only output generated by glibc-based `ldd` on linux systems (depending on how others display missing library information), but it's a good starting point. Fixes #5863 (absence of warnings about missing libraries).

The above change now results in messages about missing `libshiboken{2,6}.*` when building with PySide2/PySide6 on linux (whereas on Windows and macOS, they've already been present), so this is a good opportunity to suppress that once and for all. We first add a general mechanism for suppression patterns (similar to already-existing shared library include and exclude list), and port the Windows-specific suppression of messages about missing `api-ms-win-crt*` DLLs.

In addition, we also suppress warning for missing `ldd`, which occurs on openwrt due to libc pointing to it (`libc.so => ldd`).