### PR TITLE
hooks: rework matplotlib.backends hook

### DIFF
--- a/doc/hooks-config.rst
+++ b/doc/hooks-config.rst
@@ -89,6 +89,114 @@ translations to British English and Simplified Chinese:
         ...,
     )
 
+.. _matplotlib hook options:
+
+Matplotlib hooks
+----------------
+
+The hooks for ``matplotlib`` package allow user to control the backend
+collection behavior via ``backends`` option under the ``matplotlib``
+identifier, as described below.
+
+**Hook identifier:** ``matplotlib``
+
+**Options**
+
+ * ``backends`` [*string* or *list of strings*]: backend selection method
+   or name(s) of backend(s) to collect. Valid string values: ``'auto'``,
+   ``'all'``, or a human-readable backend name (e.g., ``'TkAgg'``). To
+   specify multiple backends to be collected, use a list of strings
+   (e.g., ``['TkAgg', 'Qt5Agg']``).
+
+**Backend selection process**
+
+If ``backends`` option is set to ``'auto'`` (or not specified), the hook
+performs auto-detection of used backends, by scanning the code for
+:func:`matplotlib.use` function calls with literal arguments. For example,
+``matplotlib.use('TkAgg')`` being used in the code results in the
+``TkAgg`` backend being collected. If no such calls are found, the default
+backend is determined as the first importable GUI-based backend, using the
+same priority list as internally used by the :func:`matplotlib.get_backend`
+and :func:`matplotlib.pyplot.switch_backend` functions: ``['MacOSX',
+'Qt5Agg', 'Gtk3Agg', 'TkAgg', 'WxAgg']``. If no GUI-based backend is
+importable, the headless ``'Agg'`` is collected instead.
+
+.. note::
+    Due to limitations of the bytecode-scanning approach, only specific
+    forms of :func:`matplotlib.use` invocation can be automatically detected.
+    The backend must be specified as string literal (as opposed to being
+    passed via a variable). The second optional argument, ``force``, can
+    also be specified, but it must also be a literal and must not be
+    specified as a keyword argument:
+
+    .. code-block:: python
+
+        import matplotlib
+
+        matplotlib.use('TkAgg')  # detected
+        matplotlib.use('TkAgg', False)  # detected
+
+        backend = 'TkAgg'
+        matplotlib.use(backend)  # not detected
+
+        matplotlib.use('TkAgg', force=False)  # not detected
+
+    In addition to ``matplotlib`` module name, its common alias, ``mpl``
+    is also recongized:
+
+    .. code-block:: python
+
+        import matplotlib as mpl
+        mpl.use('TkAgg')  # detected
+
+
+    Importing the function from the module should also work:
+
+    .. code-block:: python
+
+        from matplotlib import use
+        use('TkAgg')  # detected
+
+
+If ``backends`` option is set to ``'all'``, all (importable) backends are
+selected, which corresponds to the behavior of |PyInstaller| 4.x and earlier.
+The list of importable backends depends on the packages installed in the
+environment; for example, the ``Qt5Agg`` backend becomes importable if
+either the ``PyQt5`` or the ``PySide2`` package is installed.
+
+Otherwise, the value of the ``backends`` option is treated as a backend
+name (if it is a string) or a list of backend names (if it is a list).
+In the case of user-provided backend names, no additional validation
+is performed; the backends are collected regardless of whether they are
+importable or not.
+
+**Example**
+
+.. code-block:: python
+
+    a = Analysis(
+        ["my-matplotlib-app.py"],
+        ...,
+        hooksconfig={
+            "matplotlib": {
+                "backends": "auto",  # auto-detect; the default behavior
+                # "backends": "all",  # collect all backends
+                # "backends": "TkAgg",  # collect a specific backend
+                # "backends": ["TkAgg", "Qt5Agg"],  # collect multiple backends
+            },
+        },
+        ...,
+    )
+
+.. note::
+    The ``Qt5Agg`` backend conditionally imports both the ``PyQt5`` and
+    the ``PySide2`` package. Therefore, if both are installed in your
+    environment, |PyInstaller| will end up collecting both. In addition
+    to increasing the frozen application's size, this might also cause
+    conflicts between the collected versions of the shared libraries.
+    To prevent that, use the :option:`--exclude-module` option to exclude
+    one of the two packages (i.e., ``--exclude-module PyQt5`` or
+    ``--exclude-module PySide2``).
 
 
 

