### PR TITLE
Cleanup: Requirements: Install pytest-timeout from PyPI.

### DIFF
--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -23,8 +23,6 @@ FROM python:3.9-alpine AS wheel-factory
 RUN apk add musl-dev gcc
 # With zlib headers to compiler the bootloader,
 RUN apk add zlib-dev
-# Git to allow pip installing from version control,
-RUN apk add git
 # Development packages to build lxml from source,
 RUN apk add libxml2-dev libxslt-dev
 # Linux headers to build psutil from source.

--- a/tests/requirements-tools.txt
+++ b/tests/requirements-tools.txt
@@ -22,7 +22,7 @@ pytest >= 2.7.3
 pytest-xdist
 
 # Plugin to abort hanging tests.
-git+https://github.com/pytest-dev/pytest-timeout.git@1a35f94298c1260500907bd674b75cf59df0c949
+pytest-timeout >= 2.0.0
 # allows specifying order without duplicates
 pytest-drop-dup-tests
 # reruns failed flaky tests


### PR DESCRIPTION
pytest-timeout have just released so we no longer need to install from their Github. This removes the need to install git on the alpine test image.
