### PR TITLE
Bindepend: Fix FileNotFoundErrors in _which_library()

### DIFF
--- a/PyInstaller/depend/bindepend.py
+++ b/PyInstaller/depend/bindepend.py
@@ -802,7 +802,7 @@ def _which_library(name, dirs):
 
     """
     matcher = _library_matcher(name)
-    for path in dirs:
+    for path in filter(os.path.exists, dirs):
         for _path in os.listdir(path):
             if matcher(_path):
                 return os.path.join(path, _path)

--- a/news/6331.bugfix.rst
+++ b/news/6331.bugfix.rst
@@ -1,0 +1,2 @@
+Fix a bug since v4.6 where certain Unix system directories were incorrectly assumed to exist and resulted in
+a :class:`FileNotFoundError`.


### PR DESCRIPTION
Fixes #6331.