### PR TITLE
A new flavour of exec_statement().

### DIFF
--- a/PyInstaller/hooks/hook-PySide2.Qwt5.py
+++ b/PyInstaller/hooks/hook-PySide2.Qwt5.py
@@ -9,13 +9,23 @@
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
 
-from PyInstaller.utils.hooks import eval_statement
+from PyInstaller import isolated
 
 hiddenimports = ['PySide2.QtCore', 'PySide2.QtWidgets', 'PySide2.QtGui', 'PySide2.QtSvg']
 
-if eval_statement("from PySide2 import Qwt5; print(hasattr(Qwt5, 'toNumpy'))"):
-    hiddenimports.append("numpy")
-if eval_statement("from PySide2 import Qwt5; print(hasattr(Qwt5, 'toNumeric'))"):
-    hiddenimports.append("Numeric")
-if eval_statement("from PySide2 import Qwt5; print(hasattr(Qwt5, 'toNumarray'))"):
-    hiddenimports.append("numarray")
+
+@isolated.decorate
+def conditional_imports():
+    from PySide2 import Qwt5
+
+    out = []
+    if hasattr(Qwt5, "toNumpy"):
+        out.append("numpy")
+    if hasattr(Qwt5, "toNumeric"):
+        out.append("numeric")
+    if hasattr(Qwt5, "toNumarray"):
+        out.append("numarray")
+    return out
+
+
+hiddenimports += conditional_imports()

--- a/PyInstaller/hooks/hook-django.py
+++ b/PyInstaller/hooks/hook-django.py
@@ -20,7 +20,9 @@ from PyInstaller.utils.hooks import django
 
 logger = logging.getLogger(__name__)
 
-datas, binaries, hiddenimports = hooks.collect_all('django')
+# Collect everything. Some submodules of django are not importable without considerable external setup. Ignore the
+# errors they raise.
+datas, binaries, hiddenimports = hooks.collect_all('django', on_error="ignore")
 
 root_dir = django.django_find_root_dir()
 if root_dir:

--- a/PyInstaller/hooks/hook-matplotlib.py
+++ b/PyInstaller/hooks/hook-matplotlib.py
@@ -9,11 +9,15 @@
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
 
-from PyInstaller.utils.hooks import exec_statement
+from PyInstaller import isolated
 
-mpl_data_dir = exec_statement("import matplotlib; print(matplotlib.get_data_path())")
-assert mpl_data_dir, "Failed to determine matplotlib's data directory!"
+
+@isolated.decorate
+def mpl_data_dir():
+    import matplotlib
+    return matplotlib.get_data_path()
+
 
 datas = [
-    (mpl_data_dir, "matplotlib/mpl-data"),
+    (mpl_data_dir(), "matplotlib/mpl-data"),
 ]

--- a/PyInstaller/hooks/pre_safe_import_module/hook-setuptools.extern.six.moves.py
+++ b/PyInstaller/hooks/pre_safe_import_module/hook-setuptools.extern.six.moves.py
@@ -9,7 +9,7 @@
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
 
-from PyInstaller.utils.hooks import eval_statement
+from PyInstaller import isolated
 
 # This is basically a copy of pre_safe_import_module/hook-six.moves.py adopted to setuptools.extern.six resp.
 # setuptools._vendor.six. Please see pre_safe_import_module/hook-six.moves.py for documentation.
@@ -18,24 +18,18 @@ from PyInstaller.utils.hooks import eval_statement
 
 
 def pre_safe_import_module(api):
-    real_to_six_module_name = eval_statement(
-        """
+    @isolated.call
+    def real_to_six_module_name():
         try:
             import setuptools._vendor.six as six
         except ImportError:
             import setuptools.extern.six as six
 
-        print('{')
+        return {
+            moved.mod: 'setuptools.extern.six.moves.' + moved.name
+            for moved in six._moved_attributes if isinstance(moved, (six.MovedModule, six.MovedAttribute))
+        }
 
-        for moved in six._moved_attributes:
-            if isinstance(moved, (six.MovedModule, six.MovedAttribute)):
-                print('  %r: %r,' % (moved.mod, 'setuptools.extern.six.moves.' + moved.name))
-
-        print('}')
-        """
-    )
-    if isinstance(real_to_six_module_name, str):
-        raise SystemExit("pre-safe-import-module hook failed, needs fixing.")
     api.add_runtime_package(api.module_name)
     for real_module_name, six_module_name in real_to_six_module_name.items():
         api.add_alias_module(real_module_name, six_module_name)

