### PR TITLE
hooks: add a work-around for compatibility with setuptools 60.7.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,10 @@ jobs:
       - name: Set up environment
         run: |
           # Update pip.
-          python -m pip install -U pip setuptools wheel
+          #
+          # pip 22.0 seems to be causing issues with pytest on our Windows runners, so pin to 21.3.1
+          # until we figure out what is going on...
+          python -m pip install -U pip==21.3.1 setuptools wheel
 
           # Install dependencies for tests.
           pip install --progress-bar=off -U -r tests/requirements-tools.txt -r tests/requirements-libraries.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,10 @@ jobs:
           CC="gcc -std=gnu90" python waf all
           cd ..
 
+      # Use bash for this step, so that we can avoid dealing with PowerShell
+      # syntax for writing to environmental file on Windows.
       - name: Set up environment
+        shell: bash
         run: |
           # Update pip.
           #
@@ -94,6 +97,10 @@ jobs:
 
           # Run Qt-based tests with offscreen backend
           echo "QT_QPA_PLATFORM=offscreen" >> $GITHUB_ENV
+
+          # Prevent setuptools from replacing distutils with its vendored version, as our test suite is not
+          # ready for that.
+          echo "SETUPTOOLS_USE_DISTUTILS=not-today" >> $GITHUB_ENV
 
       - name: Start display server
         if: startsWith(matrix.os, 'ubuntu')
@@ -131,6 +138,9 @@ jobs:
       - uses: actions/checkout@v2
       - run: docker build -f alpine.dockerfile -t foo .
       - run: >
-          docker run foo pytest
+          docker run
+          -e SETUPTOOLS_USE_DISTUTILS='not-today'
+          foo
+          pytest
           -n 3 --maxfail 3 --durations 10 tests/unit tests/functional
           --force-flaky --no-flaky-report --reruns 3 --reruns-delay 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,10 +71,7 @@ jobs:
           CC="gcc -std=gnu90" python waf all
           cd ..
 
-      # Use bash for this step, so that we can avoid dealing with PowerShell
-      # syntax for writing to environmental file on Windows.
       - name: Set up environment
-        shell: bash
         run: |
           # Update pip.
           #
@@ -95,9 +92,23 @@ jobs:
           # Make sure the help options print.
           python -m pyinstaller -h
 
-          # Run Qt-based tests with offscreen backend
+      - name: Set up environment variables (non-Windows)
+        if: ${{ !startsWith(matrix.os, 'windows') }}
+        run: |
+          # Run Qt-based tests with offscreen backend. This seems to break QtWebEngine tests on Windows, so
+          # apply it only here, in non-Windows path.
           echo "QT_QPA_PLATFORM=offscreen" >> $GITHUB_ENV
 
+          # Prevent setuptools from replacing distutils with its vendored version, as our test suite is not
+          # ready for that.
+          echo "SETUPTOOLS_USE_DISTUTILS=not-today" >> $GITHUB_ENV
+
+      # Use bash for this step, so that we can avoid dealing with PowerShell
+      # syntax for writing to environmental file on Windows.
+      - name: Set up environment variables (Windows)
+        if: startsWith(matrix.os, 'windows')
+        shell: bash
+        run: |
           # Prevent setuptools from replacing distutils with its vendored version, as our test suite is not
           # ready for that.
           echo "SETUPTOOLS_USE_DISTUTILS=not-today" >> $GITHUB_ENV

--- a/PyInstaller/hooks/hook-pkg_resources.py
+++ b/PyInstaller/hooks/hook-pkg_resources.py
@@ -9,7 +9,7 @@
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
 
-from PyInstaller.utils.hooks import collect_submodules
+from PyInstaller.utils.hooks import collect_submodules, is_module_satisfies, collect_data_files
 
 # pkg_resources keeps vendored modules in its _vendor subpackage, and does sys.meta_path based import magic to expose
 # them as pkg_resources.extern.*
@@ -28,3 +28,18 @@ excludedimports = ['__main__']
 hiddenimports += collect_submodules('packaging')
 
 hiddenimports += ['pkg_resources.markers']
+
+# As of v60.7, setuptools vendored jaraco and has pkg_resources use it. There is a custom importer,
+# pkg_resources.extern.VendorImporter, that is used to find the vendored package, and redirects
+# pkg_resources.extern.jaraco to pkg_resources._vendor.jaraco. Unfortunately, that does not seem to play nicely with
+# our FrozenImporter, so for now, we work around that by collecting all pkg_resources._vendor.jaraco submodules as
+# source .py files and let the VendorImporter deal with them (which also means we need to ensure that we do not collect
+# any of those modules into our PYZ archive).
+if is_module_satisfies("setuptools >= 60.7"):
+    excludedimpoirts = ["pkg_resources._vendor.jaraco"]
+    # Despite its appearance, this actually collects all source files from pkg_resources._vendor.jaraco (plus the
+    # "Lorem Ipsum.txt" data file from pkg_resources._vendor.jaraco.text if it is present). Calling collect_data_files
+    # on pkg_resources._vendor.jaraco itself does not work due to bug(s) in its handling of namespace packages.
+    datas = collect_data_files(
+        'pkg_resources._vendor.jaraco.functools', include_py_files=True, excludes=['**/__pycache__']
+    )

--- a/news/6564.hooks.rst
+++ b/news/6564.hooks.rst
@@ -1,0 +1,2 @@
+Add a work-around for compatibility with ``setuptools 60.7.0`` and its vendoring 
+of ``jaraco.text`` in ``pkg_resources``.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@
 
 ## IMPORTANT: Keep aligned with setup.cfg
 
-setuptools<50.0.0   # 50.0.0 breaks a modulegraph regession test
+setuptools
 altgraph
 pyinstaller-hooks-contrib >= 2020.11
 pefile; sys_platform == 'win32'


### PR DESCRIPTION
Setuptools v.60.7.0 vendored `jaraco.text` package in `pkg_resources`, and their `VendoredImporter` does not seem to play nicely with our `FrozenImporter`. So ensure we do not collect the vendored package (`pkg_resources._vendor.jaraco`) and its submodules into PYZ archive, but instead collect them as source .py files, so that they are handled by `VendoredImporter` at the runtime.