### PR TITLE
hooks: unify PySide2 and PyQt5 QtWebEngineWidgets hooks

### DIFF
--- a/PyInstaller/hooks/hook-PyQt5.QtWebEngineWidgets.py
+++ b/PyInstaller/hooks/hook-PyQt5.QtWebEngineWidgets.py
@@ -9,69 +9,16 @@
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
 
-import os
-import glob
-from PyInstaller.utils.hooks.qt import add_qt5_dependencies, pyqt5_library_info
-from PyInstaller.utils.hooks import remove_prefix, get_module_file_attribute, \
-    collect_system_data_files
-from PyInstaller.depend.bindepend import getImports
-import PyInstaller.compat as compat
+from PyInstaller.utils.hooks.qt import pyqt5_library_info, \
+    add_qt5_dependencies, get_qt_webengine_binaries_and_data_files
+
 
 # Ensure PyQt5 is importable before adding info depending on it.
 if pyqt5_library_info.version is not None:
     hiddenimports, binaries, datas = add_qt5_dependencies(__file__)
 
-    # Include the web engine process, translations, and resources.
-    rel_data_path = pyqt5_library_info.qt_rel_dir
-    if compat.is_darwin:
-        # This is based on the layout of the Mac wheel from PyPi.
-        data_path = pyqt5_library_info.location['DataPath']
-        libraries = ['QtCore', 'QtWebEngineCore', 'QtQuick', 'QtQml',
-                     'QtQmlModels', 'QtNetwork', 'QtGui', 'QtWebChannel',
-                     'QtPositioning']
-        for i in libraries:
-            framework_dir = i + '.framework'
-            datas += collect_system_data_files(
-                os.path.join(data_path, 'lib', framework_dir),
-                os.path.join(rel_data_path, 'lib', framework_dir), True)
-        datas += [(os.path.join(data_path, 'lib', 'QtWebEngineCore.framework',
-                                'Resources'), os.curdir)]
-    else:
-        locales = 'qtwebengine_locales'
-        resources = 'resources'
-        datas += [
-            # Gather translations needed by Chromium.
-            (os.path.join(pyqt5_library_info.location['TranslationsPath'],
-                          locales),
-             os.path.join(rel_data_path, 'translations', locales)),
-            # Per the `docs <https://doc.qt.io/qt-5.10/qtwebengine-deploying.html#deploying-resources>`_,
-            # ``DataPath`` is the base directory for ``resources``.
-            (os.path.join(pyqt5_library_info.location['DataPath'], resources),
-             os.path.join(rel_data_path, resources)),
-            # Include the webengine process. The ``LibraryExecutablesPath`` is only
-            # valid on Windows and Linux.
-            (os.path.join(pyqt5_library_info.location['LibraryExecutablesPath'],
-                          'QtWebEngineProcess*'),
-             os.path.join(rel_data_path, remove_prefix(
-                pyqt5_library_info.location['LibraryExecutablesPath'],
-                pyqt5_library_info.location['PrefixPath'] + '/')))
-        ]
-
-    # Add Linux-specific libraries.
-    if compat.is_linux:
-        # The automatic library detection fails for `NSS
-        # <https://packages.ubuntu.com/search?keywords=libnss3>`_, which is used by
-        # QtWebEngine. In some distributions, the ``libnss`` supporting libraries
-        # are stored in a subdirectory ``nss``. Since ``libnss`` is not statically
-        # linked to these, but dynamically loads them, we need to search for and add
-        # them.
-        #
-        # First, get all libraries linked to ``PyQt5.QtWebEngineWidgets``.
-        for imp in getImports(get_module_file_attribute('PyQt5.QtWebEngineWidgets')):
-            # Look for ``libnss3.so``.
-            if os.path.basename(imp).startswith('libnss3.so'):
-                # Find the location of NSS: given a ``/path/to/libnss.so``,
-                # add ``/path/to/nss/*.so`` to get the missing NSS libraries.
-                nss_glob = os.path.join(os.path.dirname(imp), 'nss', '*.so')
-                if glob.glob(nss_glob):
-                    binaries.append((nss_glob, 'nss'))
+    # Include helper process executable, translations, and resources.
+    webengine_binaries, webengine_datas = \
+        get_qt_webengine_binaries_and_data_files(pyqt5_library_info)
+    binaries += webengine_binaries
+    datas += webengine_datas

--- a/news/6020.hooks.rst
+++ b/news/6020.hooks.rst
@@ -1,0 +1,2 @@
+Simplify the ``PySide2.QWebEngineWidgets`` and ``PyQt5.QWebEngineWidgets`` by 
+merging most of their code into a common helper function.

--- a/tests/functional/test_qt.py
+++ b/tests/functional/test_qt.py
@@ -392,35 +392,19 @@ def get_QWebEngine_html(qt_flavor, data_dir):
 def test_PyQt5_QWebEngine(pyi_builder, data_dir, monkeypatch):
     _qt_dll_path_clean(monkeypatch, 'PyQt5')
     if is_darwin:
-        # This tests running the QWebEngine on OS X. To do so, the test must:
-        #
-        # 1. Run only a onedir build -- onefile builds don't work.
+        # QWebEngine on OS X only works with a onedir build -- onefile builds
+        # don't work. Skip the test execution for onefile builds.
         if pyi_builder._mode != 'onedir':
             pytest.skip('The QWebEngine .app bundle '
                         'only supports onedir mode.')
 
-        # 2. Only test the Mac .app bundle, by modifying the executes this
-        #    fixture runs.
-        _old_find_executables = pyi_builder._find_executables
-        # Create a replacement method that selects just the .app bundle.
-
-        def _replacement_find_executables(self, name):
-            path_to_onedir, path_to_app_bundle = _old_find_executables(name)
-            return [path_to_app_bundle]
-        # Use this in the fixture. See https://stackoverflow.com/a/28060251 and
-        # https://docs.python.org/3/howto/descriptor.html.
-        pyi_builder._find_executables = \
-            _replacement_find_executables.__get__(pyi_builder)
-
-    # 3. Run the test with specific command-line arguments. Otherwise, OS X
-    # builds fail. Also use this for the Linux and Windows builds, since this
-    # is a common case.
     pyi_builder.test_source(get_QWebEngine_html('PyQt5', data_dir),
                             **USE_WINDOWED_KWARG)
 
 
 @importorskip('PySide2')
-def test_PySide2_QWebEngine(pyi_builder, data_dir):
+def test_PySide2_QWebEngine(pyi_builder, data_dir, monkeypatch):
+    _qt_dll_path_clean(monkeypatch, 'PySide2')
     if is_darwin:
         # QWebEngine on OS X only works with a onedir build -- onefile builds
         # don't work. Skip the test execution for onefile builds.


### PR DESCRIPTION
Use a common helper function to collect `QtWebEngine` binaries and data files in order to reduce code duplication and simplify maintenance of the hooks.

This will hopefully simplify addition of corresponding hooks for Qt6 which will re-introduce QtWebEngine in the upcoming 6.2 version. But it will also make it easier to sort out the macOS mess, once I get other prerequisites ready.

I've also cleaned up the code of both QtWebEngine tests to make their code visually the same, as well to synchronize their behaviors.