### PR TITLE
Use a secure HTTPS link to homepage in package metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = pyinstaller
 version = attr: PyInstaller.__version__
-url = http://www.pyinstaller.org/
+url = https://www.pyinstaller.org/
 
 description = PyInstaller bundles a Python application and all its dependencies into a single package.
 # Long description consists of README.rst only


### PR DESCRIPTION
This will direct users who click on the Homepage link [on PyPI](https://pypi.org/project/pyinstaller/4.6/) to a secure HTTPS link, rather than insecure HTTP.