### PR TITLE
hooks: qt: avoid collecting the QtQml module when not necessary

### DIFF
--- a/PyInstaller/utils/hooks/qt.py
+++ b/PyInstaller/utils/hooks/qt.py
@@ -510,6 +510,22 @@ def add_qt_dependencies(hook_file):
 
         logger.debug('add_qt%d_dependencies: raw lib %s -> parsed lib %s', qt_info.qt_major, imp, lib_name)
 
+        # PySide2 and PySide6 on linux seem to link all extension modules against libQt5Core, libQt5Network, and
+        # libQt5Qml (or their libQt6* equivalents). While the first two are reasonable, the libQt5Qml dependency pulls
+        # in whole QtQml module, along with its data and plugins, which in turn pull in several other Qt libraries,
+        # greatly inflating the bundle size (see #6447).
+        #
+        # Similarly, some extension modules (QtWebChannel, QtWebEngine*) seem to be also linked against libQt5Qml,
+        # even when the module can be used without having the whole QtQml module collected.
+        #
+        # Therefore, we explicitly prevent inclusion of QtQml based on the dynamic library dependency, except for
+        # QtQml* and QtQuick* modules, whose use directly implies the use of QtQml.
+        if lib_name in ("qt5qml", "qt6qml"):
+            short_module_name = module_name.split('.', 1)[-1]  # PySide2.QtModule -> QtModule
+            if not short_module_name.startswith(('QtQml', 'QtQuick')):
+                logger.debug('add_qt%d_dependencies: Ignoring import of %s.', qt_info.qt_major, imp)
+                continue
+
         # Follow only Qt dependencies.
         _qt_dynamic_dependencies_dict = (
             _qt5_dynamic_dependencies_dict if qt_info.qt_major == 5 else _qt6_dynamic_dependencies_dict

--- a/news/6447.hooks.rst
+++ b/news/6447.hooks.rst
@@ -1,0 +1,8 @@
+Avoid collecting the whole ``QtQml`` module and its dependencies in cases
+when it is not necessary (i.e., the application does not use ``QtQml`` or
+``QtQuick`` modules). The unnecessary collection was triggered due to
+extension modules being linked against the ``libQt5Qml`` or ``libQt6Qml``
+shared library, and affected pure widget-based applications (``PySide2``
+and ``PySide6`` on Linux) and widget-based applications that use
+``QtWebEngineWidgets`` (``PySide2``, ``PySide6``, ``PyQt5``, and ``PyQt6``
+on all OSes).


### PR DESCRIPTION
Avoid collecting the whole `QtQml` module when there is no indication that the frozen application is actually using `QtQml`, such as the import of the `QtQuick*` module(s) or the `QtQml` module itself.

On linux, the `PySide2` and `PySide6` extension modules seem to be always linked against `libQt5Core`, `libQt5Network`, and `libQt5Qml` shared library (or their Qt6 equivalent), which means that we end up collecting `QtQml` even for the basic widget-based application. And because we collect all `QtQtml` data and plugins, we end up pulling in several additional Qt libraries and modules as well.

Similarly, the `QtWebEngine*` extension modules of all four Qt-based bindings (`PyQt5`, `PyQt6`, `PySide2`, and `PySide6`) on all OSes seem to be linked against `QtQml` shared library as well, even though the module can be used in a pure widget-based application as well.

Therefore, prevent the linked `libQt5Qml`/`libQt6Qml` shared library from triggering the collection of the `QtQml` module, except for the modules whose names start with either `QtQml*` or `QtQuick*`.

Fixes #6447 (hopefully without breaking anything else).