### PR TITLE
hooks: qt5: add hooks for QtPositioning and QtLocation modules

### DIFF
--- a/PyInstaller/hooks/hook-PyQt5.QtLocation.py
+++ b/PyInstaller/hooks/hook-PyQt5.QtLocation.py
@@ -1,0 +1,14 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013-2021, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks.qt import add_qt5_dependencies
+
+hiddenimports, binaries, datas = add_qt5_dependencies(__file__)

--- a/PyInstaller/hooks/hook-PyQt5.QtPositioning.py
+++ b/PyInstaller/hooks/hook-PyQt5.QtPositioning.py
@@ -1,0 +1,14 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013-2021, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks.qt import add_qt5_dependencies
+
+hiddenimports, binaries, datas = add_qt5_dependencies(__file__)

--- a/PyInstaller/hooks/hook-PySide2.QtLocation.py
+++ b/PyInstaller/hooks/hook-PySide2.QtLocation.py
@@ -1,0 +1,14 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013-2021, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks.qt import add_qt5_dependencies
+
+hiddenimports, binaries, datas = add_qt5_dependencies(__file__)

--- a/PyInstaller/hooks/hook-PySide2.QtPositioning.py
+++ b/PyInstaller/hooks/hook-PySide2.QtPositioning.py
@@ -1,0 +1,14 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013-2021, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks.qt import add_qt5_dependencies
+
+hiddenimports, binaries, datas = add_qt5_dependencies(__file__)

--- a/news/6250.hooks.rst
+++ b/news/6250.hooks.rst
@@ -1,0 +1,3 @@
+Add hooks for ``QtPositioning`` and ``QtLocation`` modules of the Qt5-based
+packages (``PySide2`` and ``PyQt5``) to ensure that corresponding plugins
+are collected.


### PR DESCRIPTION
Add hooks for `QtPositioning` and `QtLocation` in Qt5-based packages (`PySide2`, `PyQt5`), which ensure that corresponding plugins are collected.