### PR TITLE
hooks: PIL: prevent automatic inclusion of IPython

### DIFF
--- a/PyInstaller/hooks/hook-PIL.py
+++ b/PyInstaller/hooks/hook-PIL.py
@@ -15,3 +15,7 @@
 # Ignore tkinter to prevent inclusion of Tcl/Tk library and other GUI libraries. Assume that if people are really using
 # tkinter in their application, they will also import it directly and thus PyInstaller bundles the right GUI library.
 excludedimports = ['tkinter', 'PyQt5', 'PySide2', 'PyQt6', 'PySide6']
+
+# Similarly, prevent inclusion of IPython, which in turn ends up pulling in whole matplotlib, along with its optional
+# GUI library dependencies.
+excludedimports += ['IPython']

--- a/news/6605.hooks.rst
+++ b/news/6605.hooks.rst
@@ -1,0 +1,4 @@
+Add ``IPython`` to the list of excluded packages in the ``PIL`` hook in
+order to prevent automatic collection of ``IPython`` when it is not
+imported anywhere else. This in turn prevents whole ``matplotlib`` being
+automatically pulled in when using  ``PIL.Image``.

--- a/tests/functional/test_hooks/test_pil.py
+++ b/tests/functional/test_hooks/test_pil.py
@@ -82,3 +82,27 @@ def test_pil_tkinter(pyi_builder):
             raise SystemExit('ERROR: Module tkinter is NOT bundled.')
         """
     )
+
+
+@importorskip('PIL')
+@importorskip('matplotlib')
+def test_pil_no_matplotlib(pyi_builder):
+    """
+    Ensure that using PIL.Image does not pull in `matplotlib` when the latter is not explicitly imported by the program.
+    The import chain in question,
+    PIL.Image -> PIL -> PIL.ImageShow -> IPython -> matplotlib_inline.backend_inline -> matplotlib,
+    should be broken by the PIL hook excluding IPython.
+    """
+
+    pyi_builder.test_source(
+        """
+        import PIL.Image
+
+        # Use dynamic import of matplotlib to prevent PyInstaller from picking up the import.
+        try:
+            __import__('matplotlib')
+            raise SystemExit('ERROR: matplotlib is bundled.')
+        except ImportError:
+            pass
+        """
+    )


### PR DESCRIPTION
`PIL.ImageShow` conditionally imports `IPython`, which in turn ends up pulling in whole `matplotlib`, along with its optional GUI dependencies.

So add `IPython` to the list of packages excluded by `PIL`, same as we already do for the major GUI frameworks.