### PR TITLE
Fix package side-load mode

### DIFF
--- a/bootloader/src/pyi_archive.c
+++ b/bootloader/src/pyi_archive.c
@@ -534,18 +534,17 @@ pyi_arch_open(ARCHIVE_STATUS *status)
  * Sets f_archivename, f_homepath, f_mainpath
  */
 bool
-pyi_arch_setup(ARCHIVE_STATUS *status, char const * archivePath)
+pyi_arch_setup(ARCHIVE_STATUS *status, char const * archive_path, char const * executable_path)
 {
-    /* Get the archive Path */
-    if (strlen(archivePath) >= PATH_MAX) {
-        // Should never come here, since `archivePath` was already processed
-        // by pyi_path_executable or pyi_path_archivefile.
+    /* Copy archive path and executable path */
+    if (snprintf(status->archivename, PATH_MAX, "%s", archive_path) >= PATH_MAX) {
         return false;
     }
-
-    strcpy(status->archivename, archivePath);
+    if (snprintf(status->executablename, PATH_MAX, "%s", executable_path) >= PATH_MAX) {
+        return false;
+    }
     /* Set homepath to where the archive is */
-    pyi_path_dirname(status->homepath, archivePath);
+    pyi_path_dirname(status->homepath, archive_path);
     /*
      * Initial value of mainpath is homepath. It might be overriden
      * by temppath if it is available.

--- a/bootloader/src/pyi_archive.h
+++ b/bootloader/src/pyi_archive.h
@@ -75,6 +75,7 @@ typedef struct _archive_status {
      *    (formerly called _Py_char2wchar) first.
      */
     char archivename[PATH_MAX];
+    char executablename[PATH_MAX];
     char homepath[PATH_MAX];
     char temppath[PATH_MAX];
     /*
@@ -131,11 +132,12 @@ void pyi_arch_status_free(ARCHIVE_STATUS *status);
 /*
  * Setup the paths and open the archive
  *
- * @param archivePath  The path including filename to the archive.
+ * @param archive_path  The path including filename to the archive (can be different from executable path).
+ * @param executable_path  The path including filename to the executable.
  *
  * @return true on success, false otherwise.
  */
-bool pyi_arch_setup(ARCHIVE_STATUS *status, char const * archivePath);
+bool pyi_arch_setup(ARCHIVE_STATUS *status, char const * archive_path, char const * executable_path);
 
 TOC *getFirstTocEntry(ARCHIVE_STATUS *status);
 TOC *getNextTocEntry(ARCHIVE_STATUS *status, TOC *entry);

--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -103,8 +103,11 @@ pyi_main(int argc, char * argv[])
 
     VS("LOADER: _MEIPASS2 is %s\n", (extractionpath ? extractionpath : "NULL"));
 
-    if ((! pyi_arch_setup(archive_status, executable)) &&
-        (! pyi_arch_setup(archive_status, archivefile))) {
+    /* Try opening the archive; first attempt to read it from executable
+     * itself (embedded mode), then from a stand-alone pkg file (sideload mode)
+     */
+    if ((! pyi_arch_setup(archive_status, executable, executable)) &&
+        (! pyi_arch_setup(archive_status, archivefile, executable))) {
             FATALERROR("Cannot open self %s or archive %s\n",
                        executable, archivefile);
             return -1;

--- a/bootloader/src/pyi_pythonlib.c
+++ b/bootloader/src/pyi_pythonlib.c
@@ -457,7 +457,7 @@ pyi_pylib_start_python(ARCHIVE_STATUS *status)
     pyi_pylib_set_pep540_utf8_mode();
 
     /* Decode using current locale */
-    if (!pyi_locale_char2wchar(progname_w, status->archivename, PATH_MAX)) {
+    if (!pyi_locale_char2wchar(progname_w, status->executablename, PATH_MAX)) {
         FATALERROR("Failed to convert progname to wchar_t\n");
         return -1;
     }

--- a/news/6202.bugfix.1.rst
+++ b/news/6202.bugfix.1.rst
@@ -1,0 +1,2 @@
+Fix ``sys.executable`` pointing to the external package file instead of
+the executable when in package side-load mode (``pkg_append=False``).

--- a/news/6202.bugfix.rst
+++ b/news/6202.bugfix.rst
@@ -1,0 +1,4 @@
+Fix the location of the generated stand-alone pkg file when using the
+side-load mode (``pkg_append=False``) in combination with ``onefile`` mode.
+The package file is now placed next to the executable instead of next to
+the .spec file.


### PR DESCRIPTION
Fix two bugs related to the package side-load mode (enabled by passing `append_pkg=False` argument to `EXE()`):

1. in `onefile` mode, the generated stand-alone PKG file is placed next to the .spec file instead of next to the executable. The commit fixing this also changes the name of the PKG file (for all modes) from `build/program_name/PKG-01.pkg` (or whatever the value of the counter is) to the `build/program_name/program_name.pkg`.

2. in package side-load mode, `sys.executable` ends up pointing to the external package file instead of executable.