--- a/news/6024.breaking.rst
+++ b/news/6024.breaking.rst
@@ -1,0 +1,4 @@
+The ``matplotlib.backends`` hook no longer collects all available
+``matplotlib`` backends, but rather tries to auto-detect the used
+backend(s) by default. The old behavior can be re-enabled via the
+:ref:`hook configuration option <matplotlib hook options>`.

--- a/news/6024.hooks.rst
+++ b/news/6024.hooks.rst
@@ -1,0 +1,6 @@
+Rework the ``matplotlib.backends`` hook to attempt performing
+auto-detection of the used backend(s) instead of collecting all
+available backends. Implement :ref:`hook configuration option
+<matplotlib hook options>` that allows users to swich between
+this new behavior and the old behavior of collecting all backends,
+or to manually specify the backend(s) to be collected.

--- a/tests/functional/test_hooks/test_matplotlib.py
+++ b/tests/functional/test_hooks/test_matplotlib.py
@@ -61,21 +61,21 @@ def test_matplotlib(pyi_builder, monkeypatch, backend_name, package_name, bindin
     # Script to be tested, enabling this Qt backend.
     test_script = (
         """
-        import matplotlib, os, sys, tempfile
+        import os
+        import sys
+        import tempfile
 
-        # Localize test parameters.
-        backend_name = {backend_name!r}
-        binding = {binding!r}
+        import matplotlib
 
         # Report these parameters.
-        print('Testing Matplotlib with backend', repr(backend_name), 'and binding ($QT_API)', repr(binding))
+        print('Testing Matplotlib with backend=%r and QT_API=%r' % ({backend_name!r}, {binding!r}))
 
         # Configure Matplotlib *BEFORE* calling any Matplotlib functions.
-        matplotlib.rcParams['backend'] = backend_name
-        os.environ['QT_API'] = binding
+        matplotlib.rcParams['backend'] = {backend_name!r}
+        os.environ['QT_API'] = {binding!r}
 
         # Enable the desired backend *BEFORE* plotting with this backend.
-        matplotlib.use(backend_name)
+        matplotlib.use({backend_name!r})
 
         # A runtime hook should force Matplotlib to create its configuration directory in a temporary directory
         # rather than in $HOME/.matplotlib.
@@ -87,6 +87,9 @@ def test_matplotlib(pyi_builder, monkeypatch, backend_name, package_name, bindin
         # Test access to the standard 'mpl_toolkits' namespace package installed with Matplotlib.
         # Note that this import was reported to fail under Matplotlib 1.3.0.
         from mpl_toolkits import axes_grid1
+
+        # Try importing pyplot. This will attempt to activate the selected backend.
+        from matplotlib import pyplot as plt
         """.format(backend_name=backend_name, binding=binding)
     )
 


### PR DESCRIPTION
Rework the `matplotlib` backend selection, so that it supports three distinct modes, controlled by hook config (`"matplotlib"` -> `"backends"`).

If the config key is set to `"auto"`, auto-detection is performed. This is also the new default mode. It first scans the code for any uses of `matplotlib.use()` or `mpl.use()` and constructs the list of corresponding backends. If none are found, the default  backend
is queried via `matplotlib.get_backend()`.

If the config key is set to `"all"`, then old behavior that brute-force collects all (importable) backends is enabled.

Otherwise, if the key is any other string, it is treated as a backend name. Similarly, if it is a list, it is treated as list of backend names.

In all three cases, the initial obtained list of backends is further filtered to include only backends that are actually importable.

This change aims to both prevent matplotlib from pulling in every installed UI library and also give user more control over what is collected via the config key.