### PR TITLE
Change "Mac OS" / "OS X" to "macOS" + minor docs things

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ Python interpreter! -- and puts them with your script in a single folder, or
 optionally in a single executable file.
 
 
-PyInstaller is tested against Windows, Mac OS X, and GNU/Linux.
+PyInstaller is tested against Windows, macOS, and GNU/Linux.
 However, it is not a cross-compiler:
 to make a Windows app you run PyInstaller in Windows; to make
 a GNU/Linux app you run it in GNU/Linux, etc.
@@ -37,7 +37,7 @@ Main Advantages
   tricks to make external packages work are already integrated.)
 - Libraries like PyQt5, PySide2, wxPython, matplotlib or Django are fully
   supported, without having to handle plugins or external data files manually.
-- Works with code signing on OS X.
+- Works with code signing on macOS.
 - Bundles MS Visual C++ DLLs on Windows.
 
 
@@ -77,9 +77,9 @@ Requirements and Tested Platforms
    This typically can be found in the distribution-package `binutils`,
    too.
 
-- Mac OS X (64bit):
+- macOS (64bit):
 
- - Mac OS X 10.13 (High Sierra) or newer.
+ - macOS 10.13 (High Sierra) or newer.
 
 
 Usage

--- a/doc/_common_definitions.txt
+++ b/doc/_common_definitions.txt
@@ -18,28 +18,20 @@
 .. _Django: https://www.djangoproject.com/
 .. _dnspython: http://www.dnspython.org/
 .. _Docker: https://www.docker.com/
-.. _`easy_install`: http://peak.telecommunity.com/DevCenter/EasyInstall
-.. _`Microsoft COM`: http://www.microsoft.com/com/default.mspx
 .. _`GPL License`: https://raw.github.com/pyinstaller/pyinstaller/develop/COPYING.txt
 .. _FAQ: https://github.com/pyinstaller/pyinstaller/wiki/FAQ
 .. _flake8: https://flake8.pycqa.org/
 .. _Git: http://git-scm.com/downloads
-.. _GraphicConverter: http://www.lemkesoft.de/en/products/graphic-converter/
 .. _GraphViz: https://graphviz.org/
 .. _Homebrew: http://brew.sh/
-.. _`How to Contribute`: https://github.com/pyinstaller/pyinstaller/wiki/How-to-Contribute
+.. _`How to Contribute`: https://pyinstaller.readthedocs.io/en/latest/contributing.html
 .. _`How to Report Bugs`: https://github.com/pyinstaller/pyinstaller/wiki/How-to-Report-Bugs
-.. _ImageMagick: http://www.imagemagick.org/script/index.php
 .. _`importlib.metadata`: https://docs.python.org/3/library/importlib.metadata.html
-.. _imputil: http://docs.python.org/2.7/library/imputil.html
 .. _`Info Property List`: https://developer.apple.com/library/mac/#documentation/MacOSX/Conceptual/BPRuntimeConfig/Articles/ConfigFiles.html
 .. _MacPorts: https://www.macports.org/
-.. _makeicns: https://bitbucket.org/mkae/makeicns
 .. _marshalled: http://docs.python.org/library/marshal
 .. _MinGW: http://sourceforge.net/downloads/mingw/
 .. _MinGW-w64: http://mingw-w64.sourceforge.net/
-.. _Modulefinder: http://docs.python.org/2.7/library/modulefinder.html
-.. _netpbm package: http://netpbm.sourceforge.net/
 .. _NextCloud: https://nextcloud.org
 .. _Parallels: http://www.parallels.com
 .. _pathlib: https://docs.python.org/3/library/pathlib.html
@@ -48,7 +40,6 @@
 .. _pip: http://www.pip-installer.org/
 .. _pip-Win: https://sites.google.com/site/pydatalog/python/pip-for-windows
 .. _plistlib: https://docs.python.org/3/library/plistlib.html
-.. _png2icns: http://icns.sourceforge.net/
 .. _tinyaes: https://github.com/naufraghi/tinyaes-py
 .. _PyInstaller.org: https://github.com/pyinstaller/pyinstaller/wiki/Community
 .. _`PyInstaller at GitHub`: https://github.com/pyinstaller/pyinstaller
