### PR TITLE
Backport of manifest handling changes to v4

### DIFF
--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -338,6 +338,11 @@ class EXE(Target):
                 Windows only. Setting to True creates a Manifest with will request elevation upon application start.
             uac_uiaccess
                 Windows only. Setting to True allows an elevated application to work with Remote Desktop.
+            embed_manifest
+                Windows only. Setting to True (the default) embeds the manifest into the executable. Setting to False
+                generates an external .exe.manifest file. Applicable only in onedir mode (exclude_binaries=True); in
+                onefile mode (exclude_binaries=False), the manifest is always embedded in the executable, regardless
+                of this option.
             target_arch
                 macOS only. Used to explicitly specify the target architecture; either single-arch ('x86_64' or 'arm64')
                 or 'universal2'. Used in checks that the collected binaries contain the requires arch slice(s) and/or
@@ -363,6 +368,7 @@ class EXE(Target):
         self.icon = kwargs.get('icon', None)
         self.versrsrc = kwargs.get('version', None)
         self.manifest = kwargs.get('manifest', None)
+        self.embed_manifest = kwargs.get('embed_manifest', True)
         self.resources = kwargs.get('resources', [])
         self.strip = kwargs.get('strip', False)
         self.upx_exclude = kwargs.get("upx_exclude", [])
@@ -446,6 +452,11 @@ class EXE(Target):
             self.toc.append(("pyi-disable-windowed-traceback", "", "OPTION"))
 
         if is_win:
+            if not self.exclude_binaries:
+                # onefile mode forces embed_manifest=True
+                if not self.embed_manifest:
+                    logger.warning("Ignoring embed_manifest=False setting in onefile mode!")
+                self.embed_manifest = True
             if not self.icon:
                 # --icon not specified; use default from bootloader folder
                 if self.console:
@@ -460,11 +471,11 @@ class EXE(Target):
 
             manifest_filename = os.path.basename(self.name) + ".manifest"
 
-            # In the onedir mode, we need to collect the manifest file, so that it is placed next to the executable as
-            # an external manifest. In the onefile mode, we do not need to collect the manifest, as it is embedded into
-            # the final executable by the assembly pipeline.
-            if self.exclude_binaries:
-                self.toc.append((manifest_filename, filename, 'BINARY'))  # Onedir mode.
+            # If external manifest file is requested (supported only in onedir mode), add the file to the TOC in order
+            # for it to be collected as an external manifest file. Otherwise, the assembly pipeline will embed the
+            # manifest into the executable later on.
+            if not self.embed_manifest:
+                self.toc.append((manifest_filename, filename, 'BINARY'))
 
             if self.versrsrc:
                 if not isinstance(self.versrsrc, versioninfo.VSVersionInfo) and not os.path.isabs(self.versrsrc):
@@ -500,6 +511,7 @@ class EXE(Target):
         ('uac_admin', _check_guts_eq),
         ('uac_uiaccess', _check_guts_eq),
         ('manifest', _check_guts_eq),
+        ('embed_manifest', _check_guts_eq),
         ('append_pkg', _check_guts_eq),
         ('target_arch', _check_guts_eq),
         ('codesign_identity', _check_guts_eq),
@@ -636,9 +648,8 @@ class EXE(Target):
                             resfile,
                             exc_info=1
                         )
-            # In onefile mode, we need to embed the manifest into the executable in order for manifest-related options
-            # (e.g., uac-admin) to work.
-            if self.manifest and not self.exclude_binaries:
+            # Embed the manifest into the executable.
+            if self.embed_manifest:
                 self.manifest.update_resources(tmpnm, [1])
             trash.append(tmpnm)
             exe = tmpnm

--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -460,11 +460,11 @@ class EXE(Target):
 
             manifest_filename = os.path.basename(self.name) + ".manifest"
 
