### PR TITLE
Tests: Remove one remaining usage of pytest.importorskip().

### DIFF
--- a/PyInstaller/utils/tests.py
+++ b/PyInstaller/utils/tests.py
@@ -80,13 +80,13 @@ def importorskip(package: str):
     to `sys.path` and `PATH` being polluted, which then breaks later builds.
 
     """
-    if not _importable(package):
+    if not importable(package):
         return pytest.mark.skip(f"Can't import '{package}'.")
     return pytest.mark.skipif(
         False, reason=f"Don't skip: '{package}' is importable.")
 
 
-def _importable(package: str):
+def importable(package: str):
     from importlib.util import find_spec
 
     # The find_spec() function is used by the importlib machinery to locate a
@@ -95,7 +95,7 @@ def _importable(package: str):
     if "." in package:
         # Using subprocesses is slow. If the top level module doesn't exist
         # then we can skip it.
-        if not _importable(package.split(".")[0]):
+        if not importable(package.split(".")[0]):
             return False
         # This is a submodule, import it in isolation.
         from subprocess import run, DEVNULL

--- a/tests/functional/test_pkgutil.py
+++ b/tests/functional/test_pkgutil.py
@@ -29,6 +29,7 @@ import os
 import pytest
 
 from PyInstaller.compat import exec_python_rc
+from PyInstaller.utils.tests import importable
 
 
 # Read the output file produced by test script. Each line consists of
@@ -53,7 +54,8 @@ def _read_results_file(filename):
 def test_pkgutil_iter_modules(package, script_dir, tmpdir, pyi_builder,
                               archive):
     # Ensure package is available
-    pytest.importorskip(package)
+    if not importable(package.split(".")[0]):
+        pytest.skip("Needs " + package)
 
     # Full path to test script
     test_script = 'pyi_pkgutil_iter_modules.py'


### PR DESCRIPTION
This should have been removed #6023 and is (we think) the cause of some sporadic test failures on CI.
