### PR TITLE
bootloader: Windows: fix behavior when runtime tmpdir is a drive letter

### DIFF
--- a/bootloader/src/pyi_utils.c
+++ b/bootloader/src/pyi_utils.c
@@ -264,8 +264,13 @@ wchar_t
         return NULL;
     }
     // Get the absolute path
-    wruntime_tmpdir_abspath = _wfullpath(NULL, wruntime_tmpdir_expanded,
-                                         PATH_MAX);
+    if (pyi_win32_is_drive_root(wruntime_tmpdir_expanded)) {
+        /* Disk drive (e.g., "c:"); do not attempt to call _wfullpath(), because it will return
+           the current directory of this drive. So return a verbatim copy instead. */
+        wruntime_tmpdir_abspath = _wcsdup(wruntime_tmpdir_expanded);
+    } else {
+        wruntime_tmpdir_abspath = _wfullpath(NULL, wruntime_tmpdir_expanded, PATH_MAX);
+    }
     if (!wruntime_tmpdir_abspath) {
         FATALERROR("LOADER: Failed to obtain the absolute path of the runtime-tmpdir.\n");
         return NULL;

--- a/bootloader/src/pyi_win32_utils.c
+++ b/bootloader/src/pyi_win32_utils.c
@@ -491,5 +491,34 @@ int pyi_win32_is_symlink(const wchar_t *path)
     return 0;
 }
 
+/* Check if the given path is just a drive letter */
+int pyi_win32_is_drive_root(const wchar_t *path)
+{
+    /* For now, handle just drive letter, optionally followed by the path separator.
+       E.g., "C:" or "Z:\".
+     */
+    size_t len;
+
+    len = wcslen(path);
+    if (len == 2 || len == 3) {
+        /* First character must be a letter */
+        if (!iswalpha(path[0])) {
+            return 0;
+        }
+        /* Second character must be the colon */
+        if (path[1] != L':') {
+            return 0;
+        }
+        /* Third character, if present, must be the Windows directory separator */
+        if (len > 2 && (path[2] != L'\\')) {
+            return 0;
+        }
+
+        return 1;
+    }
+
+    return 0;
+}
+
 
 #endif  /* _WIN32 */

--- a/bootloader/src/pyi_win32_utils.h
+++ b/bootloader/src/pyi_win32_utils.h
@@ -31,6 +31,8 @@ int pyi_win32_mkdir(const wchar_t *path);
 
 int pyi_win32_is_symlink(const wchar_t *path);
 
+int pyi_win32_is_drive_root(const wchar_t *path);
+
 #endif /* ifdef _WIN32 */
 
 #endif  /* UTILS_H */

--- a/news/6051.bugfix.rst
+++ b/news/6051.bugfix.rst
@@ -1,0 +1,4 @@
+(Windows) Fix ``onefile`` extraction behavior when the run-time temporary
+directory is set to a drive letter. The application's temporary directory
+is now created directly on the specified drive as opposed to the current
+directory on the specified drive.


### PR DESCRIPTION
Fix extraction behavior of Windows `onefile` builds when the run-time temporary directory (`--runtime-tmpdir`) is set to just a drive letter (e.g., `"c:"`), either directly or via an expanded environment variable, such as `%HOMEDRIVE%`.

In such cases, we must avoid calling `_wfullpath`, because as per its docs, "If the relPath argument specifies a disk drive, the
current directory of this drive is combined with the path". Instead, we should treat such paths separately, so that the final temporary directory is created in the drive's root (e.g., `"c:\_MEIXXXXX"`).

Fixes #6051.