### PR TITLE
(Windows) Remove attempt to load manifest via activation context

### DIFF
--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -470,11 +470,11 @@ class EXE(Target):
 
             manifest_filename = os.path.basename(self.name) + ".manifest"
 
-            self.toc.append((manifest_filename, filename, 'BINARY'))
-            if not self.exclude_binaries:
-                # Onefile mode: manifest file is explicitly loaded. Store name of manifest file as bootloader option.
-                # Allows the exe to be renamed.
-                self.toc.append(("pyi-windows-manifest-filename " + manifest_filename, "", "OPTION"))
+            # In the onedir mode, we need to collect the manifest file, so that it is placed next to the executable as
+            # an external manifest. In the onefile mode, we do not need to collect the manifest, as it is embedded into
+            # the final executable by the assembly pipeline.
+            if self.exclude_binaries:
+                self.toc.append((manifest_filename, filename, 'BINARY'))  # Onedir mode.
 
             if self.versrsrc:
                 if not isinstance(self.versrsrc, versioninfo.VSVersionInfo) and not os.path.isabs(self.versrsrc):
@@ -647,6 +647,8 @@ class EXE(Target):
                             resfile,
                             exc_info=1
                         )
+            # In onefile mode, we need to embed the manifest into the executable in order for manifest-related options
+            # (e.g., uac-admin) to work.
             if self.manifest and not self.exclude_binaries:
                 self.manifest.update_resources(tmpnm, [1])
             trash.append(tmpnm)

