### PR TITLE
hooks: add hook for pandas.plotting

### DIFF
--- a/PyInstaller/hooks/hook-pandas.plotting.py
+++ b/PyInstaller/hooks/hook-pandas.plotting.py
@@ -1,0 +1,18 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2021, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import is_module_satisfies
+
+# Starting with pandas 1.3.0, pandas.plotting._matplotlib is imported via importlib.import_module() and needs to be
+# added to hidden imports. But do this only if matplotlib is available in the first place (as it is soft dependency
+# of pandas).
+if is_module_satisfies('pandas >= 1.3.0') and is_module_satisfies('matplotlib'):
+    hiddenimports = ['pandas.plotting._matplotlib']

--- a/news/5994.hooks.rst
+++ b/news/5994.hooks.rst
@@ -1,0 +1,2 @@
+Add a hook for ``pandas.plotting`` to restore compatibility with ``pandas`` 1.3.0 
+and later.

--- a/tests/functional/test_libraries.py
+++ b/tests/functional/test_libraries.py
@@ -400,7 +400,10 @@ def test_pandas_plotting_matplotlib(pyi_builder):
     # is loaded via importlib.import_module(), and needs a hidden import. See #5994.
     pyi_builder.test_source(
         """
+        import matplotlib as mpl
         import pandas as pd
+
+        mpl.use('Agg')  # Use headless Agg backend to avoid dependency on display server.
 
         series = pd.Series([0, 1, 2, 3], [0, 1, 2, 3])
         series.plot()

--- a/tests/functional/test_libraries.py
+++ b/tests/functional/test_libraries.py
@@ -393,6 +393,21 @@ def test_pandas_io_formats_style(pyi_builder):
         """)
 
 
+@importorskip('pandas')
+@importorskip('matplotlib')
+def test_pandas_plotting_matplotlib(pyi_builder):
+    # Test that pandas.plotting works. Starting with pandas 1.3.0, the used pandas.plotting._matplotlib backend module
+    # is loaded via importlib.import_module(), and needs a hidden import. See #5994.
+    pyi_builder.test_source(
+        """
+        import pandas as pd
+
+        series = pd.Series([0, 1, 2, 3], [0, 1, 2, 3])
+        series.plot()
+        """
+    )
+
+
 @importorskip('win32ctypes')
 @pytest.mark.skipif(not is_win, reason='pywin32-ctypes is supported only on Windows')
 @pytest.mark.parametrize('submodule', ['win32api', 'win32cred', 'pywintypes'])


### PR DESCRIPTION
On `pandas` 1.3.0 and later, the `pandas.plotting._matplotlib` module is imported via `importlib.import_module`, so we miss it and need to add it to `hiddenimport`. (It used to be imported using `import` statement on earlier versions).

Fixes #5994.