### PR TITLE
Update typo/phrasing in WARNFILE_HEADER

### DIFF
--- a/PyInstaller/building/build_main.py
+++ b/PyInstaller/building/build_main.py
@@ -60,7 +60,7 @@ IMPORT_TYPES = [
 WARNFILE_HEADER = """\
 
 This file lists modules PyInstaller was not able to find. This does not
-necessarily mean this module is required for running you program. Python and
+necessarily mean this module is required for running your program. Python and
 Python 3rd-party packages include a lot of conditional or optional modules. For
 example the module 'ntpath' only exists on Windows, whereas the module
 'posixpath' only exists on Posix systems.
@@ -68,11 +68,11 @@ example the module 'ntpath' only exists on Windows, whereas the module
 Types if import:
 * top-level: imported at the top-level - look at these first
 * conditional: imported within an if-statement
-* delayed: imported from within a function
+* delayed: imported within a function
 * optional: imported within a try-except-statement
 
 IMPORTANT: Do NOT post this list to the issue-tracker. Use it as a basis for
-           yourself tracking down the missing module. Thanks!
+            tracking down the missing module yourself. Thanks!
 
 """
 


### PR DESCRIPTION
This is a simple PR to update the phrasing in the auto-generated WARNFILE from "running you program" to "running your program." It also standardizes the phrasing of the following bullet list to all start use the word "within." I'm a big fan of this project and happy to contribute this relatively meaningless change I noticed when debugging using the WARNFILE this morning.