### PR TITLE
building: TOC: case-normalize all file-related entry names, regardles of typecode

### DIFF
--- a/PyInstaller/building/datastruct.py
+++ b/PyInstaller/building/datastruct.py
@@ -31,7 +31,7 @@ def unique_name(entry):
     unique_name: str
     """
     name, path, typecode = entry
-    if typecode in ('BINARY', 'DATA'):
+    if typecode != 'OPTION' and name is not None:
         name = os.path.normcase(name)
 
     return name

--- a/doc/advanced-topics.rst
+++ b/doc/advanced-topics.rst
@@ -316,6 +316,26 @@ are ``None``.
 Because set membership is based on the *name* element of a tuple only,
 it is not necessary to give accurate *path* and *typecode* elements when subtracting.
 
+.. Note::
+    When determining the set membership of the file-related entries, the *name*
+    is case-normalized using the :func:`os.path.normcase` function. Therefore on
+    Windows, the *name* comparison is effectively performed in *case-insensitive*
+    way, while on the other OSes, it is performes in *case-sensitive* way, and
+    roughly mimicks the behavior of the underyling filesystem.
+
+    This means that on Windows, it is impossible to add multiple entries with
+    the same name but different case, and it is possible to remove an entry
+    via subtraction by giving its name in either upper or lower (or even mixed)
+    case.
+
+    On other OSes, it is possible to add multiple entries with differently-cased
+    name, and removal of an entry via subtraction requires an exact
+    (case-sensitive) match.
+
+    This behavior is applicable to all file-related typecodes (all typecodes
+    other than ``'OPTION'``), or when typecode is not specified (e.g., for
+    subtraction operator).
+
 In order to add files to a TOC, you need to know the *typecode* values
 and their related *path* values.
 A *typecode* is a one-word string.

--- a/news/6688.bugfix.rst
+++ b/news/6688.bugfix.rst
@@ -1,0 +1,2 @@
+(Windows) Ensure consistent behavior w.r.t. case normalization of the
+entry name when subtracting ``TOC`` entries without specified type code.

--- a/news/6689.breaking.rst
+++ b/news/6689.breaking.rst
@@ -1,0 +1,5 @@
+(Windows) The ``TOC`` class now internally case-normalizes names of
+all file-related entries, regardless of their type code, as opposed to
+just ``BINARY`` and ``DATA`` entries. This ensures the behavior that is
+consistent with the underlying case-insensitive filesystem on Windows,
+but may affect assumptions made by external ``TOC`` users.

--- a/news/6689.doc.rst
+++ b/news/6689.doc.rst
@@ -1,0 +1,3 @@
+Add a note about case normalization of the name for keeping track of the
+entries in the ``TOC`` class, and its implication on entry addition/removal
+behavior on different OSes.

--- a/tests/unit/test_TOC.py
+++ b/tests/unit/test_TOC.py
@@ -370,3 +370,49 @@ def test_insert_other_case_binary():
     if is_case_sensitive:
         expected.insert(1, elem)
     assert toc == expected
+
+
+# Test that subtraction works as expected when the entry specifies only the name, without path and typecode.
+# On Windows, the subtraction should work with case-normalized names for BINARY and DATA entries, while on other
+# OSes, it should be case sensitive for all entry types.
+def test_subtract_same_case_binary():
+    # Subtract with same case - removes element on all OSes
+    toc = TOC(ELEMS1)
+    elem = ('libCamelCase.so.1', '/lib64/libcamelcase.so.1', 'BINARY')
+    toc.append(elem)
+    toc -= [('libCamelCase.so.1', None, None)]
+    expected = list(ELEMS1)
+    assert toc == expected
+
+
+def test_subtract_other_case_binary():
+    # Subtract with different case - removes element only on Windows
+    toc = TOC(ELEMS1)
+    elem = ('libCamelCase.so.1', '/lib64/libcamelcase.so.1', 'BINARY')
+    toc.append(elem)
+    toc -= [('libcamelcase.so.1', None, None)]
+    expected = list(ELEMS1)
+    if is_case_sensitive:
+        expected.append(elem)
+    assert toc == expected
+
+
+def test_subtract_same_case_pymodule():
+    # Subtract with same case - removes element on all OSes
+    toc = TOC(ELEMS1)
+    elem = ('modCamelCase', '/lib64/python3.9/site-packages/modCamelCase.py', 'PYMODULE')
+    toc.append(elem)
+    toc -= [('modCamelCase', None, None)]
+    expected = list(ELEMS1)
+    assert toc == expected
+
+
+def test_subtract_other_case_pymodule():
+    # Subtract with different case - removes element only on Windows
+    toc = TOC(ELEMS1)
+    elem = ('modCamelCase', '/lib64/python3.9/site-packages/modCamelCase.py', 'PYMODULE')
+    toc.append(elem)
+    toc -= [('modcamelcase', None, None)]
+    expected = list(ELEMS1)
+    expected.append(elem)
+    assert toc == expected

--- a/tests/unit/test_TOC.py
+++ b/tests/unit/test_TOC.py
@@ -12,7 +12,7 @@
 # This contains tests for the class:``TOC``, see
 # https://pyinstaller.readthedocs.io/en/latest/advanced-topics.html#the-toc-and-tree-classes
 
-import pytest
+import os
 
 from PyInstaller.building.datastruct import TOC
 
@@ -57,7 +57,7 @@ def test_append_existing():
 
 
 def test_append_keep_filename():
-    # name in TOC should be the same as the one added
+    # The entry name in TOC should be identical to the one added (i.e., the case must be preserved).
     toc = TOC()
     entry = ('EnCodIngs', '/usr/lib/python2.7/encodings.py', 'BINARY')
     toc.append(entry)
@@ -81,7 +81,7 @@ def test_insert_existing():
 
 
 def test_insert_keep_filename():
-    # name in TOC should be the same as the one added
+    # The entry name in TOC should be identical to the one added (i.e., the case must be preserved).
     toc = TOC()
     entry = ('EnCodIngs', '/usr/lib/python2.7/encodings.py', 'BINARY')
     toc.insert(1, entry)
@@ -299,21 +299,24 @@ def test_setitem_2():
 
 # The following tests verify that case-insensitive comparisons are used on Windows and only for
 # appropriate TOC entry types
+is_case_sensitive = os.path.normcase('CamelCase') == 'CamelCase'
 
 
-@pytest.mark.win32
 def test_append_other_case_mixed():
-    # If a binary file is added with the same filename as an existing pymodule, it should not be added.
+    # Try appending a BINARY entry with same-but-differently-cased name as an existing PYMODULE entry.
+    # Not added on Windows, added elsewhere.
     toc = TOC(ELEMS1)
     elem = ('EnCodIngs', '/usr/lib/python2.7/encodings.py', 'BINARY')
     toc.append(elem)
     expected = list(ELEMS1)
+    if is_case_sensitive:
+        expected.append(elem)
     assert toc == expected
 
 
-@pytest.mark.win32
 def test_append_other_case_pymodule():
-    # Python modules should not use C-I comparisons. Both 'encodings' and 'EnCodIngs' should be added.
+    # Try appending a PYMODULE entry with same-but-differently-cased name as an existing PYMODULE entry.
+    # Added on all OSes.
     toc = TOC(ELEMS1)
     elem = ('EnCodIngs', '/usr/lib/python2.7/encodings.py', 'PYMODULE')
     toc.append(elem)
@@ -322,28 +325,33 @@ def test_append_other_case_pymodule():
     assert toc == expected
 
 
-@pytest.mark.win32
 def test_append_other_case_binary():
-    # Binary files should use C-I comparisons. 'LiBrEADlInE.so.6' should not be added.
+    # Try appending a BINARY entry with same-but-differently-cased name as an existing BINARY entry.
+    # Not added on Windows, added elsewhere.
     toc = TOC(ELEMS1)
-    toc.append(('LiBrEADlInE.so.6', '/lib64/libreadline.so.6', 'BINARY'))
+    elem = ('LiBrEADlInE.so.6', '/lib64/libreadline.so.6', 'BINARY')
+    toc.append(elem)
     expected = list(ELEMS1)
+    if is_case_sensitive:
+        expected.append(elem)
     assert toc == expected
 
 
-@pytest.mark.win32
 def test_insert_other_case_mixed():
-    # If a binary file is added with the same filename as an existing pymodule, it should not be added.
+    # Try inserting a BINARY entry with same-but-differently-cased name as an existing PYMODULE entry.
+    # Not added on Windows, added elsewhere.
     toc = TOC(ELEMS1)
     elem = ('EnCodIngs', '/usr/lib/python2.7/encodings.py', 'BINARY')
     toc.insert(1, elem)
     expected = list(ELEMS1)
+    if is_case_sensitive:
+        expected.insert(1, elem)
     assert toc == expected
 
 
-@pytest.mark.win32
 def test_insert_other_case_pymodule():
-    # Python modules should not use C-I comparisons. Both 'encodings' and 'EnCodIngs' should be added.
+    # Try appending a PYMODULE entry with same-but-differently-cased name as an existing PYMODULE entry.
+    # Added on all OSes.
     toc = TOC(ELEMS1)
     elem = ('EnCodIngs', '/usr/lib/python2.7/encodings.py', 'PYMODULE')
     toc.insert(1, elem)
@@ -352,10 +360,13 @@ def test_insert_other_case_pymodule():
     assert toc == expected
 
 
-@pytest.mark.win32
 def test_insert_other_case_binary():
-    # Binary files should use C-I comparisons. 'LiBrEADlInE.so.6' should not be added.
+    # Try appending a BINARY entry with same-but-differently-cased name as an existing BINARY entry.
+    # Not added on Windows, added elsewhere.
     toc = TOC(ELEMS1)
-    toc.insert(1, ('LiBrEADlInE.so.6', '/lib64/libreadline.so.6', 'BINARY'))
+    elem = ('LiBrEADlInE.so.6', '/lib64/libreadline.so.6', 'BINARY')
+    toc.insert(1, elem)
     expected = list(ELEMS1)
+    if is_case_sensitive:
+        expected.insert(1, elem)
     assert toc == expected


### PR DESCRIPTION
When storing TOC entry's name for internal bookkeeping (e.g., to prevent duplication), case-normalize names for all file-related entries (at the moment, all but `OPTION` entries) instead of just BINARY and DATA. The primary motivation is to make normalization behavior more consistent in cases when typecode is not specified (e.g., subtracting an entry that contains only the name but not source path nor typecode), but with normalizing all entry names, the behavior of TOC should be more consistent with the underlying filename. For example, on Windows, we cannot have `MyCamelCaseModule.py` and `mycamecasemodule.py` on filesystem, so it makes little sense for TOC to be case sensitive for PYMODULE entries, and allow both `MyCamelCaseModule` and `mycamelcasemodule` entries. 

The change in behavior is applicable only to Windows. Hopefully, it should not really impact anything outside of fixing the behavior when subtracting without typecode. Fixes #6688. 

Also add a note about case normalization behavior to the docs, because the behavior is different between Windows and other OSes (and it always was), and this might trip someone up.