### PR TITLE
bootloader: macOS: disable onedir argv emulation

### DIFF
--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -226,7 +226,14 @@ pyi_main(int argc, char * argv[])
             }
             /* Process Apple events; this updates argc_pyi/argv_pyi
              * accordingly */
-            pyi_process_apple_events(true);  /* short_timeout */
+            /* NOTE: processing Apple events swallows up the initial
+             * OAPP event, which seems to cause segmentation faults
+             * in tkinter-based frozen bundles made with Homebrew
+             * python 3.9 and Tcl/Tk 8.6.11. Until the exact cause
+             * is determined and addressed, this functionality must
+             * remain disabled.
+             */
+            /*pyi_process_apple_events(true);*/  /* short_timeout */
             /* Update pointer to arguments */
             pyi_utils_get_args(&archive_status->argc, &archive_status->argv);
             /* TODO: do we need to de-register Apple event handlers before

--- a/news/6043.bugfix.rst
+++ b/news/6043.bugfix.rst
@@ -1,0 +1,2 @@
+(macOS) Fix the crashes in ``onedir`` bundles of ``tkinter``-based applications
+created using Homebrew python 3.9 and Tcl/Tk 8.6.11.

--- a/news/6048.breaking.rst
+++ b/news/6048.breaking.rst
@@ -1,0 +1,7 @@
+(macOS) Disable processing of Apple events for the purpose of argv emulation
+in ``onedir`` application bundles. This functionality was introduced in
+|PyInstaller| 4.4 by (:issue:`#5920`) in response to feature requests
+(:issue:`#5436`) and (:issue:`#5908`), but was discovered to be breaking
+``tkinter``-based ``onedir`` bundles made with Homebrew python 3.9 and
+Tcl/Tk 8.6.11 (:issue:`#6043`). As such, until the cause is investigated
+and the issue addressed, this feature is reverted/disabled.

--- a/tests/functional/test_apple_events.py
+++ b/tests/functional/test_apple_events.py
@@ -30,7 +30,7 @@ from PyInstaller.utils.tests import importorskip
 
 
 @pytest.mark.darwin
-@pytest.mark.parametrize("mode", ['onedir', 'onefile'])
+@pytest.mark.parametrize("mode", ['onefile'])
 def test_osx_custom_protocol_handler(tmpdir, pyi_builder_spec, monkeypatch,
                                      mode):
     app_path = os.path.join(tmpdir, 'dist',
@@ -63,7 +63,7 @@ def test_osx_custom_protocol_handler(tmpdir, pyi_builder_spec, monkeypatch,
 
 @pytest.mark.darwin
 @importorskip('PyQt5')
-@pytest.mark.parametrize("mode", ['onedir', 'onefile'])
+@pytest.mark.parametrize("mode", ['onefile'])
 def test_osx_event_forwarding(tmpdir, pyi_builder_spec, monkeypatch, mode):
     app_path = os.path.join(tmpdir, 'dist',
                             'pyi_osx_event_forwarding.app')


### PR DESCRIPTION
Disable macOS `argv` emulation for `onedir` application bundles, which was introduced by #5920. Processing Apple events in
the main (and for onedir application, the only) process swallows up initial OAPP (`kAEOpenApplication`) event, which seems to
cause crashes in `tkinter`-based `onedir` bundles created with Homebrew python 3.9 and Tcl/Tk 8.6.11 (reported in #6043).

Therefore, until the exact cause of the crashes is determined and fixed, we need to disable Apple event processing for
`argv` emulation in `onedir` mode. This effectively reverts the corresponding part of #5920, while keeping other changes introduced there (code refactoring, filtering of `-psn*` argument from `argv`).

Fixes #6043.

Re-opens #5436 and #5908.