### PR TITLE
 bootloader: implement support for PEP540 UTF-8 mode

### DIFF
--- a/bootloader/src/pyi_python.c
+++ b/bootloader/src/pyi_python.c
@@ -40,6 +40,7 @@ DECLVAR(Py_NoUserSiteDirectory);
 DECLVAR(Py_OptimizeFlag);
 DECLVAR(Py_VerboseFlag);
 DECLVAR(Py_UnbufferedStdioFlag);
+DECLVAR(Py_UTF8Mode);
 
 /* functions with prefix `Py_` */
 DECLPROC(Py_BuildValue);
@@ -108,6 +109,9 @@ pyi_python_map_names(HMODULE dll, int pyvers)
     GETVAR(dll, Py_OptimizeFlag);
     GETVAR(dll, Py_VerboseFlag);
     GETVAR(dll, Py_UnbufferedStdioFlag);
+    if (pyvers >= 37) {
+        GETVAR(dll, Py_UTF8Mode);
+    }
 
     /* functions with prefix `Py_` */
     GETPROC(dll, Py_BuildValue);

--- a/bootloader/src/pyi_python.h
+++ b/bootloader/src/pyi_python.h
@@ -64,6 +64,7 @@ EXTDECLVAR(int, Py_IgnoreEnvironmentFlag);
 EXTDECLVAR(int, Py_DontWriteBytecodeFlag);
 EXTDECLVAR(int, Py_NoUserSiteDirectory);
 EXTDECLVAR(int, Py_UnbufferedStdioFlag);
+EXTDECLVAR(int, Py_UTF8Mode);
 
 /* This initializes the table of loaded modules (sys.modules), and creates the fundamental modules builtins, __main__ and sys. It also initializes the module search path (sys.path). It does not set sys.argv; */
 EXTDECLPROC(int, Py_Initialize, (void));

--- a/bootloader/src/pyi_pythonlib.c
+++ b/bootloader/src/pyi_pythonlib.c
@@ -247,6 +247,57 @@ pyi_pylib_set_runtime_opts(ARCHIVE_STATUS *status)
     return 0;
 }
 
