### PR TITLE
Setup: Block installation on too new Python versions.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ classifiers =
 [options]
 zip_safe = False
 include_package_data = False
-python_requires = >=3.6
+python_requires = >=3.6, <3.11
 ## IMPORTANT: Keep aligned with requirements.txt
 install_requires =
     setuptools


### PR DESCRIPTION
This actively inhibits installing PyInstaller from either PyPI or Github on a Python version we haven't explicitly declared support for. Now, attempting to do so on the Python 3.11 prerelease gives an:
```
ERROR: Package 'pyinstaller' requires a different Python: 3.11.0 not in '<3.11,>=3.6'
```
Doing so should hopefully reduce the number of issues like #6321 we get when the next version of Python comes out.