### PR TITLE
Bindepend: Add Termux-specific libraries search path.

### DIFF
--- a/PyInstaller/depend/bindepend.py
+++ b/PyInstaller/depend/bindepend.py
@@ -760,6 +760,10 @@ def findLibrary(name):
         except ImportError:
             logger.debug('Multiarch directory not detected.')
 
+        # Termux (a Ubuntu like subsystem for Android) has an additional libraries directory.
+        if os.path.isdir('/data/data/com.termux/files/usr/lib'):
+            paths.append('/data/data/com.termux/files/usr/lib')
+
         if compat.is_aix:
             paths.append('/opt/freeware/lib')
         elif compat.is_hpux:

--- a/news/6484.feature.rst
+++ b/news/6484.feature.rst
@@ -1,0 +1,1 @@
+Add strictly unofficial support for the `Termux <https://f-droid.org/en/packages/com.termux/>` platform.


### PR DESCRIPTION
According to termux/termux-app#1595, this is all we need to change to faclitate
using PyInstaller on Termux.

Closes #6479.
