### PR TITLE
tests: remove python 3.10 restrictions on libraries & tools

### DIFF
--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -30,9 +30,11 @@ babel==2.9.1
 future==0.18.2
 gevent==21.12.0
 ipython==8.0.0; python_version >= '3.8'
+matplotlib==3.5.1
+pandas==1.3.5
 pygments==2.11.2
 PyGObject==3.42.0; sys_platform == 'linux'
-pyside2==5.15.2.1; python_version < '3.10'
+pyside2==5.15.2.1
 # pyside6 6.2.2 wheel is incompatible with python < 3.8 on macOS
 pyside6==6.2.1; sys_platform == 'darwin' and python_version < '3.8'  # pyup: ignore
 pyside6==6.2.2.1; sys_platform != 'darwin' or python_version >= '3.8'
@@ -45,6 +47,7 @@ pyqt6-webengine-qt6==6.2.2  # Qt6 QtWebEngine binaries
 python-dateutil==2.8.2
 pytz==2021.3
 requests==2.27.1
+scipy==1.7.3
 # simplejson is used for text_c_extension
 simplejson==3.17.6
 sphinx==4.3.2
@@ -57,18 +60,10 @@ Pillow==9.0.0
 # Python versions not supported / supported for older package versions
 # -------------------------------------------------------
 
-# so did numpy (which also dropped support for 3.7 as of 1.22)
+# numpy dropped support for python 3.7 as of 1.22
 numpy==1.22.1; python_version >= '3.8'
 numpy==1.21.5; python_version == '3.7'  # pyup: ignore
 
-# pandas can't be tested on Python 3.10 until 3.10.1 reaches github actions.
-pandas==1.3.5; python_version < '3.10'
-
-# scipy too
-scipy==1.7.3; python_version < '3.10'
-
-# and matplotlib
-matplotlib==3.5.1; python_version < '3.10'
 
 # Install PyInstaller Hook Sample, to ensure that tests declared in
 # entry-points are discovered.

--- a/tests/requirements-tools.txt
+++ b/tests/requirements-tools.txt
@@ -35,9 +35,9 @@ psutil
 flake8
 
 # These are required by some of basic tests
-pywin32; sys_platform == 'win32' and python_version < '3.10'
+pywin32; sys_platform == 'win32'
 
-lxml; sys_platform != 'win32' or python_version < '3.10'  # no wheels for 3.10, but we can build from sdist on non-Windows
+lxml
 
 # crypto support (`--key` option)
 tinyaes ~= 1.0


### PR DESCRIPTION
By now, most components should have python 3.10 wheels available.