### PR TITLE
Fix file handle leaks.

### DIFF
--- a/PyInstaller/archive/writers.py
+++ b/PyInstaller/archive/writers.py
@@ -17,9 +17,9 @@ Utilities to create data structures for embedding Python modules and additional 
 #
 # See pyi_carchive.py for a more general archive (contains anything) that can be understood by a C program.
 
-import io
 import marshal
 import os
+import shutil
 import struct
 import sys
 import zlib
@@ -327,10 +327,8 @@ class CArchiveWriter(ArchiveWriter):
         ENTRY must have:
           entry[0] is name (under which it will be saved).
           entry[1] is fullpathname of the file.
-          entry[2] is a flag for it's storage format (0==uncompressed,
-          1==compressed)
+          entry[2] is a flag for it's storage format (0==uncompressed, 1==compressed)
           entry[3] is the entry's type code.
-          Version 5:
             If the type code is 'o':
               entry[0] is the runtime option
               eg: v  (meaning verbose imports)
@@ -338,94 +336,79 @@ class CArchiveWriter(ArchiveWriter):
                   W arg (warning option arg)
                   s  (meaning do site.py processing.
         """
-        (nm, pathnm, flag, typcd) = entry[:4]
-        # FIXME Could we make the version 5 the default one?
-        # Version 5 - allow type 'o' = runtime option.
-        code_data = None
-        fh = None
+        dest, source, compress, type = entry[:4]
         try:
-            if typcd in ('o', 'd'):
-                ulen = 0
-                flag = 0
-            elif typcd == 's':
+            if type in ('o', 'd'):
+                return self._write_blob(b"", dest, type)
+
+            if type == 's':
                 # If it is a source code file, compile it to a code object and marshall the object, so it can be
                 # unmarshalled by the bootloader.
-
-                code = get_code_object(nm, pathnm)
+                code = get_code_object(dest, source)
                 code = strip_paths_in_code(code)
+                return self._write_blob(marshal.dumps(code), dest, type, compress=compress)
 
-                code_data = marshal.dumps(code)
-                ulen = len(code_data)
-            elif typcd == 'm':
-                fh = open(pathnm, 'rb')
-                ulen = os.fstat(fh.fileno()).st_size
+            elif type == 'm':
+                with open(source, "rb") as f:
+                    data = f.read()
                 # Check if it is a PYC file
-                header = fh.read(4)
-                fh.seek(0)
-                if header == BYTECODE_MAGIC:
+                if data[:4] == BYTECODE_MAGIC:
                     # Read whole header and load code. According to PEP-552, the PYC header consists of four 32-bit
                     # words (magic, flags, and, depending on the flags, either timestamp and source file size, or a
                     # 64-bit hash).
-                    header = fh.read(16)
-                    code = marshal.load(fh)
+                    header = data[:16]
+                    code = marshal.loads(data[16:])
                     # Strip paths from code, marshal back into module form. The header fields (timestamp, size, hash,
                     # etc.) are all referring to the source file, so our modification of the code object does not affect
                     # them, and we can re-use the original header.
                     code = strip_paths_in_code(code)
                     data = header + marshal.dumps(code)
-                    # Create file-like object for timestamp re-write in the subsequent steps.
-                    fh = io.BytesIO(data)
-                    ulen = len(data)
+                if source.endswith('.__init__.py'):
+                    type = 'M'
+                return self._write_blob(data, dest, type, compress=compress)
+
+            elif type == "M":
+                with open(source, "rb") as f:
+                    return self._write_blob(fake_pyc_timestamp(f.read()), dest, type, compress=compress)
+
             else:
-                fh = open(pathnm, 'rb')
-                ulen = os.fstat(fh.fileno()).st_size
+                self._write_file(source, dest, type, compress=compress)
+
         except IOError:
-            print("Cannot find ('%s', '%s', %s, '%s')" % (nm, pathnm, flag, typcd))
+            print("Cannot find ('%s', '%s', %s, '%s')" % (dest, source, compress, type))
             raise
 
-        where = self.lib.tell()
-        assert flag in range(3)
-        if not fh and not code_data:
-            # No need to write anything.
-            pass
-        elif flag == 1:
-            comprobj = zlib.compressobj(self.LEVEL)
-            if code_data is not None:
-                self.lib.write(comprobj.compress(code_data))
-            else:
-                assert fh
-                # We only want to change it for pyc files.
-                modify_header = typcd in ('M', 'm', 's')
+    def _write_blob(self, blob: bytes, dest, type, compress=False):
+        """
+        Write the binary contents (**blob**) of a small file to both the archive and its table of contents.
+        """
+        start = self.lib.tell()
+        length = len(blob)
+        if compress:
+            blob = zlib.compress(blob, level=self.LEVEL)
+        self.lib.write(blob)
+        self.toc.add(start, len(blob), length, int(compress), type, dest)
+
+    def _write_file(self, source, dest, type, compress=False):
+        """
+        Stream copy a large file into the archive and update the table of contents.
+        """
+        start = self.lib.tell()
+        length = os.stat(source).st_size
+        with open(source, 'rb') as f:
+            if compress:
+                buffer = bytearray(16 * 1024)
+                compressor = zlib.compressobj(self.LEVEL)
                 while 1:
-                    buf = fh.read(16 * 1024)
-                    if not buf:
+                    read = f.readinto(buffer)
+                    if not read:
                         break
-                    if modify_header:
-                        modify_header = False
-                        buf = fake_pyc_timestamp(buf)
-                    self.lib.write(comprobj.compress(buf))
-            self.lib.write(comprobj.flush())
-        else:
-            if code_data is not None:
-                self.lib.write(code_data)
+                    self.lib.write(compressor.compress(buffer[:read]))
+                self.lib.write(compressor.flush())
+
             else:
-                assert fh
-                while 1:
-                    buf = fh.read(16 * 1024)
-                    if not buf:
-                        break
-                    self.lib.write(buf)
-
-        dlen = self.lib.tell() - where
-        if typcd == 'm':
-            if pathnm.find('.__init__.py') > -1:
-                typcd = 'M'
-
-        if fh:
-            fh.close()
-
-        # Record the entry in the CTOC
-        self.toc.add(where, dlen, ulen, flag, typcd, nm)
+                shutil.copyfileobj(f, self.lib)
+        self.toc.add(start, self.lib.tell() - start, length, int(compress), type, dest)
 
     def save_trailer(self, tocpos):
         """

--- a/PyInstaller/utils/win32/icon.py
+++ b/PyInstaller/utils/win32/icon.py
@@ -103,17 +103,18 @@ class IconFile:
             # The icon file can't be opened for some reason. Stop the
             # program with an informative message.
             raise SystemExit('Unable to open icon file {}'.format(path))
-        self.entries = []
-        self.images = []
-        header = self.header = ICONDIRHEADER()
-        header.fromfile(file)
-        for i in range(header.idCount):
-            entry = ICONDIRENTRY()
-            entry.fromfile(file)
-            self.entries.append(entry)
-        for e in self.entries:
-            file.seek(e.dwImageOffset, 0)
-            self.images.append(file.read(e.dwBytesInRes))
+        with file:
+            self.entries = []
+            self.images = []
+            header = self.header = ICONDIRHEADER()
+            header.fromfile(file)
+            for i in range(header.idCount):
+                entry = ICONDIRENTRY()
+                entry.fromfile(file)
+                self.entries.append(entry)
+            for e in self.entries:
+                file.seek(e.dwImageOffset, 0)
+                self.images.append(file.read(e.dwBytesInRes))
 
     def grp_icon_dir(self):
         return self.header.tostring()

--- a/news/6699.bugfix.rst
+++ b/news/6699.bugfix.rst
@@ -1,0 +1,2 @@
+Fix leakage of file handles during the build process. This is only significant
+if PyInstaller is ran repeatedly in one process of Python.

--- a/setup.cfg
+++ b/setup.cfg
@@ -149,6 +149,10 @@ filterwarnings =
    ignore:Please use assertEqual instead.:DeprecationWarning
 ; tests/unit/test_modulegraph/test_modulegraph.py::TestFunctions::test_os_listdir
    ignore:Use zipio.listdir instead of os_listdir:DeprecationWarning:
+; Enable Python's improperly closed file handle detection...
+   error::ResourceWarning:
+; ... and force pytest to raise an error if the ResourceWarning is emitted during test cleanup.
+   error::pytest.PytestUnraisableExceptionWarning:
 
 # Display summary info for (s)skipped, (X)xpassed, (x)xfailed, (f)failed and (e)errored tests
 # Skip doctest text files

--- a/tests/functional/test_import.py
+++ b/tests/functional/test_import.py
@@ -660,6 +660,8 @@ def test_nspkg_attributes_pep420(pyi_builder):
 #--- hooks related stuff ---
 
 
+# imp leaks file handles.
+@pytest.mark.filterwarnings("ignore", category=ResourceWarning)
 def test_pkg_without_hook_for_pkg(pyi_builder, script_dir):
     # The package `pkg_without_hook_for_pkg` does not have a hook, but `pkg_without_hook_for_pkg.sub1` has one. And this
     # hook includes the "hidden" import `pkg_without_hook_for_pkg.sub1.sub11`

--- a/tests/functional/test_unbuffered_stdio.py
+++ b/tests/functional/test_unbuffered_stdio.py
@@ -74,10 +74,11 @@ def test_unbuffered_stdio(tmp_path, output_stream, stream_mode, pyi_builder_spec
             "--output-stream", output_stream,
             "--stream-mode", stream_mode
         )  # yapf: disable
-        loop.run_until_complete(proc)
+        transport, _ = loop.run_until_complete(proc)
         loop.run_forever()
     finally:
         loop.close()
+        transport.close()
 
     # Check the number of received stars
     assert counter_proto.count == EXPECTED_STARS


### PR DESCRIPTION
This is mostly a refactoring of `CArchiveWriter().add()` which has gotten somewhat tangled trying to apply various file modifications whilst simultaneously juggling file streaming and optional zip compression. Since the modifications are all done on Python source/byte code files which are small, split the archive packing into two helpers, one which streams big files and a more malleable one which writes small files from memory without streaming, both of which handle the bookkeeping job of updating the TOC. This fixes a file handle leak.

Additionally take advantage of Python's builtin, but suppressed by default, file handle leakage detection; any such leakages under a pytest run will now fail the test. This requires a few other leakage fixes throughout the test suite to make
it pass.