### PR TITLE
bootloader: fix detection of 32-bit ARM platform in Thumb mode

### DIFF
--- a/PyInstaller/_shared_with_waf.py
+++ b/PyInstaller/_shared_with_waf.py
@@ -57,6 +57,10 @@ def _pyi_machine(machine, system):
     if machine.startswith(("arm", "aarch")):
         # ARM has a huge number of similar and aliased sub-versions, such as armv5, armv6l armv8h, aarch64.
         return "arm"
+    if machine in ("thumb"):
+        # Reported by waf/gcc when Thumb instruction set is enabled on 32-bit ARM. The platform.machine() returns "arm"
+        # regardless of the instruction set.
+        return "arm"
     if machine in ("x86_64", "x64", "x86"):
         return "intel"
     if re.fullmatch("i[1-6]86", machine):

--- a/news/6532.bootloader.rst
+++ b/news/6532.bootloader.rst
@@ -1,0 +1,3 @@
+Fix detection of 32-bit ``arm`` platform when Thumb instruction set is
+enabled in the compiler. In this case, the ``ctx.env.DEST_CPU`` in
+``waf`` build script is set to ``thumb`` instead of ``arm``.


### PR DESCRIPTION
When Thumb instruction set is enabled in gcc, `ctx.env.DEST_CPU` in `waf` build script ends up being set to `thumb` instead of `arm. So add a mapping of `thumb` to `arm` to properly detect the platform.

The `platform.machine()` under python reports `arm` regardless of the Thumb mode being enabled in compiler.

Fixes #6532.