### PR TITLE
loader: fix FrozenImporter.get_source for packages' __init__.py files

### DIFF
--- a/PyInstaller/loader/pyimod03_importers.py
+++ b/PyInstaller/loader/pyimod03_importers.py
@@ -308,6 +308,8 @@ class FrozenImporter:
         """
         if fullname in self.toc:
             # Try loading the .py file from the filesystem (only for collected modules)
+            if self.is_package(fullname):
+                fullname += '.__init__'
             filename = pyi_os_path.os_path_join(SYS_PREFIX, fullname.replace('.', pyi_os_path.os_sep) + '.py')
             try:
                 # Read in binary mode, then decode

--- a/news/6237.bugfix.rst
+++ b/news/6237.bugfix.rst
@@ -1,0 +1,4 @@
+Fix the ``FrozenImporter.get_source()`` to correctly handle the packages'
+``__init__.py`` source  files. This in turn fixes missing-source-file
+errors for packages that use ``pytorch`` JIT when the source .py files
+are collected and available (for example, ``kornia``).


### PR DESCRIPTION
If the specified fullname `a.b.c` is a package, we need to search for "a/b/c/__init__.py" instead of "a/b/c.py". Fixes errors about
missing source files with packages that use `pytorch`'s JIT even when the source files are, in fact, collected.

Fixes #6237.