@@ -67,7 +58,6 @@
 .. _Recipe: http://www.pyinstaller.org/wiki/Recipe
 .. _setup_tools: https://pypi.python.org/pypi/setuptools
 .. _`Package resources`: https://pythonhosted.org/setuptools/pkg_resources.html#requirements-parsing
-.. _source/common/launch.c: http://www.pyinstaller.org/browser/trunk/source/common/launch.c?rev=latest
 .. _`Supported Packages`: https://github.com/pyinstaller/pyinstaller/wiki/Supported-Packages
 .. _TDM-GCC: http://tdm-gcc.tdragon.net/
 .. _TkInter: http://wiki.python.org/moin/TkInter

--- a/doc/advanced-topics.rst
+++ b/doc/advanced-topics.rst
@@ -591,7 +591,7 @@ integer value before running |PyInstaller|.
 This forces Python to use the same random hash sequence until
 :envvar:`PYTHONHASHSEED` is unset or set to ``'random'``.
 For example, execute |PyInstaller| in a script such as
-the following (for GNU/Linux and OS X)::
+the following (for GNU/Linux and macOS)::
 
     # set seed to a known repeatable integer value
     PYTHONHASHSEED=1

--- a/doc/bootloader-building.rst
+++ b/doc/bootloader-building.rst
@@ -29,8 +29,8 @@ This will produce the |bootloader| executables for your current platform
 
 * :file:`../PyInstaller/bootloader/{OS_ARCH}/run`,
 * :file:`../PyInstaller/bootloader/{OS_ARCH}/run_d`,
-* :file:`../PyInstaller/bootloader/{OS_ARCH}/runw` (OS X and Windows only), and
-* :file:`../PyInstaller/bootloader/{OS_ARCH}/runw_d` (OS X and Windows only).
+* :file:`../PyInstaller/bootloader/{OS_ARCH}/runw` (macOS and Windows only), and
+* :file:`../PyInstaller/bootloader/{OS_ARCH}/runw_d` (macOS and Windows only).
 
 The bootloaders architecture defaults to the machine's one, but can be changed
 using the :option:`--target-arch` option – given the appropriate compiler and
@@ -123,11 +123,11 @@ Open it in some flavour of text previewer to see them::
     less bootloader/Dockerfile
 
 
-Building for Mac OS X
+Building for macOS
 ========================
 
-On Mac OS X please install Xcode_, Apple's suite of tools for developing
-software for Mac OS X.
+On macOS please install Xcode_, Apple's suite of tools for developing
+software for macOS.
 Instead of installing the full `Xcode` package, you can also install
 and use `Command Line Tools for Xcode <https://developer.apple.com/download/more/>`_.
 Installing either will provide the `clang` compiler.
@@ -163,18 +163,18 @@ architecture)::
 
     CC='clang -arch=arm64' python waf --no-universal2 all
 
-By default, the build script targets Mac OSX 10.13, which can be overridden by
+By default, the build script targets macOS 10.13, which can be overridden by
 exporting the MACOSX_DEPLOYMENT_TARGET environment variable.
 
-.. _cross-building for mac os x:
+.. _cross-building for macos:
 
-Cross-Building for Mac OS X
+Cross-Building for macOS
 -----------------------------------
 
-For cross-compiling for OS X you need the Clang/LLVM compiler, the
+For cross-compiling for macOS you need the Clang/LLVM compiler, the
 `cctools` (ld, lipo, …), and the OSX SDK. Clang/LLVM is a cross compiler by
 default and is available on nearly every GNU/Linux distribution, so you just
-need a proper port of the cctools and the OS X SDK.
+need a proper port of the cctools and the macOS SDK.
 
 This is easy to get and needs to be done only once and the result can be
 transferred to you build-system. The build-system can then be a normal
@@ -227,9 +227,9 @@ Please proceed as follows:
 Building the Bootloader
 .......................................
 
-Again, simply use the Vagrantfile to automatically build the OS X bootloaders::
+Again, simply use the Vagrantfile to automatically build the macOS bootloaders::
 
-     export TARGET=OSX  # make the Vagrantfile build for OS X
+     export TARGET=OSX  # make the Vagrantfile build for macOS
      vagrant up linux64 && vagrant halt linux
 
 This should create the bootloaders in
@@ -243,7 +243,7 @@ This should create the bootloaders in
 
      vagrant destroy build-osxcross
 
-4. If you are finished with the OS X bootloaders, unset `TARGET` again::
+4. If you are finished with the macOS bootloaders, unset `TARGET` again::
 
      unset TARGET
 
