### PR TITLE
building: macOS: modify vmsize when fixing up __LINKEDIT segment

### DIFF
--- a/news/6039.bugfix.rst
+++ b/news/6039.bugfix.rst
@@ -1,0 +1,2 @@
+(macOS) When fixing executable for codesigning, update the value of
+``vmsize`` field in the ``__LINKEDIT`` segment.


### PR DESCRIPTION
Compute the new value of `__LINKEDIT` segment's `vmsize` as value of modified `filesize`, rounded up to full page size (0x4000 on `arm64`, 0x1000 elsewhere). Fixes #6039.