### PR TITLE
Docs: Update installation requirements.

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -17,25 +17,6 @@ To install the current development version use::
     pip install https://github.com/pyinstaller/pyinstaller/tarball/develop
 
 
-Installing in Mac OS X
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-Mac OS X 10.8 comes with Python 2.7 pre-installed by Apple.
-However, Python 2.7 is end-of-life and no longer supported by |PyInstaller|,
-also
-major packages such as
-PyQt, Numpy, Matplotlib, Scipy, and the like,
-have dropped support for Python 2.7, too.
-Thus we strongly
-recommend that you install these using either `MacPorts`_ or `Homebrew`_.
-
-|PyInstaller| users report fewer problems when they use a package manager
-than when they attempt to install major packages individually.
-
-Alternatively you might install Python 3 following the
-`official guide <https://docs.python.org/3/using/mac.html>`_.
-
-
 Installing from the archive
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -17,38 +17,6 @@ To install the current development version use::
     pip install https://github.com/pyinstaller/pyinstaller/tarball/develop
 
 
-Installing in Windows
-~~~~~~~~~~~~~~~~~~~~~~~
-
-It is particularly easy to use pip-Win_ to install |PyInstaller|
-along with the correct version of PyWin32_.
-pip-Win_ also provides virtualenv_, which makes it simple
-to maintain multiple different Python interpreters and install packages
-such as |PyInstaller| in each of them.
-(For more on the uses of virtualenv, see :ref:`Supporting Multiple Platforms` below.)
-
-When pip-Win is working, enter this command in its Command field
-and click Run::
-
-    venv -c -i pyi-env-name
-
-This creates a new virtual environment rooted at ``C:\Python\pyi-env-name``
-and makes it the current environment.
-A new command shell
-window opens in which you can run commands within this environment.
-Enter the command ::
-
-    pip install PyInstaller
-
-Once it is installed, to use |PyInstaller|,
-
-* Start pip-Win
-* In the Command field enter ``venv pyi-env-name``
-* Click Run
-
-Then you have a command shell window in which commands such as
-`pyinstaller` execute in that Python environment.
-
 Installing in Mac OS X
 ~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -20,11 +20,6 @@ To install the current development version use::
 Installing in Windows
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-For Windows, PyWin32_ or the more recent pypiwin32_, is a prerequisite.
-The latter is installed automatically when you install |PyInstaller|
-using pip_ or `easy_install`_.
-If necessary, follow the pypiwin32_ link to install it manually.
-
 It is particularly easy to use pip-Win_ to install |PyInstaller|
 along with the correct version of PyWin32_.
 pip-Win_ also provides virtualenv_, which makes it simple

--- a/doc/requirements.rst
+++ b/doc/requirements.rst
@@ -10,12 +10,6 @@ Windows
 (Windows 7 should work too, but is not supported).
 It can create graphical windowed apps (apps that do not need a command window).
 
-|PyInstaller| requires two Python modules in a Windows system.
-It requires either the PyWin32_ or pypiwin32_ Python extension for Windows.
-If you install |PyInstaller| using pip, and PyWin32 is not already installed,
-pypiwin32 is automatically installed.
-|PyInstaller| also requires the pefile_ package.
-
 The pip-Win_ package is recommended, but not required.
 
 Mac OS X

--- a/doc/requirements.rst
+++ b/doc/requirements.rst
@@ -10,6 +10,11 @@ Windows
 (Windows 7 should work too, but is not supported).
 It can create graphical windowed apps (apps that do not need a command window).
 
+Users wishing to support older Windows versions must be aware that Python itself
+has dropped support for Windows versions below 8.1. To support Windows 8.0 and 7
+you must build with Python 3.8 or older and to support Windows XP you must use
+Python 3.7 or older.
+
 Mac OS
 ~~~~~~
 

--- a/doc/requirements.rst
+++ b/doc/requirements.rst
@@ -10,8 +10,6 @@ Windows
 (Windows 7 should work too, but is not supported).
 It can create graphical windowed apps (apps that do not need a command window).
 
-The pip-Win_ package is recommended, but not required.
-
 Mac OS X
 ~~~~~~~~~
 

--- a/doc/requirements.rst
+++ b/doc/requirements.rst
@@ -10,14 +10,16 @@ Windows
 (Windows 7 should work too, but is not supported).
 It can create graphical windowed apps (apps that do not need a command window).
 
-Mac OS X
-~~~~~~~~~
+Mac OS
+~~~~~~
 
-|PyInstaller| runs in Mac OS X 10.7 (Lion) or newer.
+|PyInstaller| runs on Mac OS 10.13 (High Sierra) or newer.
 It can build graphical windowed apps (apps that do not use a terminal window).
-PyInstaller builds apps that are compatible with the Mac OS X release in
+PyInstaller builds apps that are compatible with the Mac OS release in
 which you run it, and following releases.
-It can build 32-bit binaries in Mac OS X releases that support them.
+It can build ``x86_64``, ``arm64`` or hybrid *universal2* binaries on macOS
+machines of either architecture. See :ref:`macOS multi-arch support` for
+details.
 
 GNU/Linux
 ~~~~~~~~~~


### PR DESCRIPTION
This started of as a fix for #6153 but then I realised that the macOS stuff was obsolete too.

Closes #6153.