### PR TITLE
Docs: Use sphinxcontrib-towncrier-preview to render loose news items.

### DIFF
--- a/doc/CHANGES.rst
+++ b/doc/CHANGES.rst
@@ -10,6 +10,9 @@ Changelog for PyInstaller
    To add a new change log entry, please see
    https://pyinstaller.readthedocs.io/en/latest/development/changelog-entries.html
 
+.. Preview unreleased news fragments.
+.. towncrier-draft-entries:: The Next Release
+
 .. towncrier release notes start
 
 4.5 (2021-08-01)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -74,6 +74,7 @@ extensions = ['sphinx.ext.intersphinx',
               'sphinx.ext.autodoc',
               'sphinx.ext.napoleon',
               'sphinx_autodoc_typehints',
+              'sphinxcontrib.towncrier',
               'pyi_sphinx_roles']
 
 intersphinx_mapping = {
@@ -91,6 +92,10 @@ nitpick_ignore = [
     ("py:mod", "Splash"),
     ("py:class", "TOC"),
 ]
+
+# Don't include a preview if there are no news items. i.e. towncrier has already been ran.
+towncrier_draft_include_empty = False
+towncrier_draft_working_directory = os.path.abspath('..')
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -23,6 +23,8 @@ sphinxcontrib-htmlhelp==2.0.0
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
+sphinxcontrib-towncrier==0.2.0a0
+towncrier==21.3.0
 typing-extensions==3.10.0.0
 urllib3==1.26.5
 zipp==3.4.1

--- a/news/_template.rst
+++ b/news/_template.rst
@@ -1,3 +1,5 @@
+{{ versiondata.version }} ({{ versiondata.date }})
+{{ top_underline * ((versiondata.version + versiondata.date)|length + 4)}}
 {% macro print_issue_numbers(issues) %}
 {% for issue in issues if issue.startswith('#') %}
 {% if loop.first %} ({% endif %}

--- a/tests/requirements-developer.txt
+++ b/tests/requirements-developer.txt
@@ -22,7 +22,7 @@ pycmd  # Contains 'py.cleanup' that removes all .pyc files and similar.
 wheel>0.24.0  # For creating .whl packages
 twine         # For secure upload of tar.gz to PYPI.
 
-towncrier>=19.2.0    # For creating the change-log file.
+towncrier>=21.3.0    # For creating the change-log file.
 
 zest.releaser>=6.18  # Makes releasing easier
 # Addons for zest.releaser:


### PR DESCRIPTION
I've just discovered a really neat sphinx plugin which injects the output of `towncrier build --draft` into a sphinx directive so that loose news fragments can be rendered and verified without manually running a towncrier build.

In doing so, I noticed towncrier has made a non-backwards and non-forwards compatible change. I've updated our configuration so that we're on the new side of the breaking version. If we merge this, @Legorooj please update to `towncrier >=  21.3.0` before the next release - otherwise we'll get two copies of the same heading instead of one.