### PR TITLE
building: makespec: do not hard-code spec file's directory as pathex

### DIFF
--- a/PyInstaller/building/makespec.py
+++ b/PyInstaller/building/makespec.py
@@ -659,11 +659,6 @@ def main(
     if not os.path.exists(specpath):
         os.makedirs(specpath)
 
-    # Append specpath to PYTHONPATH - where to look for additional Python modules.
-    pathex = pathex or []
-    pathex = pathex[:]
-    pathex.append(specpath)
-
     # Handle additional EXE options.
     exe_options = ''
     if version_file:
@@ -754,7 +749,7 @@ def main(
 
     d = {
         'scripts': scripts,
-        'pathex': pathex,
+        'pathex': pathex or [],
         'binaries': preamble.binaries,
         'datas': preamble.datas,
         'hiddenimports': preamble.hiddenimports,

--- a/news/6254.bugfix.rst
+++ b/news/6254.bugfix.rst
@@ -1,0 +1,2 @@
+When generating spec files, avoid hard-coding the spec file's location as the
+``pathex`` argument to the ``Analysis``. 


### PR DESCRIPTION
Do not hardcode the spec file's parent directory as `pathex` in the generated spec file.

Doing so makes the spec file appear non-portable, as the hard-coded absolute path is both OS-specific and depends on current location of the spec file.

In practice, the spec file's location should also have little relevance to the module search path. The spec file is either located in a different directory than the entry-point script(s), which makes its location irrelevant. Or, it is located in the same directory as the entry-point script(s), in which case the location is dynamically added to `pathex` due to Analysis calling its `_extend_pathex()` method:
https://github.com/pyinstaller/pyinstaller/blob/9ad67540033b598d41f0cab836516065fe615f7b/PyInstaller/building/build_main.py#L248