### PR TITLE
hooks: add support for setuptools 60.7.1, mark 60.7.0 as unsupported

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,10 @@ jobs:
       - name: Set up environment
         run: |
           # Update pip.
-          python -m pip install -U pip setuptools wheel
+          #
+          # pip 22.0 seems to be causing issues with pytest on our Windows runners, so pin to 21.3.1
+          # until we figure out what is going on...
+          python -m pip install -U pip==21.3.1 setuptools wheel
 
           # Install dependencies for tests.
           pip install --progress-bar=off -U -r tests/requirements-tools.txt -r tests/requirements-libraries.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,10 @@ jobs:
           CC="gcc -std=gnu90" python waf all
           cd ..
 
+      # Use bash for this step, so that we can avoid dealing with PowerShell
+      # syntax for writing to environmental file on Windows.
       - name: Set up environment
+        shell: bash
         run: |
           # Update pip.
           #
@@ -94,6 +97,10 @@ jobs:
 
           # Run Qt-based tests with offscreen backend
           echo "QT_QPA_PLATFORM=offscreen" >> $GITHUB_ENV
+
+          # Prevent setuptools from replacing distutils with its vendored version, as our test suite is not
+          # ready for that.
+          echo "SETUPTOOLS_USE_DISTUTILS=not-today" >> $GITHUB_ENV
 
       - name: Start display server
         if: startsWith(matrix.os, 'ubuntu')
@@ -131,6 +138,9 @@ jobs:
       - uses: actions/checkout@v2
       - run: docker build -f alpine.dockerfile -t foo .
       - run: >
-          docker run foo pytest
+          docker run
+          -e SETUPTOOLS_USE_DISTUTILS='not-today'
+          foo
+          pytest
           -n 3 --maxfail 3 --durations 10 tests/unit tests/functional
           --force-flaky --no-flaky-report --reruns 3 --reruns-delay 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,10 +74,7 @@ jobs:
       - name: Set up environment
         run: |
           # Update pip.
-          #
-          # pip 22.0 seems to be causing issues with pytest on our Windows runners, so pin to 21.3.1
-          # until we figure out what is going on...
-          python -m pip install -U pip==21.3.1 setuptools wheel
+          python -m pip install -U pip setuptools wheel
 
           # Install dependencies for tests.
           pip install --progress-bar=off -U -r tests/requirements-tools.txt -r tests/requirements-libraries.txt
@@ -128,9 +125,8 @@ jobs:
           echo "PYTEST_DEBUG_TEMPROOT=$RUNNER_TEMP" >> $GITHUB_ENV
 
       - name: Run tests
-        uses: xoviat/actions-pytest@0.1-alpha2
-        with:
-          args: >
+        run: >
+            pytest
             -n 3 --maxfail 3 --durations 10 tests/unit tests/functional
             --force-flaky --no-flaky-report --reruns 3 --reruns-delay 10
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,10 +71,7 @@ jobs:
           CC="gcc -std=gnu90" python waf all
           cd ..
 
-      # Use bash for this step, so that we can avoid dealing with PowerShell
-      # syntax for writing to environmental file on Windows.
       - name: Set up environment
-        shell: bash
         run: |
           # Update pip.
           #
@@ -95,9 +92,23 @@ jobs:
           # Make sure the help options print.
           python -m pyinstaller -h
 
-          # Run Qt-based tests with offscreen backend
+      - name: Set up environment variables (non-Windows)
+        if: ${{ !startsWith(matrix.os, 'windows') }}
+        run: |
+          # Run Qt-based tests with offscreen backend. This seems to break QtWebEngine tests on Windows, so
+          # apply it only here, in non-Windows path.
           echo "QT_QPA_PLATFORM=offscreen" >> $GITHUB_ENV
 
