### PR TITLE
building: fix errors due to collected foreign binaries

### DIFF
--- a/PyInstaller/building/utils.py
+++ b/PyInstaller/building/utils.py
@@ -31,7 +31,7 @@ from PyInstaller.depend import dylib
 from PyInstaller.depend.bindepend import match_binding_redirect
 from PyInstaller.utils import misc
 
-if is_win:
+if is_win or is_cygwin:
     from PyInstaller.utils.win32 import versioninfo, winmanifest, winresource
 
 if is_darwin:
@@ -245,7 +245,7 @@ def checkCache(
             return cachedfile
 
     # Optionally change manifest and its dependencies to private assemblies.
-    if fnm.lower().endswith(".manifest"):
+    if fnm.lower().endswith(".manifest") and (is_win or is_cygwin):
         manifest = winmanifest.Manifest()
         manifest.filename = fnm
         with open(fnm, "rb") as f:
@@ -276,7 +276,7 @@ def checkCache(
                 entitlements_file=entitlements_file
             )
         # We need to avoid using UPX with Windows DLLs that have Control Flow Guard enabled, as it breaks them.
-        if is_win and versioninfo.pefile_check_control_flow_guard(fnm):
+        if (is_win or is_cygwin) and versioninfo.pefile_check_control_flow_guard(fnm):
             logger.info('Disabling UPX for %s due to CFG!', fnm)
         elif misc.is_file_qt_plugin(fnm):
             logger.info('Disabling UPX for %s due to it being a Qt plugin!', fnm)
@@ -314,7 +314,7 @@ def checkCache(
             pass
     os.chmod(cachedfile, 0o755)
 
-    if os.path.splitext(fnm.lower())[1] in (".pyd", ".dll"):
+    if os.path.splitext(fnm.lower())[1] in (".pyd", ".dll") and (is_win or is_cygwin):
         # When shared assemblies are bundled into the app, they may optionally be changed into private assemblies.
         try:
             res = winmanifest.GetManifestResources(os.path.abspath(cachedfile))

--- a/PyInstaller/building/utils.py
+++ b/PyInstaller/building/utils.py
@@ -374,10 +374,16 @@ def checkCache(
     # to avoid potential bugs in the codesign utility, like the one reported on Mac OS 10.13 in #6167).
     # The forced re-signing at the end should take care of the invalidated signatures.
     if is_darwin:
-        osxutils.binary_to_target_arch(cachedfile, target_arch, display_name=fnm)
-        #osxutils.remove_signature_from_binary(cachedfile)  # Disabled as per comment above.
-        dylib.mac_set_relative_dylib_deps(cachedfile, dist_nm)
-        osxutils.sign_binary(cachedfile, codesign_identity, entitlements_file)
+        try:
+            osxutils.binary_to_target_arch(cachedfile, target_arch, display_name=fnm)
+            #osxutils.remove_signature_from_binary(cachedfile)  # Disabled as per comment above.
+            dylib.mac_set_relative_dylib_deps(cachedfile, dist_nm)
+            osxutils.sign_binary(cachedfile, codesign_identity, entitlements_file)
+        except osxutils.InvalidBinaryError:
+            # Raised by osxutils.binary_to_target_arch when the given file is not a valid macOS binary (for example,
+            # a linux .so file; see issue #6327). The error prevents any further processing, so just ignore it.
+            pass
+
     return cachedfile
 
 

--- a/PyInstaller/utils/osx.py
+++ b/PyInstaller/utils/osx.py
@@ -261,12 +261,22 @@ def _get_arch_string(header):
     assert False, 'Unhandled architecture!'
 
 
+class InvalidBinaryError(Exception):
+    """
+    Exception raised by ˙get_binary_architectures˙ when it is passed an invalid binary.
+    """
+    pass
+
+
 def get_binary_architectures(filename):
     """
     Inspects the given binary and returns tuple (is_fat, archs), where is_fat is boolean indicating fat/thin binary,
     and arch is list of architectures with lipo/codesign compatible names.
     """
-    executable = MachO(filename)
+    try:
+        executable = MachO(filename)
+    except ValueError as e:
+        raise InvalidBinaryError("Invalid Mach-O binary!") from e
     return bool(executable.fat), [_get_arch_string(hdr.header) for hdr in executable.headers]
 
 

--- a/news/6327.bugfix.1.rst
+++ b/news/6327.bugfix.1.rst
@@ -1,0 +1,2 @@
+Fix build errors when a linux shared library (.so) file is collected as
+a binary on macOS.

--- a/news/6327.bugfix.rst
+++ b/news/6327.bugfix.rst
@@ -1,0 +1,2 @@
+Fix build errors when a Windows DLL/PYD file is collected as a binary on
+a non-Windows OS.


### PR DESCRIPTION
Fix two corner cases revealed by #6327 (where `tkinterdnd2` wheel includes binaries for Windows, linux, and macOS):
* when a Windows DLL/PYD file is collected as binary, perform Windows-specific processing only if we are running on Windows (because import of submodules from `PyInstaller.utils.win32` is under `is_win` guard). Apply the same restriction to processing of `.manifest` files, just in case.
* when a linux .so library is collected on macOS, avoid performing macOS-specific processing on it (i.e., detect invalid binary and short-circuit the rest of the processing).

In addition, the `is_win` guards in `building.utils` are now consistently extended to `(is_win or is_cygwin)`.

Fixes #6327 (although we should probably also upgrade `collect_dynamic_libraries` to collect only OS-specific binaries).