### PR TITLE
bootloader: set NTDDI_VERSION & _WIN32_WINNT when compiling for Windows

### DIFF
--- a/bootloader/src/pyi_win32_utils.c
+++ b/bootloader/src/pyi_win32_utils.c
@@ -22,9 +22,6 @@
 
 #ifdef _WIN32
 
-/* windows.h will use API for WinServer 2003 with SP1 and WinXP with SP2 */
-#define _WIN32_WINNT 0x0502
-
 #include <windows.h>
 #include <commctrl.h> /* InitCommonControls */
 #include <stdio.h>    /* _fileno */

--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -575,6 +575,11 @@ def configure(ctx):
     if ctx.env.DEST_OS == 'win32':
         ctx.env.append_value('DEFINES', 'WIN32')
         ctx.env.append_value('CPPPATH', '../zlib')
+        # Set minimum feature level for Windows headers to Windows 7.
+        # As per MSDN: "If you define NTDDI_VERSION, you must also define _WIN32_WINNT."
+        # https://docs.microsoft.com/en-us/windows/win32/winprog/using-the-windows-headers#macros-for-conditional-declarations
+        ctx.env.append_value('DEFINES', 'NTDDI_VERSION=0x06010000')
+        ctx.env.append_value('DEFINES', '_WIN32_WINNT=0x0601')
 
     elif ctx.env.DEST_OS == 'sunos':
         ctx.env.append_value('DEFINES', 'SUNOS')

--- a/news/6338.bootloader.rst
+++ b/news/6338.bootloader.rst
@@ -1,0 +1,5 @@
+(Windows) Explicitly set ``NTDDI_VERSION=0x06010000`` and
+``_WIN32_WINNT=0x0601`` when compiling Windows bootloaders to request
+Windows 7 feature level for Windows headers. The windowed bootloader
+requires at least Windows Vista feature level, and some toolchains
+(e.g., mingw cross-compiler on linux) set too low level by default.


### PR DESCRIPTION
When compiling bootloaders for Windows, set `NTDDI_VERSION` and `_WIN32_WINNT` to `Windows 7` feature level (`0x06010000` and `0x0601`) so that the version is applied when compiling all source files.

We require at least Windows Vista feature level in Windows headers to compile the unhandled exception dialog. Toolchains on Windows appear to define sufficiently high level by default (e.g., `Visual Studio 2017` uses `0x0A000006` / `Windows 10 1809 "Redstone 5"`; `MSYS2/MINGW64` uses `0x6010000` / `Windows 7`). However, the `x86_64-w64-mingw32-gcc` cross-compiler on linux (gcc 10.3) seems to use `0x5020000` / `Windows Server 2003` by default, and thus fails to compile the windowed bootloader variants.

Also, remove the explicit  `_WIN32_WINNT=0x0502` definition from the `pyi_win32_utils.c` in favor of the global one, so that the same feature level setting is used when compiling all source files.

Fixes #6338.