### PR TITLE
Assorted environment checks.

### DIFF
--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -21,6 +21,7 @@ import platform
 import site
 import subprocess
 import sys
+import shutil
 
 from PyInstaller._shared_with_waf import _pyi_machine
 from PyInstaller.exceptions import ExecCommandFailed
@@ -737,3 +738,8 @@ def check_requirements():
     # Fail hard if Python does not have minimum required version
     if sys.version_info < (3, 6):
         raise EnvironmentError('PyInstaller requires at Python 3.6 or newer.')
+
+    # Bail out if binutils is not installed.
+    if is_linux and shutil.which("objdump") is None:
+        raise SystemExit("On Linux, objdump is required. It is typically provided by the 'binutils' package "
+                         "installable via your Linux distribution's package manager.")

--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -209,9 +209,11 @@ if is_win:
             )
     except Exception:
         if sys.flags.optimize == 2:
-            raise SystemExit("pycparser, a Windows only indirect dependency of PyInstaller, is incompatible with "
-                             "Python's \"discard docstrings\" (-OO) flag mode. For more information see:\n"
-                             "    https://github.com/pyinstaller/pyinstaller/issues/6345")
+            raise SystemExit(
+                "pycparser, a Windows only indirect dependency of PyInstaller, is incompatible with "
+                "Python's \"discard docstrings\" (-OO) flag mode. For more information see:\n"
+                "    https://github.com/pyinstaller/pyinstaller/issues/6345"
+            )
         raise
 
 # macOS's platform.architecture() can be buggy, so we do this manually here. Based off the python documentation:
@@ -753,11 +755,15 @@ def check_requirements():
         except PackageNotFoundError:
             pass
         else:
-            raise SystemExit(f"The '{name}' package is an obsolete backport of a standard library package and is "
-                             f"incompatible with PyInstaller. Please "
-                             f"`{'conda remove' if is_conda else 'pip uninstall'} {name}` then try again.")
+            raise SystemExit(
+                f"The '{name}' package is an obsolete backport of a standard library package and is "
+                f"incompatible with PyInstaller. Please "
+                f"`{'conda remove' if is_conda else 'pip uninstall'} {name}` then try again."
+            )
 
     # Bail out if binutils is not installed.
     if is_linux and shutil.which("objdump") is None:
-        raise SystemExit("On Linux, objdump is required. It is typically provided by the 'binutils' package "
-                         "installable via your Linux distribution's package manager.")
+        raise SystemExit(
+            "On Linux, objdump is required. It is typically provided by the 'binutils' package "
+            "installable via your Linux distribution's package manager."
+        )

--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -206,6 +206,12 @@ if is_win:
                 'Please install pywin32-ctypes.\n\n'
                 'pip install pywin32-ctypes\n'
             )
+    except Exception:
+        if sys.flags.optimize == 2:
+            raise SystemExit("pycparser, a Windows only indirect dependency of PyInstaller, is incompatible with "
+                             "Python's \"discard docstrings\" (-OO) flag mode. For more information see:\n"
+                             "    https://github.com/pyinstaller/pyinstaller/issues/6345")
+        raise
 
 # macOS's platform.architecture() can be buggy, so we do this manually here. Based off the python documentation:
 # https://docs.python.org/3/library/platform.html#platform.architecture

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -120,49 +120,6 @@ Is equivalent to:
     pyinstaller my_script.py --onefile --windowed
 
 
-Running |PyInstaller| with Python optimizations
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. Note::
-
-    When using this feature, you should be aware of how the Python bytecode
-    optimization mechanism works. When using ``-O``, ``__debug__`` is set
-    to ``False`` and ``assert`` statements are removed from the bytecode.
-    The ``-OO`` flag additionally removes docstrings.
-
-    Using this feature affects not only your main script, but *all* modules
-    included by |PyInstaller|. If your code (or any module imported by your
-    script) relies on these features, your program may break or have
-    unexpected behavior.
-
-|PyInstaller| can be run with Python optimization flags (``-O`` or ``-OO``)
-by executing it as a Python module, rather than using the ``pyinstaller``
-command::
-
-    # run with basic optimizations
-    python -O -m PyInstaller myscript.py
-
-    # also discard docstrings
-    python -OO -m PyInstaller myscript.py
-
-Or, by explicitly setting the ``PYTHONOPTIMIZE`` environment variable
-to a non-zero value::
-
-    # Unix
-    PYTHONOPTIMIZE=1 pyinstaller myscript.py
-
-    # Windows
-    set PYTHONOPTIMIZE=1 && pyinstaller myscript.py
-
-You can use any |PyInstaller| options that are otherwise available with
-the ``pyinstaller`` command. For example::
-
-    python -O -m PyInstaller --onefile myscript.py
-
-Alternatively, you can also use the path to pyinstaller::
-
-    python -O /path/to/pyinstaller myscript.py
-
 Using UPX
 ~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
A few explicit environment validation steps to make the errors that would otherwise be raised less cryptic.

- Windows: Catch/re-raise failure to load win32ctypes under `-OO` (#6345).
- Docs: Remove running with optimisations section (#6345).
- Linux: Explicitly check that binutils tools are available (https://github.com/pyinstaller/pyinstaller/issues/6358#issuecomment-963159795).
- Abort build if any obsolete stdlib backports are installed (#5728 and quit a few similar issues).
