### PR TITLE
building: Complete the exclude_system_libraries feature

### DIFF
--- a/doc/spec-files.rst
+++ b/doc/spec-files.rst
@@ -451,8 +451,8 @@ to not exclude library files that match those wildcards in the bundle.
 For example to exclude all non-Python system libraries except "libexpat"
 and anything containing "krb" use this::
 
-    a = Analysis( ...
-                )
+    a = Analysis(...)
+
     a.exclude_system_libraries(list_of_exceptions=['libexpat*', '*krb*'])
 
 

--- a/news/6022.feature.rst
+++ b/news/6022.feature.rst
@@ -1,0 +1,4 @@
+(POSIX) Add ``exclude_system_libraries`` function to the Analysis class
+for .spec files,
+to exclude most or all non-Python system libraries from the bundle.
+Documented in new :ref:`POSIX Specific Options` section.


### PR DESCRIPTION
The last version of the commit in pr #6022 which was merged accidentally
left out the news file.  This adds it back.  In addition, the example in
the documentation used a format for the Analysis step that was inconsistent
with examples in the immediately following sections.  This makes the format
consistent.