### PR TITLE
macOS: improve forwarding of the initial apple event in onefile app bundles

### DIFF
--- a/bootloader/src/pyi_apple_events.c
+++ b/bootloader/src/pyi_apple_events.c
@@ -636,7 +636,7 @@ void pyi_apple_submit_oapp_event()
     }
 
     // ... and send it
-    err = AESendMessage(&event, NULL, kAENoReply, 60 /* 60 = about 1.0 seconds timeout */);
+    err = AESendMessage(&event, NULL, kAENoReply, kAEDefaultTimeout);
     if (err != noErr) {
         OTHERERROR("LOADER [AppleEvent]: Failed to send event: %d\n", (int)err);
         goto cleanup;

--- a/bootloader/src/pyi_apple_events.h
+++ b/bootloader/src/pyi_apple_events.h
@@ -44,6 +44,15 @@ void pyi_apple_process_events(float timeout);
  */
 void pyi_apple_submit_oapp_event();
 
+/* Check if we have a pending event that we need to forward. */
+int pyi_apple_has_pending_event();
+
+/* Attempt to re-send the pending event after the specified delay. */
+int pyi_apple_send_pending_event(float delay);
+
+/* Clean-up the pending event data and status. */
+void pyi_apple_cleanup_pending_event();
+
 #endif  /* defined(__APPLE__) && defined(WINDOWED) */
 
 #endif  /* PYI_APPLE_EVENTS_H */


### PR DESCRIPTION
This is a revision of 2bf2d1d8ccfeee966ff22ae9432acd656f295a59 from #6089. The 5-second time window* chosen for repeated attempts at forwarding the event to the child process appears to be insufficient, as indicated by occasional CI failures of the [`test_apple_event_handling_carbon[noemu-onefile]`](https://github.com/pyinstaller/pyinstaller/runs/3454912736?check_suite_focus=true#step:11:3517). (EDIT: actually, the effective time window was only 2.5 seconds due to a typo).

So instead of imposing time limit on forwarding attempts, we now attempt to forward the event for as long as the child process lives. This effectively suspends the processing/forwarding of subsequent events, because it makes no sense to try forwarding the events if the child is unable to receive them in the first place.

A bit of refactoring is required to bring the forwarding re-attempt to the "main loop", where the `waitpid()` is being called to check the child status.

The second commit is similar to 3c24127190de21fc1301bddaf994a3d3846f51a3, but it addresses the code that was introduced in one of later commits (3665eedd6b4de94d4c42e3e2ea8d4261206bf9d9) from #6089, where I forgot to replace the explicit timeout with `kAEDefaultTimeout`).