### PR TITLE
tests & ci: sync pinned package versions with develop branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu')
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -qq \
+          sudo apt-get install -qq --no-install-recommends \
             libxml2-dev libxslt1-dev gfortran libatlas-base-dev \
             libespeak1 libxcb-image0 libxcb-keysyms1 libxcb-render-util0 \
             libxkbcommon-x11-0 libxcb-icccm4 libxcb1 openssl \
@@ -47,7 +47,8 @@ jobs:
             libxcb-shape0-dev libxcb-xkb-dev xvfb \
             libopengl0 libegl1 \
             libpulse0 libpulse-mainloop-glib0 \
-            libgstreamer-plugins-base1.0-0 libgstreamer-gl1.0-0
+            libgstreamer-plugins-base1.0-0 libgstreamer-gl1.0-0 \
+            gir1.2-gtk-3.0 libgirepository1.0-dev
 
       - name: Download AppImage tool
         if: startsWith(matrix.os, 'ubuntu')

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -9,7 +9,7 @@
 -r requirements-tools.txt
 
 # Backport of importlib.resources for python 3.8 and earlier.
-importlib_resources==5.2.2; python_version < '3.9'
+importlib_resources==5.4.0; python_version < '3.9'
 
 # Needs work
 # ----------
@@ -19,8 +19,6 @@ importlib_resources==5.2.2; python_version < '3.9'
 #
 # - v. 2.2 and above fails.
 Django==2.1.8  # pyup: ignore
-# - v 21.1.0 fails; earlier versions not tested.
-keyring==19.2.0  # pyup: ignore
 
 
 # Working
@@ -28,40 +26,54 @@ keyring==19.2.0  # pyup: ignore
 # These packages work with no (known) issues.
 babel==2.9.1
 future==0.18.2
-gevent==21.8.0
-pygments==2.10.0
-pyside2==5.15.2; python_version < '3.10'
+gevent==21.12.0
+# keyring >= 23.1 requires python >= 3.8.7 on macOS 11 and later (with dyld shared cache support)
+# For python 3.6, we pin keyring in the "unsupported versions" section.
+keyring==23.0.1; python_version > '3.6' and (sys_platform == 'darwin' and python_version < '3.8.7')  # pyup: ignore
+keyring==23.5.0; python_version > '3.6' and (sys_platform != 'darwin' or python_version >= '3.8.7')
+pygments==2.11.2
+PyGObject==3.42.0; sys_platform == 'linux'
+pyside2==5.15.2.1
 # pyside6 6.2.2 wheel is incompatible with python < 3.8 on macOS
 pyside6==6.2.1; sys_platform == 'darwin' and python_version < '3.8'  # pyup: ignore
-pyside6==6.2.2; sys_platform != 'darwin' or python_version >= '3.8'
+pyside6==6.2.3; sys_platform != 'darwin' or python_version >= '3.8'
 pyqt5==5.15.6; python_version < '3.10'
 pyqtwebengine==5.15.5; python_version < '3.10'
-pyqt6==6.2.2  # PyQt6 Qt6 bindings
-pyqt6-qt6==6.2.2  # Qt6 binaries (keep in sync with pyqt6 version!)
+pyqt6==6.2.3  # PyQt6 Qt6 bindings
+pyqt6-qt6==6.2.3  # Qt6 binaries (keep in sync with pyqt6 version!)
 pyqt6-webengine==6.2.1  # PyQt6 QtWebEngine bindings
-pyqt6-webengine-qt6==6.2.2  # Qt6 QtWebEngine binaries
+pyqt6-webengine-qt6==6.2.3  # Qt6 QtWebEngine binaries
 python-dateutil==2.8.2
-pytz==2021.1
-requests==2.26.0
+pytz==2021.3
+requests==2.27.1
 # simplejson is used for text_c_extension
-simplejson==3.17.5
-sphinx==4.2.0
+simplejson==3.17.6
+sphinx==4.4.0
 # Required for test_namespace_package
-sqlalchemy==1.4.25
+sqlalchemy==1.4.31
 zope.interface==5.4.0
-Pillow==8.3.2
+Pillow==9.0.1; python_version > '3.6'
+Pillow==8.4.0; python_version <= '3.6'  # pyup: ignore
 
 
 # Python versions not supported / supported for older package versions
 # -------------------------------------------------------
 
+# keyring 23.4.1 is the last version available for python 3.6.
+# As python 3.6 is not supported on macOS 11 anyway, we do not need
+# to worry about keyring >= 23.1 requiring dyld shared cache support,
+# and can pin to latest supported version, 23.4.1.
+keyring==23.4.1; python_version <= '3.6'  # pyup: ignore
+
 # iPython 7.17 dropped support for python 3.6
-# https://ipython.readthedocs.io/en/stable/whatsnew/version7.html#ipython-7-17
-ipython==7.28.0; python_version > '3.6'
+# iPython 8.0 dropped support for python 3.7
+ipython==8.0.1; python_version >= '3.8'
+ipython==7.31.0; python_version == '3.7'  # pyup: ignore
 ipython==7.16.1; python_version <= '3.6'  # pyup: ignore
 
 # pandas also dropped support
-pandas==1.3.3; python_version > '3.6' and python_version < '3.10'
+pandas==1.4.1; python_version >= '3.8'
+pandas==1.3.5; python_version == '3.7'  # pyup: ignore
 pandas==1.1.5; python_version <= '3.6'  # pyup: ignore
 
 # so did numpy (which also dropped support for 3.7 as of 1.22)
@@ -75,7 +87,8 @@ scipy==1.7.3; python_version == '3.7'  # pyup: ignore
 scipy==1.5.4; python_version <= '3.6'  # pyup: ignore
 
 # and matplotlib
-matplotlib==3.4.3; python_version > '3.6' and python_version < '3.10'
+matplotlib==3.5.1; python_version >= '3.8'
+matplotlib==3.4.3; python_version == '3.7'  # pyup: ignore
 matplotlib==3.3.4; python_version <= '3.6'  # pyup: ignore
 
 # Install PyInstaller Hook Sample, to ensure that tests declared in


### PR DESCRIPTION
Manually sync the pinned versions in `requirements-libraries.txt` with those in develop branch in order to extend test coverage on python 3.10.

Also enable `PyGObject` tests on linux.