### PR TITLE
Fix declared string lengths in embedded VSVersionInfo

### DIFF
--- a/PyInstaller/utils/win32/versioninfo.py
+++ b/PyInstaller/utils/win32/versioninfo.py
@@ -519,13 +519,13 @@ class StringStruct:
         raw_name = getRaw(self.name)
         raw_val = getRaw(self.val)
         # TODO: document the size of vallen and sublen.
-        vallen = len(raw_val) + 2
+        vallen = len(self.val) + 1  # Number of (wide-)characters, not bytes!
         typ = 1
         sublen = 6 + len(raw_name) + 2
         pad = b''
         if sublen % 4:
             pad = b'\000\000'
-        sublen = sublen + len(pad) + vallen
+        sublen = sublen + len(pad) + (vallen * 2)
         return struct.pack('hhh', sublen, vallen, typ) + raw_name + b'\000\000' + pad + raw_val + b'\000\000'
 
     def __eq__(self, other):

--- a/news/6219.bugfix.rst
+++ b/news/6219.bugfix.rst
@@ -1,0 +1,4 @@
+(Windows) Fix the declared length of strings in the optional embedded
+product version information resource structure. The declared lengths
+were twice too long, and resulted in trailing garbage characters when
+the version information was read using `ctypes` and winver API.

--- a/tests/unit/test_miscutils.py
+++ b/tests/unit/test_miscutils.py
@@ -9,8 +9,13 @@
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
 
+import os
+import array
+import shutil
+
 import pytest
 
+from PyInstaller import HOMEPATH, PLATFORM
 from PyInstaller.utils.misc import load_py_data_struct, save_py_data_struct
 
 
@@ -73,3 +78,88 @@ def test_versioninfo_str(tmp_path):
     vsinfo2 = eval(vs_info_str)
 
     assert vsinfo == vsinfo2
+
+
+@pytest.mark.win32
+def test_versioninfo_written_to_exe(tmp_path):
+    from PyInstaller.utils.win32 import versioninfo
+    from PyInstaller.utils.win32.versioninfo import VSVersionInfo, \
+        FixedFileInfo, StringFileInfo, StringTable, StringStruct, \
+        VarFileInfo, VarStruct
+
+    # Test/expected values
+    FILE_DESCRIPTION = 'versioninfo test'
+    PRODUCT_NAME = 'Test Product'
+    PRODUCT_VERSION = '2021.09.18.00'
+
+    # Create a version info structure...
+    vsinfo = VSVersionInfo(
+        ffi=FixedFileInfo(
+            filevers=(1, 2, 3, 4),
+            prodvers=(5, 6, 7, 8),
+            mask=0x3f,
+            flags=0x1,
+            OS=0x40004,
+            fileType=0x42,
+            subtype=0x42,
+            date=(0, 0)
+        ),
+        kids=[
+            StringFileInfo([
+                StringTable(
+                    '040904b0', [
+                        StringStruct('FileDescription', FILE_DESCRIPTION),
+                        StringStruct('ProductName', PRODUCT_NAME),
+                        StringStruct('ProductVersion', PRODUCT_VERSION)
+                    ]
+                )
+            ]),
+            VarFileInfo([VarStruct('Translation', [1033, 1200])])
+        ]
+    )
+
+    # Locate bootloader executable
+    bootloader_file = os.path.join(HOMEPATH, 'PyInstaller', 'bootloader', PLATFORM, 'run.exe')
+
+    # Create a local copy
+    test_file = str(tmp_path / 'test_file.exe')
+    shutil.copyfile(bootloader_file, test_file)
+
+    # Embed version info
+    versioninfo.SetVersion(test_file, vsinfo)
+
+    # Read back the values from the string table.
+    def read_file_version_info(filename, *attributes):
+        import ctypes
+        winver = ctypes.WinDLL('version.dll')
+
+        # Read the version information.
+        info_len = winver.GetFileVersionInfoSizeW(filename, None)
+        assert info_len, "No version information found!"
+        info_buf = ctypes.create_string_buffer(info_len)
+        rc = winver.GetFileVersionInfoW(filename, None, info_len, info_buf)
+        assert rc, "Failed to read version information!"
+
+        # Look for the codepages and take the first one.
+        entry_ptr = ctypes.c_void_p()
+        entry_len = ctypes.c_uint()
+        winver.VerQueryValueW(info_buf, r'\VarFileInfo\Translation', ctypes.byref(entry_ptr), ctypes.byref(entry_len))
+        assert entry_len.value, "No codepages found!"
+        codepage = array.array('H', ctypes.string_at(entry_ptr.value, 4))
+        codepage = "%04x%04x" % tuple(codepage)
+
+        # Query attributes.
+        attr_values = []
+        for attr in attributes:
+            entry_name = fr'\StringFileInfo\{codepage}\{attr}'
+            rc = winver.VerQueryValueW(info_buf, entry_name, ctypes.byref(entry_ptr), ctypes.byref(entry_len))
+            if not rc:
+                entry_value = None
+            else:
+                entry_value = ctypes.wstring_at(entry_ptr.value, entry_len.value - 1)
+            attr_values.append(entry_value)
+
+        return attr_values
+
+    values = read_file_version_info(test_file, 'FileDescription', 'ProductName', 'ProductVersion')
+    assert values == [FILE_DESCRIPTION, PRODUCT_NAME, PRODUCT_VERSION]


### PR DESCRIPTION
The declared string lengths in `VSVersionInfo` structure (or rather, its string table) were set to the number of bytes instead of number of (wide-)characters. Therefore, when the strings were read, they included garbage characters at the end. In C-based programs, this is usually not visible because of the terminating NULL character at the actual end of the string, but when reading the strings in python via `ctypes` and winver API, the contents of the whole buffer are visible.

Fixes #6219.