### PR TITLE
Remove some over-egear subprocess timeouts

### DIFF
--- a/news/6644.bugfix.rst
+++ b/news/6644.bugfix.rst
@@ -1,0 +1,2 @@
+(macOS) Remove the 60 seconds timeout for each ``codesign`` and ``lipo`` operation which caused build abortion when
+processing huge binaries.

--- a/news/6647.bugfix.rst
+++ b/news/6647.bugfix.rst
@@ -1,0 +1,2 @@
+(Linux) Remove the timeout on ``objcopy`` operations to prevent wrongful
+abortions when processing large executables on slow disks.


### PR DESCRIPTION
- macOS: Remove the timeouts for codesigning/signature stripping/lipo. (fixes #6644)
- Linux: Replace the timeout on ``objcopy`` operations with progress logs.
