### PR TITLE
bootloader: remove the check for unused windres utility

### DIFF
--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -414,16 +414,6 @@ def set_arch_flags(ctx):
             # TODO: verify if this option being as default might cause any side effects.
             ctx.env.append_value('LINKFLAGS', '-Wl,--large-address-aware')
 
-    # We need to pass architecture switch to the 'windres' tool.
-    if ctx.env.DEST_OS == 'win32' and ctx.env.CC_NAME != 'msvc':
-        if ctx.env.PYI_ARCH == '32bit':
-            ctx.env.WINRCFLAGS = ['--target=pe-i386']
-        else:
-            ctx.env.WINRCFLAGS = ['--target=pe-x86-64']
-        # Since WINRC config changed above, must set other options as well
-        ctx.env.WINRC_TGT_F = '-o'
-        ctx.env.WINRC_SRC_F = '-i'
-
 
 # A bare minimum zlib program. Testing zlib-dev availability requires explicitly using libz-provided symbols instead of
 # just compiling 'include <zlib.h>' with `-lz`, because while zlib's development headers may be installed, the library
@@ -504,12 +494,6 @@ def configure(ctx):
         # Do not embed manifest file when using MSVC (Visual Studio). Manifest file will be added in the phase of
         # packaging python application by PyInstaller.
         ctx.env.MSVC_MANIFEST = False
-
-        if ctx.env.CC_NAME != 'msvc':
-            # Load tool to process *.rc* files for C/C++ like icon for exe files. For msvc, waf loads this tool
-            # automatically.
-            find_program_next_to_cc(ctx, 'windres', var='WINRC')
-            ctx.load('winres')
 
     # ** C Compiler optimizations **
     # TODO Set proper optimization flags for MSVC (Visual Studio).

--- a/news/6339.bootloader.rst
+++ b/news/6339.bootloader.rst
@@ -1,0 +1,2 @@
+(Windows) Remove the check for the unused ``windres`` utility when compiling 
+with MinGW toolchain.


### PR DESCRIPTION
We do not use `windres` utility anymore (as we do not have Windows .rc resource files anymore), so the check for windres utility is completely redundant (and currently broken for prefixed toolchains).

Fixes #6339.

This does not fix the underlying cause for the check failure (which also affects `strip` utility in prefixed toolchains), but we will address that separately. And with the unused `windres` out of the way, there will be one less thing to worry about...