### PR TITLE
hookutils: add support for resolving metadata .egg-info files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,3 +15,4 @@ news
 .github
 PyInstaller/bootloader/Windows*
 **/*.egg-info
+!tests/functional/modules/pyi_single_file_metadata/my_test_package-1.0.egg-info

--- a/PyInstaller/building/build_main.py
+++ b/PyInstaller/building/build_main.py
@@ -262,6 +262,14 @@ class Analysis(Target):
         logger.info('Extending PYTHONPATH with paths\n' + pprint.pformat(self.pathex))
         sys.path.extend(self.pathex)
 
+        # If pkg_resources has already been imported, force update of its working set to account for changes made to
+        # sys.path. Otherwise, distribution data in the added path(s) may not be discovered.
+        if 'pkg_resources' in sys.modules:
+            # See https://github.com/pypa/setuptools/issues/373
+            import pkg_resources
+            if hasattr(pkg_resources, '_initialize_master_working_set'):
+                pkg_resources._initialize_master_working_set()
+
         # Set global variable to hold assembly binding redirects
         CONF['binding_redirects'] = []
 

--- a/news/6692.bugfix.rst
+++ b/news/6692.bugfix.rst
@@ -1,0 +1,4 @@
+Fix collection of package metadata when the latter is provided in the
+form of ``.egg-info`` file instead of more conventional ``.egg-info``
+directory or standard ``.dist-info`` directory. Such metadata format
+is often found in Debian and Ubuntu deb packages of python software.

--- a/tests/functional/modules/pyi_single_file_metadata/README
+++ b/tests/functional/modules/pyi_single_file_metadata/README
@@ -1,0 +1,4 @@
+Package metadata stored in a single-file .egg-info format, as commonly
+found in Debian/Ubuntu packages. Used by test_misc::test_single_file_metadata
+which adds this directory to its search path.
+

--- a/tests/functional/modules/pyi_single_file_metadata/my_test_package-1.0.egg-info
+++ b/tests/functional/modules/pyi_single_file_metadata/my_test_package-1.0.egg-info
@@ -1,0 +1,14 @@
+Metadata-Version: 2.1
+Name: my-test-package
+Version: 1.0
+Summary: Test package for single-file metadata
+Author: PyInstaller Team
+License: MIT
+Platform: Windows
+Platform: Linux
+Platform: Solaris
+Platform: Mac OS-X
+Platform: Unix
+Requires-Python: >=3.6
+
+The package for single-file metadata.

--- a/tests/functional/test_misc.py
+++ b/tests/functional/test_misc.py
@@ -132,3 +132,25 @@ def test_onefile_cleanup_symlinked_dir(pyi_builder, tmpdir):
     for idx in range(5):
         output_file = os.path.join(output_dir, f'output-{idx}.txt')
         assert os.path.isfile(output_file)
+
+
+# Test that single-file metadata (as commonly found in Debian/Ubuntu packages) is properly collected by copy_metadata().
+def test_single_file_metadata(pyi_builder):
+    # Add directory containing the my-test-package metadata to search path
+    extra_path = os.path.join(_MODULES_DIR, "pyi_single_file_metadata")
+
+    pyi_builder.test_source(
+        """
+        import pkg_resources
+
+        # The pkg_resources.get_distribution() call automatically triggers collection of the metadata. While it does not
+        # raise an error if metadata is not found while freezing, the calls below will fall at run-time in that case.
+        dist = pkg_resources.get_distribution('my-test-package')
+
+        # Sanity check
+        assert dist.project_name == 'my-test-package'
+        assert dist.version == '1.0'
+        assert dist.egg_name() == f'my_test_package-{dist.version}-py{sys.version_info[0]}.{sys.version_info[1]}'
+        """,
+        pyi_args=['--paths', extra_path]
+    )


### PR DESCRIPTION
Debian and Ubuntu linux seem to often package python packages with metadata stored in an `.egg-info` file as opposed to `.egg-info` directory or the standard `.dist-info` directory. In such cases, `pkg_resources.get_distribution()` returns an instance of `pkg_resources.EggInfoDistribution` that has `egg_info` field set to `None`, and we need to attempt to resolve the egg-info path
ourselves.

This commit effectively restores a fallback that was in place before #5774, but adds an additional search pattern based on
`project_name` and `version` to supplement the original pattern based on `egg_name()`.

Fixes #6692. The additional search is implemented as a fallback to avoid any interference with the established codepath (which presumably deals only with directories).