### PR TITLE
bootloader: fix crash in windowed mode when traceback is unavailable

### DIFF
--- a/bootloader/src/pyi_launch.c
+++ b/bootloader/src/pyi_launch.c
@@ -380,7 +380,7 @@ _pyi_extract_exception_message(PyObject *pvalue)
     if (pvalue_cchar) {
         retval = strdup(pvalue_cchar);
     }
-    Py_DECREF(pvalue_str);
+    PI_Py_DecRef(pvalue_str);
 
     return retval;
 }
@@ -429,16 +429,16 @@ _pyi_extract_exception_traceback(PyObject *ptype, PyObject *pvalue,
                 /* Join the list using empty string */
                 PyObject *tb_empty = PI_PyUnicode_FromString("");
                 tb_str = PI_PyUnicode_Join(tb_empty, tb);
-                Py_DECREF(tb_empty);
+                PI_Py_DecRef(tb_empty);
                 if (fmt_mode == PYI_TB_FMT_CRLF) {
                     /* Replace LF with CRLF */
                     PyObject *lf = PI_PyUnicode_FromString("\n");
                     PyObject *crlf = PI_PyUnicode_FromString("\r\n");
                     PyObject *tb_str_crlf = PI_PyUnicode_Replace(tb_str, lf, crlf, -1);
-                    Py_DECREF(lf);
-                    Py_DECREF(crlf);
+                    PI_Py_DecRef(lf);
+                    PI_Py_DecRef(crlf);
                     /* Swap */
-                    Py_DECREF(tb_str);
+                    PI_Py_DecRef(tb_str);
                     tb_str = tb_str_crlf;
                 }
             }
@@ -446,12 +446,12 @@ _pyi_extract_exception_traceback(PyObject *ptype, PyObject *pvalue,
             if (tb_cchar) {
                 retval = strdup(tb_cchar);
             }
-            Py_DECREF(tb);
-            Py_DECREF(tb_str);
+            PI_Py_DecRef(tb);
+            PI_Py_DecRef(tb_str);
         }
-        Py_DECREF(func);
+        PI_Py_DecRef(func);
     }
-    Py_DECREF(module);
+    PI_Py_DecRef(module);
 
     return retval;
 }
@@ -499,7 +499,7 @@ pyi_launch_run_scripts(ARCHIVE_STATUS *status)
             VS("LOADER: Running %s.py\n", ptoc->name);
             __file__ = PI_PyUnicode_FromString(buf);
             PI_PyObject_SetAttrString(__main__, "__file__", __file__);
-            Py_DECREF(__file__);
+            PI_Py_DecRef(__file__);
 
             /* Unmarshall code object */
             code = PI_PyMarshal_ReadObjectFromString((const char *) data, ptoc->ulen);