@@ -495,7 +495,7 @@ All guests [#]_ will automatically build the bootloader when running
 `vagrant provision GUEST`. They will build both 32- and 64-bit bootloaders.
 
 .. [#] Except of guest `osxcross`, which will build the OS X SDK and cctools
-       as described in section :ref:`cross-building for mac os x`.
+       as described in section :ref:`cross-building for macos`.
 
 When building the bootloaders, the guests are sharing
 the PyInstaller distribution folder and will put the built executables onto
@@ -531,8 +531,8 @@ We currently provide this guests:
 :linux64:  GNU/Linux (some recent version) used to build the GNU/Linux
            bootloaders.
 
-           * If ``TARGET=OSX`` is set, cross-builds the bootloaders for OS X
-             (see :ref:`cross-building for mac os x`).
+           * If ``TARGET=OSX`` is set, cross-builds the bootloaders for macOS
+             (see :ref:`cross-building for macos`).
 
            * If ``TARGET=WINDOWS`` is set, cross-builds the bootloaders
              for Windows using mingw. Please have in mind that this imposes
@@ -552,7 +552,7 @@ We currently provide this guests:
                       `Passw0rd!`).
 
 :build-osxcross: GNU/Linux guest used to build the OS X SDK and `cctools` as
-                 described in section :ref:`cross-building for mac os x`.
+                 described in section :ref:`cross-building for macos`.
 
 
 .. include:: _common_definitions.txt

--- a/doc/development/documentation.rst
+++ b/doc/development/documentation.rst
@@ -78,7 +78,7 @@ reStructuredText Cheat-sheet
 
 * Combining markup and links::
 
-    The easies way to install PyInstaller is using |pip|_::
+    The easiest way to install PyInstaller is using |pip|_::
 
     .. |pip| replace:: :command:`pip`
     .. _pip: https://pip.pypa.io/

--- a/doc/development/testing.rst
+++ b/doc/development/testing.rst
@@ -54,7 +54,7 @@ To run the test-suite, please proceed as follows.
 
 
 To learn how we run the test-suite in the continuous integration tests please
-have a look at |.travis.yml|_ (for GNU/Linux and OS X) and |appveyor.yml|_
+have a look at |.travis.yml|_ (for GNU/Linux and macOS) and |appveyor.yml|_
 (for Windows).
 
 

--- a/doc/hooks.rst
+++ b/doc/hooks.rst
@@ -268,7 +268,7 @@ for example::
 
 .. py:data:: is_darwin
 
-   True in Mac OS X.
+   True in macOS.
 
 .. py:data:: is_linux
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -30,7 +30,7 @@ Inside is a script named ``setup.py``.
 Execute ``python setup.py install``
 with administrator privilege to install or upgrade |PyInstaller|.
 
-For platforms other than Windows, GNU/Linux and Mac OS, you must first
+For platforms other than Windows, GNU/Linux and macOS, you must first
 build a |bootloader| program for your platform: see :ref:`Building the Bootloader`.
 After the |bootloader| has been created,
 use ``python setup.py install`` with administrator privileges
@@ -46,19 +46,19 @@ execution path. To verify this, enter the command::
 
     pyinstaller --version
 
-The result should resemble ``3.n`` for a released version,
-and ``3.n.dev0-xxxxxx`` for a development branch.
+The result should resemble ``4.n`` for a released version,
+and ``4.n.dev0-xxxxxx`` for a development branch.
 
 If the command is not found, make sure the execution path includes
 the proper directory:
 
 * Windows: ``C:\PythonXY\Scripts`` where *XY* stands for the
   major and minor Python version number,
-  for example ``C:\Python34\Scripts`` for Python 3.4)
+  for example ``C:\Python38\Scripts`` for Python 3.8)
 * GNU/Linux: ``/usr/bin/``
-* OS X (using the default Apple-supplied Python) ``/usr/bin``
-* OS X (using Python installed by homebrew) ``/usr/local/bin``
-* OS X (using Python installed by macports) ``/opt/local/bin``
+* macOS (using the default Apple-supplied Python) ``/usr/bin``
+* macOS (using Python installed by homebrew) ``/usr/local/bin``
+* macOS (using Python installed by macports) ``/opt/local/bin``
 
 To display the current path in Windows the command is ``echo %path%``
 and in other systems, ``echo $PATH``.

