### PR TITLE
splash: use bundled vcruntime140.dll in Windows onefile builds

### DIFF
--- a/news/6284.bugfix.rst
+++ b/news/6284.bugfix.rst
@@ -1,0 +1,3 @@
+(Windows) Fix the splash screen in onefile build not using the bundled copy
+of ``vcruntime140.dll`` and thus failing to load the Tcl/Tk shared libraries
+when the system has no ``vcruntime140.dll`` available.


### PR DESCRIPTION
On Windows, add `vcruntime140.dll` to the list of splash requirements in order to have it extracted into the initial runtime directory when running in `onefile` mode. This way, when we try to load Tcl/Tk shared libraries, the extracted copy of `vcruntime140.dll` is used instead of system-installed copy (which may be unavailable if the system does not have VC runtime installed).

Fixes #6284.