### PR TITLE
Tests: Requirements: Resyncronise pyqt6 and pyqt6-libs versions.

### DIFF
--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -32,10 +32,10 @@ gevent==21.8.0
 pygments==2.10.0
 PyGObject==3.42.0; sys_platform == 'linux'
 pyside2==5.15.2; python_version < '3.10'
-pyside6==6.2.0
+pyside6==6.2.1
 pyqt5==5.15.6; python_version < '3.10'
 pyqtwebengine==5.15.5; python_version < '3.10'
-pyqt6==6.2.0  # PyQt6 Qt6 bindings
+pyqt6==6.2.1  # PyQt6 Qt6 bindings
 pyqt6-qt6==6.2.1  # Qt6 binaries (keep in sync with pyqt6 version!)
 python-dateutil==2.8.2
 pytz==2021.3


### PR DESCRIPTION
Address https://github.com/pyinstaller/pyinstaller/pull/6328#issuecomment-955781516. I'm mostly only doing this as a PR to see if CI/CD might reveal why PyUp didn't do this automatically.