--- a/doc/man/pyinstaller.rst
+++ b/doc/man/pyinstaller.rst
@@ -20,7 +20,7 @@ DESCRIPTION
 ============
 
 PyInstaller is a program that freezes (packages) Python programs into
-stand-alone executables, under Windows, GNU/Linux, Mac OS X,
+stand-alone executables, under Windows, GNU/Linux, macOS,
 FreeBSD, OpenBSD, Solaris and AIX.
 Its main advantages over similar tools are that PyInstaller works with
 Python 3.7-3.10, it builds smaller executables thanks to transparent

--- a/doc/operating-mode.rst
+++ b/doc/operating-mode.rst
@@ -150,7 +150,7 @@ This is the heart of the ``myscript`` executable in the folder.
 
 The |PyInstaller| |bootloader| is a binary
 executable program for the active platform
-(Windows, GNU/Linux, Mac OS X, etc.).
+(Windows, GNU/Linux, macOS, etc.).
 When the user launches your program, it is the |bootloader| that runs.
 The |bootloader| creates a temporary Python environment
 such that the Python interpreter will find all imported modules and
@@ -230,7 +230,7 @@ nothing is shared.
 
 The :file:`_MEI{xxxxxx}` folder is not removed if the program crashes
 or is killed (kill -9 on Unix, killed by the Task Manager on Windows,
-"Force Quit" on Mac OS).
+"Force Quit" on macOS).
 Thus if your app crashes frequently, your users will lose disk space to
 multiple :file:`_MEI{xxxxxx}` temporary folders.
 
@@ -262,13 +262,13 @@ Using a Console Window
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 By default the |bootloader| creates a command-line console
-(a terminal window in GNU/Linux and Mac OS, a command window in Windows).
+(a terminal window in GNU/Linux and macOS, a command window in Windows).
 It gives this window to the Python interpreter for its standard input and output.
 Your script's use of ``print`` and ``input()`` are directed here.
 Error messages from Python and default logging output
 also appear in the console window.
 
-An option for Windows and Mac OS is to tell |PyInstaller| to not provide a console window.
+An option for Windows and macOS is to tell |PyInstaller| to not provide a console window.
 The |bootloader| starts Python with no target for standard output or input.
 Do this when your script has a graphical interface for user input and can properly
 report its own diagnostics.

--- a/doc/requirements.rst
+++ b/doc/requirements.rst
@@ -15,12 +15,12 @@ has dropped support for Windows versions below 8.1. To support Windows 8.0 and 7
 you must build with Python 3.8 or older and to support Windows XP you must use
 Python 3.7 or older.
 
-Mac OS
+macOS
 ~~~~~~
 
-|PyInstaller| runs on Mac OS 10.13 (High Sierra) or newer.
+|PyInstaller| runs on macOS 10.13 (High Sierra) or newer.
 It can build graphical windowed apps (apps that do not use a terminal window).
-PyInstaller builds apps that are compatible with the Mac OS release in
+PyInstaller builds apps that are compatible with the macOS release in
 which you run it, and following releases.
 It can build ``x86_64``, ``arm64`` or hybrid *universal2* binaries on macOS
 machines of either architecture. See :ref:`macOS multi-arch support` for

--- a/doc/spec-files.rst
+++ b/doc/spec-files.rst
@@ -367,16 +367,16 @@ For example modify the spec file this way::
    versions. The unbuffered text layer requires Python 3.7 or later.
 
 
-.. _spec file options for a mac os x bundle:
+.. _spec file options for a macOS bundle:
 
