### PR TITLE
Fix tests on macOS 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,13 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
-        os: ['windows-latest', 'ubuntu-latest', 'macos-10.15']
+        os: ['windows-latest', 'ubuntu-latest', 'macos-10.15', 'macos-latest']
+        exclude:
+          # Python 3.6 is not available on macOS 11
+          - os: macos-11
+            python-version: 3.6
+          - os: macos-latest
+            python-version: 3.6
       fail-fast: false
     steps:
       - uses: actions/checkout@v2
@@ -93,6 +99,14 @@ jobs:
           Xvfb :99 &
           echo "DISPLAY=:99" >> $GITHUB_ENV
           echo "QT_DEBUG_PLUGINS=1" >> $GITHUB_ENV
+
+      # Required on macOS 11 by tests that register custom URL schema. This could also be achieved by passing
+      # --basetemp to pytest, but using environment variable allows us to have a unified "Run test" step for
+      # all OSes.
+      - name: Relocate temporary dir
+        if: matrix.os == 'macos-11' || matrix.os == 'macos-latest'
+        run: |
+          echo "PYTEST_DEBUG_TEMPROOT=$RUNNER_TEMP" >> $GITHUB_ENV
 
       - name: Run tests
         uses: xoviat/actions-pytest@0.1-alpha2

--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -58,6 +58,19 @@ is_unix = is_linux or is_solar or is_aix or is_freebsd or is_hpux or is_openbsd
 # compiled bootloaders. On musl systems, ldd with no arguments prints 'musl' and its version.
 is_musl = is_linux and "musl" in subprocess.getoutput(["ldd"])
 
+# macOS versions
+# macOS 11 (Big Sur): if python is not compiled with Big Sur support, it ends up in compatibility mode by default, which
+# is indicated by platform.mac_ver() returning '10.16'. The lack of proper Big Sur support breaks find_library()
+# function from ctypes.util module, as starting with Big Sur, shared libraries are not visible on disk anymore. Support
+# for the new library search mechanism was added in python 3.9 when compiled with Big Sur support. In such cases,
+# platform.mac_ver() reports version as '11.x'. The behavior can be further modified via SYSTEM_VERSION_COMPAT
+# environment variable; which allows explicitly enabling or disabling the compatibility mode. However, note that
+# disabling the compatibility mode and using python that does not properly support Big Sur still leaves find_library()
+# broken (which is a scenario that we ignore at the moment).
+is_macos_11_compat = is_darwin and platform.mac_ver()[0].startswith('10.16')
+is_macos_11_native = is_darwin and platform.mac_ver()[0].startswith('11')
+is_macos_11 = is_macos_11_compat or is_macos_11_native
+
 # On different platforms is different file for dynamic python library.
 # TODO: When removing support for is_py37, the "m" variants can be
 # removed, see <https://docs.python.org/3/whatsnew/3.8.html#build-and-c-api-changes>

--- a/PyInstaller/depend/bindepend.py
+++ b/PyInstaller/depend/bindepend.py
@@ -19,7 +19,6 @@ import re
 import sys
 # Required for extracting eggs.
 import zipfile
-from glob import glob
 import subprocess
 
 from PyInstaller import compat

--- a/tests/unit/test_depend_utils.py
+++ b/tests/unit/test_depend_utils.py
@@ -14,7 +14,7 @@ import pytest
 import textwrap
 
 from PyInstaller.depend import utils
-from PyInstaller.compat import is_win, is_musl
+from PyInstaller.compat import is_win, is_musl, is_macos_11_compat
 
 CTYPES_CLASSNAMES = (
     'CDLL', 'ctypes.CDLL',
@@ -67,6 +67,7 @@ def test_ctypes_LibraryLoader_LoadLibrary(monkeypatch, classname, extended_args)
 
 @pytest.mark.parametrize('extended_args', [False, True])
 @pytest.mark.skipif(is_musl, reason="find_library() doesn't work on musl")
+@pytest.mark.skipif(is_macos_11_compat, reason="find_library() requires python built with Big Sur support.")
 def test_ctypes_util_find_library(monkeypatch, extended_args):
     # for lind_library() we need a lib actually existing on the system
     if is_win:


### PR DESCRIPTION
Fix tests on macOS 11 and enable `macos-latest` on the CI.

An updated and revised version of #5488.