### PR TITLE
Work around macos-11 CI issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9, '3.10']
-        os: ['windows-latest', 'ubuntu-latest', 'macos-10.15', 'macos-latest']
+        os: ['windows-latest', 'ubuntu-latest', 'macos-10.15', 'macos-11']
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/tests/functional/scripts/pyi_lib_tkinter.py
+++ b/tests/functional/scripts/pyi_lib_tkinter.py
@@ -10,6 +10,11 @@
 #-----------------------------------------------------------------------------
 
 # Ensure that environment variables TCL_LIBRARY and TK_LIBRARY are set properly, and that data files are collected.
+# NOTE: "library" here refers to the scripts directory as in "collection", not as a dynamic/shared library.
+
+# NOTE: on macOS, we do collect Tcl/Tk files when the _tkinter module is linked against system copy of Tcl/Tk framework.
+# In that case, TCL_LIBRARY and TK_LIBRARY environment variables are not set by the runtime hook, and this test is
+# reduced to a basic "import tkinter" test.
 
 import glob
 import os
@@ -35,8 +40,16 @@ def compare(test_name, expect, frozen):
         raise SystemExit('Data directory does not contain .tcl files.')
 
 
-tcl_dir = os.environ['TCL_LIBRARY']
-tk_dir = os.environ['TK_LIBRARY']
+# Tcl scripts directory
+tcl_dir = os.environ.get('TCL_LIBRARY')
+if tcl_dir:
+    compare('Tcl', os.path.join(sys.prefix, 'tcl'), tcl_dir)
+elif sys.platform != 'darwin':
+    raise SystemExit("TCL_LIBRARY environment variable is not set!")
 
-compare('Tcl', os.path.join(sys.prefix, 'tcl'), tcl_dir)
-compare('Tk', os.path.join(sys.prefix, 'tk'), tk_dir)
+# Tk scripts directory
+tk_dir = os.environ.get('TK_LIBRARY')
+if tk_dir:
+    compare('Tk', os.path.join(sys.prefix, 'tk'), tk_dir)
+elif sys.platform != 'darwin':
+    raise SystemExit("TK_LIBRARY environment variable is not set!")

--- a/tests/functional/test_basic.py
+++ b/tests/functional/test_basic.py
@@ -214,7 +214,6 @@ def test_module_attributes(tmpdir, pyi_builder):
     pyi_builder.test_script('pyi_module_attributes.py')
 
 
-@xfail(is_darwin, reason='Issue #1895.')
 def test_module_reload(pyi_builder):
     pyi_builder.test_script('pyi_module_reload.py')
 

--- a/tests/functional/test_hooks/test_pil.py
+++ b/tests/functional/test_hooks/test_pil.py
@@ -15,8 +15,10 @@ Note that the original unmaintained PIL has been obsoleted by the PIL-compatible
 which retains the same Python package `PIL`.
 """
 
-from PyInstaller.compat import is_darwin
-from PyInstaller.utils.tests import importorskip, skip, xfail
+import pytest
+
+from PyInstaller.utils.tests import importorskip, skip
+from PyInstaller.utils.hooks import can_import_module
 
 
 # "excludedimports" support is currently non-deterministic and hence cannot be marked as @xfail. If this test was
@@ -53,9 +55,10 @@ def test_pil_no_tkinter(pyi_builder):
     )
 
 
+# The tkinter module may be available for import, but not actually importable due to missing shared libraries.
+# Therefore, we need to use `can_import_module`-based skip decorator instead of `@importorskip`.
 @importorskip('PIL')
-@importorskip('tkinter')
-@xfail(is_darwin, reason='Issue #1895. Known to fail with macpython - python.org binary.')
+@pytest.mark.skipif(not can_import_module("tkinter"), reason="tkinter cannot be imported.")
 def test_pil_tkinter(pyi_builder):
     """
     Ensure that the Tkinter package excluded by `PIL` package hooks is importable by frozen applications explicitly

--- a/tests/functional/test_import.py
+++ b/tests/functional/test_import.py
@@ -18,7 +18,7 @@ import ctypes.util
 
 import pytest
 