-Spec File Options for a Mac OS X Bundle
+Spec File Options for a macOS Bundle
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When you build a windowed Mac OS X app
-(that is, running in Mac OS X, you specify the :option:`--onefile`
+When you build a windowed macOS app
+(that is, running in macOS, you specify the :option:`--onefile`
 :option:`--windowed` options),
 the spec file contains an additional statement to
-create the Mac OS X application bundle, or app folder::
+create the macOS application bundle, or app folder::
 
     app = BUNDLE(exe,
              name='myscript.app',
@@ -388,7 +388,7 @@ that you specify using the :option:`--icon` option.
 The ``bundle_identifier`` will have the value you specify with the
 :option:`--osx-bundle-identifier` option.
 
-An :file:`Info.plist` file is an important part of a Mac OS X app bundle.
+An :file:`Info.plist` file is an important part of a macOS app bundle.
 (See the `Apple bundle overview`_ for a discussion of the contents
 of ``Info.plist``.)
 
@@ -426,10 +426,10 @@ XML types.  Here's an example::
              )
 
 In the above example, the key/value ``'NSPrincipalClass': 'NSApplication'`` is
-necessary to allow Mac OS X to render applications using retina resolution.
+necessary to allow macOS to render applications using retina resolution.
 The key ``'NSAppleScriptEnabled'`` is assigned the Python boolean
 ``False``, which will be output to :file:`Info.plist` properly as ``<false/>``.
-Finally the key ``CFBundleDocumentTypes`` tells Mac OS X what filetypes your
+Finally the key ``CFBundleDocumentTypes`` tells macOS what filetypes your
 application supports (see `Apple document types`_).
 
 
@@ -515,9 +515,9 @@ since the splash binaries do not need to be included into the executable::
                   ...)
 
 On Windows/macOS images with per-pixel transparency are supported. This allows
-non-rectengular splash screen images. On Windows the transparent borders of the image
+non-rectangular splash screen images. On Windows the transparent borders of the image
 are hard-cuted, meaning that fading transparent values are not supported. There is
-no common implementation for non-rectengular windows on Linux, so images with per-
+no common implementation for non-rectangular windows on Linux, so images with per-
 pixel transparency is not supported.
 
 The splash target can be configured in various ways. The constructor of the :mod:`Splash`

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -147,7 +147,7 @@ command-line option.
     the collected binaries are not processed even if UPX is found. The
     shared libraries (e.g., the Python shared library) built on modern
     linux distributions seem to break when processed with UPX, resulting
-    in defunct application bundles. On Mac OS, UPX currently fails to
+    in defunct application bundles. On macOS, UPX currently fails to
     process .dylib shared libraries; furthermore the UPX-compressed files
     fail the validation check of the ``codesign`` utility, and therefore
     cannot be code-signed (which is a requirement on the Apple M1 platform).
@@ -329,7 +329,7 @@ Note that when using `venv`, the path to the |PyInstaller| commands is:
 
 Under Windows, the pip-Win_ package makes it
 especially easy to set up different environments and switch between them.