+          # Prevent setuptools from replacing distutils with its vendored version, as our test suite is not
+          # ready for that.
+          echo "SETUPTOOLS_USE_DISTUTILS=not-today" >> $GITHUB_ENV
+
+      # Use bash for this step, so that we can avoid dealing with PowerShell
+      # syntax for writing to environmental file on Windows.
+      - name: Set up environment variables (Windows)
+        if: startsWith(matrix.os, 'windows')
+        shell: bash
+        run: |
           # Prevent setuptools from replacing distutils with its vendored version, as our test suite is not
           # ready for that.
           echo "SETUPTOOLS_USE_DISTUTILS=not-today" >> $GITHUB_ENV

--- a/PyInstaller/hooks/hook-pkg_resources.py
+++ b/PyInstaller/hooks/hook-pkg_resources.py
@@ -9,7 +9,7 @@
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
 
-from PyInstaller.utils.hooks import collect_submodules
+from PyInstaller.utils.hooks import collect_submodules, is_module_satisfies
 
 # pkg_resources keeps vendored modules in its _vendor subpackage, and does sys.meta_path based import magic to expose
 # them as pkg_resources.extern.*
@@ -28,3 +28,24 @@ excludedimports = ['__main__']
 hiddenimports += collect_submodules('packaging')
 
 hiddenimports += ['pkg_resources.markers']
+
+# As of v60.7, setuptools vendored jaraco and has pkg_resources use it. Currently, the pkg_resources._vendor.jaraco
+# namespace package cannot be automatically scanned due to limited support for pure namespace packages in our hook
+# utilities.
+#
+# In setuptools 60.7.0, the vendored jaraco.text package included "Lorem Ipsum.txt" data file, which also has to be
+# collected. However, the presence of the data file (and the resulting directory hierarchy) confuses the importer's
+# redirection logic; instead of trying to work-around that, tell user to upgrade or downgrade their setuptools.
+if is_module_satisfies("setuptools == 60.7.0"):
+    raise SystemExit(
+        "ERROR: Setuptools 60.7.0 is incompatible with PyInstaller. "
+        "Downgrade to an earlier version or upgrade to a later version."
+    )
+# In setuptools 60.7.1, the "Lorem Ipsum.txt" data file was dropped from the vendored jaraco.text package, so we can
+# accommodate it with couple of hidden imports.
+elif is_module_satisfies("setuptools >= 60.7.1"):
+    hiddenimports += [
+        'pkg_resources._vendor.jaraco.functools',
+        'pkg_resources._vendor.jaraco.context',
+        'pkg_resources._vendor.jaraco.text',
+    ]

--- a/news/6564.hooks.rst
+++ b/news/6564.hooks.rst
@@ -1,0 +1,3 @@
+Add support for ``setuptools 60.7.1`` and its vendoring  of ``jaraco.text``
+in ``pkg_resources``. Exit with an error message if ``setuptools 60.7.0``
+is encountered due to incompatibility with PyInstaller's loader logic.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@
 
 ## IMPORTANT: Keep aligned with setup.cfg
 
-setuptools<50.0.0   # 50.0.0 breaks a modulegraph regession test
+setuptools
 altgraph
 pyinstaller-hooks-contrib >= 2020.11
 pefile; sys_platform == 'win32'


### PR DESCRIPTION
As of 60.7.0, `setuptools` vendored `jaraco.text` package in its `pkg_resources`, and their `VendoredImporter` does not seem to play nicely with our `FrozenImporter` when we collect the `Lorem Ipsum.txt` data file that is required by the vendored `jaraco.text` package.

In 60.7.1, `setuptools` dropped the `Lorem Ipsum.txt` data file from the vendored `jaraco.text` package, so we can accommodate it with a couple of hidden imports.

Initially, we also had a work-around for 60.7.0, but that worked only because it accidentally de-vendored the `jaraco.text` package, and may not play nicely in situations when the application also uses the actual jaraco.text package. So it is easier and safer to exit with an error in case `setuptools` 60.7.0 is encountered, and tell user to perform either downgrade or upgrade.

Fixes #6564. Fixes #6565. (Provided the user updates to 60.7.1).