### PR TITLE
building: fix TOC.__sub__ operator

### DIFF
--- a/PyInstaller/building/datastruct.py
+++ b/PyInstaller/building/datastruct.py
@@ -105,17 +105,9 @@ class TOC(list):
             self.append(entry)
 
     def __sub__(self, other):
+        # Construct new TOC with entries not contained in the other TOC
         other = TOC(other)
-        filenames = self.filenames - other.filenames
-        result = TOC()
-        for entry in self:
-            unique = unique_name(entry)
-
-            if unique in filenames:
-                # Directly use list.append() instead of TOC.append() to avoid unnecessary uniqueness checks.
-                # Hence the use of super(TOC, result).
-                super(TOC, result).append(entry)
-        return result
+        return TOC([entry for entry in self if unique_name(entry) not in other.filenames])
 
     def __rsub__(self, other):
         result = TOC(other)

--- a/news/6669.bugfix.rst
+++ b/news/6669.bugfix.rst
@@ -1,0 +1,2 @@
+Fix the behavior of ``TOC.__sub__`` operator where repeated subtractions
+result in an empty TOC.

--- a/tests/unit/test_TOC.py
+++ b/tests/unit/test_TOC.py
@@ -264,6 +264,14 @@ def test_sub_after_setitem():
     assert len(toc) == 3
 
 
+def test_sub_after_sub():
+    toc = TOC(ELEMS1)
+    toc -= [ELEMS1[0]]
+    toc -= [ELEMS1[1]]
+    expected = list(ELEMS1[2:])
+    assert toc == expected
+
+
 def test_setitem_1():
     toc = TOC()
     toc[:] = ELEMS1


### PR DESCRIPTION
Replace the `TOC.__sub__` operator implementation with a simpler one that properly keeps track of the filenames. Add a test that
involves two subsequent subtractions to demonstrate the bug in the old implementation.

Fixes #6669.