### PR TITLE
compat: extend is_macos_11 flag to cover macOS 11 or later

### DIFF
--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -59,7 +59,9 @@ is_unix = is_linux or is_solar or is_aix or is_freebsd or is_hpux or is_openbsd
 # compiled bootloaders. On musl systems, ldd with no arguments prints 'musl' and its version.
 is_musl = is_linux and "musl" in subprocess.getoutput(["ldd"])
 
-# macOS versions
+# macOS version
+_macos_ver = tuple(int(x) for x in platform.mac_ver()[0].split('.')) if is_darwin else None
+
 # macOS 11 (Big Sur): if python is not compiled with Big Sur support, it ends up in compatibility mode by default, which
 # is indicated by platform.mac_ver() returning '10.16'. The lack of proper Big Sur support breaks find_library()
 # function from ctypes.util module, as starting with Big Sur, shared libraries are not visible on disk anymore. Support
@@ -68,9 +70,10 @@ is_musl = is_linux and "musl" in subprocess.getoutput(["ldd"])
 # environment variable; which allows explicitly enabling or disabling the compatibility mode. However, note that
 # disabling the compatibility mode and using python that does not properly support Big Sur still leaves find_library()
 # broken (which is a scenario that we ignore at the moment).
-is_macos_11_compat = is_darwin and platform.mac_ver()[0].startswith('10.16')
-is_macos_11_native = is_darwin and platform.mac_ver()[0].startswith('11')
-is_macos_11 = is_macos_11_compat or is_macos_11_native
+# The same logic applies to macOS 12 (Monterey).
+is_macos_11_compat = _macos_ver and _macos_ver[0:2] == (10, 16)  # Big Sur or newer in compat mode
+is_macos_11_native = _macos_ver and _macos_ver[0:2] >= (11, 0)  # Big Sur or newer in native mode
+is_macos_11 = is_macos_11_compat or is_macos_11_native  # Big Sur or newer
 
 # On different platforms is different file for dynamic python library.
 # TODO: When removing support for is_py37, the "m" variants can be


### PR DESCRIPTION
On macOS 12 Monterey, `platform.mac_ver()[0]` returns '10.16' if in compatibility mode (i.e., running python without Big Sur support) or '12.0.1' if in native mode (python with Big Sur support).

Therefore, extend the `is_macos_11` flag to signify that we are running on macOS 11 or later (instead of just macOS 11).

This ensures that problematic tests are skipped on macOS 12 Monterey, same as they are on macOS 11 Big Sur:
* `test_ctypes_util_find_library` if we are running in compatibility mode, in which `ctypes.util.find_library()` does not find system libraries
* `test_apple_event_handling_carbon` if `pytest`'s base temporary directory is in the default location (`/var`), in which case the custom URL and file schema registration does not work for app bundles.