### PR TITLE
hooks: add support for Anaconda-installed PyQtWebEngine on macOS

### DIFF
--- a/PyInstaller/hooks/rthooks/pyi_rth_pyqt5webengine.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_pyqt5webengine.py
@@ -19,9 +19,14 @@ if sys.platform == 'darwin':
     if not os.path.isdir(pyqt_path):
         # ... and fall back to the older version
         pyqt_path = os.path.join(sys._MEIPASS, 'PyQt5', 'Qt')
-    os.environ['QTWEBENGINEPROCESS_PATH'] = os.path.normpath(
+
+    # If QtWebEngineProcess was collected from a framework-based Qt build, we need to set QTWEBENGINEPROCESS_PATH.
+    # If not (a dylib-based build; Anaconda on macOS), it should be found automatically, same as on other OSes.
+    process_path = os.path.normpath(
         os.path.join(
             pyqt_path, 'lib', 'QtWebEngineCore.framework', 'Helpers', 'QtWebEngineProcess.app', 'Contents', 'MacOS',
             'QtWebEngineProcess'
         )
     )
+    if os.path.exists(process_path):
+        os.environ['QTWEBENGINEPROCESS_PATH'] = process_path

--- a/PyInstaller/hooks/rthooks/pyi_rth_pyside2webengine.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_pyside2webengine.py
@@ -13,9 +13,13 @@ import os
 import sys
 
 if sys.platform == 'darwin':
-    os.environ['QTWEBENGINEPROCESS_PATH'] = os.path.normpath(
+    # If QtWebEngineProcess was collected from a framework-based Qt build, we need to set QTWEBENGINEPROCESS_PATH.
+    # If not (a dylib-based build; Anaconda on macOS), it should be found automatically, same as on other OSes.
+    process_path = os.path.normpath(
         os.path.join(
             sys._MEIPASS, 'PySide2', 'Qt', 'lib', 'QtWebEngineCore.framework', 'Helpers', 'QtWebEngineProcess.app',
             'Contents', 'MacOS', 'QtWebEngineProcess'
         )
     )
+    if os.path.exists(process_path):
+        os.environ['QTWEBENGINEPROCESS_PATH'] = process_path

--- a/PyInstaller/utils/hooks/qt.py
+++ b/PyInstaller/utils/hooks/qt.py
@@ -708,7 +708,16 @@ def get_qt_webengine_binaries_and_data_files(qt_library_info):
     # qt_library_info.qt_rel_dir)
     rel_data_path = qt_library_info.qt_rel_dir
 
+    is_macos_framework = False
     if compat.is_darwin:
+        # Determine if we are dealing with a framework-based Qt build (e.g., PyPI wheels) or a dylib-based one
+        # (e.g., Anaconda). The former requires special handling, while the latter is handled in the same way as
+        # Windows and Linux builds.
+        is_macos_framework = os.path.exists(
+            os.path.join(qt_library_info.location['LibrariesPath'], 'QtWebEngineCore.framework')
+        )
+
+    if is_macos_framework:
         # On macOS, Qt shared libraries are provided in form of .framework bundles. However, PyInstaller collects shared
         # library from the bundle into top-level application directory, breaking the bundle structure.
         #
@@ -746,7 +755,7 @@ def get_qt_webengine_binaries_and_data_files(qt_library_info):
             )
         datas += [(os.path.join(data_path, 'lib', 'QtWebEngineCore.framework', 'Resources'), os.curdir)]
     else:
-        # Windows and linux
+        # Windows and linux (or Anaconda on macOS)
         locales = 'qtwebengine_locales'
         resources = 'resources'
 
@@ -767,7 +776,7 @@ def get_qt_webengine_binaries_and_data_files(qt_library_info):
             rel_data_path,
             os.path.relpath(qt_library_info.location['LibraryExecutablesPath'], qt_library_info.location['PrefixPath'])
         )
-        datas.append((os.path.join(qt_library_info.location['LibraryExecutablesPath'], 'QtWebEngineProcess*'), dest))
+        binaries.append((os.path.join(qt_library_info.location['LibraryExecutablesPath'], 'QtWebEngineProcess*'), dest))
 
     # Add Linux-specific libraries.
     if compat.is_linux:

--- a/news/6373.hooks.rst
+++ b/news/6373.hooks.rst
@@ -1,0 +1,1 @@
+(macOS) Add support for Anaconda-installed ``PyQtWebEngine``.


### PR DESCRIPTION
Add support for Anaconda-installed `PyQtWebEngine` (Qt5) on macOS. In contrast to PyPI wheels that ship framework-based Qt5 build, the Anaconda's Qt5 build is dylib-based and thus similar to Linux and Windows builds. Therefore, the following changes are needed:

1. modify the `get_qt_webengine_binaries_and_data_files` helper to identify non-framework-based Qt build on macOS, and divert the execution to shared-lib-based (Windows, Linux) codepath.

2. modify `PyQt5.QtWebEngine` runtime hook to set the `QTWEBENGINEPROCESS_PATH` environment variable only if the
`QtWebEngineProcess` executable was collected from a framework-based build (this is determined by its location, or rather, its existence in pre-determined location). In a dylib-based build, the executable is discovered without having to set the environment variable, same as on Windows and Linux. The `PySide2` hook is also modified in the same way to keep them in sync.

3. modfy the `get_qt_webengine_binaries_and_data_files` helper to collect the `QtWebEngineProcess` executable as a binary file instead of a data file. On Windows and Linux, this makes no difference, but on macOS it ensures that the library paths are properly rewritten so that the helper executable can find the collected Qt5 libs.

Closes #6373.