### PR TITLE
Fix when the entry-point script and a package have the same name.

### DIFF
--- a/news/6711.bugfix.rst
+++ b/news/6711.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a mix up when the entry-point script and a package have the same name.

--- a/setup.cfg
+++ b/setup.cfg
@@ -178,6 +178,7 @@ exclude =
    bootloader,
    PyInstaller/lib,
    tests/functional/data/sphinx/conf.py,
+   tests/functional/data/name_clash_with_entry_point
    tests/unit/test_modulegraph,
 show-source = True
 # E265 - block comment should start with '# '

--- a/tests/functional/data/name_clash_with_entry_point/matching_name.py
+++ b/tests/functional/data/name_clash_with_entry_point/matching_name.py
@@ -1,0 +1,2 @@
+print("Running matching_name.py as", __name__)
+from matching_name import submodule

--- a/tests/functional/data/name_clash_with_entry_point/matching_name/__init__.py
+++ b/tests/functional/data/name_clash_with_entry_point/matching_name/__init__.py
@@ -1,0 +1,1 @@
+print("Running matching_name/__init__.py as", __name__)

--- a/tests/functional/data/name_clash_with_entry_point/matching_name/submodule.py
+++ b/tests/functional/data/name_clash_with_entry_point/matching_name/submodule.py
@@ -1,0 +1,1 @@
+print("Running matching_name/submodule.py as", __name__)


### PR DESCRIPTION
Turns out that producing a functional executable out of this seemingly ambiguous case is not only possible but also not that difficult.

When the entry point script's bytecode is collected before archiving, the bytecode of the `__init__.py` of a package with the same name would be collected instead if it exists. This mix-up can be avoided simply by removing the complex `pkgutil` shenanigans used to get the entry-point's bytecode in a way that makes of pycache. Given that there is rarely more than one entry-point script, this loss of performance is insignificant.

Fixes #4771, fixes #6702.