-Under GNU/Linux and Mac OS, you switch environments at the command line.
+Under GNU/Linux and macOS, you switch environments at the command line.
 
 See :pep:`405`
 and the official `Python Tutorial on Virtual Environments and Packages
@@ -341,7 +341,7 @@ Supporting Multiple Operating Systems
 ---------------------------------------
 
 If you need to distribute your application for more than one OS,
-for example both Windows and Mac OS X, you must install |PyInstaller|
+for example both Windows and macOS, you must install |PyInstaller|
 on each platform and bundle your app separately on each.
 
 You can do this from a single machine using virtualization.
@@ -371,7 +371,7 @@ but writes its work files and the bundled app in folders that
 are local to the virtual machine.
 
 If you share the same home directory on multiple platforms, for
-example GNU/Linux and OS X, you will need to set the PYINSTALLER_CONFIG_DIR
+example GNU/Linux and macOS, you will need to set the PYINSTALLER_CONFIG_DIR
 environment variable to different values on each platform otherwise
 PyInstaller may cache files for one platform and use them on the other
 platform, as by default it uses a subdirectory of your home directory
@@ -457,10 +457,10 @@ Or you can apply the ``unicode()`` function to the object
 to reproduce the version text file.
 
 
-Building Mac OS X App Bundles
+Building macOS App Bundles
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Under Mac OS X, |PyInstaller| always builds a UNIX executable in
+Under macOS, |PyInstaller| always builds a UNIX executable in
 :file:`dist`.
 If you specify :option:`--onedir`, the output is a folder named :file:`myscript`
 containing supporting files and an executable named :file:`myscript`.
@@ -470,7 +470,7 @@ Either executable can be started from a Terminal command line.
 Standard input and output work as normal through that Terminal window.
 
 If you specify :option:`--windowed` with either option, the ``dist`` folder
-also contains an OS X application named :file:`myscript.app`.
+also contains a macOS application named :file:`myscript.app`.
 
 As you probably know, an application is a special type of folder.
 The one built by |PyInstaller| contains a folder always named
@@ -493,7 +493,7 @@ This becomes the ``CFBundleIdentifier`` used in code-signing
 and for more detail, the `Apple code signing overview`_ technical note).
 
 You can add other items to the :file:`Info.plist` by editing the spec file;
-see :ref:`Spec File Options for a Mac OS X Bundle` below.
+see :ref:`Spec File Options for a macOS Bundle` below.
 
 
 Platform-specific Notes
@@ -558,13 +558,13 @@ So you have the following options:
 
 
 
-Mac OS X
+macOS
 -------------------
 
-Making Mac OS apps Forward-Compatible
+Making macOS apps Forward-Compatible
 =====================================
 
-On Mac OS, system components from one version of the OS are usually compatible
+On macOS, system components from one version of the OS are usually compatible
 with later versions, but they may not work with earlier versions. While
 |PyInstaller| does not collect system components of the OS, the collected
 3rd party binaries (e.g., python extension modules) are built against
@@ -585,7 +585,7 @@ your application in that environment; the generated frozen application
 should be compatible with that and later versions of macOS.
 
 
-Building 32-bit Apps in Mac OS X
+Building 32-bit Apps in macOS
 ================================
 
 .. note:: This section is largely obsolete, as support for 32-bit application
@@ -595,7 +595,7 @@ Building 32-bit Apps in Mac OS X
           and 32-bit/64-bit Python installers are stil available from
           python.org for (some) versions of Python 3.7.
 
-Older versions of Mac OS X supported both 32-bit and 64-bit executables.
+Older versions of macOS supported both 32-bit and 64-bit executables.
 PyInstaller builds an app using the the word-length of the Python used to execute it.
 That will typically be a 64-bit version of Python,
 resulting in a 64-bit executable.
@@ -640,7 +640,7 @@ Getting the Opened Document Names
 
 When user double-clicks a document of a type that is registered with
 your application, or when a user drags a document and drops it
-on your application's icon, Mac OS launches your application
+on your application's icon, macOS launches your application
 and provides the name(s) of the opened document(s) in the
 form of an OpenDocument AppleEvent.
 

--- a/doc/when-things-go-wrong.rst
+++ b/doc/when-things-go-wrong.rst
@@ -128,7 +128,7 @@ are checked in most systems.
 If you cannot put the python library there,
 try setting the correct path in the environment variable
 ``LD_LIBRARY_PATH`` in GNU/Linux or
-``DYLD_LIBRARY_PATH`` in OS X.
+``DYLD_LIBRARY_PATH`` in macOS.
 
 
 Getting Debug Messages
@@ -149,7 +149,7 @@ application.
 
 .. _DebugView: https://docs.microsoft.com/en-us/sysinternals/downloads/debugview
 
-For a :option:`--windowed` Mac OS app they are not displayed.
+For a :option:`--windowed` macOS app they are not displayed.
 
 Consider bundling without :option:`--debug` for your production version.
 Debugging messages require system calls and have an impact on performance.
@@ -183,7 +183,7 @@ your bundled application may fail to start with an error message like
 In this case, you will want to get more verbose output to find out
 what is going on.
 
-* For Mac OS, you can run your application on the command line,
+* For macOS, you can run your application on the command line,
   i.e. ``./dist/my_gui``
   in `Terminal` instead of clicking on ``my_gui.app``.
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -32,7 +32,7 @@ run the following command:
 
     py.test
 
-Or, to speed up test runs by sending tests to multiple CPUs:
+Or, to speed up test runs by sending tests to multiple CPUs: (requires pytest-xdist)
 
     py.test -n NUM
 


### PR DESCRIPTION
I thought the docs ought to say "macOS" instead of "Mac OS", or "Mac OS X", or "OS X." OS X sounds a little old fashioned these days, and is incorrect, since Apple is on macOS 12 now. "macOS" is what Apple uses in their materials.

This is more correct, but it will affect some external links to the site, since the text is in some section headers that could be linked to. I believe I got all the internal site links.

I also saw some ancient looking links in the common definitions file, so I removed ones that weren't referenced in any of the documentation.

There are also a couple small clarifications or updates or typo fixes I happened to see.

I also noticed in the `requirements` page that "The [pip-Win](https://sites.google.com/site/pydatalog/python/pip-for-windows) package is recommended, but not required." -- is that still accurate? This looks like it's probably a holdout from 5-15 years ago.