### PR TITLE
utils/hooks: Fix import error with GTK apps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,14 +39,15 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu')
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -qq \
+          sudo apt-get install -qq --no-install-recommends \
             libxml2-dev libxslt1-dev gfortran libatlas-base-dev \
             libespeak1 libxcb-image0 libxcb-keysyms1 libxcb-render-util0 \
             libxkbcommon-x11-0 libxcb-icccm4 libxcb1 openssl \
             libxcb-randr0-dev libxcb-xtest0-dev libxcb-xinerama0-dev \
             libxcb-shape0-dev libxcb-xkb-dev xvfb \
             libopengl0 libegl1 \
-            libpulse0 libpulse-mainloop-glib0
+            libpulse0 libpulse-mainloop-glib0 \
+            gir1.2-gtk-3.0 libgirepository1.0-dev
 
       - name: Download AppImage tool
         if: startsWith(matrix.os, 'ubuntu')

--- a/PyInstaller/utils/hooks/gi.py
+++ b/PyInstaller/utils/hooks/gi.py
@@ -22,9 +22,11 @@ logger = logging.getLogger(__name__)
 
 @isolated.decorate
 def get_gi_libdir(module, version):
+    import os
     import gi
     gi.require_version("GIRepository", "2.0")
     from gi.repository import GIRepository
+    from PyInstaller.depend.bindepend import findSystemLibrary
 
     repo = GIRepository.Repository.get_default()
     repo.require(module, version, GIRepository.RepositoryLoadFlags.IREPOSITORY_LOAD_FLAG_LAZY)

--- a/PyInstaller/utils/hooks/gi.py
+++ b/PyInstaller/utils/hooks/gi.py
@@ -30,10 +30,13 @@ def get_gi_libdir(module, version):
 
     repo = GIRepository.Repository.get_default()
     repo.require(module, version, GIRepository.RepositoryLoadFlags.IREPOSITORY_LOAD_FLAG_LAZY)
-    libs = repo.get_shared_library(module)
-    for lib in libs:
+    libs = repo.get_shared_library(module)  # comma-separated list of paths to shared libraries or None
+    if not libs:
+        raise ValueError("Could not find shared library for %s-%s" % (module, version))
+    for lib in libs.split(','):
         path = findSystemLibrary(lib)
-        return os.path.normpath(os.path.dirname(path))
+        if path:
+            return os.path.normpath(os.path.dirname(path))
 
     raise ValueError("Could not find libdir for %s-%s" % (module, version))
 

--- a/news/6300.bugfix.rst
+++ b/news/6300.bugfix.rst
@@ -1,0 +1,2 @@
+Fix import errors when calling ``get_gi_libdir()`` during packaging of GTK apps.
+Enable CI tests of GTK by adding PyGObject dependencies for the Ubuntu builds.

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -30,6 +30,7 @@ babel==2.9.1
 future==0.18.2
 gevent==21.8.0
 pygments==2.10.0
+PyGObject==3.42.0; sys_platform == 'linux'
 pyside2==5.15.2; python_version < '3.10'
 pyside6==6.2.0
 pyqt5==5.15.4; python_version < '3.10'


### PR DESCRIPTION
Fixes #6298 by adding imports that were missing from the isolated environment. Add Ubuntu dependencies so that the
test_gi tests will be run during CI.