### PR TITLE
tests: fix matplotlib test for matplotlib >= 3.5.0 compatibility

### DIFF
--- a/tests/functional/test_hooks/test_matplotlib.py
+++ b/tests/functional/test_hooks/test_matplotlib.py
@@ -14,16 +14,27 @@ Functional tests for Matplotlib.
 
 import pytest
 from PyInstaller.utils.tests import importorskip
+from PyInstaller.utils.hooks import is_module_satisfies
 
 # List of 3-tuples "(backend_name, package_name, binding)", where:
 #
 # * "backend_name" is the name of a Matplotlib backend to be tested below.
 # * "package_name" is the name of the external package required by this backend.
 # * "binding" is the binding to use (and to set environment-variable QT_API to).
-backend_rcParams_key_values = [
-    ('Qt5Agg', 'PyQt5', 'pyqt5'),
-    ('Qt5Agg', 'PySide2', 'pyside2'),
-]
+#
+if is_module_satisfies("matplotlib >= 3.5.0"):
+    # Matplotlib 3.5.0 introduced a unified Qt backend that supports PySide2, PyQt5, PySide6, and PyQt6.
+    backend_rcParams_key_values = [
+        ('QtAgg', 'PyQt5', 'pyqt5'),
+        ('QtAgg', 'PySide2', 'pyside2'),
+        ('QtAgg', 'PyQt6', 'pyqt6'),
+        ('QtAgg', 'PySide6', 'pyside6'),
+    ]
+else:
+    backend_rcParams_key_values = [
+        ('Qt5Agg', 'PyQt5', 'pyqt5'),
+        ('Qt5Agg', 'PySide2', 'pyside2'),
+    ]
 
 # Same list, decorated to skip all backends whose packages are unimportable#.
 backend_rcParams_key_values_skipped_if_unimportable = [


### PR DESCRIPTION
If testing against `matplotlib` 3.5.0 or newer, switch to using the new unified Qt backend, and test it against all available bindings (`PySide2`, `PyQt5`, `PySide6`, and `PyQt6`). This in turn ensures that all non-used bindings are properly excluded with each test.