-            self.toc.append((manifest_filename, filename, 'BINARY'))
-            if not self.exclude_binaries:
-                # Onefile mode: manifest file is explicitly loaded. Store name of manifest file as bootloader option.
-                # Allows the exe to be renamed.
-                self.toc.append(("pyi-windows-manifest-filename " + manifest_filename, "", "OPTION"))
+            # In the onedir mode, we need to collect the manifest file, so that it is placed next to the executable as
+            # an external manifest. In the onefile mode, we do not need to collect the manifest, as it is embedded into
+            # the final executable by the assembly pipeline.
+            if self.exclude_binaries:
+                self.toc.append((manifest_filename, filename, 'BINARY'))  # Onedir mode.
 
             if self.versrsrc:
                 if not isinstance(self.versrsrc, versioninfo.VSVersionInfo) and not os.path.isabs(self.versrsrc):
@@ -636,6 +636,8 @@ class EXE(Target):
                             resfile,
                             exc_info=1
                         )
+            # In onefile mode, we need to embed the manifest into the executable in order for manifest-related options
+            # (e.g., uac-admin) to work.
             if self.manifest and not self.exclude_binaries:
                 self.manifest.update_resources(tmpnm, [1])
             trash.append(tmpnm)

--- a/PyInstaller/building/makespec.py
+++ b/PyInstaller/building/makespec.py
@@ -480,6 +480,13 @@ def __add_options(parser):
         help="Add manifest FILE or XML to the exe.",
     )
     g.add_argument(
+        "--no-embed-manifest",
+        dest="embed_manifest",
+        action="store_false",
+        help="Generate an external .exe.manifest file instead of embedding the manifest into the exe. Applicable only "
+        "to onedir mode; in onefile mode, the manifest is always embedded, regardless of this option.",
+    )
+    g.add_argument(
         "-r",
         "--resource",
         dest="resources",
@@ -601,6 +608,7 @@ def main(
     binaries=None,
     icon_file=None,
     manifest=None,
+    embed_manifest=True,
     resources=None,
     bundle_identifier=None,
     hiddenimports=None,
@@ -677,6 +685,8 @@ def main(
         else:
             # Assume filename
             exe_options = "%s, manifest='%s'" % (exe_options, quote_win_filepath(manifest))
+    if not embed_manifest:
+        exe_options = "%s, embed_manifest=%s" % (exe_options, 'False')
     if resources:
         resources = list(map(quote_win_filepath, resources))
         exe_options = "%s, resources=%s" % (exe_options, repr(resources))

--- a/bootloader/src/pyi_launch.c
+++ b/bootloader/src/pyi_launch.c
@@ -604,19 +604,7 @@ pyi_launch_run_scripts(ARCHIVE_STATUS *status)
 void
 pyi_launch_initialize(ARCHIVE_STATUS * status)
 {
-#if defined(_WIN32)
-    char * manifest;
-    manifest = pyi_arch_get_option(status, "pyi-windows-manifest-filename");
-
-    if (NULL != manifest) {
-        char manifest_path[PATH_MAX];
-        if (pyi_path_join(manifest_path, status->mainpath, manifest) == NULL) {
-            FATALERROR("Path of manifest-file (%s) length exceeds "
-                       "buffer[%d] space\n", status->mainpath, PATH_MAX);
-        };
-        CreateActContext(manifest_path);
-    }
-#endif /* if defined(_WIN32) */
+    /* Nothing to do here at the moment. */
 }
 
 /*

--- a/bootloader/src/pyi_win32_utils.c
+++ b/bootloader/src/pyi_win32_utils.c
@@ -37,13 +37,6 @@
 #include "pyi_utils.h"
 #include "pyi_win32_utils.h"
 
-static HANDLE hCtx = INVALID_HANDLE_VALUE;
-static ULONG_PTR actToken;
-
-#ifndef STATUS_SXS_EARLY_DEACTIVATION
-    #define STATUS_SXS_EARLY_DEACTIVATION 0xC015000F
-#endif
-
 #define ERROR_STRING_MAX 4096
 static char errorString[ERROR_STRING_MAX];
 
@@ -90,53 +83,6 @@ char * GetWinErrorString(DWORD error_code) {
         return "PyInstaller: pyi_win32_utils_to_utf8 failed.";
     }
     return errorString;
-}
-
-int
-CreateActContext(const char *manifestpath)
-{
-    wchar_t * manifestpath_w;
-    ACTCTXW ctx;
-    BOOL activated;
-    HANDLE k32;
-
-    HANDLE (WINAPI * CreateActCtx)(PACTCTXW pActCtx);
-    BOOL (WINAPI * ActivateActCtx)(HANDLE hActCtx, ULONG_PTR * lpCookie);
-
-    /* Setup activation context */
-    VS("LOADER: manifestpath: %s\n", manifestpath);
-    manifestpath_w = pyi_win32_utils_from_utf8(NULL, manifestpath, 0);
-
-    k32 = LoadLibraryA("kernel32");
-    CreateActCtx = (void*)GetProcAddress(k32, "CreateActCtxW");
-    ActivateActCtx = (void*)GetProcAddress(k32, "ActivateActCtx");
-
-    if (!CreateActCtx || !ActivateActCtx) {
-        VS("LOADER: Cannot find CreateActCtx/ActivateActCtx exports in kernel32.dll\n");
-        return 0;
-    }
-
-    ZeroMemory(&ctx, sizeof(ctx));
-    ctx.cbSize = sizeof(ACTCTX);
-    ctx.lpSource = manifestpath_w;
-    ctx.dwFlags = ACTCTX_FLAG_SET_PROCESS_DEFAULT;
-
-    hCtx = CreateActCtx(&ctx);
-    free(manifestpath_w);
-
-    if (hCtx != INVALID_HANDLE_VALUE) {
-        VS("LOADER: Activation context created\n");
-        activated = ActivateActCtx(hCtx, &actToken);
-
-        if (activated) {
-            VS("LOADER: Activation context activated\n");
-            return 1;
-        }
-    }
-
-    hCtx = INVALID_HANDLE_VALUE;
-    VS("LOADER: Error activating the context: ActivateActCtx: \n%s\n", GetWinErrorString(0));
-    return 0;
 }
 
 /* Convert a wide string to an ANSI string.

--- a/bootloader/src/pyi_win32_utils.h
+++ b/bootloader/src/pyi_win32_utils.h
@@ -18,7 +18,6 @@
 #ifdef _WIN32
 
 char * GetWinErrorString(DWORD error_code);
-int CreateActContext(const char *manifestpath);
 
 char ** pyi_win32_argv_to_utf8(int argc, wchar_t **wargv);
 wchar_t ** pyi_win32_wargv_from_utf8(int argc, char **argv);

--- a/news/6248.breaking.rst
+++ b/news/6248.breaking.rst
@@ -1,0 +1,5 @@
+(Windows) By default, manifest is now embedded into the executable in
+``onedir`` mode. The old behavior of generating the external manifest
+file can be re-enabled using the :option:`--no-embed-manifest`
+command-line switch, or via the ``embed_manifest=False`` argument to
+``EXE()`` in the .spec file.

--- a/news/6248.bugfix.rst
+++ b/news/6248.bugfix.rst
@@ -1,0 +1,7 @@
+(Windows) Remove the attempt to load the manifest of a ``onefile``
+frozen executable via the activation context, which fails with ``An
+attempt to set the process default activation context failed because
+the process default activation context was already set.`` message that
+can be observed in debug builds. This approach has been invalid ever
+since :issue:`3746` implemented direct manifest embedding into the
+``onefile`` executable.

--- a/news/6248.feature.rst
+++ b/news/6248.feature.rst
@@ -1,0 +1,8 @@
+(Windows) Embed the manifest into generated ``onedir`` executables by
+default, in order to avoid potential issues when user renames the executable
+(e.g., the manifest not being found anymore due to activation context
+caching when user renames the executable and attempts to run it before
+also renaming the manifest file). The old behavior of generating the
+external manifest file in ``onedir`` mode can be re-enabled using the
+:option:`--no-embed-manifest` command-line switch, or via the
+``embed_manifest=False`` argument to ``EXE()`` in the .spec file.


### PR DESCRIPTION
This is a back-port of manifest handling changes from #6243 and its prerequisite, #6203, to the `v4` branch.

Closes #6223.