### PR TITLE
Update numpy hook for compatibility with 1.22

### DIFF
--- a/PyInstaller/hooks/hook-numpy.py
+++ b/PyInstaller/hooks/hook-numpy.py
@@ -22,7 +22,7 @@ Feel free to @mention either bwoodsend or Legorooj on Github for help keeping it
 """
 
 from PyInstaller.compat import is_conda, is_pure_conda
-from PyInstaller.utils.hooks import collect_dynamic_libs
+from PyInstaller.utils.hooks import collect_dynamic_libs, is_module_satisfies
 
 # Collect all DLLs inside numpy's installation folder, dump them into built app's root.
 binaries = collect_dynamic_libs("numpy", ".")
@@ -45,9 +45,15 @@ excludedimports = [
     "scipy",
     "pytest",
     "nose",
-    "distutils",
     "f2py",
     "setuptools",
     "numpy.f2py",
-    "numpy.distutils",
 ]
+
+# As of version 1.22, numpy.testing (imported for example by some scipy modules) requires numpy.distutils and distutils.
+# So exclude them only for earlier versions.
+if is_module_satisfies("numpy < 1.22"):
+    excludedimports += [
+        "distutils",
+        "numpy.distutils",
+    ]

--- a/news/6474.hooks.rst
+++ b/news/6474.hooks.rst
@@ -1,0 +1,4 @@
+Update ``numpy`` hook for compatibility with version 1.22; the hook
+cannot exclude ``distutils`` and ``numpy.distutils`` anymore, as they
+are required by ``numpy.testing``, which is used by some external
+packages, such as ``scipy``.

--- a/tests/functional/test_hooks/test_scipy.py
+++ b/tests/functional/test_hooks/test_scipy.py
@@ -12,12 +12,9 @@
 Functional tests for SciPy.
 """
 
-from PyInstaller.compat import is_darwin, is_win
-from PyInstaller.utils.tests import importorskip, xfail
+from PyInstaller.utils.tests import importorskip
 
 
-@xfail(is_win, reason='Issue scipy/scipy#5461.')
-@xfail(is_darwin, reason='Issue #1895.')
 @importorskip('scipy')
 def test_scipy(pyi_builder):
     pyi_builder.test_source(
@@ -46,8 +43,6 @@ def test_scipy(pyi_builder):
     )
 
 
-@xfail(is_win, reason='Issue scipy/scipy#5461.')
-@xfail(is_darwin, reason='Issue #1895.')
 @importorskip('scipy')
 def test_scipy_special(pyi_builder):
     """

--- a/tests/functional/test_hooks/test_scipy.py
+++ b/tests/functional/test_hooks/test_scipy.py
@@ -19,8 +19,6 @@ from PyInstaller.utils.tests import importorskip
 def test_scipy(pyi_builder):
     pyi_builder.test_source(
         """
-        from distutils.version import LooseVersion
-
         # Test top-level SciPy importability.
         import scipy
         from scipy import *
@@ -34,11 +32,8 @@ def test_scipy(pyi_builder):
         import scipy.signal
 
         # SciPy >= 0.16 privatized the previously public "scipy.lib" package as "scipy._lib".
-        # Since this package is problematic, test its importability regardless of SciPy version.
-        if LooseVersion(scipy.__version__) >= LooseVersion('0.16.0'):
-            import scipy._lib
-        else:
-            import scipy.lib
+        # Since this package is problematic, test its importability regardless of its private status.
+        import scipy._lib
         """
     )
 

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -65,8 +65,9 @@ ipython==7.16.1; python_version <= '3.6'  # pyup: ignore
 pandas==1.3.5; python_version > '3.6' and python_version < '3.10'
 pandas==1.1.5; python_version <= '3.6'  # pyup: ignore
 
-# so did numpy
-numpy==1.21.5; python_version > '3.6' and (python_version < '3.10' or sys_platform != 'darwin')
+# so did numpy (which also dropped support for 3.7 as of 1.22)
+numpy==1.22.0; python_version >= '3.8'
+numpy==1.21.5; python_version == '3.7'  # pyup: ignore
 numpy==1.19.4; python_version <= '3.6'  # pyup: ignore
 
 # scipy too


### PR DESCRIPTION
As of `numpy` 1.22.0, `numpy.testing` [imports `numpy.testing._private.extbuild`](https://github.com/numpy/numpy/blob/4adc87dff15a247e417d50f10cc4def8e1c17a03/numpy/testing/__init__.py#L12), which in turn imports `numpy.distutils` and `distutils` that we explicitly [exclude in the hook](https://github.com/pyinstaller/pyinstaller/blob/db95de4fa6c88a96d04cfb7a94e1d06b3bb3813a/PyInstaller/hooks/hook-numpy.py#L44-L53). 

The `numpy.testing` is imported by `scipy.optimize` (via `scipy.optimize._constraints`); therefore, a frozen application using that module and numpy 1.22 ends up with missing `numpy.distutils` module error, as seen in #6473.

But before we tackle `numpy` hook itself, the scipy tests need to be cleaned up a bit - the lack of failure on Windows and macOS runners due to xfail does not exactly inspire confidence...