--- a/bootloader/src/pyi_launch.c
+++ b/bootloader/src/pyi_launch.c
@@ -604,19 +604,7 @@ pyi_launch_run_scripts(ARCHIVE_STATUS *status)
 void
 pyi_launch_initialize(ARCHIVE_STATUS * status)
 {
-#if defined(_WIN32)
-    char * manifest;
-    manifest = pyi_arch_get_option(status, "pyi-windows-manifest-filename");
-
-    if (NULL != manifest) {
-        char manifest_path[PATH_MAX];
-        if (pyi_path_join(manifest_path, status->mainpath, manifest) == NULL) {
-            FATALERROR("Path of manifest-file (%s) length exceeds "
-                       "buffer[%d] space\n", status->mainpath, PATH_MAX);
-        };
-        CreateActContext(manifest_path);
-    }
-#endif /* if defined(_WIN32) */
+    /* Nothing to do here at the moment. */
 }
 
 /*

--- a/bootloader/src/pyi_win32_utils.c
+++ b/bootloader/src/pyi_win32_utils.c
@@ -37,13 +37,6 @@
 #include "pyi_utils.h"
 #include "pyi_win32_utils.h"
 
-static HANDLE hCtx = INVALID_HANDLE_VALUE;
-static ULONG_PTR actToken;
-
-#ifndef STATUS_SXS_EARLY_DEACTIVATION
-    #define STATUS_SXS_EARLY_DEACTIVATION 0xC015000F
-#endif
-
 #ifndef IO_REPARSE_TAG_SYMLINK
     #define IO_REPARSE_TAG_SYMLINK 0xA000000CL
 #endif
@@ -94,53 +87,6 @@ char * GetWinErrorString(DWORD error_code) {
         return "PyInstaller: pyi_win32_utils_to_utf8 failed.";
     }
     return errorString;
-}
-
-int
-CreateActContext(const char *manifestpath)
-{
-    wchar_t * manifestpath_w;
-    ACTCTXW ctx;
-    BOOL activated;
-    HANDLE k32;
-
-    HANDLE (WINAPI * CreateActCtx)(PACTCTXW pActCtx);
-    BOOL (WINAPI * ActivateActCtx)(HANDLE hActCtx, ULONG_PTR * lpCookie);
-
-    /* Setup activation context */
-    VS("LOADER: manifestpath: %s\n", manifestpath);
-    manifestpath_w = pyi_win32_utils_from_utf8(NULL, manifestpath, 0);
-
-    k32 = LoadLibraryA("kernel32");
-    CreateActCtx = (void*)GetProcAddress(k32, "CreateActCtxW");
-    ActivateActCtx = (void*)GetProcAddress(k32, "ActivateActCtx");
-
-    if (!CreateActCtx || !ActivateActCtx) {
-        VS("LOADER: Cannot find CreateActCtx/ActivateActCtx exports in kernel32.dll\n");
-        return 0;
-    }
-
-    ZeroMemory(&ctx, sizeof(ctx));
-    ctx.cbSize = sizeof(ACTCTX);
-    ctx.lpSource = manifestpath_w;
-    ctx.dwFlags = ACTCTX_FLAG_SET_PROCESS_DEFAULT;
-
-    hCtx = CreateActCtx(&ctx);
-    free(manifestpath_w);
-
-    if (hCtx != INVALID_HANDLE_VALUE) {
-        VS("LOADER: Activation context created\n");
-        activated = ActivateActCtx(hCtx, &actToken);
-
-        if (activated) {
-            VS("LOADER: Activation context activated\n");
-            return 1;
-        }
-    }
-
-    hCtx = INVALID_HANDLE_VALUE;
-    VS("LOADER: Error activating the context: ActivateActCtx: \n%s\n", GetWinErrorString(0));
-    return 0;
 }
 
 /* Convert a wide string to an ANSI string.

--- a/bootloader/src/pyi_win32_utils.h
+++ b/bootloader/src/pyi_win32_utils.h
@@ -18,7 +18,6 @@
 #ifdef _WIN32
 
 char * GetWinErrorString(DWORD error_code);
-int CreateActContext(const char *manifestpath);
 
 char ** pyi_win32_argv_to_utf8(int argc, wchar_t **wargv);
 wchar_t ** pyi_win32_wargv_from_utf8(int argc, char **argv);

--- a/news/6203.bugfix.rst
+++ b/news/6203.bugfix.rst
@@ -1,0 +1,7 @@
+(Windows) Remove the attempt to load the manifest of a ``onefile``
+frozen executable via the activation context, which fails with ``An
+attempt to set the process default activation context failed because
+the process default activation context was already set.`` message that
+can be observed in debug builds. This approach has been invalid ever
+since :issue:`3746` implemented direct manifest embedding into the
+``onefile`` executable.


### PR DESCRIPTION
This clean-up PR removes a Windows-only codepath that, while technically being in use, is essentially a no-op at this point.

While trying to figure out the manifest-related issue in `onefile` builds reported in https://github.com/pyinstaller/pyinstaller/discussions/6196#discussioncomment-1302204, it turned out that in `onefile`, we are using two approaches to applying the manifest:

1. The first approach is, we [collect the manifest into the frozen bundle](https://github.com/pyinstaller/pyinstaller/blob/a6f41dc99b2647b5bc68fc150599e2d4a697de97/PyInstaller/building/api.py#L475), and then pass its name to the bootloader via the `"pyi-windows-manifest-filename"` [bootloader option](https://github.com/pyinstaller/pyinstaller/blob/a6f41dc99b2647b5bc68fc150599e2d4a697de97/PyInstaller/building/api.py#L479). Once the application is started, the bootloader [checks for the presence of the `"pyi-windows-manifest-filename"`](https://github.com/pyinstaller/pyinstaller/blob/a6f41dc99b2647b5bc68fc150599e2d4a697de97/bootloader/src/pyi_launch.c#L609-L617) and, if available, tries to create [a custom activation context](https://github.com/pyinstaller/pyinstaller/blob/a6f41dc99b2647b5bc68fc150599e2d4a697de97/bootloader/src/pyi_win32_utils.c#L100-L144) with the manifest and activate it as the default context.

2. The second approach is that, once the final executable is built, we [embed the manifest into it](https://github.com/pyinstaller/pyinstaller/blob/a6f41dc99b2647b5bc68fc150599e2d4a697de97/PyInstaller/building/api.py#L653-L654).

The problem is, these two approaches appear to be mutually exclusive. The presence of the manifest (embedded or external) seems to create the default activation context for the process, so the activation of our custom context (which we mark as default)
fails with the following error: `An attempt to set the process default activation context failed because the process default activation context was already set.` Since embedded manifest already did its job, the error is non-fatal, and the error
message is not shown in non-debug builds because `VS()` is used.

The second approach was added by #3746 in response to manifest-related options (e.g., `--uac-admin`) not working in `onefile` mode with the first approach (#1729). Ever since, the first approach has been no-op, and can be removed. This also removes the need for collecting the manifest file into `onefile` bundle.

Perhaps things played out differently in older python versions (2.x) and/or older Windows versions? But going forward, I think it makes sense to clean up this piece of code, if only to make it more clear where and how the manifest is actually handled.