### PR TITLE
loader: FrozenImporter: handle encodings when reading source files 

### DIFF
--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -602,6 +602,7 @@ PY3_BASE_MODULES = {
     'sre_compile',
     'sre_constants',
     'sre_parse',
+    'tokenize',  # used by loader/pymod03_importers.py
     'traceback',  # for startup errors
     'types',
     'weakref',

--- a/PyInstaller/loader/pyimod03_importers.py
+++ b/PyInstaller/loader/pyimod03_importers.py
@@ -63,6 +63,7 @@ def _decode_source(source_bytes):
     https://github.com/python/cpython/blob/3.9/Lib/importlib/_bootstrap_external.py#L679-L688
     """
     # Local imports to avoid bootstrap issues
+    # NOTE: both modules are listed in compat.PY3_BASE_MODULES and collected into base_library.zip.
     import io
     import tokenize
 

--- a/news/6143.bugfix.rst
+++ b/news/6143.bugfix.rst
@@ -1,0 +1,2 @@
+Fix handling of encodings when reading the collected .py source files
+via ``FrozenImporter.get_source()``.

--- a/tests/functional/modules/module_with_utf8_emoji.py
+++ b/tests/functional/modules/module_with_utf8_emoji.py
@@ -1,0 +1,14 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2021, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+x = '🚀'  # 😓
+
+# ⏳✔️ <- These seem to be undecodable by 'cp1252' codec (default on my Windows).

--- a/tests/functional/test_import.py
+++ b/tests/functional/test_import.py
@@ -156,6 +156,22 @@ def test_module_with_coding_utf8(pyi_builder):
     pyi_builder.test_source("import module_with_coding_utf8")
 
 
+# Test that our FrozenImporter's get_source() method can load source files with utf-8 emoji characters. See issue #6143.
+def test_source_utf8_emoji(pyi_builder):
+    # Collect the module's source as data file
+    datas = os.pathsep.join((os.path.join(_MODULES_DIR, 'module_with_utf8_emoji.py'), os.curdir))
+    pyi_builder.test_source(
+        """
+        import inspect
+
+        import module_with_utf8_emoji
+
+        # Retrieve source code
+        source = inspect.getsource(module_with_utf8_emoji)
+        """, ['--add-data', datas]
+    )
+
+
 def test_hiddenimport(pyi_builder):
     # The script simply does nothing, not even print out a line. The check is done by comparing with
     # logs/test_hiddenimport.toc


### PR DESCRIPTION
When reading collected .py source files via `FrozenImporter`'s `get_source()` method, open the file with encoding explicitly set to UTF-8 (the default encoding for source files in Python 3). Failing to specify encoding leads to platform-specific default being used (e.g., `cp1252` on Windows), which results in an error if the source file contains unicode emojis.

Fixes #6143.