### PR TITLE
building: fix python3.dll not being found when using MS App Store python

### DIFF
--- a/PyInstaller/building/build_main.py
+++ b/PyInstaller/building/build_main.py
@@ -140,6 +140,15 @@ def find_binary_dependencies(binaries, binding_redirects, import_packages):
     :return: expanded list of binaries and then dependencies.
     """
     from PyInstaller.depend import bindepend
+    from PyInstaller import compat
+
+    # In the case of MS App Store python, add compat.base_prefix to extra library search paths. In addition to
+    # python38.dll (that we manage to resolve by other means, if necessary), this directory also contains
+    # python3.dll that might be required by some 3rd-party extension modules, and would otherwise end up missing
+    # during the dependency analysis.
+    extra_libdirs = []
+    if compat.is_ms_app_store:
+        extra_libdirs.append(compat.base_prefix)
 
     # Import collected packages to set up environment
     for package in import_packages:
@@ -149,7 +158,7 @@ def find_binary_dependencies(binaries, binding_redirects, import_packages):
             pass
 
     # Search for dependencies of the given binaries
-    return bindepend.Dependencies(binaries, redirects=binding_redirects)
+    return bindepend.Dependencies(binaries, redirects=binding_redirects, xtrapath=extra_libdirs)
 
 
 class Analysis(Target):

--- a/news/6390.bugfix.rst
+++ b/news/6390.bugfix.rst
@@ -1,0 +1,2 @@
+(Windows) Fix the ``python3.dll`` shared library not being found and
+collected when using Python from MS App Store.


### PR DESCRIPTION
If using MS App Store python, we need to explicitly add its base directory (stored in `compat.base_prefix`) to library search path when we perform binary dependency analysis. Otherwise, we end up missing the `python3.dll` shared library, which may be required by some 3rd party extensions.

Fixes #6390.