--- a/PyInstaller/hooks/pre_safe_import_module/hook-urllib3.packages.six.moves.py
+++ b/PyInstaller/hooks/pre_safe_import_module/hook-urllib3.packages.six.moves.py
@@ -9,27 +9,22 @@
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
 
-from PyInstaller.utils.hooks import eval_statement
+from PyInstaller import isolated
 
 # This basically is a copy of pre_safe_import_module/hook-six.moves.py adopted to urllib3.packages.six. Please see
 # pre_safe_import_module/hook-six.moves.py for documentation.
 
 
 def pre_safe_import_module(api):
-    real_to_six_module_name = eval_statement(
-        """
+    @isolated.call
+    def real_to_six_module_name():
         import urllib3.packages.six as six
-        print('{')
 
-        for moved in six._moved_attributes:
-            if isinstance(moved, (six.MovedModule, six.MovedAttribute)):
-                print('  %r: %r,' % (moved.mod, 'urllib3.packages.six.moves.' + moved.name))
+        return {
+            moved.mod: 'urllib3.packages.six.moves.' + moved.name
+            for moved in six._moved_attributes if isinstance(moved, (six.MovedModule, six.MovedAttribute))
+        }
 
-        print('}')
-        """
-    )
-    if isinstance(real_to_six_module_name, str):
-        raise SystemExit("pre-safe-import-module hook failed, needs fixing.")
     api.add_runtime_package(api.module_name)
     for real_module_name, six_module_name in real_to_six_module_name.items():
         api.add_alias_module(real_module_name, six_module_name)

--- a/PyInstaller/isolated/__init__.py
+++ b/PyInstaller/isolated/__init__.py
@@ -1,0 +1,31 @@
+# -----------------------------------------------------------------------------
+# Copyright (c) 2021, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+# -----------------------------------------------------------------------------
+"""
+PyInstaller hooks typically will need to import the package which they are written for but doing so may manipulate
+globals such as :data:`sys.path` or :data:`os.environ` in ways that affect the build. For example, on Windows,
+Qt's binaries are added to then loaded via ``PATH`` in such a way that if you import multiple Qt variants in one
+session then there is no guarantee which variant's binaries each variant will get!
+
+To get around this, PyInstaller does any such tasks in an isolated Python subprocess and ships a
+:mod:`PyInstaller.isolated` submodule to do so in hooks. ::
+
+    from PyInstaller import isolated
+
+This submodule provides:
+
+*   :func:`isolated.call() <call>` to evaluate functions in isolation.
+*   :func:`@isolated.decorate <decorate>` to mark a function as always called in isolation.
+*   :class:`isolated.Python() <Python>` to efficiently call many functions in a single child instance of Python.
+
+"""
+
+# flake8: noqa
+from ._parent import Python, call, decorate

