### PR TITLE
Fix import leaks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,8 @@ jobs:
             libxkbcommon-x11-0 libxcb-icccm4 libxcb1 openssl \
             libxcb-randr0-dev libxcb-xtest0-dev libxcb-xinerama0-dev \
             libxcb-shape0-dev libxcb-xkb-dev xvfb \
-            libopengl0 libegl1
+            libopengl0 libegl1 \
+            libpulse0 libpulse-mainloop-glib0
 
       - name: Download AppImage tool
         if: startsWith(matrix.os, 'ubuntu')

--- a/PyInstaller/depend/analysis.py
+++ b/PyInstaller/depend/analysis.py
@@ -743,6 +743,14 @@ class PyiModuleGraph(ModuleGraph):
 
         return out
 
+    def get_collected_packages(self) -> list:
+        """
+        Return the list of collected python packages.
+        """
+        return [
+            node.identifier for node in self.iter_graph(start=self._top_script_node) if type(node).__name__ == 'Package'
+        ]
+
 
 _cached_module_graph_ = None
 

--- a/PyInstaller/hooks/hook-django.py
+++ b/PyInstaller/hooks/hook-django.py
@@ -63,7 +63,7 @@ if root_dir:
         'django.contrib.sites.migrations',
     ]
     # Include migration scripts of Django-based apps too.
-    installed_apps = eval(hooks.get_module_attribute(settings_module, 'INSTALLED_APPS'))
+    installed_apps = hooks.get_module_attribute(settings_module, 'INSTALLED_APPS')
     migration_modules.extend(set(app + '.migrations' for app in installed_apps))
     # Copy migration files.
     for mod in migration_modules:

--- a/PyInstaller/utils/hooks/__init__.py
+++ b/PyInstaller/utils/hooks/__init__.py
@@ -268,6 +268,7 @@ def remove_file_extension(filename):
     return os.path.splitext(filename)[0]
 
 
+@isolated.decorate
 def can_import_module(module_name):
     """
     Check if the specified module can be imported.
@@ -285,16 +286,11 @@ def can_import_module(module_name):
     bool
         Boolean indicating whether the module can be imported or not.
     """
-
-    rc = exec_statement_rc(
-        """
-        try:
-            import {0}
-        except ModuleNotFoundError:
-            raise SystemExit(1)
-        """.format(module_name)
-    )
-    return rc == 0
+    try:
+        __import__(module_name)
+        return True
+    except Exception:
+        return False
 
 
 # TODO: Replace most calls to exec_statement() with calls to this function.

--- a/PyInstaller/utils/hooks/__init__.py
+++ b/PyInstaller/utils/hooks/__init__.py
@@ -12,7 +12,6 @@
 import copy
 import glob
 import os
-import pkgutil
 import sys
 import textwrap
 from pathlib import Path

--- a/PyInstaller/utils/hooks/qt.py
+++ b/PyInstaller/utils/hooks/qt.py
@@ -449,8 +449,10 @@ def add_qt_dependencies(hook_file):
 
         # On Windows, find this library; other platforms already provide the full path.
         if compat.is_win:
-            # First, look for Qt binaries in the local Qt install.
-            imp = bindepend.getfullnameof(imp, qt_info.location['BinariesPath'])
+            # First, look for Qt binaries in the local Qt install. For PyQt5 and PyQt6, DLLs should be in BinariesPath,
+            # while for PySide2 and PySide6, they should be in PrefixPath.
+            dll_location = qt_info.location['BinariesPath' if qt_info.is_pyqt else 'PrefixPath']
+            imp = bindepend.getfullnameof(imp, dll_location)
 
         # Strip off the extension and ``lib`` prefix (Linux/Mac) to give the raw name.
         # Lowercase (since Windows always normalizes names to lowercase).

--- a/news/6169.breaking.rst
+++ b/news/6169.breaking.rst
@@ -1,0 +1,4 @@
+The :func:`PyInstaller.utils.hooks.get_module_attribute` function now
+returns the actual attribute value instead of its string representation.
+The external users (e.g., 3rd party hooks) of this function must adjust
+their handling of the return value accordingly.

--- a/news/6169.bugfix.1.rst
+++ b/news/6169.bugfix.1.rst
@@ -1,0 +1,2 @@
+Fix an import leak when :func:`PyInstaller.utils.hooks.is_package`
+is called with a sub-module or a sub-package name.

--- a/news/6169.bugfix.rst
+++ b/news/6169.bugfix.rst
@@ -1,0 +1,2 @@
+Fix an import leak when :func:`PyInstaller.utils.hooks.get_module_file_attribute`
+is called with a sub-module or a sub-package name.

--- a/tests/functional/test_qt.py
+++ b/tests/functional/test_qt.py
@@ -65,27 +65,8 @@ def _ensure_qt_library_info_is_initialized():
 _ensure_qt_library_info_is_initialized()
 
 
