### PR TITLE
bootloader: implement single-process onedir mode for Linux

### DIFF
--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -92,6 +92,21 @@ pyi_main(int argc, char * argv[])
      * might get overwritten later on (on Windows and macOS, single
      * process is used for --onedir mode). */
     in_child = (extractionpath != NULL);
+    if (in_child) {
+        /* Check if _PYI_ONEDIR_MODE is set to 1; this is set by linux/unix
+         * bootloaders when they restart themselves within the same process
+         * to achieve single-process onedir execution mode. This case should
+         * be treated as if extractionpath was not set at this point yet,
+         * i.e., in_child needs to be reset to 0. */
+        char *pyi_onedir_mode = pyi_getenv("_PYI_ONEDIR_MODE");
+        if (pyi_onedir_mode) {
+            if (strcmp(pyi_onedir_mode, "1") == 0) {
+                in_child = 0;
+            }
+            free(pyi_onedir_mode);
+            pyi_unsetenv("_PYI_ONEDIR_MODE");
+        }
+    }
 
     /* If the Python program we are about to run invokes another PyInstaller
      * one-file program as subprocess, this subprocess must not be fooled into
@@ -141,6 +156,40 @@ pyi_main(int argc, char * argv[])
     if (!extractionpath && !pyi_launch_need_to_extract_binaries(archive_status)) {
         VS("LOADER: No need to extract files to run; setting extractionpath to homepath\n");
         extractionpath = homepath;
+    }
+
+#else
+
+    /* On other OSes (linux and unix-like), we also use single-process for
+     * --onedir mode. However, in contrast to Windows and macOS, we need to
+     * set environment (i.e., LD_LIBRARY_PATH) and then restart/replace the
+     * process via exec() without fork() for the environment changes (library
+     * search path) to take effect. */
+     if (!extractionpath && !pyi_launch_need_to_extract_binaries(archive_status)) {
+        VS("LOADER: No need to extract files to run; setting up environment and restarting bootloader...\n");
+
+        /* Set _MEIPASS2, so that the restarted bootloader process will enter
+         * the codepath that corresponds to child process. */
+        pyi_setenv("_MEIPASS2", homepath);
+
+        /* Set _PYI_ONEDIR_MODE to signal to restarted bootloader that it
+         * should reset in_child variable even though it is operating in
+         * child-process mode. This is necessary for splash screen to
+         * be shown. */
+        pyi_setenv("_PYI_ONEDIR_MODE", "1");
+
+        /* Set up the environment, especially LD_LIBRARY_PATH. This is the
+         * main reason we are going to restart the bootloader in the first
+         * place. */
+        if (pyi_utils_set_environment(archive_status) == -1) {
+            return -1;
+        }
+
+        /* Restart the process. The helper function performs exec() without
+         * fork(), so we never return from the call. */
+        if (pyi_utils_replace_process(executable, argc, argv) == -1) {
+            return -1;
+        }
     }
 
 #endif

--- a/bootloader/src/pyi_utils.c
+++ b/bootloader/src/pyi_utils.c
@@ -1119,6 +1119,32 @@ cleanup:
     return 1;
 }
 
+
+#if !defined(__APPLE__)
+
+/* Replace the current process with another instance of itself, i.e.,
+ * restart the process in-place (exec() without fork()). Used on linux
+ * and unix-like OSes to achieve single-process onedir execution mode.
+ */
+int pyi_utils_replace_process(const char *thisfile, const int argc, char *const argv[])
+{
+    int rc;
+
+    /* Use helper to copy argv into NULL-terminated arguments array, argv_pyi. */
+    if (pyi_utils_initialize_args(argc, argv) < 0) {
+        return -1;
+    }
+    /* Replace the current executable image. */
+    rc = execvp(thisfile, argv_pyi);
+    /* This part is reached only if exec() failed. */
+    if (rc < 0) {
+        VS("Failed to exec: %s\n", strerror(errno));
+    }
+    return rc;
+}
+
+#endif /* !defined(__APPLE) */
+
 #endif /* _WIN32 */
 
 

--- a/bootloader/src/pyi_utils.h
+++ b/bootloader/src/pyi_utils.h
@@ -56,6 +56,10 @@ pid_t pyi_utils_get_child_pid();
 #endif
 int pyi_utils_set_environment(const ARCHIVE_STATUS *status);
 
+#if !defined(_WIN32) && !defined(__APPLE__)
+int pyi_utils_replace_process(const char *thisfile, const int argc, char *const argv[]);
+#endif
+
 /* Argument handling */
 int pyi_utils_initialize_args(const int argc, char *const argv[]);
 int pyi_utils_append_to_args(const char *arg);

--- a/news/6407.bootloader.rst
+++ b/news/6407.bootloader.rst
@@ -1,0 +1,5 @@
+Implement single-process ``onedir`` mode for Linux and Unix-like OSes as a
+replacement for previously-used two-process implementation. The new mode 
+uses ``exec()`` without ``fork()`` to restart the bootloader executable
+image within the same process after setting up the environment (i.e., the
+``LD_LIBRARY_PATH`` and other environment variables).

--- a/news/6407.feature.rst
+++ b/news/6407.feature.rst
@@ -1,0 +1,4 @@
+Replace the dual-process ``onedir`` mode on Linux and other Unix-like OSes
+with a single-process implementation. This makes ``onedir`` mode on these
+OSes comparable to Windows and macOS, where single-process ``onedir`` mode
+has already been used for a while.


### PR DESCRIPTION
Replace the two-process `onedir` mode implementation for Linux and other Unix-like OSes with new, single-process implementation. This makes the `onedir` mode on Linux comparable to Windows and macOS, where `onedir` mode has already been using only a single process.

In contrast to Windows and macOS, where `onedir` mode can directly use the original process, on Linux we need to restart the process after setting up custom environment (i.e., `LD_LIBRARY_PATH` variable so that the dynamic library loader can find shared libraries in the frozen application bundle). But, we can use `exec()` without `fork()` to achieve the restart within the same process, without having to use the `onefile`'s parent-and-child process model.

Closes #6407.