--- a/PyInstaller/isolated/_child.py
+++ b/PyInstaller/isolated/_child.py
@@ -1,0 +1,91 @@
+# -----------------------------------------------------------------------------
+# Copyright (c) 2021, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+# -----------------------------------------------------------------------------
+"""
+The child process to be invoked by IsolatedPython().
+
+This file is to be run directly with pipe handles for reading from and writing to the parent process as command line
+arguments.
+
+"""
+
+import sys
+import os
+import types
+from marshal import loads, dumps
+from base64 import b64encode, b64decode
+from traceback import format_exception
+
+if os.name == "nt":
+    from msvcrt import open_osfhandle
+
+    def _open(osf_handle, mode):
+        # Convert system file handles to file descriptors before opening them.
+        return open(open_osfhandle(osf_handle, 0), mode)
+else:
+    _open = open
+
+
+def run_next_command(read_fh, write_fh):
+    """
+    Listen to **read_fh** for the next function to run. Write the result to **write_fh**.
+    """
+
+    # Check the first line of input. Receiving an empty line is the signal that there are no more tasks to be ran.
+    first_line = read_fh.readline()
+    if first_line == b"\n":
+        # It's time to end this child process
+        return False
+
+    # There are 3 lines to read: The function's code, its args, then it kwargs.
+    code = loads(b64decode(first_line.strip()))
+    args = loads(b64decode(read_fh.readline().strip()))
+    kwargs = loads(b64decode(read_fh.readline().strip()))
+
+    try:
+        # Define the global namespace available to the function.
+        GLOBALS = {"__builtins__": __builtins__, "__isolated__": True}
+        # Reconstruct the function.
+        function = types.FunctionType(code, GLOBALS)
+
+        # Run it.
+        output = function(*args, **kwargs)
+
+        # Verify that the output is serialise-able (i.e. no custom types or module or function references) here so that
+        # it's caught if it fails.
+        marshalled = dumps((True, output))
+
+    except BaseException as ex:
+        # An exception happened whilst either running the function or serialising its output. Send back a string
+        # version of the traceback (unfortunately raw traceback objects are not marshal-able) and a boolean to say
+        # that it failed.
+        tb_lines = format_exception(type(ex), ex, ex.__traceback__)
+        if tb_lines[0] == "Traceback (most recent call last):\n":
+            # This particular line is distracting. Get rid of it.
+            tb_lines = tb_lines[1:]
+        marshalled = dumps((False, "".join(tb_lines).rstrip()))
+
+    # Send the output (return value or traceback) back to the parent.
+    write_fh.write(b64encode(marshalled))
+    write_fh.write(b"\n")
+    write_fh.flush()
+
+    # Signal that an instruction was ran (successfully or otherwise).
+    return True
+
+
+if __name__ == '__main__':
+    read_from_parent, write_to_parent = map(int, sys.argv[1:])
+
+    with _open(read_from_parent, "rb") as read_fh:
+        with _open(write_to_parent, "wb") as write_fh:
+            # Keep receiving and running instructions until the parent sends the signal to stop.
+            while run_next_command(read_fh, write_fh):
+                pass

