### PR TITLE
hookutils: qt: fix library handling for Anaconda-installed Qt on macOS

### DIFF
--- a/news/6181.hooks.rst
+++ b/news/6181.hooks.rst
@@ -1,0 +1,1 @@
+(macOS) Fix compatibility with Anaconda ``PyQt5`` package.


### PR DESCRIPTION
Fix the Qt shared library name handling to properly account for the naming scheme used by Anaconda-installed Qt on macOS. Fixes Qt dependent module scanning and collection when freezing with on macOS with Anaconda-installed `pyqt` package.

Fixes #6181.