### PR TITLE
bootloader: fix building on FreeBSD

### DIFF
--- a/bootloader/src/pyi_utils.h
+++ b/bootloader/src/pyi_utils.h
@@ -21,6 +21,10 @@
 
 #include "pyi_archive.h"
 
+#ifndef _WIN32
+#include <sys/types.h> /* pid_t */
+#endif
+
 // some platforms do not provide strnlen
 #ifndef HAVE_STRNLEN
 size_t strnlen(const char *str, size_t n);


### PR DESCRIPTION
Include `sys/types.h` in `pyi_utils.h` to avoid `unknown type name 'pid_t'` error.

Fixes #6438. 

No news fragment because this is a `develop`-only regression that has not been released yet (introduced by #6089, which we did not backport).