--- a/PyInstaller/isolated/_parent.py
+++ b/PyInstaller/isolated/_parent.py
@@ -1,0 +1,268 @@
+# -----------------------------------------------------------------------------
+# Copyright (c) 2021, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+# -----------------------------------------------------------------------------
+
+import os
+from pathlib import Path
+from marshal import loads, dumps
+from base64 import b64encode, b64decode
+import functools
+
+from PyInstaller.compat import __wrap_python
+
+if os.name == "nt":
+    from msvcrt import get_osfhandle, open_osfhandle
+
+    def open(osf_handle, mode):
+        # Convert system file handles to file descriptors before opening them.
+        return os.fdopen(open_osfhandle(osf_handle, 0), mode)
+
+    def close(osf_handle):
+        # Likewise when closing.
+        return os.close(open_osfhandle(osf_handle, 0))
+
+else:
+    close = os.close
+
+CHILD_PY = Path(__file__).with_name("_child.py")
+
+
+def pipe():
+    """
+    Create a one-way pipe for sending data to child processes.
+
+    Returns:
+        A read/write pair of file descriptors (which are just integers) on posix or system file handle on Windows.
+
+    The pipe may be used either by this process or subprocesses of this process but not globally.
+
+    """
+    read, write = os.pipe()
+    # The default behaviour of pipes is that they are process specific. i.e. they can only be used for this process to
+    # talk to itself. Setting these means that child processes may also use these pipes.
+    os.set_inheritable(read, True)
+    os.set_inheritable(write, True)
+
+    # On Windows, file descriptors are not shareable. They need to be converted to system file handles here then
+    # converted back with open_osfhandle() by the child.
+    if os.name == "nt":
+        read, write = get_osfhandle(read), get_osfhandle(write)
+
+    return read, write
+
+
+def child(read_from_parent: int, write_to_parent: int):
+    """
+    Spawn a Python subprocess sending it the two file descriptors it needs to talk back to this parent process.
+    """
+    from subprocess import Popen
+
+    # Run the _child.py script directly passing it the two file descriptors it needs to talk back to the parent.
+    cmd, options = __wrap_python(
+        [str(CHILD_PY), str(read_from_parent), str(write_to_parent)],
+        # Explicitly disabling close_fds is a requirement for making file descriptors inheritable by child processes.
+        dict(close_fds=False, env=_subprocess_env()),
+    )
+    # I'm intentionally leaving stdout and stderr alone so that print() can still be used for emergency debugging and
+    # unhandled errors in the child are still visible.
+    return Popen(cmd, **options)
+
+
+def _subprocess_env():
+    """
+    Define the environment variables to be readable in a child process.
+    """
+    from PyInstaller.config import CONF
+    python_path = CONF["pathex"]
+    if "PYTHONPATH" in os.environ:
+        python_path = python_path + [os.environ["PYTHONPATH"]]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join(python_path)
+    return env
+
+
+class Python(object):
+    """
+    Start and connect to a separate Python subprocess.
+
+    This is the lowest level of public API provided by this module. The advantage of using this class directly is
+    that it allows multiple functions to be evaluated in a single subprocess, making it faster than multiple calls to
+    :func:`call`.
+
+    Examples:
+        To call some predefined functions ``x = foo()``, ``y = bar("numpy")`` and ``z = bazz(some_flag=True)`` all using
+        the same isolated subprocess use::
+
+            with isolated.Python() as child:
+                x = child.call(foo)
+                y = child.call(bar, "numpy")
+                z = child.call(bazz, some_flag=True)
+
+    """
+    def __init__(self):
+        self._child = None
+
+    def __enter__(self):
+        # We need two pipes. One for the child to send data to the parent.
+        self._read_from_child, self._write_to_parent = pipe()
+        # And one for the parent to send data to the child.
+        self._read_from_parent, self._write_to_child = pipe()
+
+        # Spawn a Python subprocess sending it the two file descriptors it needs to talk back to this parent process.
+        self._child = child(self._read_from_parent, self._write_to_parent)
+
+        # Open file handles to talk to the child.
+        self._write_handle = open(self._write_to_child, "wb")
+        self._read_handle = open(self._read_from_child, "rb")
+
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        # Send the signal (a blank line) to the child to tell it that it's time to stop.
+        self._write_handle.write(b"\n")
+        self._write_handle.flush()
+        self._child.wait()
+
+        # Then close all the pipes and handles. These steps were determined empirically to appease the corresponding
+        # test: tests/unit/test_isolation.py::test_pipe_leakage
+        # I don't really understand why they must be this way.
+        close(self._read_from_parent)
+        close(self._write_to_parent)
+        self._write_handle.close()
+        self._read_handle.close()
+        del self._read_handle, self._write_handle
+        self._child = None
+
+    def call(self, function, *args, **kwargs):
+        """
+        Call a function in the child Python. Retrieve its return value. Usage of this method is identical to that
+        of the :func:`call` function.
+        """
+        if self._child is None:
+            raise RuntimeError("An isolated.Python object must be used in a 'with' clause.")
+
+        # Send 3 lines to the child process: The function's code attribute and its args and kwargs, all serialised.
+        self._write_handle.writelines([
+            b64encode(dumps(function.__code__)), b"\n",
+            b64encode(dumps(args)), b"\n",
+            b64encode(dumps(kwargs)), b"\n",
+        ])  # yapf: disable
+
+        # Flushing is very important. Without it, the data is not sent but forever sits in a buffer so that the child is
+        # forever waiting for its data and the parent in turn is forever waiting for the child's response.
+        self._write_handle.flush()
+
+        # Read a single line of output back from the child. This contains if the function worked and either its return
+        # value or a traceback. This will block indefinitely until it receives a '\n' byte.
+        ok, output = loads(b64decode(self._read_handle.readline()))
+
+        # If all went well, then ``output`` is the return value.
+        if ok:
+            return output
+
+        # Otherwise an error happened and ``output`` is a string-ified stacktrace. Raise an error appending the
+        # stacktrace. Having the output in this order gives a nice fluent transition from parent to child in the stack
+        # trace.
+        raise RuntimeError(f"Child process call to {function.__name__}() failed with:\n" + output)
+
+
+def call(function, *args, **kwargs):
+    r"""
+    Call a function with arguments in a separate child Python. Retrieve its return value.
+
+    Args:
+        function:
+            The function to send and invoke.
+        *args:
+        **kwargs:
+            Positional and keyword arguments to send to the function. These must be simple builtin types - not custom
+            classes.
+    Returns:
+        The return value of the function. Again, these must be basic types serialisable by :func:`marshal.dumps`.
+    Raises:
+        RuntimeError:
+            Any exception which happens inside an isolated process is caught and reraised in the parent process.
+
+    To use, define a function which returns the information you're looking for. Any imports it requires must happen in
+    the body of the function. For example, to safely check the output of ``matplotlib.get_data_path()`` use::
+
+        # Define a function to be ran in isolation.
+        def get_matplotlib_data_path():
+            import matplotlib
+            return matplotlib.get_data_path()
+
+        # Call it with isolated.call().
+        get_matplotlib_data_path = isolated.call(matplotlib_data_path)
+
+    For single use functions taking no arguments like the above you can abuse the decorator syntax slightly to define
+    and execute a function in one go. ::
+
+        >>> @isolated.call
+        ... def matplotlib_data_dir():
+        ...     import matplotlib
+        ...     return matplotlib.get_data_path()
+        >>> matplotlib_data_dir
+        '/home/brenainn/.pyenv/versions/3.9.6/lib/python3.9/site-packages/matplotlib/mpl-data'
+
+    Functions may take positional and keyword arguments and return most generic Python data types. ::
+
+        >>> def echo_parameters(*args, **kwargs):
+        ...     return args, kwargs
+        >>> isolated.call(echo_parameters, 1, 2, 3)
+        (1, 2, 3), {}
+        >>> isolated.call(echo_parameters, foo=["bar"])
+        (), {'foo': ['bar']}
+
+    Notes:
+        To make a function behave differently if it's isolated, check for the ``__isolated__`` global. ::
+
+            if globals().get("__isolated__", False):
+                # We're inside a child process.
+                ...
+            else:
+                # This is the master process.
+                ...
+
+    """
+    with Python() as isolated:
+        return isolated.call(function, *args, **kwargs)
+
+
+def decorate(function):
+    """
+    Decorate a function so that it is always called in an isolated subprocess.
+
+    Examples:
+
+        To use, write a function then prepend ``@isolated.decorate``. ::
+
+            @isolated.decorate
+            def add_1(x):
+                '''Add 1 to ``x``, displaying the current process ID.'''
+                import os
+                print(f"Process {os.getpid()}: Adding 1 to {x}.")
+                return x + 1
+
+        The resultant ``add_1()`` function can now be called as you would a
+        normal function and it'll automatically use a subprocess.
+
+            >>> add_1(4)
+            Process 4920: Adding 1 to 4.
+            5
+            >>> add_1(13.2)
+            Process 4928: Adding 1 to 13.2.
+            14.2
+
+    """
+    @functools.wraps(function)
+    def wrapped(*args, **kwargs):
+        return call(function, *args, **kwargs)
+
+    return wrapped

