### PR TITLE
Hooks: Runtime hook for subprocess

### DIFF
--- a/PyInstaller/hooks/rthooks.dat
+++ b/PyInstaller/hooks/rthooks.dat
@@ -23,4 +23,5 @@
     'win32api':   ['pyi_rth_win32api.py'],
     'win32com':   ['pyi_rth_win32comgenpy.py'],
     'multiprocessing': ['pyi_rth_multiprocessing.py'],
+    'subprocess': ['pyi_rth_subprocess.py'],
 }

--- a/PyInstaller/hooks/rthooks/pyi_rth_subprocess.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_subprocess.py
@@ -1,0 +1,28 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2021, PyInstaller Development Team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: Apache-2.0
+#-----------------------------------------------------------------------------
+
+import subprocess
+import sys
+import io
+
+
+class Popen(subprocess.Popen):
+
+    # In windowed mode, force any unused pipes (stdin, stdout and stderr) to be DEVNULL instead of inheriting the
+    # invalid corresponding handles from this parent process.
+    if not isinstance(sys.stdout, io.IOBase):
+
+        def _get_handles(self, stdin, stdout, stderr):
+            stdin, stdout, stderr = (subprocess.DEVNULL if pipe is None else pipe for pipe in (stdin, stdout, stderr))
+            return super()._get_handles(stdin, stdout, stderr)
+
+
+subprocess.Popen = Popen

--- a/PyInstaller/hooks/rthooks/pyi_rth_subprocess.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_subprocess.py
@@ -18,7 +18,7 @@ class Popen(subprocess.Popen):
 
     # In windowed mode, force any unused pipes (stdin, stdout and stderr) to be DEVNULL instead of inheriting the
     # invalid corresponding handles from this parent process.
-    if not isinstance(sys.stdout, io.IOBase):
+    if sys.platform == "win32" and not isinstance(sys.stdout, io.IOBase):
 
         def _get_handles(self, stdin, stdout, stderr):
             stdin, stdout, stderr = (subprocess.DEVNULL if pipe is None else pipe for pipe in (stdin, stdout, stderr))

--- a/news/6364.bugfix.1.rst
+++ b/news/6364.bugfix.1.rst
@@ -1,0 +1,3 @@
+Prevent invalid handle errors when an application compiled in :option:`--windowed` mode uses :mod:`subprocess` without
+explicitly setting **stdin**, **stdout** and **stderr** to either :data:`~subprocess.PIPE` or
+:data:`~subprocess.DEVNULL`.

--- a/news/6364.bugfix.1.rst
+++ b/news/6364.bugfix.1.rst
@@ -1,3 +1,3 @@
 Windows: Prevent invalid handle errors when an application compiled in :option:`--windowed` mode uses :mod:`subprocess`
-withoutexplicitly setting **stdin**, **stdout** and **stderr** to either :data:`~subprocess.PIPE` or
+without explicitly setting **stdin**, **stdout** and **stderr** to either :data:`~subprocess.PIPE` or
 :data:`~subprocess.DEVNULL`.

--- a/news/6364.bugfix.1.rst
+++ b/news/6364.bugfix.1.rst
@@ -1,3 +1,3 @@
-Prevent invalid handle errors when an application compiled in :option:`--windowed` mode uses :mod:`subprocess` without
-explicitly setting **stdin**, **stdout** and **stderr** to either :data:`~subprocess.PIPE` or
+Windows: Prevent invalid handle errors when an application compiled in :option:`--windowed` mode uses :mod:`subprocess`
+withoutexplicitly setting **stdin**, **stdout** and **stderr** to either :data:`~subprocess.PIPE` or
 :data:`~subprocess.DEVNULL`.

--- a/tests/functional/test_basic.py
+++ b/tests/functional/test_basic.py
@@ -772,7 +772,6 @@ def test_sys_executable(pyi_builder, append_pkg, monkeypatch):
     )
 
 
-@pytest.mark.darwin
 @pytest.mark.win32
 def test_subprocess_in_windowed_mode(pyi_windowed_builder):
     """Test invoking subprocesses from a PyInstaller app built in windowed mode."""

--- a/tests/functional/test_basic.py
+++ b/tests/functional/test_basic.py
@@ -770,3 +770,32 @@ def test_sys_executable(pyi_builder, append_pkg, monkeypatch):
         assert exe_basename == '{}', "Unexpected basename(sys.executable): " + exe_basename
         """.format(exe_basename)
     )
+
+
+@pytest.mark.darwin
+@pytest.mark.win32
+def test_subprocess_in_windowed_mode(pyi_windowed_builder):
+    """Test invoking subprocesses from a PyInstaller app built in windowed mode."""
+
+    pyi_windowed_builder.test_source(
+        r"""
+        from subprocess import PIPE, run
+        from unittest import TestCase
+
+        # Lazily use unittest's rich assertEqual() for assertions with builtin diagnostics.
+        assert_equal = TestCase().assertEqual
+
+        run([{0}, "-c", ""], check=True)
+
+        # Verify that stdin, stdout and stderr still work and haven't been muddled.
+        p = run([{0}, "-c", "print('foo')"], stdout=PIPE, universal_newlines=True)
+        assert_equal(p.stdout, "foo\n", p.stdout)
+
+        p = run([{0}, "-c", r"import sys; sys.stderr.write('bar\n')"], stderr=PIPE, universal_newlines=True)
+        assert_equal(p.stderr, "bar\n", p.stderr)
+
+        p = run([{0}], input="print('foo')\nprint('bar')\n", stdout=PIPE, universal_newlines=True)
+        assert_equal(p.stdout, "foo\nbar\n", p.stdout)
+        """.format(repr(sys.executable)),
+        pyi_args=["--windowed"]
+    )


### PR DESCRIPTION
A windowed app's `stdin`, `stdout` and `stderr` are not valid pipes. Invoking `subprocess.run()` (or any of its siblings) without explicitly setting all three\ pipes to either `subprocess.PIPE` or `subprocess.DEVNULL` causes pipe inheritance where `subprocess` will attempt to use the invalid parent process's pipe. This causes a errors such as #5601 and half of #6359.

Add a runtime hook which monkey-patches `subprocess.Popen()` so that any unused pipes are replaced with `DEVNULL`.

I was hoping to tackle #6334 in this PR too but I can't think of any way of doing it that's both reasonably sane for users and backwards compatible so it'll have to be a v5.0 change.