### PR TITLE
utils: misc: fix needs_compile check in compile_py_files

### DIFF
--- a/PyInstaller/utils/misc.py
+++ b/PyInstaller/utils/misc.py
@@ -151,7 +151,7 @@ def compile_py_files(toc, workpath):
 
         # We need to perform a build ourselves if obj_fnm does not exist, or if src_fnm is newer than obj_fnm, or if
         # obj_fnm was created by a different Python version.
-        needs_compile = mtime(src_fnm) > mtime(obj_fnm)
+        needs_compile = not os.path.exists(obj_fnm) or mtime(src_fnm) > mtime(obj_fnm)
         if not needs_compile:
             with open(obj_fnm, 'rb') as fh:
                 needs_compile = fh.read(4) != BYTECODE_MAGIC
@@ -185,7 +185,7 @@ def compile_py_files(toc, workpath):
                     os.makedirs(leading)
 
                 obj_fnm = os.path.join(leading, mod_name + ext)
-                needs_compile = mtime(src_fnm) > mtime(obj_fnm)
+                needs_compile = not os.path.exists(obj_fnm) or mtime(src_fnm) > mtime(obj_fnm)
                 if not needs_compile:
                     with open(obj_fnm, 'rb') as fh:
                         needs_compile = fh.read(4) != BYTECODE_MAGIC

--- a/news/6625.bugfix.rst
+++ b/news/6625.bugfix.rst
@@ -1,0 +1,2 @@
+Fix an attempt to collect a non-existent ``.pyc`` file when the corresponding
+source ``.py`` file has ``st_mtime`` set to zero.


### PR DESCRIPTION
When determining whether `utils.misc.compile_py_files` needs to (re)compile a `.pyc` file, explicitly check for its existence before comparing modification times.

This prevents `utils.misc.compile_py_files` from trying to collect a non-existent `.pyc` file when the corresponding source `.py` file happens to have its `st_mtime` set to zero.

Fixes #6625.