--- a/PyInstaller/utils/hooks/__init__.py
+++ b/PyInstaller/utils/hooks/__init__.py
@@ -87,6 +87,10 @@ def exec_statement(statement):
         mpl_data_dir = exec_statement("import matplotlib; print(matplotlib.get_data_path())")
         datas = [ (mpl_data_dir, "") ]
 
+    Notes:
+        As of v4.6.0, usage of this function is discouraged in favour of the
+        new :mod:`PyInstaller.isolated` module.
+
     """
     return __exec_statement(statement, capture_stdout=True)
 
@@ -152,6 +156,11 @@ def eval_statement(statement):
          ''')
       for db in databases:
          hiddenimports.append("sqlalchemy.databases." + db)
+
+    Notes:
+        As of v4.6.0, usage of this function is discouraged in favour of the
+        new :mod:`PyInstaller.isolated` module.
+
     """
     txt = exec_statement(statement).strip()
     if not txt:

--- a/doc/hooks.rst
+++ b/doc/hooks.rst
@@ -358,6 +358,19 @@ Support for Conda
 
 .. autofunction:: PyInstaller.utils.hooks.conda.collect_dynamic_libs
 
+
+Subprocess isolation with :mod:`PyInstaller.isolated`
+-----------------------------------------------------
+
+.. currentmodule:: PyInstaller.isolated
+.. automodule:: PyInstaller.isolated
+.. autofunction:: call
+.. autofunction:: decorate
+.. autoclass:: Python
+    :members: call
+.. currentmodule:: PyInstaller.utils.hooks
+
+
 .. _the hook(hook_api) function:
 
 The ``hook(hook_api)`` Function

