### PR TITLE
bootloader: prevent onefile cleanup from recursing into symlinked directories

### DIFF
--- a/bootloader/src/pyi_utils.c
+++ b/bootloader/src/pyi_utils.c
@@ -478,12 +478,15 @@ remove_one(wchar_t *wfnm, size_t pos, struct _wfinddata_t wfinfo)
     wfnm[pos] = PYI_NULLCHAR;
     wcscat(wfnm, wfinfo.name);
 
-    if (wfinfo.attrib & _A_SUBDIR) {
-        /* Use recursion to remove subdirectories. */
-        /* TODO: prevent recursion into symlinked directories to match
-         * the behavior of non-Windows codepath */
-        pyi_win32_utils_to_utf8(fnm, wfnm, PATH_MAX);
-        pyi_remove_temp_path(fnm);
+    if ((wfinfo.attrib & _A_SUBDIR)) {
+        if (!pyi_win32_is_symlink(wfnm)) {
+            /* Use recursion to remove subdirectories. */
+            pyi_win32_utils_to_utf8(fnm, wfnm, PATH_MAX);
+            pyi_remove_temp_path(fnm);
+        } else {
+            /* Remove only directory link */
+            _wrmdir(wfnm);
+        }
     }
     else if (_wremove(wfnm)) {
         /* HACK: Possible concurrency issue... spin a little while */

--- a/bootloader/src/pyi_utils.c
+++ b/bootloader/src/pyi_utils.c
@@ -480,6 +480,8 @@ remove_one(wchar_t *wfnm, size_t pos, struct _wfinddata_t wfinfo)
 
     if (wfinfo.attrib & _A_SUBDIR) {
         /* Use recursion to remove subdirectories. */
+        /* TODO: prevent recursion into symlinked directories to match
+         * the behavior of non-Windows codepath */
         pyi_win32_utils_to_utf8(fnm, wfnm, PATH_MAX);
         pyi_remove_temp_path(fnm);
     }
@@ -534,7 +536,9 @@ remove_one(char *pnm, int pos, const char *fnm)
     pnm[pos] = PYI_NULLCHAR;
     strcat(pnm, fnm);
 
-    if (stat(pnm, &sbuf) == 0) {
+    /* Use lstat() instead of stat() to prevent recursion into
+     * symlinked directories */
+    if (lstat(pnm, &sbuf) == 0) {
         if (S_ISDIR(sbuf.st_mode) ) {
             /* Use recursion to remove subdirectories. */
             pyi_remove_temp_path(pnm);

--- a/bootloader/src/pyi_win32_utils.h
+++ b/bootloader/src/pyi_win32_utils.h
@@ -30,6 +30,8 @@ char * pyi_win32_utf8_to_mbs(char * dst, const char * src, size_t max);
 
 int pyi_win32_mkdir(const wchar_t *path);
 
+int pyi_win32_is_symlink(const wchar_t *path);
+
 #endif /* ifdef _WIN32 */
 
 #endif  /* UTILS_H */

--- a/news/6074.bugfix.rst
+++ b/news/6074.bugfix.rst
@@ -1,0 +1,2 @@
+On non-Windows, prevent ``onefile`` cleanup from recursing into symlinked
+directories and just remove the link instead.

--- a/news/6074.bugfix.rst
+++ b/news/6074.bugfix.rst
@@ -1,2 +1,2 @@
-On non-Windows, prevent ``onefile`` cleanup from recursing into symlinked
-directories and just remove the link instead.
+Prevent ``onefile`` cleanup from recursing into symlinked directories and
+just remove the link instead.

--- a/tests/functional/test_misc.py
+++ b/tests/functional/test_misc.py
@@ -92,8 +92,6 @@ def test_utf8_mode_locale(locale, pyi_builder, monkeypatch):
 
 
 # Test that onefile cleanup does not remove contents of a directory that user symlinks into sys._MEIPASS (see #6074).
-@pytest.mark.linux
-@pytest.mark.darwin
 def test_onefile_cleanup_symlinked_dir(pyi_builder, tmpdir):
     if pyi_builder._mode != 'onefile':
         pytest.skip('The test is relevant only to onefile builds.')
@@ -105,6 +103,12 @@ def test_onefile_cleanup_symlinked_dir(pyi_builder, tmpdir):
         output_file = os.path.join(output_dir, f'preexisting-{idx}.txt')
         with open(output_file, 'w') as fp:
             fp.write(f'Pre-existing file #{idx}')
+
+    # Check if OS supports creation of symbolic links
+    try:
+        os.symlink(output_dir, str(tmpdir / 'testdir'))
+    except OSError:
+        pytest.skip("OS does not support (unprivileged) creation of symbolic links.")
 
     # Run the test program
     pyi_builder.test_source(


### PR DESCRIPTION
See #6074. 