### PR TITLE
depend: suppress warnings about missing api-ms-win-core-* DLLs

### DIFF
--- a/PyInstaller/depend/dylib.py
+++ b/PyInstaller/depend/dylib.py
@@ -271,6 +271,7 @@ if compat.is_linux:
 # Suppress false warnings on win 10 and UCRT (see issue #1566).
 if compat.is_win_10:
     _warning_suppressions.append(r'api-ms-win-crt.*')
+    _warning_suppressions.append(r'api-ms-win-core.*')
 
 
 class MissingLibWarningSuppressionList:

--- a/news/6201.bugfix.rst
+++ b/news/6201.bugfix.rst
@@ -1,0 +1,1 @@
+(Windows) Suppress missing library warnings for ``api-ms-win-core-*`` DLLs.


### PR DESCRIPTION
Like `api-ms-win-crt-*` DLLs, `api-ms-win-core-*` DLLs typically cannot be resolved (except under Anaconda), so the warnings should be suppressed as false positives to avoid confusing users.