### PR TITLE
 building: macOS: limit binaries' architecture validation to extensions

### DIFF
--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -273,7 +273,8 @@ class PKG(Target):
                         dist_nm=inm,
                         target_arch=self.target_arch,
                         codesign_identity=self.codesign_identity,
-                        entitlements_file=self.entitlements_file
+                        entitlements_file=self.entitlements_file,
+                        strict_arch_validation=(typ == 'EXTENSION'),
                     )
 
                     mytoc.append((inm, fnm, self.cdict.get(typ, 0), self.xformdict.get(typ, 'b')))
@@ -889,7 +890,8 @@ class COLLECT(Target):
                     dist_nm=inm,
                     target_arch=self.target_arch,
                     codesign_identity=self.codesign_identity,
-                    entitlements_file=self.entitlements_file
+                    entitlements_file=self.entitlements_file,
+                    strict_arch_validation=(typ == 'EXTENSION'),
                 )
             if typ != 'DEPENDENCY':
                 if os.path.isdir(fnm):

--- a/PyInstaller/building/osx.py
+++ b/PyInstaller/building/osx.py
@@ -184,7 +184,8 @@ class BUNDLE(Target):
                     dist_nm=inm,
                     target_arch=self.target_arch,
                     codesign_identity=self.codesign_identity,
-                    entitlements_file=self.entitlements_file
+                    entitlements_file=self.entitlements_file,
+                    strict_arch_validation=(typ == 'EXTENSION'),
                 )
             # Add most data files to a list for symlinking later.
             if typ == 'DATA' and base_path not in _QT_BASE_PATH:

--- a/doc/feature-notes.rst
+++ b/doc/feature-notes.rst
@@ -192,6 +192,26 @@ is manually addressed (for example, by downloading the wheel corresponding to
 the missing architecture, and stiching the offending binary files together
 using the ``lipo`` utility).
 
+.. versionchanged:: 4.10
+   In earlier |PyInstaller| versions, the architecture validation was performed
+   on all collected binaries, such as python extension modules and the
+   shared libraries referenced by those extensions. As of |PyInstaller| 4.10,
+   the architecture validation is limited to only python extension modules.
+
+   The individual architecture slices in a multi-arch ``universal2`` extension
+   may be linked against (slices in) ``universal2`` shared libraries, or
+   against distinct single-arch thin shared libraries. This latter case makes
+   it impossible to reliably validate architecture of the collected shared
+   libraries w.r.t. the target application architecture.
+
+   However, the extension modules do need to be fully compatible with the target
+   application architecture. Therefore, their continued validation should
+   hopefully suffice to detect attempts at using incompatible single-arch
+   python packages [*]_.
+
+.. [*] Although nothing really prevents a package from having distinct,
+   architecture-specific extension modules...
+
 
 Trimming fat binaries for single-arch targets
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/news/6587.bugfix.rst
+++ b/news/6587.bugfix.rst
@@ -1,0 +1,5 @@
+(macOS) Limit the strict architecture validation for collected binaries to
+extension modules only. Fixes architecture validation errors when a
+``universal2`` package has its multi-arch extension modules' arch slices
+linked against distinct single-arch thin shared libraries, as is the
+case with ``scipy`` 1.8.0 macOS ``universal2`` wheel.

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -49,9 +49,7 @@ pyqt6-webengine-qt6==6.2.3  # Qt6 QtWebEngine binaries
 python-dateutil==2.8.2
 pytz==2021.3
 requests==2.27.1
-# scipy's universal2 wheels contain universal2 extension modules whose slices
-# are linked to different thin binaries which our bindepend lacks support for.
-scipy==1.7.3  # pyup: ignore
+scipy==1.8.0; python_version >= '3.8'
 # simplejson is used for text_c_extension
 simplejson==3.17.6
 sphinx==4.4.0


### PR DESCRIPTION
As demonstrated by `scipy` 1.8.0, the multi-arch `universal2` extensions may have their individual arch slices linked against distinct single-arch thin shared libraries.

Such thin shared libraries will fail the current strict architecture validation, either by virtue of being single-arch (whereas the target architecture is `universal2`) or by virtue of at least one single-arch thin shared library being of incompatible architecture (e.g., `arm64` thin shared library will be flagged as incompatible for `x86_64` target, and `x86_64` thin shared library will be flagged as incompatible for `arm64` target).

Therefore, limit the architecture validation only to python extension modules, which do need to be fully compatible with the target arch (at least until someone decides to ship distinct, arch-specific modules. But if that does happen, we can probably prevent the collection of incompatible module via hooks). The extension validation should hopefully still catch the attempts at using incompatible single-arch packages when trying to build a `universal2` application or a single-arch application for architecture that's different from the running one.