--- a/news/6052.feature.1.rst
+++ b/news/6052.feature.1.rst
@@ -1,0 +1,2 @@
+Make the error handing of :func:`~PyInstaller.utils.hooks.collect_submodules`
+configurable.

--- a/news/6052.feature.rst
+++ b/news/6052.feature.rst
@@ -1,0 +1,1 @@
+Add a :mod:`PyInstaller.isolated` submodule as a safer replacement to :func:`PyInstaller.utils.hooks.exec_statement`.

--- a/tests/unit/hookutils_files/hookutils_package/raises_error_on_import_1/__init__.py
+++ b/tests/unit/hookutils_files/hookutils_package/raises_error_on_import_1/__init__.py
@@ -1,0 +1,1 @@
+assert 0, "I cannot be imported!"

--- a/tests/unit/hookutils_files/hookutils_package/raises_error_on_import_2/__init__.py
+++ b/tests/unit/hookutils_files/hookutils_package/raises_error_on_import_2/__init__.py
@@ -1,0 +1,1 @@
+assert 0, "I cannot be imported!"

--- a/tests/unit/test_isolation.py
+++ b/tests/unit/test_isolation.py
@@ -1,0 +1,217 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2021, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+import os
+
+import pytest
+
+from PyInstaller import isolated
+from PyInstaller.utils.tests import requires
+
+
+def add_1(x):
+    return x + 1
+
+
+def fail():
+    assert 0, "It's broken!"
+
+
+def test_basic():
+    assert isolated.call(add_1, 10) == 11
+    assert isolated.call(add_1, x=4) == 5
+    assert isolated.call(lambda: print("hello")) is None
+
+
+def test_exception_handling():
+    """
+    Test the behaviour which an error is raised in the child process.
+    """
+    # Raising an error in a subprocess should propagate to a runtime error in the master process.
+    with pytest.raises(RuntimeError) as ex_info:
+        isolated.call(fail)
+    # The exception should include the offending function's name and the child's traceback which itself includes the
+    # breaking line of code and the exception type and message (in that order). Unfortunately, there seems to be a bug
+    # in pytest's exception rewriting which makes the exception type and message unverifiable when ran under pytest.
+    assert ex_info.match(r"(?s) call to fail\(\) failed .* " 'assert 0, "It\'s broken!".*')
+    # It should have removed the following line.
+    assert "Traceback (most recent call last)" not in str(ex_info.value)
+
+
+def test_multiple_calls():
+    """
+    Test running multiple functions in one process.
+    """
+    with isolated.Python() as child:
+        assert child.call(add_1, 1) == 2
+        assert child.call(add_1, 2) == 3
+        assert child.call(add_1, 3) == 4
+
+
+def use_builtins():
+    """
+    Test builtin functions, classes and constants are available.
+    """
+    assert sum([1, 2, 3]) == 6
+    list(range(10))
+    print("hello")
+    Ellipsis
+    ...
+    NotImplemented
+
+
+def use_imports():
+    """
+    Test that import-ing is possible.
+    """
+    import string
+    string.digits
+
+    import psutil
+    return psutil.boot_time()
+
+
+def test_builtins_access():
+    """
+    Ensure that generic builtins are accessible and that imports work.
+    """
+    with isolated.Python() as child:
+        child.call(use_builtins)
+        child.call(use_imports)
+
+
+def test_context_wrapping():
+    """
+    Test the `with` mechanisms of IsolatedPython().
+
+    We can land in some pretty horrible deadlocks if we try talking to a subprocess which either doesn't yet exist or
+    has died. Make sure neither of these are possible.
+
+    """
+    self = isolated.Python()
+
+    # Don't allow calling a function without using the context manager.
+    with pytest.raises(RuntimeError, match="isolated.Python .* 'with' clause"):
+        assert self.call(add_1, 1) == 2
+
+    # Multiple enters/exits should work (although they're technically pointless, being equivalent to two
+    # isolated.Python() instances).
+    with self:
+        assert self.call(add_1, 5.1) == 6.1
+    with self:
+        self.call(add_1, 2) == 3
+
+    # The isolator should remain alive and functional after raising an error.
+    with self:
+        with pytest.raises(RuntimeError):
+            self.call(add_1, "I should be a number")
+        assert self.call(add_1, 2.5) == 3.5
+
+
+def add_spam_to_environ():
+    """
+    Set an environment variable.
+    """
+    import os
+    os.environ["SPAM"] = "More Spam"
+    return "Done it!"
+
+
+def get_spam_environ():
+    import os
+    return os.environ.get("SPAM")
+
+
+def test_environment_propagation(monkeypatch):
+    """
+    Test that environment variables from the parent process are copied by the child but not the other way around.
+    """
+    # Clear the SPAM variable globally.
+    monkeypatch.delenv("SPAM", raising=False)
+
+    with isolated.Python() as child:
+        # There should be no SPAM defined in the child.
+        assert child.call(get_spam_environ) is None
+
+        # Define SPAM in the child.
+        child.call(add_spam_to_environ)
+        # This should change the child environment...
+        assert child.call(get_spam_environ) == "More Spam"
+        # ... but not the parent.
+        assert get_spam_environ() is None
+
+    # Define SPAM globally.
+    monkeypatch.setenv("SPAM", "More Spam")
+    assert get_spam_environ() == "More Spam"
+    # SPAM should be forwarded to new children.
+    assert isolated.call(get_spam_environ) == "More Spam"
+
+
+def test_decorator():
+    """
+    Test decorating a function with @wrap_with_isolation().
+    """
+    wrapped = isolated.decorate(add_spam_to_environ)
+    assert wrapped.__doc__ == add_spam_to_environ.__doc__
+
+    assert wrapped() == "Done it!"
+    assert "SPAM" not in os.environ
+
+
+@requires("psutil")
+def test_pipe_leakage():
+    """
+    There is a finite number of open pipes/file handles/file descriptors allowed per process. Ensure that all
+    opened handles eventually get closed to prevent such *leakages* causing crashes in very long processes (such as
+    the rest of our test suite).
+    """
+
+    from psutil import Process
+    parent = Process()
+
+    # Get this platform's *count open handles* method.
+    open_fds = parent.num_handles if os.name == "nt" else parent.num_fds
+    old = open_fds()
+
+    # Creating an isolated.Python() does nothing.
+    child = isolated.Python()
+    assert open_fds() == old
+
+    # Entering its context creates the child process and 4 handles for sending/receiving to/from it. Then on Windows,
+    # opening the parent's ends of the two pipes creates another two handles and starting the subprocess adds another
+    # two (although I don't know what for).
+    EXPECTED_INCREASE_IN_FDS = (4 if os.name != "nt" else 8)
+
+    with child:
+        assert open_fds() == old + EXPECTED_INCREASE_IN_FDS
+    # Exiting must close them all imediately. No implicit closure by garbage collect.
+    assert open_fds() == old
+
+    # Do it again just to be sure that the context manager properly restarts.
+    with child:
+        assert open_fds() == old + EXPECTED_INCREASE_IN_FDS
+    assert open_fds() == old
+
+
+def is_isolated():
+    """
+    This is the recommended way of testing if you currently in an isolated process.
+    """
+    return globals().get("__isolated__", False)
+
+
+def test_is_isolated():
+    """
+    Verify that the is_isolated() check returns true in isolation and false in this parent process.
+    """
+    assert is_isolated() is False
+    assert isolated.call(is_isolated) is True
+    assert is_isolated() is False


