### PR TITLE
building: add __setitem__ to TOC()

### DIFF
--- a/PyInstaller/building/datastruct.py
+++ b/PyInstaller/building/datastruct.py
@@ -94,6 +94,11 @@ class TOC(list):
         result.extend(self)
         return result
 
+    def __iadd__(self, other):
+        for entry in other:
+            self.append(entry)
+        return self
+
     def extend(self, other):
         # TODO: look if this can be done more efficient with out the loop, e.g. by not using a list as base at all.
         for entry in other:
@@ -115,6 +120,27 @@ class TOC(list):
     def __rsub__(self, other):
         result = TOC(other)
         return result.__sub__(self)
+
+    def __setitem__(self, key, value):
+        if isinstance(key, slice):
+            if key == slice(None, None, None):
+                # special case: set the entire list
+                self.filenames = set()
+                self.clear()
+                self.extend(value)
+                return
+            else:
+                raise KeyError("TOC.__setitem__ doesn't handle slices")
+
+        else:
+            old_value = self[key]
+            old_name = unique_name(old_value)
+            self.filenames.remove(old_name)
+
+            new_name = unique_name(value)
+            if new_name not in self.filenames:
+                self.filenames.add(new_name)
+                super(TOC, self).__setitem__(key, value)
 
 
 class Target:

--- a/tests/unit/test_TOC.py
+++ b/tests/unit/test_TOC.py
@@ -257,6 +257,38 @@ def test_rsub_non_existing():
     assert result == expected
 
 
+def test_sub_after_setitem():
+    toc = TOC(ELEMS1)
+    toc[1] = ('lib-dynload/_random', '/usr/lib/python2.7/lib-dynload/_random.so', 'EXTENSION')
+    toc -= []
+    assert len(toc) == 3
+
+
+def test_setitem_1():
+    toc = TOC()
+    toc[:] = ELEMS1
+    for e in ELEMS1:
+        assert e in toc
+        assert e[0] in toc.filenames
+
+
+def test_setitem_2():
+    toc = TOC(ELEMS1)
+    toc[1] = ELEMS3[0]
+
+    assert ELEMS1[0] in toc
+    assert ELEMS1[0][0] in toc.filenames
+
+    assert ELEMS3[0] in toc
+    assert ELEMS3[0][0] in toc.filenames
+
+    assert ELEMS1[2] in toc
+    assert ELEMS1[2][0] in toc.filenames
+
+    for e in toc:
+        assert e[0] in toc.filenames
+
+
 # The following tests verify that case-insensitive comparisons are used on Windows and only for
 # appropriate TOC entry types
 


### PR DESCRIPTION
This PR implements `TOC.__setitem__`

Background: I was trying to remove a few specific items from `Analysis.binaries` using `TOC.__sub__` and it wasn't working as expected -- even subtracting an empty list would remove other items unexpectedly!

After some digging, I determined that there were several places in the code that were updating `Analysis.binaries` using `__setitem__` instead of `append` or `extend`. As such, `TOC.filenames` wasn't being updated, leading to the screwy behavior in `TOC.__sub__`.

To fix the problem, I wrote a basic implementation of `TOC.__setitem__`. It is "basic" because it only handles integers and `[:]` slices as keys; it fails with a `KeyError` on more complicated slices. These are the only two ways that `TOC.__setitem__` is currently called in the codebase.

I've also included a couple of basic unit tests. The first tests `TOC.__sub__` to expose the problematic behavior; the second and third test the new `TOC.__setitem__` directly.
