### PR TITLE
hooks: add missing imports back to Kivy hook

### DIFF
--- a/PyInstaller/hooks/hook-kivy.py
+++ b/PyInstaller/hooks/hook-kivy.py
@@ -13,7 +13,8 @@ from PyInstaller import log as logging
 from PyInstaller.utils.hooks import is_module_satisfies
 
 if is_module_satisfies('kivy >= 1.9.1'):
-    from kivy.tools.packaging.pyinstaller_hooks import (add_dep_paths, get_deps_all, get_factory_modules, kivy_modules)
+    from kivy.tools.packaging.pyinstaller_hooks import (
+        add_dep_paths, excludedimports, datas, get_deps_all, get_factory_modules, kivy_modules)
 
     add_dep_paths()
 

--- a/PyInstaller/hooks/hook-kivy.py
+++ b/PyInstaller/hooks/hook-kivy.py
@@ -14,7 +14,8 @@ from PyInstaller.utils.hooks import is_module_satisfies
 
 if is_module_satisfies('kivy >= 1.9.1'):
     from kivy.tools.packaging.pyinstaller_hooks import (
-        add_dep_paths, excludedimports, datas, get_deps_all, get_factory_modules, kivy_modules)
+        add_dep_paths, excludedimports, datas, get_deps_all, get_factory_modules, kivy_modules
+    )
 
     add_dep_paths()
 

--- a/PyInstaller/hooks/hook-kivy.py
+++ b/PyInstaller/hooks/hook-kivy.py
@@ -13,9 +13,8 @@ from PyInstaller import log as logging
 from PyInstaller.utils.hooks import is_module_satisfies
 
 if is_module_satisfies('kivy >= 1.9.1'):
-    from kivy.tools.packaging.pyinstaller_hooks import (
-        add_dep_paths, excludedimports, datas, get_deps_all, get_factory_modules, kivy_modules
-    )
+    from kivy.tools.packaging.pyinstaller_hooks import (add_dep_paths, get_deps_all, get_factory_modules, kivy_modules)
+    from kivy.tools.packaging.pyinstaller_hooks import excludedimports, datas  # noqa: F401
 
     add_dep_paths()
 


### PR DESCRIPTION
This change was introduced in [this](https://github.com/pyinstaller/pyinstaller/commit/5173381248a4c52d1ece05470b0bc6c2bf0733d3) commit.
Original:
https://github.com/pyinstaller/pyinstaller/blob/76600a4c46cba29b066d1de08b725247570af367/PyInstaller/hooks/hook-kivy.py#L16-L18
But why?