### PR TITLE
Windows: Allow reading VSVersionInfo files with BOMs.

### DIFF
--- a/PyInstaller/utils/misc.py
+++ b/PyInstaller/utils/misc.py
@@ -17,6 +17,10 @@ import os
 import pprint
 import py_compile
 import sys
+import codecs
+import re
+import tokenize
+import io
 
 from PyInstaller import log as logging
 from PyInstaller.compat import BYTECODE_MAGIC, is_win
@@ -283,3 +287,28 @@ def is_file_qt_plugin(filename):
             return False
 
         return True
+
+
+BOM_MARKERS_TO_DECODERS = {
+    codecs.BOM_UTF32_LE: codecs.utf_32_le_decode,
+    codecs.BOM_UTF32_BE: codecs.utf_32_be_decode,
+    codecs.BOM_UTF32: codecs.utf_32_decode,
+    codecs.BOM_UTF16_LE: codecs.utf_16_le_decode,
+    codecs.BOM_UTF16_BE: codecs.utf_16_be_decode,
+    codecs.BOM_UTF16: codecs.utf_16_decode,
+    codecs.BOM_UTF8: codecs.utf_8_decode,
+}
+BOM_RE = re.compile(rb"\A(%s)?(.*)" % b"|".join(map(re.escape, BOM_MARKERS_TO_DECODERS)), re.DOTALL)
+
+
+def decode(raw: bytes):
+    """
+    Decode bytes to string, respecting and removing any byte-order marks if present, or respecting but not removing any
+    PEP263 encoding comments (# encoding: cp1252).
+    """
+    bom, raw = BOM_RE.match(raw).groups()
+    if bom:
+        return BOM_MARKERS_TO_DECODERS[bom](raw)[0]
+
+    encoding, _ = tokenize.detect_encoding(io.BytesIO(raw).readline)
+    return raw.decode(encoding)

--- a/PyInstaller/utils/win32/versioninfo.py
+++ b/PyInstaller/utils/win32/versioninfo.py
@@ -642,8 +642,10 @@ def SetVersion(exenm, versionfile):
     if isinstance(versionfile, VSVersionInfo):
         vs = versionfile
     else:
-        with codecs.open(versionfile, 'r', 'utf-8') as fp:
-            txt = fp.read()
+        # Read and parse the version file. It may have a byte order marker or encoding cookie - respect it if it does.
+        from PyInstaller.utils.misc import decode
+        with open(versionfile, 'rb') as fp:
+            txt = decode(fp.read())
         vs = eval(txt)
 
     # Remember overlay

--- a/news/6259.bugfix.rst
+++ b/news/6259.bugfix.rst
@@ -1,0 +1,2 @@
+(Windows) Tolerate reading Windows VSVersionInfo files with unicode byte order
+marks.

--- a/news/6259.feature.rst
+++ b/news/6259.feature.rst
@@ -1,0 +1,2 @@
+(Windows) Respect :pep:`239` encoding specifiers in Window's VSVersionInfo
+files.

--- a/tests/unit/test_miscutils.py
+++ b/tests/unit/test_miscutils.py
@@ -163,3 +163,30 @@ def test_versioninfo_written_to_exe(tmp_path):
 
     values = read_file_version_info(test_file, 'FileDescription', 'ProductName', 'ProductVersion')
     assert values == [FILE_DESCRIPTION, PRODUCT_NAME, PRODUCT_VERSION]
+
+
+CHINESE_LOREM_IPSUM = """
+索感歴新策理通幻月続本初迷検価泉属速棄者。料流重者県作軽渡獲県行選見。意鑑民供変介画同表後院苦面例紙約度電心
+時盤止野断希茶術同懲上権策全崎査応校匹国。真村辺名下周一場庭戸原図会正前対校米利。岩録開教純止表乗都偉別際政難然始京国京
+校県水路中旅続球是校高約止性振下上派若福。案神整細番公流関閲元弊導説大実枝際確導
+"""
+
+
+def test_decode():
+    """
+    Test PyInstaller.utils.misc.decode().
+    """
+    import codecs
+    from PyInstaller.utils.misc import decode
+
+    # Test UTF8 with or without the BOM.
+    assert decode(CHINESE_LOREM_IPSUM.encode()) == CHINESE_LOREM_IPSUM
+    assert decode(codecs.BOM_UTF8 + CHINESE_LOREM_IPSUM.encode()) == CHINESE_LOREM_IPSUM
+
+    # Test non-default UTF variants specified via a BOM.
+    assert decode(codecs.BOM_UTF32_LE + codecs.utf_32_le_encode(CHINESE_LOREM_IPSUM)[0]) == CHINESE_LOREM_IPSUM
+    assert decode(codecs.BOM_UTF16_BE + codecs.utf_16_be_encode(CHINESE_LOREM_IPSUM)[0]) == CHINESE_LOREM_IPSUM
+
+    # Test using the encoding comment.
+    with_cookie = "# encoding: gb18030\n" + CHINESE_LOREM_IPSUM
+    assert decode(with_cookie.encode("GB18030")) == with_cookie


### PR DESCRIPTION
Fixes #6259. I've only enabled this byte order marker tolerance for reading VSVersionInfo files - in theory I imagine that this could be extended to anywhere that we read a text file but I'd rather err on the side of not complicating things unless we know we need to.