### PR TITLE
building: Add exclude_system_libraries method

### DIFF
--- a/PyInstaller/building/build_main.py
+++ b/PyInstaller/building/build_main.py
@@ -39,8 +39,8 @@ from PyInstaller.building.datastruct import TOC, Target, Tree, _check_guts_eq
 from PyInstaller.building.splash import Splash
 from PyInstaller.building.osx import BUNDLE
 from PyInstaller.building.toc_conversion import DependencyProcessor
-from PyInstaller.building.utils import \
-    _check_guts_toc_mtime, format_binaries_and_datas
+from PyInstaller.building.utils import _check_guts_toc_mtime, \
+    format_binaries_and_datas, _should_include_system_binary
 from PyInstaller.depend.utils import \
     create_py3_base_library, scan_code_for_ctypes
 from PyInstaller.archive import pyz_crypto
@@ -602,6 +602,19 @@ class Analysis(Target):
         logger.debug('Adding Python library to binary dependencies')
         binaries.append((os.path.basename(python_lib), python_lib, 'BINARY'))
         logger.info('Using Python library %s', python_lib)
+
+    def exclude_system_libraries(self, list_of_exceptions=[]):
+        """
+        This method may be optionally called from the spec file to exclude
+        any system libraries from the list of binaries other than those
+        containing the shell-style wildcards in list_of_exceptions.
+        Those that match '*python*' or are stored under 'lib-dynload' are
+        always treated as exceptions and not excluded.
+        """
+
+        self.binaries = \
+            [i for i in self.binaries
+                if _should_include_system_binary(i, list_of_exceptions)]
 
 
 class ExecutableBuilder(object):

--- a/doc/spec-files.rst
+++ b/doc/spec-files.rst
@@ -433,6 +433,29 @@ Finally the key ``CFBundleDocumentTypes`` tells Mac OS X what filetypes your
 application supports (see `Apple document types`_).
 
 
+.. _posix specific options:
+
+POSIX Specific Options
+~~~~~~~~~~~~~~~~~~~~~~
+
+By default all required system libraries are bundled.
+To exclude all or most non-Python shared system libraries from the bundle,
+you can add a call to the function ``exclude_system_libraries``
+from the Analysis class.
+System libraries are defined as files that come from under ``/lib*`` or
+``/usr/lib*``
+as is the case on POSIX and related operating systems.
+The function accepts an optional parameter
+that is a list of file wildcards exceptions,
+to not exclude library files that match those wildcards in the bundle.
+For example to exclude all non-Python system libraries except "libexpat"
+and anything containing "krb" use this::
+
+    a = Analysis( ...
+                )
+    a.exclude_system_libraries(list_of_exceptions=['libexpat*', '*krb*'])
+
+
 .. _splash screen target:
 
 

--- a/tests/unit/test_building_utils.py
+++ b/tests/unit/test_building_utils.py
@@ -127,3 +127,43 @@ def test_add_suffix_to_extension():
         # it unchanged (i.e., does not mangle it)
         toc3 = utils.add_suffix_to_extension(*toc2)
         assert toc3 == toc2
+
+
+def test_should_include_system_binary():
+    CASES = [
+        ('lib-dynload/any',
+         '/usr/lib64/any',
+         [],
+         True),
+        ('libany',
+         '/lib64/libpython.so',
+         [],
+         True),
+        ('any',
+         '/lib/python/site-packages/any',
+         [],
+         True),
+        ('libany',
+         '/etc/libany',
+         [],
+         True),
+        ('libany',
+         '/usr/lib/libany',
+         ['*any*'],
+         True),
+        ('libany2',
+         '/lib/libany2',
+         ['libnone*', 'libany*'],
+         True),
+        ('libnomatch',
+         '/lib/libnomatch',
+         ['libnone*', 'libany*'],
+         False),
+    ]
+
+    for case in CASES:
+        tuple = (case[0], case[1])
+        excepts = case[2]
+        expected = case[3]
+
+        assert utils._should_include_system_binary(tuple, excepts) == expected


### PR DESCRIPTION
This implements the feature requested in issue #2732.  It adds a
method in the Analysis class called exclude_system_libraries
that excludes all but python system libraries by default, and
accepts a list of exceptions that are file wildcards of libraries
to continue to including.