### PR TITLE
bootloader: replace PyRun_SimpleString with PyRun_SimpleStringFlags

### DIFF
--- a/bootloader/src/pyi_python.c
+++ b/bootloader/src/pyi_python.c
@@ -73,7 +73,7 @@ DECLPROC(PyObject_CallFunctionObjArgs);
 DECLPROC(PyObject_SetAttrString);
 DECLPROC(PyObject_GetAttrString);
 DECLPROC(PyObject_Str);
-DECLPROC(PyRun_SimpleString);
+DECLPROC(PyRun_SimpleStringFlags);
 DECLPROC(PySys_AddWarnOption);
 DECLPROC(PySys_SetArgvEx);
 DECLPROC(PySys_GetObject);
@@ -145,7 +145,7 @@ pyi_python_map_names(HMODULE dll, int pyvers)
     GETPROC(dll, PyObject_GetAttrString);
     GETPROC(dll, PyObject_Str);
 
-    GETPROC(dll, PyRun_SimpleString);
+    GETPROC(dll, PyRun_SimpleStringFlags);
 
     GETPROC(dll, PySys_AddWarnOption);
     GETPROC(dll, PySys_SetArgvEx);

--- a/bootloader/src/pyi_python.h
+++ b/bootloader/src/pyi_python.h
@@ -47,10 +47,12 @@
  */
 
 /* Forward declarations of opaque Python types. */
-struct _object;
-typedef struct _object PyObject;
+struct _PyObject;
+typedef struct _PyObject PyObject;
 struct _PyThreadState;
 typedef struct _PyThreadState PyThreadState;
+struct _PyCompilerFlags;
+typedef struct _PyCompilerFlags PyCompilerFlags;
 
 /* The actual declarations of var & function entry points used. */
 
@@ -84,7 +86,7 @@ EXTDECLPROC(wchar_t *, Py_GetPath, (void));  /* new in Python 3 */
 
 EXTDECLPROC(void, PySys_SetPath, (wchar_t *));
 EXTDECLPROC(int, PySys_SetArgvEx, (int, wchar_t **, int));
-EXTDECLPROC(int, PyRun_SimpleString, (char *));  /* Py3: UTF-8 encoded string */
+EXTDECLPROC(int, PyRun_SimpleStringFlags, (const char *, PyCompilerFlags *));  /* Py3: UTF-8 encoded string */
 
 /* In Python 3 for these the first argument has to be a UTF-8 encoded string: */
 EXTDECLPROC(PyObject *, PyImport_ExecCodeModule, (char *, PyObject *));

--- a/bootloader/src/pyi_pythonlib.c
+++ b/bootloader/src/pyi_pythonlib.c
@@ -757,16 +757,16 @@ pyi_pylib_finalize(ARCHIVE_STATUS *status)
             VS("LOADER: Manually flushing stdout and stderr\n");
 
             /* sys.stdout.flush() */
-            PI_PyRun_SimpleString(
+            PI_PyRun_SimpleStringFlags(
                 "import sys; sys.stdout.flush(); \
                 (sys.__stdout__.flush if sys.__stdout__ \
-                is not sys.stdout else (lambda: None))()");
+                is not sys.stdout else (lambda: None))()", NULL);
 
             /* sys.stderr.flush() */
-            PI_PyRun_SimpleString(
+            PI_PyRun_SimpleStringFlags(
                 "import sys; sys.stderr.flush(); \
                 (sys.__stderr__.flush if sys.__stderr__ \
-                is not sys.stderr else (lambda: None))()");
+                is not sys.stderr else (lambda: None))()", NULL);
 
         #endif
 

--- a/news/6332.bootloader.rst
+++ b/news/6332.bootloader.rst
@@ -1,0 +1,1 @@
+Replace use of ``PyRun_SimpleString`` with ``PyRun_SimpleStringFlags``.


### PR DESCRIPTION
`PyRun_SimpleString` was removed at some point during python 3.10 development cycle, but was re-instated later, albeit with the note that this is "Deprecated C API function still provided for binary compatibility".

Therefore, use the non-deprecated `PyRun_SimpleStringFlags`, with second argument set to NULL, which is what `PyRun_SimpleString` does.

See:
https://github.com/python/cpython/commit/46bd5ed94cf3d5e03f45eecf9afea1659980c8bf

Closes #6332. 