+/* Enable UTF-8 mode as per PEP540. Applicable to Python 3.7 and later.
+ * It seems Py_UTF8Mode must be set before Py_SetPath is called, but
+ * in practice, it is probably a good idea to call it before any
+ * Py_* functions are used
+ */
+static void
+pyi_pylib_set_pep540_utf8_mode()
+{
+    int enable_utf8_mode = -1;
+    char *env_utf8 = NULL;
+
+    /* Applicable only to Python 3.7 and later */
+    if (pyvers < 37) {
+        return;
+    }
+
+    /* Honor the setting via PYTHONUTF8 environment variable (valid
+     * values are 0 and 1, same as with python interpreter) */
+    env_utf8 = pyi_getenv("PYTHONUTF8");
+    if (env_utf8) {
+        if (strcmp(env_utf8, "0") == 0) {
+            enable_utf8_mode = 0;
+        } else if (strcmp(env_utf8, "1") == 0) {
+            enable_utf8_mode = 1;
+        } else {
+            OTHERERROR("Invalid value for PYTHONUTF8=%s; disabling utf-8 mode!\n", env_utf8);
+            enable_utf8_mode = 0;
+        }
+    }
+
+#ifndef _WIN32
+    if (enable_utf8_mode < 0) {
+        /* On non-Windows, the C locale and the POSIX locale enable the
+         * UTF-8 Mode (PEP 540) */
+        const char *ctype_loc = setlocale(LC_CTYPE, NULL);
+        if (ctype_loc != NULL && (strcmp(ctype_loc, "C") == 0 || strcmp(ctype_loc, "POSIX") == 0)) {
+            enable_utf8_mode = 1;
+        }
+    }
+#endif
+
+    /* Enable/disable UTF-8 mode */
+    if (enable_utf8_mode > 0) {
+        VS("LOADER: Enabling UTF-8 mode\n");
+        *PI_Py_UTF8Mode = 1;
+    } else {
+        *PI_Py_UTF8Mode = 0;
+    }
+}
+
+
 void
 pyi_free_wargv(wchar_t ** wargv)
 {
@@ -399,6 +450,11 @@ pyi_pylib_start_python(ARCHIVE_STATUS *status)
     static wchar_t pypath_w[MAX_PYPATH_SIZE];
     static wchar_t pyhome_w[PATH_MAX + 1];
     static wchar_t progname_w[PATH_MAX + 1];
+
+    /* Enable PEP540 UTF-8 mode, if necessary. Must be done before Py_SetPath()
+     * is called for the setting to take effect (but we should probably also
+     * set it before pyi_locale_char2wchar() calls). */
+    pyi_pylib_set_pep540_utf8_mode();
 
     /* Decode using current locale */
     if (!pyi_locale_char2wchar(progname_w, status->archivename, PATH_MAX)) {

--- a/news/6054.bugfix.rst
+++ b/news/6054.bugfix.rst
@@ -1,0 +1,3 @@
+Running a frozen application under ``C`` or ``POSIX`` locale enables
+PEP540 UTF-8 mode in order to keep behavior consistent with that of
+python interpreter (Python 3.7 or later; Linux and macOS only).

--- a/news/6065.feature.rst
+++ b/news/6065.feature.rst
@@ -1,0 +1,5 @@
+Implement support for PEP540 UTF-8 mode to match behavior of Python
+interpreter (applicable to Python 3.7 and later). The UTF-8 mode can be
+explicitly enabled or disabled via ``PYTHONUTF8`` environment variable.
+Unless explicitly disabled, it is auto-enabled on linux and macOS when
+locale is set to ``C`` or ``POSIX``.

--- a/tests/functional/test_misc.py
+++ b/tests/functional/test_misc.py
@@ -11,6 +11,11 @@
 
 import os
 
+import pytest
+
+from PyInstaller.compat import is_py37
+from PyInstaller.utils.tests import skipif
+
 # Directory with testing modules used in some tests.
 _MODULES_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'modules')
 
@@ -58,3 +63,29 @@ def test_dis_main(pyi_builder):
         print(dis.dis(sys.modules["__main__"].__loader__.get_code("__main__")))
         """
     )
+
+
+# Test that setting PYTHONUTF8 controls the PEP540 UTF-8 mode on all OSes, regardless of current locale setting.
+@skipif(not is_py37, reason="PEP540 UTF-8 mode is available in Python 3.7 and later.")
+@pytest.mark.parametrize('python_utf8', [True, False])
+def test_utf8_mode_envvar(python_utf8, pyi_builder, monkeypatch):
+    monkeypatch.setenv('PYTHONUTF8', str(int(python_utf8)))
+    pyi_builder.test_source(
+        """
+        import sys
+        assert sys.flags.utf8_mode == {}
+        """.format(python_utf8)
+    )
+
+
+# Test that PEP540 UTF-8 mode is automatically enabled for C and POSIX locales (applicable only to macOS and linux).
+@pytest.mark.linux
+@pytest.mark.darwin
+@skipif(not is_py37, reason="PEP540 UTF-8 mode is available in Python 3.7 and later.")
+@pytest.mark.parametrize('locale', ['C', 'POSIX'])
+def test_utf8_mode_locale(locale, pyi_builder, monkeypatch):
+    monkeypatch.setenv('LC_CTYPE', locale)
+    pyi_builder.test_source("""
+        import sys
+        assert sys.flags.utf8_mode == 1
+        """)


### PR DESCRIPTION
Enable [PEP540](https://www.python.org/dev/peps/pep-0540/) UTF-8 mode if `PYTHONUTF8` environment is set to 1 (on all OSes, regardless of locale setting). On non-Windows, enable PEP540 UTF-8 mode for `C` and `POSIX` locales to match the behavior of the python interpreter.

Fixes #6054.

The UTF-8 mode handling code is separate from other runtime options handling, because it seems that `Py_UTF8Mode` needs to be set *before* `Py_SetPath()` is called to have any effect. On the other hand, it seems that setting the warning flags via `PySys_AddWarnOption()` in `pyi_pylib_set_runtime_opts()` needs to be  done *after* `Py_SetPath()` is called. Therefore, UTF-8 mode handling code is implemented as a separate utility function and called at the beginning of `pyi_pylib_start_python()`, while the call to `pyi_pylib_set_runtime_opts()` is left unchanged.