### PR TITLE
Fixed pkgutil.iter_modules and improved the code a bit

### DIFF
--- a/PyInstaller/hooks/rthooks/pyi_rth_pkgutil.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_pkgutil.py
@@ -43,36 +43,35 @@ def _pyi_pkgutil_iter_modules(path=None, prefix=''):
     else:
         return
 
-    if not path:
+    if path is None:
         # Search for all top-level packages/modules. These will have no dots in their entry names.
         for entry in importer.toc:
-            if entry.count('.') != 0:
-                continue
-            is_pkg = importer.is_package(entry)
-            yield pkgutil.ModuleInfo(importer, prefix + entry, is_pkg)
+            if entry.count('.') == 0:
+                is_pkg = importer.is_package(entry)
+                yield pkgutil.ModuleInfo(importer, prefix + entry, is_pkg)
     else:
         # Declare SYS_PREFIX locally, to avoid clash with eponymous global symbol from pyi_rth_pkgutil hook.
         SYS_PREFIX = sys._MEIPASS + os.path.sep
         SYS_PREFIXLEN = len(SYS_PREFIX)
-        # Only single path is supported, and it must start with sys._MEIPASS.
-        pkg_path = os.path.normpath(path[0])
-        assert pkg_path.startswith(SYS_PREFIX)
-        # Construct package prefix from path...
-        pkg_prefix = pkg_path[SYS_PREFIXLEN:]
-        pkg_prefix = pkg_prefix.replace(os.path.sep, '.')
-        # ... and ensure it ends with a dot (so we can directly filter out the package itself).
-        if not pkg_prefix.endswith('.'):
-            pkg_prefix += '.'
-        pkg_prefix_len = len(pkg_prefix)
 
-        for entry in importer.toc:
-            if not entry.startswith(pkg_prefix):
-                continue
-            name = entry[pkg_prefix_len:]
-            if name.count('.') != 0:
-                continue
-            is_pkg = importer.is_package(entry)
-            yield pkgutil.ModuleInfo(importer, prefix + name, is_pkg)
+        for pkg_path in path:
+            pkg_path = os.path.normpath(pkg_path)
+            # if the path does not start with sys._MEIPASS then it cannot be a bundled package.
+            if pkg_path.startswith(SYS_PREFIX):
+                # Construct package prefix from path...
+                pkg_prefix = pkg_path[SYS_PREFIXLEN:]
+                pkg_prefix = pkg_prefix.replace(os.path.sep, '.')
+                # ... and ensure it ends with a dot (so we can directly filter out the package itself).
+                if not pkg_prefix.endswith('.'):
+                    pkg_prefix += '.'
+                pkg_prefix_len = len(pkg_prefix)
+
+                for entry in importer.toc:
+                    if entry.startswith(pkg_prefix):
+                        name = entry[pkg_prefix_len:]
+                        if name.count('.') == 0:
+                            is_pkg = importer.is_package(entry)
+                            yield pkgutil.ModuleInfo(importer, prefix + name, is_pkg)
 
 
 pkgutil.iter_modules = _pyi_pkgutil_iter_modules

--- a/PyInstaller/hooks/rthooks/pyi_rth_pkgutil.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_pkgutil.py
@@ -46,9 +46,10 @@ def _pyi_pkgutil_iter_modules(path=None, prefix=''):
     if path is None:
         # Search for all top-level packages/modules. These will have no dots in their entry names.
         for entry in importer.toc:
-            if entry.count('.') == 0:
-                is_pkg = importer.is_package(entry)
-                yield pkgutil.ModuleInfo(importer, prefix + entry, is_pkg)
+            if entry.count('.') != 0:
+                continue
+            is_pkg = importer.is_package(entry)
+            yield pkgutil.ModuleInfo(importer, prefix + entry, is_pkg)
     else:
         # Declare SYS_PREFIX locally, to avoid clash with eponymous global symbol from pyi_rth_pkgutil hook.
         SYS_PREFIX = sys._MEIPASS + os.path.sep
@@ -56,22 +57,25 @@ def _pyi_pkgutil_iter_modules(path=None, prefix=''):
 
         for pkg_path in path:
             pkg_path = os.path.normpath(pkg_path)
-            # if the path does not start with sys._MEIPASS then it cannot be a bundled package.
-            if pkg_path.startswith(SYS_PREFIX):
-                # Construct package prefix from path...
-                pkg_prefix = pkg_path[SYS_PREFIXLEN:]
-                pkg_prefix = pkg_prefix.replace(os.path.sep, '.')
-                # ... and ensure it ends with a dot (so we can directly filter out the package itself).
-                if not pkg_prefix.endswith('.'):
-                    pkg_prefix += '.'
-                pkg_prefix_len = len(pkg_prefix)
+            if not pkg_path.startswith(SYS_PREFIX):
+                # if the path does not start with sys._MEIPASS then it cannot be a bundled package.
+                continue
+            # Construct package prefix from path...
+            pkg_prefix = pkg_path[SYS_PREFIXLEN:]
+            pkg_prefix = pkg_prefix.replace(os.path.sep, '.')
+            # ... and ensure it ends with a dot (so we can directly filter out the package itself).
+            if not pkg_prefix.endswith('.'):
+                pkg_prefix += '.'
+            pkg_prefix_len = len(pkg_prefix)
 
-                for entry in importer.toc:
-                    if entry.startswith(pkg_prefix):
-                        name = entry[pkg_prefix_len:]
-                        if name.count('.') == 0:
-                            is_pkg = importer.is_package(entry)
-                            yield pkgutil.ModuleInfo(importer, prefix + name, is_pkg)
+            for entry in importer.toc:
+                if not entry.startswith(pkg_prefix):
+                    continue
+                name = entry[pkg_prefix_len:]
+                if name.count('.') != 0:
+                    continue
+                is_pkg = importer.is_package(entry)
+                yield pkgutil.ModuleInfo(importer, prefix + name, is_pkg)
 
 
 pkgutil.iter_modules = _pyi_pkgutil_iter_modules

--- a/news/6529.bugfix.rst
+++ b/news/6529.bugfix.rst
@@ -1,0 +1,3 @@
+Add support for external paths when running ``pkgutil.iter_modules``.
+Add support for multiple search paths to ``pkgutil.iter_modules``.
+Correctly handle ``pkgutil.iter_modules`` with an empty list.


### PR DESCRIPTION
The old implementation would only work if the path started with the _MEIPASS directory and would throw an assertion error if it did not.
This version only runs the pyinstaller code if the path starts with _MEIPASS and allows other paths to work.
It also supports multiple paths and correctly handles an empty list.
I have also cleaned up the code a little to make it more readable.

I could not find a contributing file so hopefully this meets your requirements.

The tests may need updating since this supports multiple paths like the vanilla function does.

Fixes #6528 