-from PyInstaller.compat import is_darwin, is_win
+from PyInstaller.compat import is_win
 import PyInstaller.depend.utils
 from PyInstaller.utils.tests import skipif, importorskip, skipif_no_compiler, xfail, has_compiler
 
@@ -668,7 +668,6 @@ def test_pkg_without_hook_for_pkg(pyi_builder, script_dir):
     )
 
 
-@xfail(is_darwin, reason='Issue #1895.')
 def test_app_with_plugin(pyi_builder, data_dir, monkeypatch):
     datas = os.pathsep.join(('data/*/static_plugin.py', os.curdir))
     pyi_builder.test_script('pyi_app_with_plugin.py', pyi_args=['--add-data', datas])

--- a/tests/functional/test_libraries.py
+++ b/tests/functional/test_libraries.py
@@ -15,8 +15,9 @@ import os
 import pytest
 import py
 
-from PyInstaller.compat import is_win, is_darwin, is_linux
+from PyInstaller.compat import is_win, is_linux
 from PyInstaller.utils.tests import importorskip, xfail, skipif, requires
+from PyInstaller.utils.hooks import can_import_module
 
 # :todo: find a way to get this from `conftest` or such directory with testing modules used in some tests.
 _MODULES_DIR = py.path.local(os.path.abspath(__file__)).dirpath('modules')
@@ -47,7 +48,9 @@ def test_gevent_monkey(pyi_builder):
     )
 
 
-@xfail(is_darwin, reason='Issue #1895.')
+# The tkinter module may be available for import, but not actually importable due to missing shared libraries.
+# Therefore, we need to use `can_import_module`-based skip decorator instead of `@importorskip`.
+@pytest.mark.skipif(not can_import_module("tkinter"), reason="tkinter cannot be imported.")
 def test_tkinter(pyi_builder):
     pyi_builder.test_script('pyi_lib_tkinter.py')
 
@@ -106,7 +109,10 @@ def test_zope_interface(pyi_builder):
     )
 
 
+# The tkinter module may be available for import, but not actually importable due to missing shared libraries.
+# Therefore, we need to use `can_import_module`-based skip decorator instead of `@importorskip`.
 @importorskip('idlelib')
+@pytest.mark.skipif(not can_import_module("tkinter"), reason="tkinter cannot be imported.")
 def test_idlelib(pyi_builder):
     pyi_builder.test_source(
         """

--- a/tests/functional/test_libraries.py
+++ b/tests/functional/test_libraries.py
@@ -117,10 +117,7 @@ def test_idlelib(pyi_builder):
     pyi_builder.test_source(
         """
         # This file depends on loading some icons, located based on __file__.
-        try:
-            import idlelib.TreeWidget
-        except:
-            import idlelib.tree
+        import idlelib.tree
         """
     )
 


### PR DESCRIPTION
So it turns out that the failing `test_idlelib` on our `3.10, macos-latest` CI pipeline is in fact due to Tcl/Tk shared libraries missing from the `macos-11` image (upstream issue: actions/virtual-environments#4931). We have couple of other `tkinter`-based tests, but those have been marked as `xfail` for macOS, so we do not see them fail (but they do fail, for the same reason). As mentioned [here](https://github.com/pyinstaller/pyinstaller/pull/6446#issuecomment-1016776710), I initially failed to reproduce the problem on my PyInstaller fork, which turned out to be due to `macos-latest` still translating to `macos-10.15` there.

In light of the above, this PR attempts work around tkinter problems by:
- explicitly using `macos-11` instead of `macos-latest`. So that we get the same behavior in main repository and in personal forks
- remove the old `xfail` marks on `tkinter`-based tests
- instead, `tkinter` tests are now skipped if `tkinter` cannot be imported (as a side note, we used to already have that, but we lost this check when we changed our `importorskip` decorator so that it does not actually import the module)
- fix the `test_tkinter` script, which did not properly account for the case of macOS and system Tcl/Tk framework; and the failure was masked by the `xfail` mark
