### PR TITLE
ci: fix news fragment validation for breaking changes

### DIFF
--- a/doc/development/changelog-entries.rst
+++ b/doc/development/changelog-entries.rst
@@ -23,7 +23,7 @@ few simple rules:
   Our categories are:
   ``feature``,
   ``bugfix``,
-  ``break`` (breaking changes),
+  ``breaking`` (breaking changes),
   ``hooks`` (all hook-related changes),
   ``bootloader``,
   ``moduleloader``,

--- a/scripts/verify-news-fragments.py
+++ b/scripts/verify-news-fragments.py
@@ -26,7 +26,7 @@ CHANGELOG_GUIDE = (
     "https://github.com/pyinstaller/pyinstaller/"
     "blob/develop/doc/development/changelog-entries.rst#changelog-entries")
 
-CHANGE_TYPES = {'bootloader', 'break', 'bugfix', 'build', 'core', 'doc',
+CHANGE_TYPES = {'bootloader', 'breaking', 'bugfix', 'build', 'core', 'doc',
                 'feature', 'hooks', 'moduleloader', 'process', 'tests'}
 
 NEWS_PATTERN = re.compile(r"(\d+)\.(\w+)\.(?:(\d+)\.)?rst")


### PR DESCRIPTION
The towncrier is configured to look for `breaking` entries, but the verify-news-fragment.py script incorrectly looks for `break`
ones. Similarly, the `news/README.rst` incorrectly lists `break` as a category. Fix both to use `breaking` instead.