### PR TITLE
Fix compatibility issues with python.org python 3.9.8

### DIFF
--- a/PyInstaller/utils/win32/winmanifest.py
+++ b/PyInstaller/utils/win32/winmanifest.py
@@ -215,6 +215,7 @@ class Manifest:
     """
     def __init__(
         self,
+        manifestType="assembly",
         manifestVersion=None,
         noInheritable=False,
         noInherit=False,
@@ -233,7 +234,7 @@ class Manifest:
     ):
         self.filename = None
         self.optional = None
-        self.manifestType = "assembly"
+        self.manifestType = manifestType
         self.manifestVersion = manifestVersion or [1, 0]
         self.noInheritable = noInheritable
         self.noInherit = noInherit
@@ -833,22 +834,23 @@ class Manifest:
                 docE.aChild(fE)
 
         # Add compatibility section: http://stackoverflow.com/a/10158920
-        cE = doc.cE("compatibility")
-        cE.setAttribute("xmlns", "urn:schemas-microsoft-com:compatibility.v1")
-        caE = doc.cE("application")
-        supportedOS_guids = {
-            "Vista": "{e2011457-1546-43c5-a5fe-008deee3d3f0}",
-            "7": "{35138b9a-5d96-4fbd-8e2d-a2440225f93a}",
-            "8": "{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}",
-            "8.1": "{1f676c76-80e1-4239-95bb-83d0f6d0da78}",
-            "10": "{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"
-        }
-        for guid in supportedOS_guids.values():
-            sosE = doc.cE("supportedOS")
-            sosE.setAttribute("Id", guid)
-            caE.aChild(sosE)
-        cE.aChild(caE)
-        docE.aChild(cE)
+        if self.manifestType == "assembly":
+            cE = doc.cE("compatibility")
+            cE.setAttribute("xmlns", "urn:schemas-microsoft-com:compatibility.v1")
+            caE = doc.cE("application")
+            supportedOS_guids = {
+                "Vista": "{e2011457-1546-43c5-a5fe-008deee3d3f0}",
+                "7": "{35138b9a-5d96-4fbd-8e2d-a2440225f93a}",
+                "8": "{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}",
+                "8.1": "{1f676c76-80e1-4239-95bb-83d0f6d0da78}",
+                "10": "{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"
+            }
+            for guid in supportedOS_guids.values():
+                sosE = doc.cE("supportedOS")
+                sosE.setAttribute("Id", guid)
+                caE.aChild(sosE)
+            cE.aChild(caE)
+            docE.aChild(cE)
 
         # Add application.windowsSettings section to enable longPathAware
         # option (issue #5423).
@@ -1029,12 +1031,13 @@ def create_manifest(filename, manifest, console, uac_admin=False, uac_uiaccess=F
         # Add Microsoft.Windows.Common-Controls to dependent assemblies.
         manifest.dependentAssemblies.append(
             Manifest(
+                manifestType='dependentAssembly',
                 type_="win32",
                 name="Microsoft.Windows.Common-Controls",
                 language="*",
                 processorArchitecture=processor_architecture(),
                 version=(6, 0, 0, 0),
-                publicKeyToken="6595b64144ccf1df"
+                publicKeyToken="6595b64144ccf1df",
             )
         )
     if uac_admin:

--- a/PyInstaller/utils/win32/winmanifest.py
+++ b/PyInstaller/utils/win32/winmanifest.py
@@ -1027,7 +1027,7 @@ def create_manifest(filename, manifest, console, uac_admin=False, uac_uiaccess=F
             if assembly.name not in dep_names:
                 manifest.dependentAssemblies.append(assembly)
                 dep_names.add(assembly.name)
-    if not console and "Microsoft.Windows.Common-Controls" not in dep_names:
+    if "Microsoft.Windows.Common-Controls" not in dep_names:
         # Add Microsoft.Windows.Common-Controls to dependent assemblies.
         manifest.dependentAssemblies.append(
             Manifest(

--- a/news/6367.bugfix.rst
+++ b/news/6367.bugfix.rst
@@ -1,0 +1,2 @@
+(Windows) Fix compatibility issues with python 3.9.8 from python.org, arising 
+from the lack of embedded manifest in the ``python.exe`` executable.


### PR DESCRIPTION
As discussed in #6366, python 3.9.8 from python.org lacks the embedded manifest in the `python.exe` executable, from which we typically obtain the dependent assembly entry for MS Common Controls v6. We already have a fallback that should take care of this by manually adding such an entry, but
a) it was enabled only for noconsole/windowed builds
b) it generated an invalid dependent assembly entry, causing error when trying to run executable with such manifest embedded.

So `console`-enabled builds made with python.org python 3.9.8 use legacy dialogs (as noted in #6366), whereas `noconsole` builds refuse to start with `The application has failed to start because its side-by-side configuration is incorrect. Please see the application event log or use the command-line sxstrace.exe tool for more detail.`, as seen [here](https://github.com/pyinstaller/pyinstaller/runs/4198998024?check_suite_focus=true#step:12:2095).
