### PR TITLE
bootloader: restore compatibility with -std=gnu90

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,14 @@ jobs:
           path: ${{ env.pip_cache_dir }}
           key: ${{ runner.os }}-${{ matrix.python-version }}
 
+      - name: Check if bootloader code conforms to gnu90 C standard
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+          # Compile bootloader
+          cd bootloader
+          CC="gcc -std=gnu90" python waf all
+          cd ..
+
       - name: Set up environment
         run: |
           # Update pip.

--- a/bootloader/src/pyi_archive.c
+++ b/bootloader/src/pyi_archive.c
@@ -394,7 +394,7 @@ _pyi_find_cookie_offset(FILE *fp)
     /* Search the file back to front, in overlapping SEARCH_CHUNK_SIZE
      * chunks. */
     do {
-        size_t chunk_size;
+        size_t chunk_size, i;
         start_pos = (end_pos >= SEARCH_CHUNK_SIZE) ? (end_pos - SEARCH_CHUNK_SIZE) : 0;
         chunk_size = (size_t)(end_pos - start_pos);
 
@@ -414,7 +414,7 @@ _pyi_find_cookie_offset(FILE *fp)
         }
 
         /* Scan the chunk */
-        for (size_t i = chunk_size - MAGIC_SIZE + 1; i > 0; i--) {
+        for (i = chunk_size - MAGIC_SIZE + 1; i > 0; i--) {
             if (_pyi_match_magic(buffer + i - 1)) {
                 offset = start_pos + i - 1;
                 goto cleanup;


### PR DESCRIPTION
Move the declaration of index variable outside of the for-loop statement to avoid requiring C99 mode.

Fixes #6081.