### PR DESCRIPTION
I've long felt that our `PyInstaller.utils.hooks.exec_statement()`, with its stdout pollution issues, its lack of exception handling and the need to manually serialise/deserialise non trivial return values, is hopelessly inadequate. So I've finally buried my nose into the murky depths of `os.pipe()` long enough to come up with a replacement.

So... define a new `PyInstaller.isolated` submodule with functions to supersede and eventually replace `utils.hooks.exec_statement()` and friends.

Example:

```python
from PyInstaller import isolated

@isolated.decorate
def get_matplotlib_backends():
    """Get matplotlib's backends and the current backend."""
    # Code to be ran in an isolated subprocess.
    import matplotlib

    print("This print statement will not affect the output. It could just be used for debugging.")

    # Provide output by returning. This can be anything that marshal.dumps() accepts.
    return matplotlib.rcsetup.all_backends, matplotlib.get_backend()

all_backends, current_backend = get_matplotlib_backends()
```

And its outputs.

```python
>>> all_backends
['GTK3Agg', 'GTK3Cairo', 'MacOSX', 'nbAgg', 'Qt4Agg', 'Qt4Cairo', 'Qt5Agg', 'Qt5Cairo', 'TkAgg', 'TkCairo', 'WebAgg', 'WX', 'WXAgg', 'WXCairo', 'agg', 'cairo', 'pdf', 'pgf', 'ps', 'svg', 'template']
>>> current_backend
'module://backend_interagg'
```

