### PR TITLE
hooks: fix pkgutil.iter_modules when paths involve symbolic links

### DIFF
--- a/news/6537.bugfix.rst
+++ b/news/6537.bugfix.rst
@@ -1,0 +1,2 @@
+Fix handling of symbolic links in the path matching part of the
+PyInstaller's ``pkgutil.iter_modules`` replacement/override.

--- a/tests/functional/scripts/pyi_pkgutil_iter_modules.py
+++ b/tests/functional/scripts/pyi_pkgutil_iter_modules.py
@@ -9,6 +9,7 @@
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
 
+import os
 import sys
 import argparse
 import pkgutil
@@ -28,6 +29,12 @@ parser.add_argument(
     help="Optional prefix to pass to iter_modules.",
 )
 parser.add_argument(
+    '--resolve-pkg-path',
+    action='store_true',
+    default=False,
+    help="Resolve symbolic links in package path before passing it to pkgutil.iter_modules.",
+)
+parser.add_argument(
     '--output-file',
     default=None,
     type=str,
@@ -43,7 +50,10 @@ else:
 
 # Iterate over package's module
 package = importlib.import_module(args.package)
-for module in pkgutil.iter_modules(package.__path__, args.prefix):
+pkg_path = package.__path__
+if args.resolve_pkg_path:
+    pkg_path = [os.path.realpath(path) for path in pkg_path]
+for module in pkgutil.iter_modules(pkg_path, args.prefix):
     print("%s;%d" % (module.name, module.ispkg), file=fp)
 
 # Cleanup


### PR DESCRIPTION
In our `pkgutil.iter_module` replacement, we need to fully resolve both the `sys._MEIPASS` and the given search paths, in case either contains a symbolic link. Failing to do so leads to path mis-match when symbolic links are involved and the given search paths are already fully resolved. This may happen on macOS with onefile builds if the caller of `pkgutil.iter_module` fully resolves the search path(s) before calling the function (issue #6537).

Add a test that reproduces scenario from #6537.

Fixes #6537.