### PR TITLE
hooks: qt: prevent potential error due to partially-installed PyQt6

### DIFF
--- a/PyInstaller/utils/hooks/qt.py
+++ b/PyInstaller/utils/hooks/qt.py
@@ -56,7 +56,19 @@ class QtLibraryInfo:
                 self.qt_rel_dir = os.path.join('PyQt5', 'Qt')
         elif namespace == 'PyQt6':
             # Similarly to PyQt5, PyQt6 switched from PyQt6/Qt to PyQt6/Qt6 in 6.0.3
-            if hooks.is_module_satisfies("PyQt6 >= 6.0.3"):
+            try:
+                # The call below might fail with AttributeError in case of a partial PyQt6 installation. For example,
+                # user installs PyQt6 via pip, which also installs PyQt6-Qt6 and PyQt6-sip. Then they naively uninstall
+                # PyQt6 package, which leaves the other two behind. PyQt6 now becomes a namespace package and there is
+                # no dist metadata, so a fallback codepath in is_module_satisfies tries to check for __version__
+                # attribute that does not exist, either. Handle such errors gracefully and assume new layout (with
+                # PyQt6, the new layout is more likely); it does not really matter what layout we assume, as library is
+                # not usable anyway, but we do neeed to be able to return an instance of QtLibraryInfo with "version"
+                # attribute set to a falsey value.
+                new_layout = hooks.is_module_satisfies("PyQt6 >= 6.0.3")
+            except AttributeError:
+                new_layout = True
+            if new_layout:
                 self.qt_rel_dir = os.path.join('PyQt6', 'Qt6')
             else:
                 self.qt_rel_dir = os.path.join('PyQt6', 'Qt')

--- a/news/6141.hooks.rst
+++ b/news/6141.hooks.rst
@@ -1,0 +1,2 @@
+Prevent potential error in hooks for Qt-based packages that could be triggered 
+by a partial ``PyQt6`` installation.


### PR DESCRIPTION
Prevent potential errors on importing `PyInstaller.utils.hooks.qt` module, caused by a partial `PyQt6 installation` (e.g., only
`PyQt6-Qt6` and `PyQt6-sip` remaining installed after user uninstalls `PyQt6` package). As the error is raised on import of the `qt` hookutils module, it then affects *all* hooks for *all* Qt-based packages (not just `PyQt6`).