### PR TITLE
hooks: update sphinx hook for compatibility with v4.2.0

### DIFF
--- a/news/6330.hooks.rst
+++ b/news/6330.hooks.rst
@@ -1,0 +1,1 @@
+Update ``sphinx`` hook for compatibility with latest version (4.2.0).

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -42,7 +42,7 @@ pytz==2021.3
 requests==2.26.0
 # simplejson is used for text_c_extension
 simplejson==3.17.5
-sphinx==2.4.4 # pyup: ignore
+sphinx==4.2.0
 # Required for test_namespace_package
 sqlalchemy==1.4.26
 zope.interface==5.4.0


### PR DESCRIPTION
Simplify the hook by collecting all submodules from the `sphinx` package. This ensures that we do not have to worry about built-in extension modules becoming packages.