### PR TITLE
hooks: sysconfig: fix collection of data module under MSYS2/MINGW

### DIFF
--- a/PyInstaller/hooks/hook-distutils.py
+++ b/PyInstaller/hooks/hook-distutils.py
@@ -19,9 +19,10 @@ This hook freezes the external `Makefile` and `pyconfig.h` files bundled with th
 # config vars to a module (see hook-sysconfig.py). It doesn't use a nice `get module name` function like ``sysconfig``
 # does to help us locate it but the module is the same file that ``sysconfig`` uses so we can use the
 # ``_get_sysconfigdata_name()`` from regular ``sysconfig``.
-import sysconfig
-
-from PyInstaller import compat
-
-if not compat.is_win and hasattr(sysconfig, '_get_sysconfigdata_name'):
+try:
+    import sysconfig
     hiddenimports = [sysconfig._get_sysconfigdata_name()]
+except AttributeError:
+    # Either sysconfig has no attribute _get_sysconfigdata_name (i.e., the function does not exist), or this is Windows
+    # and the _get_sysconfigdata_name() call failed due to missing sys.abiflags attribute.
+    pass

--- a/PyInstaller/hooks/hook-sysconfig.py
+++ b/PyInstaller/hooks/hook-sysconfig.py
@@ -9,12 +9,15 @@
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
 
-import sysconfig
-
-from PyInstaller.compat import is_win
-
-if not is_win and hasattr(sysconfig, '_get_sysconfigdata_name'):
-    # Python 3.6 uses additional modules like `_sysconfigdata_m_linux_x86_64-linux-gnu`, see
-    # https://github.com/python/cpython/blob/3.6/Lib/sysconfig.py#L417
-    # Note: Some versions of Anaconda backport this feature to before 3.6. See issue #3105.
+# Python 3.6 uses additional modules like `_sysconfigdata_m_linux_x86_64-linux-gnu`, see
+# https://github.com/python/cpython/blob/3.6/Lib/sysconfig.py#L417
+# Note: Some versions of Anaconda backport this feature to before 3.6. See issue #3105.
+# Note: on Windows, python.org and Anaconda python provide _get_sysconfigdata_name, but calling it fails due to sys
+# module lacking abiflags attribute. It does work on MSYS2/MINGW python, where we need to collect corresponding file.
+try:
+    import sysconfig
     hiddenimports = [sysconfig._get_sysconfigdata_name()]
+except AttributeError:
+    # Either sysconfig has no attribute _get_sysconfigdata_name (i.e., the function does not exist), or this is Windows
+    # and the _get_sysconfigdata_name() call failed due to missing sys.abiflags attribute.
+    pass

--- a/news/6118.bugfix.rst
+++ b/news/6118.bugfix.rst
@@ -1,0 +1,2 @@
+(Windows) Fix collection of ``sysconfig`` platform-specific data module when
+using MSYS2/MINGW python.


### PR DESCRIPTION
Under MSYS2/MINGW, we need to collect the platform-specific data module obtained via `sysconfig._get_sysconfigdata_name()`. That call fails under other python flavors on Windows, but that is better handled by try/except block anyway.

Fixes #6118.