### PR TITLE
building: Windows: embed manifest into onedir executable by default

### DIFF
--- a/PyInstaller/building/makespec.py
+++ b/PyInstaller/building/makespec.py
@@ -480,6 +480,13 @@ def __add_options(parser):
         help="Add manifest FILE or XML to the exe.",
     )
     g.add_argument(
+        "--no-embed-manifest",
+        dest="embed_manifest",
+        action="store_false",
+        help="Generate an external .exe.manifest file instead of embedding the manifest into the exe. Applicable only "
+        "to onedir mode; in onefile mode, the manifest is always embedded, regardless of this option.",
+    )
+    g.add_argument(
         "-r",
         "--resource",
         dest="resources",
@@ -610,6 +617,7 @@ def main(
     binaries=None,
     icon_file=None,
     manifest=None,
+    embed_manifest=True,
     resources=None,
     bundle_identifier=None,
     hiddenimports=None,
@@ -687,6 +695,8 @@ def main(
         else:
             # Assume filename
             exe_options += "\n    manifest='%s'," % escape_win_filepath(manifest)
+    if not embed_manifest:
+        exe_options += "\n    embed_manifest=False,"
     if resources:
         resources = list(map(escape_win_filepath, resources))
         exe_options += "\n    resources=%s," % repr(resources)

--- a/news/6223.breaking.rst
+++ b/news/6223.breaking.rst
@@ -1,0 +1,5 @@
+(Windows) By default, manifest is now embedded into the executable in
+``onedir`` mode. The old behavior of generating the external manifest
+file can be re-enabled using the :option:`--no-embed-manifest`
+command-line switch, or via the ``embed_manifest=False`` argument to
+``EXE()`` in the .spec file.

--- a/news/6223.feature.rst
+++ b/news/6223.feature.rst
@@ -1,0 +1,8 @@
+(Windows) Embed the manifest into generated ``onedir`` executables by
+default, in order to avoid potential issues when user renames the executable
+(e.g., the manifest not being found anymore due to activation context
+caching when user renames the executable and attempts to run it before
+also renaming the manifest file). The old behavior of generating the
+external manifest file in ``onedir`` mode can be re-enabled using the
+:option:`--no-embed-manifest` command-line switch, or via the
+``embed_manifest=False`` argument to ``EXE()`` in the .spec file.


### PR DESCRIPTION
Embed the manifest in `onedir` executable by default, in order to avoid potential issues when user renames the executable. For example, the manifest not being found anymore due to activation context caching when user renames the executable and attempts to run it before also renaming the manifest file (see #6223).
    
If the old behavior of generating an external manifest file is required for some reason (e.g., manual modification in a post-processing step), it can be re-enabled using the new `--no-embed-manifest` command-line switch or by setting the new `embed_manifest` argument to `EXE()` to `False`.

Closes #6223.