### PR TITLE
splash: add always_on_top option for behavior configuration

### DIFF
--- a/PyInstaller/building/splash.py
+++ b/PyInstaller/building/splash.py
@@ -120,6 +120,11 @@ class Splash(Target):
             resized to fit the maximum width (to keep the original aspect ratio). This option can be disabled by
             setting it to None. Default: (760, 480)
         :type max_img_size: Tuple[int, int]
+        :keyword always_on_top:
+            Force the splashscreen to be always on top of other windows. If disabled, other windows (e.g., from other
+            applications) can cover the splash screen by user bringing them to front. This might be useful for
+            frozen applications with long startup times. Default: True
+        :type always_on_top: bool
         """
         from ..config import CONF
         Target.__init__(self)
@@ -151,6 +156,9 @@ class Splash(Target):
         self.text_font = kwargs.get("text_font", "TkDefaultFont")
         self.text_color = kwargs.get("text_color", "black")
         self.text_default = kwargs.get("text_default", "Initializing")
+
+        # always-on-top behavior
+        self.always_on_top = kwargs.get("always_on_top", True)
 
         # Save the generated file separately so that it is not necessary to generate the data again and again
         root = os.path.splitext(self.tocfilename)[0]
@@ -244,6 +252,7 @@ class Splash(Target):
         ('text_font', _check_guts_eq),
         ('text_color', _check_guts_eq),
         ('text_default', _check_guts_eq),
+        ('always_on_top', _check_guts_eq),
         ('full_tk', _check_guts_eq),
         ('minify_script', _check_guts_eq),
         ('rundir', _check_guts_eq),
@@ -416,7 +425,7 @@ class Splash(Target):
                 'font_size': self.text_size,
                 'default_text': self.text_default,
             })
-        script = splash_templates.build_script(text_options=d)
+        script = splash_templates.build_script(text_options=d, always_on_top=self.always_on_top)
 
         if self.minify_script:
             # Remove any documentation, empty lines and unnecessary spaces

--- a/PyInstaller/building/templates.py
+++ b/PyInstaller/building/templates.py
@@ -137,5 +137,6 @@ splashtmpl = """splash = Splash(
     text_pos=None,
     text_size=12,
     minify_script=True,
+    always_on_top=True,
 )
 """

--- a/news/6641.feature.rst
+++ b/news/6641.feature.rst
@@ -1,0 +1,5 @@
+Add an optional ``always_on_top`` boolean argument to the ``Splash`` class.
+This allows users to disable the always-on-top behavior of the splash
+screen for their application in order to make it less obnoxious.
+By default, the always-on-top behavior is enabled for the sake of
+consistency with earlier releases.


### PR DESCRIPTION
Allow user to enable or disable the always-on-top behavior at build time via `always_on_top` boolean argument to `Splash()`.

By default, the always-on-top behavior is enabled for the sake of consistency with previous releases.

Closes #6641.