### PR TITLE
Bootloader build: Enable Control Flow Guard for Windows binaries.

### DIFF
--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -700,6 +700,11 @@ def configure(ctx):
             ctx.env.append_value(
                 'LINKFLAGS', '/SUBSYSTEM:CONSOLE,%s' % ('5.01' if ctx.env.PYI_ARCH == '32bit' else '5.02')
             )
+
+            # Enable support for Control Flow Guard
+            # https://docs.microsoft.com/en-us/windows/win32/secbp/control-flow-guard
+            ctx.env.append_value('CFLAGS', '/guard:cf')
+            ctx.env.append_value('LINKFLAGS', '/guard:cf')
         else:
             # Use Visual C++ compatible alignment
             ctx.env.append_value('CFLAGS', '-mms-bitfields')

--- a/news/6136.build.rst
+++ b/news/6136.build.rst
@@ -1,0 +1,2 @@
+(Windows) Enable `Control Flow Guard <https://docs.microsoft.com/en-us/windows/win32/secbp/control-flow-guard>`_
+for the Windows bootloader.


### PR DESCRIPTION
The motivation here is to enable a "highly-optimized platform security
feature that was created to combat memory corruption vulnerabilities".

Note that "CFG enabled code works fine on "CFG-Unaware" versions 
of Windows and is therefore fully compatible with them"

Quotes from
https://docs.microsoft.com/en-us/windows/win32/secbp/control-flow-guard