### PR TITLE
tests/ci: pin version of pyqt6-qt6

### DIFF
--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -34,7 +34,9 @@ pyside2==5.15.2
 pyside6==6.1.0
 pyqt5==5.15.4
 pyqtwebengine==5.15.4
-pyqt6==6.1.0
+# NOTE: keep pyqt6-qt6 pinned together with pyqt6 until we switch to 6.2.0
+pyqt6==6.1.0  # pyup: ignore
+pyqt6-qt6==6.1.0  # pyup: ignore
 python-dateutil==2.8.2
 pytz==2021.1
 requests==2.26.0


### PR DESCRIPTION
We need to pin version of the `pyqt6-qt6` package in addition to that of the `pyqt6` package. Otherwise, we end up with `pyqt6` pinned to 6.1.0, and with `pyqt6-qt6` at the latest version, which is now 6.2.0 and which we do not support yet due to changes it introduces.