-# Clean up PATH so that of all potentially installed Qt-based packages (PyQt5, PyQt6, PySide2, and PySide6), only the Qt
-# shared libraries of the specified package (namespace) remain in the PATH.
-# This is necessary to prevent DLL interference in tests when multiple Qt-based packages are installed. Applicable only
-# on Windows, as on other OSes the Qt shared library path(s) are not added to PATH.
-def _qt_dll_path_clean(monkeypatch, namespace):
-    if not is_win:
-        return
-
-    # Remove all other Qt5/6 bindings from PATH
-    all_namespaces = set(_QT_PY_PACKAGES)
-    all_namespaces.discard(namespace)
-    new_path = os.pathsep.join([
-        x for x in os.environ['PATH'].split(os.pathsep) if not any(ns in x for ns in all_namespaces)
-    ])
-    monkeypatch.setenv('PATH', new_path)
-
-
 @QtPyLibs
-def test_Qt_QtWidgets(pyi_builder, QtPyLib, monkeypatch):
-    _qt_dll_path_clean(monkeypatch, QtPyLib)
-
+def test_Qt_QtWidgets(pyi_builder, QtPyLib):
     pyi_builder.test_source(
         """
         import sys
@@ -115,9 +96,7 @@ def test_Qt_QtWidgets(pyi_builder, QtPyLib, monkeypatch):
 
 @PYQT5_NEED_OPENGL
 @QtPyLibs
-def test_Qt_QtQml(pyi_builder, QtPyLib, monkeypatch):
-    _qt_dll_path_clean(monkeypatch, QtPyLib)
-
+def test_Qt_QtQml(pyi_builder, QtPyLib):
     pyi_builder.test_source(
         """
         import sys
@@ -172,9 +151,7 @@ def test_Qt_QtQml(pyi_builder, QtPyLib, monkeypatch):
         qt_param('PySide6', marks=xfail(is_win, reason='PySide6 wheels on Windows do not include SSL DLLs.')),
     ]
 )
