### PR TITLE
isolated: add support for default (kw)args in isolated function calls

### DIFF
--- a/PyInstaller/isolated/_child.py
+++ b/PyInstaller/isolated/_child.py
@@ -44,8 +44,10 @@ def run_next_command(read_fh, write_fh):
         # It's time to end this child process
         return False
 
-    # There are 3 lines to read: The function's code, its args, then it kwargs.
+    # There are 5 lines to read: The function's code, its default args, its default kwargs, its args, and its kwargs.
     code = loads(b64decode(first_line.strip()))
+    _defaults = loads(b64decode(read_fh.readline().strip()))
+    _kwdefaults = loads(b64decode(read_fh.readline().strip()))
     args = loads(b64decode(read_fh.readline().strip()))
     kwargs = loads(b64decode(read_fh.readline().strip()))
 
@@ -54,6 +56,8 @@ def run_next_command(read_fh, write_fh):
         GLOBALS = {"__builtins__": __builtins__, "__isolated__": True}
         # Reconstruct the function.
         function = types.FunctionType(code, GLOBALS)
+        function.__defaults__ = _defaults
+        function.__kwdefaults__ = _kwdefaults
 
         # Run it.
         output = function(*args, **kwargs)

--- a/PyInstaller/isolated/_parent.py
+++ b/PyInstaller/isolated/_parent.py
@@ -148,9 +148,12 @@ class Python:
         if self._child is None:
             raise RuntimeError("An isolated.Python object must be used in a 'with' clause.")
 
-        # Send 3 lines to the child process: The function's code attribute and its args and kwargs, all serialised.
+        # Send 5 lines to the child process: The function's code attribute, its default args and kwargs, and its actual
+        # args and kwargs, all serialised.
         self._write_handle.writelines([
             b64encode(dumps(function.__code__)), b"\n",
+            b64encode(dumps(function.__defaults__)), b"\n",
+            b64encode(dumps(function.__kwdefaults__)), b"\n",
             b64encode(dumps(args)), b"\n",
             b64encode(dumps(kwargs)), b"\n",
         ])  # yapf: disable

--- a/tests/unit/test_isolation.py
+++ b/tests/unit/test_isolation.py
@@ -215,3 +215,39 @@ def test_is_isolated():
     assert is_isolated() is False
     assert isolated.call(is_isolated) is True
     assert is_isolated() is False
+
+
+def test_default_args():
+    """
+    Verify that default arguments are properly passed to the isolated function call.
+    """
+    def isolated_function(arg1='default1', arg2='default2', arg3='default3'):
+        return arg1, arg2, arg3
+
+    # Sanity check
+    assert isolated_function.__defaults__ == ('default1', 'default2', 'default3')
+    assert isolated_function.__kwdefaults__ is None
+
+    # Test by keeping the second argument at the default value
+    expected = 'override1', 'default2', 'override3'
+    with isolated.Python() as child:
+        actual = child.call(isolated_function, arg1='override1', arg3='override3')
+    assert actual == expected
+
+
+def test_default_kwargs():
+    """
+    Verify that default keyword-only arguments are properly passed to the isolated function call.
+    """
+    def isolated_function(*args, kwarg1='default1', kwarg2='default2', kwarg3='default3'):
+        return kwarg1, kwarg2, kwarg3
+
+    # Sanity check
+    assert isolated_function.__defaults__ is None
+    assert isolated_function.__kwdefaults__ == {'kwarg1': 'default1', 'kwarg2': 'default2', 'kwarg3': 'default3'}
+
+    # Test by keeping the second keyword-only argument at the default value
+    expected = 'override1', 'default2', 'override3'
+    with isolated.Python() as child:
+        actual = child.call(isolated_function, kwarg1='override1', kwarg3='override3')
+    assert actual == expected


### PR DESCRIPTION
In addition to function's `__code__` and `args` and `kwargs`, also transfer `__defaults__` and `__kwdefaults__` in order to avoid
missing-positional-argument errors when the isolated function is invoked without the optional arguments being explicitly set.