### PR TITLE
Building: Replace .exe suffix of temporary EXE files (#6467).

### DIFF
--- a/news/6467.bugfix.rst
+++ b/news/6467.bugfix.rst
@@ -1,0 +1,3 @@
+(Windows) Use a made up (not ``.exe``) suffix for intermediate executable files during the build process to prevent
+antiviruses from attempting to scan the file whilst PyInstaller is still working on it leading to a
+:class:`PermissionError` at build time.


### PR DESCRIPTION
Whenever an intermediate/temporary executable file needs to be written, give it the filename extension `.notanexecutable` instead of `.exe`. This fools Microsoft Defender into thinking that the file is not an executable which requires scanning.

I thought it might be easier to target the `v4` branch then forward-port instead of targetting `develop`.