There is also a slightly lower level `isolated.call()` which takes a function (and possibly some arguments), runs it in a child process then returns the return value. And an even lower level `isolated.Python()` context manager which allows sending multiple functions to a child process:
```python
from PyInstaller import isolated

def print_pid():
    import os
    print("This is process", os.getpid())

print_pid()
with isolated.Python() as child:
    child.call(print_pid)
    child.call(print_pid)
```
```
This is process 2176
This is process 208350
This is process 208350
```
<details><summary>I go into more details about the differences in the commit message which I'll paste here.</summary>
    
* New syntax: Instead of providing a long string of Python code to `exec()` with `print()` statements for output, `isolated.call()` takes a function as input and its return value as output.
    
* All communication happens in specially created pipes. `std{in,out,err}` and resultantly `print()` are all untouched meaning that they may be polluted freely by imported libraries or used for debugging without disrupting the end output. This prevents errors such as #4813 and removes the need for manual *guarding* techniques such as 741d70b01916dfe62c9785245b8e59db98502477.
    
* Exception handling is builtin by default. If an error happens in the child process then it propagates to the parent. This will prevent (or at least reduce the subtlety of) errors like #5504 where an empty output due to an error *appears* to still be valid. As a bonus, because Python functions know where they were defined, filenames and line numbers in tracebacks from errors in the child process will correctly point to the function's source code rather than an unknown `<string>` file.
    
* Serialisation is automated via marshal. i.e. If you want to output a list then you just use `return ["some", "list"]` rather than having to covert to text in the child then back to a list in the parent process. No more DIY serialisation!

There are also two new potential routes for optimisation.
    
* As this implementation doesn't use `compile()` directly, py-cache is no longer circumvented. This should reduce the surprisingly large amount of time PyInstaller spends compiling bytecode.
    
* The `isolated.Python()` class allows executing multiple instructions in one instance of Python. This makes it feasible to *merge* combination functions such as `collect_all()` so that they only use one child process.
    
   ```python
  from PyInstaller import isolated
  

  # Define the child functions privately, ignoring isolation here.
  def _collect_foo(module):
      import importlib
      return importlib.import_module(module).foo
    

  def _collect_bar(module):
      import importlib
      return importlib.import_module(module).bar
    

  # Define isolated versions publicly.
  collect_foo = isolated.decorate(_collect_foo)
  collect_bar = isolated.decorate(_collect_bar)

    
  def collect_foo_and_bar(module):
      """Collect both foo and bar using only one child process."""
      # Create one child process.
      with isolated.Python() as child:
          # And call both private functions in it.
          foo = child.call(_collect_foo, module)
          bar = child.call(_collect_bar, module)
      return foo, bar
  ```
    
  This design makes the assumption that the original `collect_xxx()` functions do all their work in the child process which is the opposite to how most of our hook utilities are defined meaning that it would take substantial re-jiggling to make this optimisation happen in practice.

</details>

I've replaced some of the uglier usages of `exec_statement()` but left matplotlib alone to avoid merge conflicts with #6024. I'll add some docs and a changelog in a bit...

I think that it's best if we keep this out of v4.4.1 - partly because it'll be a new feature and partly because I'd rather it had some time reveal any bugs before releasing. Either delay merging this until after the 4.4.1 release or drop it out depending on what's easiest.