### PR TITLE
Hooks: support GtkSource versions greater than 3.0

### DIFF
--- a/PyInstaller/hooks/hook-gi.repository.GtkSource.py
+++ b/PyInstaller/hooks/hook-gi.repository.GtkSource.py
@@ -10,7 +10,20 @@
 #-----------------------------------------------------------------------------
 
 from PyInstaller.utils.hooks.gi import (collect_glib_share_files, get_gi_typelibs)
+from PyInstaller.utils.hooks import (get_hook_config, logger)
 
-binaries, datas, hiddenimports = get_gi_typelibs('GtkSource', '3.0')
 
-datas += collect_glib_share_files('gtksourceview-3.0')
+def hook(hook_api):
+    module_versions = get_hook_config(hook_api, 'gi', 'module-versions')
+    if module_versions:
+        version = module_versions.get('GtkSource', '3.0')
+    else:
+        version = '3.0'
+    logger.info(f'GtkSource version is {version}')
+
+    binaries, datas, hiddenimports = get_gi_typelibs('GtkSource', version)
+
+    datas += collect_glib_share_files(f'gtksourceview-{version}')
+    hook_api.add_datas(datas)
+    hook_api.add_binaries(binaries)
+    hook_api.add_imports(*hiddenimports)

--- a/doc/hooks-config.rst
+++ b/doc/hooks-config.rst
@@ -62,17 +62,22 @@ from the system ``/usr/share`` directory.
    collect all available translations.
 
  * ``icons`` [*list of strings*]: list of icon themes (e.g., `Adwaita`)
-   that shoud be collected. By default, ``gi`` hooks collect all available
+   that should be collected. By default, ``gi`` hooks collect all available
    icon themes.
 
  * ``themes`` [*list of strings*]: list of Gtk themes (e.g., `Adwaita`)
-   that shoud be collected. By default, ``gi`` hooks collect all available
+   that should be collected. By default, ``gi`` hooks collect all available
    icon themes.
+
+ * ``module-versions`` [*dict of version strings*]: versions of gi modules to
+   use. For example, a key of 'GtkSource' and value to '4' will use
+   gtksourceview4.
 
 **Example**
 
-Collect only ``Adwaita`` theme and icons, and limit the collected
-translations to British English and Simplified Chinese:
+Collect only ``Adwaita`` theme and icons, limit the collected
+translations to British English and Simplified Chinese, and use
+version 3.0 of Gtk and version 4 of GtkSource:
 
 .. code-block:: python
 
@@ -84,10 +89,16 @@ translations to British English and Simplified Chinese:
                 "icons": ["Adwaita"],
                 "themes": ["Adwaita"],
                 "languages": ["en_GB", "zh_CN"],
+                "module-versions": {
+                    "Gtk": "3.0",
+                    "GtkSource": "4",
+                },
             },
         },
         ...,
     )
+
+.. note:: Currently only the ``module-versions`` configuration is available for ``GtkSource``.
 
 .. _matplotlib hook options:
 

--- a/news/6267.hooks.rst
+++ b/news/6267.hooks.rst
@@ -1,0 +1,3 @@
+Update the ``gi.repository.GtkSource`` hook to accept a module-versions
+hooksconfig dict in order to allow the hook to be used with GtkSource versions
+greater than 3.0.


### PR DESCRIPTION
The current hook for GtkSource is hardcoded to version 3.0. This makes the version configurable using the hooksconfig mechanism.