### PR TITLE
hooks: update QtNetwork hooks for Qt 6.2 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,9 @@ jobs:
           # Make sure the help options print.
           python -m pyinstaller -h
 
+          # Run Qt-based tests with offscreen backend
+          echo "QT_QPA_PLATFORM=offscreen" >> $GITHUB_ENV
+
       - name: Start display server
         if: startsWith(matrix.os, 'ubuntu')
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,6 @@ jobs:
         run: |
           Xvfb :99 &
           echo "DISPLAY=:99" >> $GITHUB_ENV
-          echo "QT_DEBUG_PLUGINS=1" >> $GITHUB_ENV
 
       # Required on macOS 11 by tests that register custom URL schema. This could also be achieved by passing
       # --basetemp to pytest, but using environment variable allows us to have a unified "Run test" step for

--- a/PyInstaller/utils/hooks/qt.py
+++ b/PyInstaller/utils/hooks/qt.py
@@ -195,6 +195,27 @@ def qt_plugins_dir(namespace):
     return qt_plugin_paths
 
 
+def _qt_filter_release_plugins(plugin_files):
+    """
+    Filter the provided list of Qt plugin files and remove the debug variants, under the assumption that both the
+    release version of a plugin (qtplugin.dll) and its debug variant (qtplugind.dll) appear in the list.
+    """
+    # All basenames for lookup
+    plugin_basenames = {os.path.normcase(os.path.basename(f)) for f in plugin_files}
+    # Process all given filenames
+    release_plugin_files = []
+    for plugin_filename in plugin_files:
+        plugin_basename = os.path.normcase(os.path.basename(plugin_filename))
+        if plugin_basename.endswith('d.dll'):
+            # If we can find a variant without trailing 'd' in the plugin list, then the DLL we are dealing with is a
+            # debug variant and needs to be excluded.
+            release_name = os.path.splitext(plugin_basename)[0][:-1] + '.dll'
+            if release_name in plugin_basenames:
+                continue
+        release_plugin_files.append(plugin_filename)
+    return release_plugin_files
+
+
 def qt_plugins_binaries(plugin_type, namespace):
     """
     Return list of dynamic libraries formatted for mod.binaries.
@@ -216,7 +237,7 @@ def qt_plugins_binaries(plugin_type, namespace):
     # this would grab debug copies of Qt plugins, which then causes PyInstaller to add a dependency on the Debug CRT
     # *in addition* to the release CRT.
     if compat.is_win:
-        files = [f for f in files if not f.endswith("d.dll")]
+        files = _qt_filter_release_plugins(files)
 
     logger.debug("Found plugin files %s for plugin %s", files, plugin_type)
     dest_dir = os.path.join(qt_info.qt_rel_dir, 'plugins', plugin_type)

--- a/PyInstaller/utils/hooks/qt.py
+++ b/PyInstaller/utils/hooks/qt.py
@@ -424,7 +424,12 @@ _qt5_dynamic_dependencies_dict = {
 # The dynamic dependency dictionary for Qt6 is constructed automatically from its Qt5 counterpart, by copying the
 # entries and substituting qt5 in the name with qt6. If the entry already exists in the dictionary, it is not
 # copied, which allows us to provide Qt6-specific overrides, should they prove necessary.
-_qt6_dynamic_dependencies_dict = {}
+_qt6_dynamic_dependencies_dict = {
+    # Qt6Network:
+    # networkinformationbackends plugins were introduced in Qt 6.1, and renamed to networkinformation in Qt 6.2
+    # tls plugins were introduced in Qt 6.2
+    "qt6network":               (".QtNetwork",             "qtbase",           "networkinformationbackend", "networkinformation", "tls"),  # noqa
+}  # yapf: disable
 
 for lib_name, content in _qt5_dynamic_dependencies_dict.items():
     if lib_name.startswith('qt5'):

--- a/news/6276.hooks.rst
+++ b/news/6276.hooks.rst
@@ -1,0 +1,2 @@
+Update ``QtNetwork`` hook for ``PyQt6`` and ``PySide6``  to collect the
+new ``tls`` plugins that were introduced in Qt 6.2.

--- a/setup.cfg
+++ b/setup.cfg
@@ -121,7 +121,7 @@ log_level = DEBUG
 # 'thread' timeout method adds more overhead but works in Travis containers.
 
 # Add a global timeout to prevent a hung CI
-timeout = 300
+timeout = 600
 
 # Look for tests only in tests directories.
 # Later we could change this to just "tests/**/test_*.py"

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -31,12 +31,11 @@ future==0.18.2
 gevent==21.8.0
 pygments==2.10.0
 pyside2==5.15.2
-pyside6==6.1.0
+pyside6==6.2.0
 pyqt5==5.15.4
 pyqtwebengine==5.15.4
-# NOTE: keep pyqt6-qt6 pinned together with pyqt6 until we switch to 6.2.0
-pyqt6==6.1.0  # pyup: ignore
-pyqt6-qt6==6.1.0  # pyup: ignore
+pyqt6==6.2.0  # PyQt6 Qt6 bindings
+pyqt6-qt6==6.2.0  # Qt6 binaries (keep in sync with pyqt6 version!)
 python-dateutil==2.8.2
 pytz==2021.3
 requests==2.26.0


### PR DESCRIPTION
Qt 6.2 introduced new set of `tls` plugins that need to be collected for `QSslSocket` to work.
