### PR TITLE
Update PyInstaller.utils.tests.requires to catch all ResolutionErrors

### DIFF
--- a/PyInstaller/utils/tests.py
+++ b/PyInstaller/utils/tests.py
@@ -118,7 +118,7 @@ def requires(requirement: str):
     try:
         pkg_resources.require(requirement)
         return pytest.mark.skipif(False, reason=f"Don't skip: '{requirement}' is satisfied.")
-    except pkg_resources.DistributionNotFound:
+    except pkg_resources.ResolutionError:
         return pytest.mark.skip("Requires " + requirement)
 
 


### PR DESCRIPTION
Catch all ResolutionErrors including pkg_resources.VersionConflict.

See: https://github.com/pyinstaller/pyinstaller-hooks-contrib/pull/295#issuecomment-905701335