### PR TITLE
bootloader: normalize the caught exception before processing it

### DIFF
--- a/bootloader/src/pyi_launch.c
+++ b/bootloader/src/pyi_launch.c
@@ -548,6 +548,7 @@ pyi_launch_run_scripts(ARCHIVE_STATUS *status)
                     #endif
 
                     PI_PyErr_Fetch(&ptype, &pvalue, &ptraceback);
+                    PI_PyErr_NormalizeException(&ptype, &pvalue, &ptraceback);
                     msg_exc = _pyi_extract_exception_message(pvalue);
                     if (pyi_arch_get_option(status, "pyi-disable-windowed-traceback") != NULL) {
                         /* Traceback is disabled via option */

--- a/bootloader/src/pyi_python.c
+++ b/bootloader/src/pyi_python.c
@@ -60,6 +60,7 @@ DECLPROC(PyErr_Occurred);
 DECLPROC(PyErr_Print);
 DECLPROC(PyErr_Fetch);
 DECLPROC(PyErr_Restore);
+DECLPROC(PyErr_NormalizeException);
 
 DECLPROC(PyImport_AddModule);
 DECLPROC(PyImport_ExecCodeModule);
@@ -132,6 +133,7 @@ pyi_python_map_names(HMODULE dll, int pyvers)
     GETPROC(dll, PyErr_Print);
     GETPROC(dll, PyErr_Fetch);
     GETPROC(dll, PyErr_Restore);
+    GETPROC(dll, PyErr_NormalizeException);
     GETPROC(dll, PyImport_AddModule);
     GETPROC(dll, PyImport_ExecCodeModule);
     GETPROC(dll, PyImport_ImportModule);

--- a/bootloader/src/pyi_python.h
+++ b/bootloader/src/pyi_python.h
@@ -134,6 +134,7 @@ EXTDECLPROC(PyObject *, PyMarshal_ReadObjectFromString, (const char *, size_t));
 /* Used to get traceback information while launching run scripts */
 EXTDECLPROC(void, PyErr_Fetch, (PyObject **, PyObject **, PyObject **));
 EXTDECLPROC(void, PyErr_Restore, (PyObject *, PyObject *, PyObject *));
+EXTDECLPROC(void, PyErr_NormalizeException, (PyObject **, PyObject **, PyObject **));
 EXTDECLPROC(PyObject *, PyObject_Str, (PyObject *));
 EXTDECLPROC(PyObject *, PyObject_GetAttrString, (PyObject *, const char *));
 EXTDECLPROC(const char *, PyUnicode_AsUTF8, (PyObject *));

--- a/news/6426.bootloader.rst
+++ b/news/6426.bootloader.rst
@@ -1,0 +1,5 @@
+When user script terminates with an uncaught exception, ensure that the
+exception data obtained via ``PyErr_Fetch`` is normalized by also calling
+``PyErr_NormalizeException``. Otherwise, trying to format the traceback
+via ``traceback.format_exception`` fails in some circumstances, and no
+traceback can be displayed in the windowed bootloader's error report.

--- a/news/6426.bugfix.rst
+++ b/news/6426.bugfix.rst
@@ -1,0 +1,3 @@
+Fix a bug that prevented traceback from uncaught exception to be
+retrieved and displayed in the windowed bootloader's error reporting
+facility (uncaught exception dialog on Windows, syslog on macOS).


### PR DESCRIPTION
When the user script terminates with uncaught exception and we retrieve its data via `PyErr_Fetch()`, we must also normalize the retrieved data via `PyErr_NormalizeException()` before trying to process it further.

Otherwise, the retrieved value instance may not be an instance of the indicated class object, which results in an error when we try
to format traceback via `traceback.format_exception()`. Consequently, we fail to retrieve traceback to display in the windowed bootloader's error reporting facility (i.e., the uncaught exception dialog on Windows; syslog on macOS).