### PR TITLE
tests: gevent tests: remove no-op excludes

### DIFF
--- a/tests/functional/test_libraries.py
+++ b/tests/functional/test_libraries.py
@@ -26,26 +26,18 @@ _DATA_DIR = py.path.local(os.path.abspath(__file__)).dirpath('data')
 
 @importorskip('gevent')
 def test_gevent(pyi_builder):
-    pyi_builder.test_source(
-        """
+    pyi_builder.test_source("""
         import gevent
         gevent.spawn(lambda: x)
-        """,
-        # Reduce footprint of the test (and avoid issued introduced by one of these packages breaking).
-        excludes=["PySide2", "PyQt5", "numpy", "scipy"]
-    )
+        """)
 
 
 @importorskip('gevent')
 def test_gevent_monkey(pyi_builder):
-    pyi_builder.test_source(
-        """
+    pyi_builder.test_source("""
         from gevent.monkey import patch_all
         patch_all()
-        """,
-        # Reduce footprint of the test (and avoid issued introduced by one of these packages breaking).
-        excludes=["PySide2", "PyQt5", "numpy", "scipy"]
-    )
+        """)
 
 
 # The tkinter module may be available for import, but not actually importable due to missing shared libraries.


### PR DESCRIPTION
The `gevent` tests seem to be attempting to exclude several packages. As per comment in 416e1a0e83bf5a4924cc50d2befa2bb622b55107, this was introduced in an attempt to break the following Windows-specific
import chain: `setuptools.msvc` -> `numpy` -> `numpy.testing` -> `pytest` -> `pygments` -> `PIL` -> `PIL.ImageQt` -> `PySide2`.

However, nowadays we already break that chain in two places: our [`setuptools.msvc` hook](https://github.com/pyinstaller/pyinstaller/blob/9db19c9f0ad00766f13abd19548c279f102d810a/PyInstaller/hooks/hook-setuptools.msvc.py#L13) excludes `numpy`, and our [`numpy` hook](https://github.com/pyinstaller/pyinstaller/blob/9db19c9f0ad00766f13abd19548c279f102d810a/PyInstaller/hooks/hook-numpy.py#L46) excludes `pytest`.

More importantly, `excludes` is not a valid keyword argument for the `pyi_builder.test_source` (anymore?), and is quietly swallowed by the `**kwargs`. So those exclude lists achieve nothing, except confusing people who look at existing code to find a way to exclude packages in a test. (As a side note, the tests that do use `excludes` keyword argument are passing it to the modulegraph's functions, not the  `pyi_builder` fixture ones.)