### PR TITLE
Analysis: Fix detection of recursive metadata requirements.

### DIFF
--- a/PyInstaller/depend/analysis.py
+++ b/PyInstaller/depend/analysis.py
@@ -809,7 +809,7 @@ class PyiModuleGraph(ModuleGraph):
         for method in methods:
             need_metadata.update(bytecode.any_alias(package + "." + method))
         for method in recursive_methods:
-            need_metadata.update(bytecode.any_alias(package + "." + method))
+            need_recursive_metadata.update(bytecode.any_alias(package + "." + method))
 
         out = set()
 

--- a/news/6069.bugfix.rst
+++ b/news/6069.bugfix.rst
@@ -1,0 +1,3 @@
+Fix a bug in implicit metadata collection where, on seeing
+``pkg_resources.require("foo")``, PyInstaller would only collect ``foo``\ s
+metadata instead of ``foo`` plus all its dependencies.

--- a/news/6069.bugfix.rst
+++ b/news/6069.bugfix.rst
@@ -1,3 +1,3 @@
 Fix a bug in implicit metadata collection where, on seeing
 ``pkg_resources.require("foo")``, PyInstaller would only collect ``foo``\ s
-metadata instead of ``foo`` plus all its dependencies.
+metadata instead of metadata for ``foo`` and all its dependencies.


### PR DESCRIPTION
Fix for #6069.

On seeing ``pkg_resources.require("foo")``, PyInstaller should collect metadata for ``foo`` and all its dependencies but, due to a bogus line of code, only foo's metadata was collected. 

The fix itself is only one line but I've added another unit test to keep an eye on it.