### PR TITLE
ci: enable workflows on v4 branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,12 @@
 name: CI
 
 # Controls when the action will run. Triggers the workflow on push or pull request
-## events but only for the master branch
+# events for develop and v4 branche.
 on:
   push:
     branches:
       - 'develop'
+      - 'v4'
   pull_request:
     branches:
       - '**'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,9 +1,10 @@
 name: Lint
 
 on:
-  pull_request:  # Trigger on PRs to develop
+  pull_request:  # Trigger on PRs to develop and v4
     branches:
       - develop
+      - v4
 
 
 jobs:

--- a/.github/workflows/validate-new-news.yml
+++ b/.github/workflows/validate-new-news.yml
@@ -2,9 +2,10 @@
 name: Validate new news entries
 
 on:
-  pull_request:  # Trigger on PRs to develop
+  pull_request:  # Trigger on PRs to develop and v4
     branches:
       - develop
+      - v4
 
 jobs:
   run:


### PR DESCRIPTION
Enable CI on `v4` branch. Enable lint and news entry validation on PRs that are opened against `v4` branch.

The idea is to "backport" this configuration to `v4` and keep it in sync between both branches (as opposed to have each branch its own workflow configuration).