### PR TITLE
bootloader: set bootloader's stack size on Windows to 2 MB

### DIFF
--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -702,6 +702,11 @@ def configure(ctx):
             # https://docs.microsoft.com/en-us/windows/win32/secbp/control-flow-guard
             ctx.env.append_value('CFLAGS', '/guard:cf')
             ctx.env.append_value('LINKFLAGS', '/guard:cf')
+
+            # Increase the executable's stack size from the default 1 MiB (0x100000) to 2 MB (0x1E8480) to match
+            # the stack size under the Python interpreter.
+            # https://github.com/python/cpython/blob/a9e0b2b49374df91c40fe409508cfcdc6332450e/PCbuild/python.vcxproj#L97
+            ctx.env.append_value('LINKFLAGS', '/stack:2000000')
         else:
             # Use Visual C++ compatible alignment
             ctx.env.append_value('CFLAGS', '-mms-bitfields')
@@ -711,6 +716,12 @@ def configure(ctx):
 
             # Use Unicode entry point wmain/wWinMain
             ctx.env.append_value('LINKFLAGS', '-municode')
+
+            # Set the executable's stack size to 2 MB (0x1E8480) to match the stack size under the Python interpreter.
+            # The MSYS2/MINGW64 gcc toolchain seems to use 2 MiB (0x200000) stack by default, so we are slightly
+            # decreasing the stack size here, in order to keep it synchronized with the python itself and with the
+            # MSVC-compiled bootloaders.
+            ctx.env.append_value('LINKFLAGS', '-Wl,--stack,2000000')
 
     # On linux link only with needed libraries.
     # On some platforms (Mac OS, Solaris, AIX), -Wl,--as-needed is detected as supported during configuration,

--- a/news/6459.bootloader.rst
+++ b/news/6459.bootloader.rst
@@ -1,0 +1,2 @@
+(Windows) Set the bootloader executable's stack size to 2 MB to match the
+stack size of the python interpreter executable.

--- a/news/6459.bugfix.rst
+++ b/news/6459.bugfix.rst
@@ -1,0 +1,2 @@
+(Windows) Fix stack overflow in `pyarmor`-protected frozen applications, caused 
+by the executable's stack being smaller than that of the python interpreter.


### PR DESCRIPTION
When building the bootloader executables on Windows, set their stack size to 2 MB to match the stack size of the python executable, in order to eliminate behavior differences stemming from difference in stack size (e.g., stack overflow occurring sooner in a frozen version compared to the unfrozen one, due to default stack size of MSVC-compiled binaries being 1 MiB, while python uses 2 MB).

Fixes #6459 (originally discussed in #6443).