--- a/bootloader/src/pyi_launch.c
+++ b/bootloader/src/pyi_launch.c
@@ -418,33 +418,38 @@ _pyi_extract_exception_traceback(PyObject *ptype, PyObject *pvalue,
     if (module != NULL) {
         PyObject *func = PI_PyObject_GetAttrString(module, "format_exception");
         if (func) {
-            PyObject *tb, *tb_str;
+            PyObject *tb = NULL;
+            PyObject *tb_str = NULL;
             const char *tb_cchar = NULL;
             tb = PI_PyObject_CallFunctionObjArgs(func, ptype, pvalue,
                                                  ptraceback, NULL);
-            if (fmt_mode == PYI_TB_FMT_REPR) {
-                /* Represent the list as string */
-                tb_str = PI_PyObject_Str(tb);
-            } else {
-                /* Join the list using empty string */
-                PyObject *tb_empty = PI_PyUnicode_FromString("");
-                tb_str = PI_PyUnicode_Join(tb_empty, tb);
-                PI_Py_DecRef(tb_empty);
-                if (fmt_mode == PYI_TB_FMT_CRLF) {
-                    /* Replace LF with CRLF */
-                    PyObject *lf = PI_PyUnicode_FromString("\n");
-                    PyObject *crlf = PI_PyUnicode_FromString("\r\n");
-                    PyObject *tb_str_crlf = PI_PyUnicode_Replace(tb_str, lf, crlf, -1);
-                    PI_Py_DecRef(lf);
-                    PI_Py_DecRef(crlf);
-                    /* Swap */
-                    PI_Py_DecRef(tb_str);
-                    tb_str = tb_str_crlf;
+            if (tb != NULL) {
+                if (fmt_mode == PYI_TB_FMT_REPR) {
+                    /* Represent the list as string */
+                    tb_str = PI_PyObject_Str(tb);
+                } else {
+                    /* Join the list using empty string */
+                    PyObject *tb_empty = PI_PyUnicode_FromString("");
+                    tb_str = PI_PyUnicode_Join(tb_empty, tb);
+                    PI_Py_DecRef(tb_empty);
+                    if (fmt_mode == PYI_TB_FMT_CRLF) {
+                        /* Replace LF with CRLF */
+                        PyObject *lf = PI_PyUnicode_FromString("\n");
+                        PyObject *crlf = PI_PyUnicode_FromString("\r\n");
+                        PyObject *tb_str_crlf = PI_PyUnicode_Replace(tb_str, lf, crlf, -1);
+                        PI_Py_DecRef(lf);
+                        PI_Py_DecRef(crlf);
+                        /* Swap */
+                        PI_Py_DecRef(tb_str);
+                        tb_str = tb_str_crlf;
+                    }
                 }
             }
-            tb_cchar = PI_PyUnicode_AsUTF8(tb_str);
-            if (tb_cchar) {
-                retval = strdup(tb_cchar);
+            if (tb_str != NULL) {
+                tb_cchar = PI_PyUnicode_AsUTF8(tb_str);
+                if (tb_cchar) {
+                    retval = strdup(tb_cchar);
+                }
             }
             PI_Py_DecRef(tb);
             PI_Py_DecRef(tb_str);

--- a/bootloader/src/pyi_python.h
+++ b/bootloader/src/pyi_python.h
@@ -137,25 +137,6 @@ EXTDECLPROC(const char *, PyUnicode_AsUTF8, (PyObject *));
 EXTDECLPROC(PyObject *, PyUnicode_Join, (PyObject *, PyObject *));
 EXTDECLPROC(PyObject *, PyUnicode_Replace, (PyObject *, PyObject *, PyObject *, size_t));  /* Py_ssize_t */
 
-/*
- * Macros for reference counting through exported functions
- * (that is: without binding to the binary structure of a PyObject.
- * These rely on the Py_IncRef/Py_DecRef API functions on Pyhton 2.4+.
- *
- * Python versions before 2.4 do not export IncRef/DecRef as a binary API,
- * but only as macros in header files. Since we support Python 2.4+ we do not
- * need to provide an emulated incref/decref as it was with older Python
- * versions.
- *
- * We do not want to depend on Python.h for many reasons (including the fact
- * that we would like to have a single binary for all Python versions).
- */
-
-#define Py_XINCREF(o)    PI_Py_IncRef(o)
-#define Py_XDECREF(o)    PI_Py_DecRef(o)
-#define Py_DECREF(o)     Py_XDECREF(o)
-#define Py_INCREF(o)     Py_XINCREF(o)
-
 int pyi_python_map_names(HMODULE dll, int pyvers);
 
 #endif  /* PYI_PYTHON_H */

--- a/news/6070.bugfix.rst
+++ b/news/6070.bugfix.rst
@@ -1,0 +1,2 @@
+Fix crash in windowed bootloader when the traceback for unhandled exception
+cannot be retrieved.


### PR DESCRIPTION
Fix a crash I came across on macOS in windowed (app bundle) mode.

Also remove Py_*REF macros, because every time I see them I start wondering whether they can be passed NULL or not...