### PR TITLE
Fix crash when building with --onefile after building normally

### DIFF
--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -25,7 +25,8 @@ from PyInstaller import log as logging
 from PyInstaller.archive.writers import CArchiveWriter, ZlibArchiveWriter
 from PyInstaller.building.datastruct import TOC, Target, _check_guts_eq
 from PyInstaller.building.utils import (
-    _check_guts_toc, _make_clean_directory, add_suffix_to_extension, checkCache, get_code_object, strip_paths_in_code
+    _check_guts_toc, _make_clean_directory, _rmtree, add_suffix_to_extension, checkCache, get_code_object,
+    strip_paths_in_code
 )
 from PyInstaller.compat import (exec_command_all, is_cygwin, is_darwin, is_linux, is_win)
 from PyInstaller.depend import bindepend
@@ -592,7 +593,10 @@ class EXE(Target):
         from PyInstaller.config import CONF
         logger.info("Building EXE from %s", self.tocbasename)
         if os.path.exists(self.name):
-            os.remove(self.name)
+            if os.path.isdir(self.name):
+                _rmtree(self.name)  # will prompt for confirmation if --noconfirm is not given
+            else:
+                os.remove(self.name)
         if not os.path.exists(os.path.dirname(self.name)):
             os.makedirs(os.path.dirname(self.name))
         exe = self.exefiles[0][1]  # pathname of bootloader

--- a/news/6418.bugfix.rst
+++ b/news/6418.bugfix.rst
@@ -1,0 +1,2 @@
+Fix a crash when a onefile build attempts to overwrite an existing onedir build
+on macOS or Linux


### PR DESCRIPTION
I'm new to `pyinstaller` so I ran it with default options first:

    pyinstaller my.py

That produced a directory rather than a packed binary like I expected. I saw that I had forgotten `--onefile`, so I specified that now:

    pyinstaller my.py --onefile

This produces the stack trace:

```
...
3676 INFO: checking EXE
3677 INFO: Building because name changed
3677 INFO: Building EXE from EXE-00.toc
Traceback (most recent call last):
  File "/home/me/.local/bin/pyinstaller", line 8, in <module>
    sys.exit(run())
  File "/home/me/.local/lib/python3.8/site-packages/PyInstaller/__main__.py", line 124, in run 
    run_build(pyi_config, spec_file, **vars(args))
  File "/home/me/.local/lib/python3.8/site-packages/PyInstaller/__main__.py", line 58, in run_build
    PyInstaller.building.build_main.main(pyi_config, spec_file, **kwargs)
  File "/home/me/.local/lib/python3.8/site-packages/PyInstaller/building/build_main.py", line 782, in main
    build(specfile, kw.get('distpath'), kw.get('workpath'), kw.get('clean_build'))
  File "/home/me/.local/lib/python3.8/site-packages/PyInstaller/building/build_main.py", line 714, in build
    exec(code, spec_namespace)
  File "/home/me/my.spec", line 23, in <module>
    exe = EXE(pyz,
  File "/home/me/.local/lib/python3.8/site-packages/PyInstaller/building/api.py", line 507, in __init__
    self.__postinit__()
  File "/home/me/.local/lib/python3.8/site-packages/PyInstaller/building/datastruct.py", line 155, in __postinit__
    self.assemble()
  File "/home/me/.local/lib/python3.8/site-packages/PyInstaller/building/api.py", line 584, in assemble
    os.remove(self.name)
IsADirectoryError: [Errno 21] Is a directory: '/home/me/dist/my'
```

The indicated line 584 is incorrect. I installed from pip and the last release was 7 days after the last commit to that file, so not sure what's wrong there (released from another branch perhaps?). The trace indicates it's in the `assemble` function, though, and the line exists in that function about ten lines further into the file. I added a check whether the target is a directory and use `shutil.rmtree` rather than `os.remove` if so.