### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,8 @@
 name = pyinstaller
 version = attr: PyInstaller.__version__
 url = https://www.pyinstaller.org/
+project_urls =
+    Source = https://github.com/pyinstaller/pyinstaller
 
 description = PyInstaller bundles a Python application and all its dependencies into a single package.
 # Long description consists of README.rst only


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)