### PR TITLE
Bootloader: Building: macOS: Leave arch unspecified when given --no-universal2.

### DIFF
--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -192,7 +192,12 @@ def options(ctx):
                    action='store_false',
                    help='When building for 64-bit platform, build a thin '
                         'binary. Allows building with older toolchains that '
-                        'do not support universal2 binaries.',
+                        'do not support universal2 binaries. '
+                        'The resultant architecture is determined by the '
+                        'compiler\'s default which is usually to build a '
+                        'native executable. This may be overrode by '
+                        "setting the CC environment variable "
+                        "(CC='clang -arch=arm64' python waf all).",
                    default=None,
                    dest='macos_universal2')
 
@@ -365,9 +370,9 @@ def set_arch_flags(ctx):
             if ctx.options.macos_universal2:
                 mac_arch = UNIVERSAL2_FLAGS
             else:
-                mac_arch = ['-arch', 'x86_64']
+                # Default to whatever the compiler is configured to build.
+                mac_arch = []
         ctx.env.append_value('CFLAGS', mac_arch)
-        ctx.env.append_value('CXXFLAGS', mac_arch)
         ctx.env.append_value('LINKFLAGS', mac_arch)
 
     # AIX specific flags

--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -195,7 +195,7 @@ def options(ctx):
                         'do not support universal2 binaries. '
                         'The resultant architecture is determined by the '
                         'compiler\'s default which is usually to build a '
-                        'native executable. This may be overrode by '
+                        'native executable. This may be overridden by '
                         "setting the CC environment variable "
                         "(CC='clang -arch=arm64' python waf all).",
                    default=None,

--- a/doc/bootloader-building.rst
+++ b/doc/bootloader-building.rst
@@ -138,7 +138,26 @@ built. This behavior can be controlled by passing ``--universal2`` or
 use ``--universal2`` flag and a toolchain that lacks support for
 `universal2` binaries will result in configuration error.
 
-Now you can build the bootloader as shown above.
+The ``--no-universal2`` flag leaves the target architecture unspecified letting
+the resultant executable's architecture be the C compiler's default (which is
+almost certainly the architecture of the build machine). Should you want to
+build a thin executable of either architecture, use the ``--no-universal2`` flag
+and then optionally override the compiler, adding the ``-arch`` flag, via the
+``CC`` environment variable.
+
+Build a thin, native executable::
+
+    python waf --no-universal2 all
+
+Build a thin, ``x86_64`` executable (irregardless of the build machine's
+architecture)::
+
+    CC='clang -arch=x86_64' python waf --no-universal2  all
+
+Build a thin, ``arm64`` executable (irregardless of the build machine's
+architecture)::
+
+    CC='clang -arch=arm64' python waf --no-universal2 all
 
 By default, the build script targets Mac OSX 10.13, which can be overridden by
 exporting the MACOSX_DEPLOYMENT_TARGET environment variable.

--- a/news/6096.bootloader.rst
+++ b/news/6096.bootloader.rst
@@ -1,0 +1,3 @@
+Change the behaviour of the ``--no-universal2`` flag so that it now assumes the
+target architecture of the compiler (which may be overridden via the ``CC``
+environment variable to facilitate cross compiling).


### PR DESCRIPTION
Implement what [I suggested here](https://github.com/pyinstaller/pyinstaller/issues/6091#issuecomment-892212070) - to turn the `--no-univesal2` flag into a *let the user choose* option. Doing so gives the user the option to build a thin bootloader of either architecture.

Closes #6091.
