### PR TITLE
building: fix python3.dll not being found when using MS App store python [v4]

### DIFF
--- a/PyInstaller/building/build_main.py
+++ b/PyInstaller/building/build_main.py
@@ -491,7 +491,18 @@ class Analysis(Target):
 
         # Add remaining binary dependencies - analyze Python C-extensions and what DLLs they depend on.
         logger.info('Looking for dynamic libraries')
-        self.binaries.extend(bindepend.Dependencies(self.binaries, redirects=self.binding_redirects))
+
+        # In the case of MS App Store python, add compat.base_prefix to extra library search paths. In addition to
+        # python38.dll (that we manage to resolve by other means, if necessary), this directory also contains
+        # python3.dll that might be required by some 3rd-party extension modules, and would otherwise end up missing
+        # during the dependency analysis.
+        extra_libdirs = []
+        if compat.is_ms_app_store:
+            extra_libdirs.append(compat.base_prefix)
+
+        self.binaries.extend(
+            bindepend.Dependencies(self.binaries, redirects=self.binding_redirects, xtrapath=extra_libdirs)
+        )
 
         # Include zipped Python eggs.
         logger.info('Looking for eggs')

--- a/news/6390.bugfix.rst
+++ b/news/6390.bugfix.rst
@@ -1,0 +1,2 @@
+(Windows) Fix the ``python3.dll`` shared library not being found and
+collected when using Python from MS App Store.


### PR DESCRIPTION
If using MS App Store python, we need to explicitly add its base directory (stored in `compat.base_prefix`) to library search path when we perform binary dependency analysis. Otherwise, we end up missing the `python3.dll` shared library, which may be required by some 3rd party extensions.

Fixes #6390. This is a `v4` version of #6394, because the codepaths have diverged too much for a simple cherry pick.