-def test_Qt_QtNetwork_SSL_support(pyi_builder, monkeypatch, QtPyLib):
-    _qt_dll_path_clean(monkeypatch, QtPyLib)
-
+def test_Qt_QtNetwork_SSL_support(pyi_builder, QtPyLib):
     pyi_builder.test_source(
         """
         from {0}.QtNetwork import QSslSocket
@@ -184,8 +161,7 @@ def test_Qt_QtNetwork_SSL_support(pyi_builder, monkeypatch, QtPyLib):
 
 
 @QtPyLibs
-def test_Qt_QTranslate(pyi_builder, monkeypatch, QtPyLib):
-    _qt_dll_path_clean(monkeypatch, QtPyLib)
+def test_Qt_QTranslate(pyi_builder, QtPyLib):
     pyi_builder.test_source(
         """
         from {0}.QtWidgets import QApplication
@@ -215,8 +191,7 @@ def test_Qt_QTranslate(pyi_builder, monkeypatch, QtPyLib):
 
 @PYQT5_NEED_OPENGL
 @QtPyLibs
-def test_Qt_Ui_file(tmpdir, pyi_builder, data_dir, monkeypatch, QtPyLib):
-    _qt_dll_path_clean(monkeypatch, QtPyLib)
+def test_Qt_Ui_file(tmpdir, pyi_builder, data_dir, QtPyLib):
     # Note that including the data_dir fixture copies files needed by this test.
     pyi_builder.test_source(
         """
@@ -289,8 +264,7 @@ def test_Qt_Ui_file(tmpdir, pyi_builder, data_dir, monkeypatch, QtPyLib):
     is_module_satisfies('PyQt5 == 5.11.3') and is_darwin,
     reason='This version of the OS X wheel does not include QWebEngine.'
 )
-def test_PyQt5_Qt(pyi_builder, monkeypatch):
-    _qt_dll_path_clean(monkeypatch, 'PyQt5')
+def test_PyQt5_Qt(pyi_builder):
     pyi_builder.test_source('from PyQt5.Qt import QLibraryInfo', **USE_WINDOWED_KWARG)
 
 
@@ -329,8 +303,7 @@ def get_QWebEngine_html(qt_flavor, data_dir):
     reason='This version of the OS X wheel does not include QWebEngine.'
 )
 @requires('PyQt5')
-def test_PyQt5_QWebEngine(pyi_builder, data_dir, monkeypatch):
-    _qt_dll_path_clean(monkeypatch, 'PyQt5')
+def test_PyQt5_QWebEngine(pyi_builder, data_dir):
     if is_darwin:
         # QWebEngine on Mac OS only works with a onedir build -- onefile builds do not work.
         # Skip the test execution for onefile builds.
@@ -341,8 +314,7 @@ def test_PyQt5_QWebEngine(pyi_builder, data_dir, monkeypatch):
 
 
 @requires('PySide2')
-def test_PySide2_QWebEngine(pyi_builder, data_dir, monkeypatch):
-    _qt_dll_path_clean(monkeypatch, 'PySide2')
+def test_PySide2_QWebEngine(pyi_builder, data_dir):
     if is_darwin:
         # QWebEngine on Mac OS only works with a onedir build -- onefile builds do not work.
         # Skip the test execution for onefile builds.

--- a/tests/functional/test_qt.py
+++ b/tests/functional/test_qt.py
@@ -43,38 +43,8 @@ QtPyLibs = pytest.mark.parametrize('QtPyLib', [qt_param(i) for i in _QT_PY_PACKA
 USE_WINDOWED_KWARG = dict(pyi_args=['--windowed']) if is_darwin else {}
 
 
-# This is an ugly work-around for an even uglier problem on Windows: we need to ensure that each Qt-based package that
-# is going to be used in a test is imported wihout ``pytest.monkeypatch`` being active.
-#
-# The imports used to happen either during test collection (e.g., due to ``@pytest.importorskip`` annotation on the
-# test) or during the actual test execution - either due to ``pytest.importorskip()`` call inside the test, or when
-# actually building the frozen test application. With the introduction of ``PyInstaller.utils.tests.requires`` that does
-# not actually import the package (but rather just checks its availability), the imports happen only within the tests,
-# when building the application. This leads to problems if the very first import of the package happens inside the test
-# that uses ``pytest.monkeypatch``.
-#
-# Specifically, when a Qt-based package is imported, it adds the path to its Qt DLLs to PATH (applies only to Windows).
-# Therefore, if (first) import happens under ``pytest.monkeypatch``, the PATH modification is lost for subsequent tests
-# (that use the same package). This in turn causes incomplete builds of the test programs, because ``pyi_builder`` calls
-# PyInstaller's ``pyi_main.run()`` within the test process instead of spawning a separate process.
-#
-# Therefore, we manually try to import each Qt-based package, to ensure that their first-time import happens outside of
-# the ``pytest.monkeypatch``.
-def _ensure_qt_packages_are_imported():
-    for pkg in _QT_PY_PACKAGES:
-        try:
-            __import__(pkg)
-        except Exception:
-            pass
-
-
-if is_win:
-    _ensure_qt_packages_are_imported()  # Applicable only to Windows
-
-
-# Similarly to the above PATH-related concerns on Windows, we also need to ensure that all QtLibraryInfo structures in
-# Qt hook utils are initialized at this point, before the actual tests start. This is to prevent test-order-dependent
-# behavior and potential issues, and applies to all platforms.
+# We need to ensure that all QtLibraryInfo structures in Qt hook utils are initialized at this point, before the actual
+# tests start. This is to prevent test-order-dependent behavior and potential issues, and applies to all platforms.
 #
 # Some tests (e.g., test_import::test_import_pyqt5_uic_port) may modify search path to fake PyQt5 module, and if that
 # test is the point of initialization for the corresponding QtLibraryInfo structure (triggered by hooks' access to

--- a/tests/unit/test_hookutils.py
+++ b/tests/unit/test_hookutils.py
@@ -329,7 +329,9 @@ def data_lists(monkeypatch, request):
         sorted_list = sorted(list(sequence))
         return tuple(sorted_list)
 
-    # Add path with 'hookutils_files' module to ``sys.path``, so tests can find this module - useful for subprocesses.
+    # Add path with 'hookutils_files' module to ``sys.path`` (so analysis in the main process can find it),
+    # and to ``pathex`` (so subprocess-isolated code can find it).
+    monkeypatch.setattr('PyInstaller.config.CONF', {'pathex': [TEST_MOD_PATH]})
     monkeypatch.syspath_prepend(TEST_MOD_PATH)
     # Use the hookutils_test_files package for testing.
     args, kwargs, subfiles = request.param


### PR DESCRIPTION
Fix import leaks that happen when`PyInstaller.utils.hooks.get_module_file_attribute` or `PyInstaller.utils.hooks.is_package` is called with a sub-package or a sub-module name, which causes the `pkgutil.find_loader` to import the parent package.

In addition, several other hookutils functions have been ported to the new `PyInstaller.isolated` framework. The most notable is `get_module_attribute` which now returns actual attribute values (in their original type) rather than their string representations.

As we now manage to completely avoid importing collected packages in the main process, the binary dependencies search need to be performed in an isolated subprocess that first imports all collected packages (so that their imports properly set up search paths). Instead of importing just packages, we should perhaps be importing all collected modules in case some of those are stand-alone and contain search-path initialization themselves.