### PR TITLE
macOS: robustify macOS assembly pipeline

### DIFF
--- a/PyInstaller/building/utils.py
+++ b/PyInstaller/building/utils.py
@@ -369,11 +369,13 @@ def checkCache(
     cache_index[basenm] = digest
     misc.save_py_data_struct(cacheindexfn, cache_index)
 
-    # On Mac OS we need relative paths to dll dependencies starting with @executable_path. Modifying headers
-    # invalidates signatures, so remove any existing signature and then re-add it after paths are rewritten.
+    # On Mac OS we need relative paths to dll dependencies starting with @executable_path. While modifying
+    # the headers invalidates existing signatures, we avoid removing them in order to speed things up (and
+    # to avoid potential bugs in the codesign utility, like the one reported on Mac OS 10.13 in #6167).
+    # The forced re-signing at the end should take care of the invalidated signatures.
     if is_darwin:
         osxutils.binary_to_target_arch(cachedfile, target_arch, display_name=fnm)
-        osxutils.remove_signature_from_binary(cachedfile)
+        #osxutils.remove_signature_from_binary(cachedfile)  # Disabled as per comment above.
         dylib.mac_set_relative_dylib_deps(cachedfile, dist_nm)
         osxutils.sign_binary(cachedfile, codesign_identity, entitlements_file)
     return cachedfile

--- a/PyInstaller/utils/osx.py
+++ b/PyInstaller/utils/osx.py
@@ -192,8 +192,8 @@ def fix_exe_for_code_signing(filename):
     # both should be aligned with the end of the file (as we are in the last or the only arch slice).
     #
     # However, when removing the signature from the executable using codesign under Mac OS 10.13, the codesign utility
-    # may produce an invalid file, with declared length of __LINKEDIT segment (linkedit_seg.filesize), as reported in
-    # issue #6167.
+    # may produce an invalid file, with the declared length of the __LINKEDIT segment (linkedit_seg.filesize) pointing
+    # beyond the end of file, as reported in issue #6167.
     #
     # We can compensate for that by not using the declared sizes anywhere, and simply recompute them. In the final
     # binary, the __LINKEDIT segment and the SYMTAB section MUST end at the end of the file (otherwise, we have bigger

--- a/news/6167.bugfix.rst
+++ b/news/6167.bugfix.rst
@@ -1,0 +1,2 @@
+(macOS) Robustify the macOS assembly pipeline to work around the issues with 
+the ``codesign`` utility on macOS 10.13 High Sierra.


### PR DESCRIPTION
Two changes that make our assembly pipeline on macOS a bit more robust to bogus behavior of the `codesign` utility on 10.13 High Sierra (which is EOL at this point, but apparently still popular enough), and fix #6167.

I think we can live without signature removal when modifying the headers of collected binaries regardless of macOS version, as forced re-sign should take care of invalidated signatures. If this was not the case, we'd probably be seeing issue reports on earlier versions of PyInstaller where users had to do re-signing themselves. So by skipping signature removal we avoid one call to `codesign` and one file resizing (which can be problematic on 10.13).

The revised segment and section size computation is more direct, and allows us to compensate for oddities with 10.13 codesign when removing signature from bootloader executable. It is also more consistent with slice size adjustment that we do for fat binaries at the end of that function.