### PR TITLE
bootloader: avoid using PRIu64 with PyUnicode_FromFormat

### DIFF
--- a/bootloader/src/pyi_pythonlib.c
+++ b/bootloader/src/pyi_pythonlib.c
@@ -664,7 +664,7 @@ int
 pyi_pylib_install_zlib(ARCHIVE_STATUS *status, TOC *ptoc)
 {
     int rc = 0;
-    uint64_t zlibpos = status->pkgstart + ptoc->pos;
+    unsigned long long zlibpos = status->pkgstart + ptoc->pos;
     PyObject * sys_path, *zlib_entry, *archivename_obj;
 
     /* Note that sys.path contains PyUnicode on py3. Ensure
@@ -682,7 +682,7 @@ pyi_pylib_install_zlib(ARCHIVE_STATUS *status, TOC *ptoc)
      */
     archivename_obj = PI_PyUnicode_DecodeFSDefault(status->archivename);
 #endif
-    zlib_entry = PI_PyUnicode_FromFormat("%U?%" PRIu64, archivename_obj, zlibpos);
+    zlib_entry = PI_PyUnicode_FromFormat("%U?%llu", archivename_obj, zlibpos);
     PI_Py_DecRef(archivename_obj);
 
     sys_path = PI_PySys_GetObject("path");

--- a/news/6686.bugfix.rst
+++ b/news/6686.bugfix.rst
@@ -1,0 +1,5 @@
+Fix frozen module loading errors during the frozen application's bootstrap
+that arise from the bootloader's use of the ``PRIu64`` macro with the
+``PyUnicode_FromFormat`` call and the former translating to an incompatible
+format specifier on some toolchains (e.g., when cross-compiling Windows
+bootloader with mingw-w64 7.0.0 toolchain on Ubuntu 20.04 LTS).


### PR DESCRIPTION
The value of `PRIu64` can translate to a format specifier not understood by the `PyUnicode_FromFormat()`. Use `%llu` instead, and change the type of `zlibpos` from `uint64_t` to `unsigned long long` to ensure that the expected type width always matches (technically, `uint64_t` is exactly 64-bit, while `unsigned long long` is at least 64-bit).

Fixes #6686.