### PR TITLE
Make --add-data and --add-binary path separators OS independent

### DIFF
--- a/doc/runtime-information.rst
+++ b/doc/runtime-information.rst
@@ -93,7 +93,7 @@ Placing data files at expected locations inside the bundle
 
 To place the data-files where your code expects them to be (i.e., relative
 to the main script or bundle directory), you can use the **dest** parameter
-of the :option:`--add-data=source:dest <--add-data>` command-line switches.
+of the :option:`--add-data="source:dest" <--add-data>` command-line switches.
 Assuming you normally
 use the following code in a file named ``my_script.py`` to locate a file
 ``file.dat`` in the same folder::
@@ -110,7 +110,7 @@ And ``my_script.py`` is **not** part of a package (not in a folder containing
 an ``__init_.py``), then ``__file__`` will be ``[app root]/my_script.pyc``
 meaning that if you put ``file.dat`` in the root of your package, using::
 
-    PyInstaller --add-data=/path/to/file.dat:.
+    PyInstaller --add-data="/path/to/file.dat:."
 
 It will be found correctly at runtime without changing ``my_script.py``.
 
@@ -120,7 +120,7 @@ If ``__file__`` is checked from inside a package or library (say
 ``my_library.data``) then ``__file__`` will be
 ``[app root]/my_library/data.pyc`` and :option:`--add-data` should mirror that::
 
-    PyInstaller --add-data=/path/to/my_library/file.dat:./my_library
+    PyInstaller --add-data="/path/to/my_library/file.dat:./my_library"
 
 However, in this case it is much easier to switch to :ref:`the spec file
 <Using Spec Files>` and use the

--- a/doc/spec-files.rst
+++ b/doc/spec-files.rst
@@ -163,11 +163,9 @@ you could modify the spec file as follows::
              ...
              )
 
-And the command line equivalent (see
-:ref:`What To Bundle, Where To Search`
-for platform-specific details)::
+And the command line equivalent::
 
-    pyinstaller --add-data 'src/README.txt:.' myscript.py
+    pyinstaller --add-data "src/README.txt:." myscript.py
 
 You have made the ``datas=`` argument a one-item list.
 The item is a tuple in which the first string says the existing file
@@ -296,11 +294,9 @@ You could add it to the bundle this way::
              binaries=[ ( '/usr/lib/libiodbc.2.dylib', '.' ) ],
              ...
 
-Or via the command line (again, see
-:ref:`What To Bundle, Where To Search`
-for platform-specific details)::
+Or via the command line::
 
-    pyinstaller --add-binary '/usr/lib/libiodbc.2.dylib:.' myscript.py
+    pyinstaller --add-binary "/usr/lib/libiodbc.2.dylib:." myscript.py
 
 If you wish to store ``libiodbc.2.dylib`` on a specific folder inside the bundle,
 for example ``vendor``, then you could specify it, using the second element of the tuple::

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -88,9 +88,9 @@ Or in Windows, use the little-known BAT file line continuation::
 
     pyinstaller --noconfirm --log-level=WARN ^
         --onefile --nowindow ^
-        --add-data="README;." ^
-        --add-data="image1.png;img" ^
-        --add-binary="libfoo.so;lib" ^
+        --add-data="README:." ^
+        --add-data="image1.png:img" ^
+        --add-binary="libfoo.so:lib" ^
         --hidden-import=secret1 ^
         --hidden-import=secret2 ^
         --icon=..\MLNMFLCN.ICO ^

--- a/news/6724.feature.rst
+++ b/news/6724.feature.rst
@@ -1,0 +1,5 @@
+(Windows) The :option:`--add-data` and :option:`--add-binary` options accept the
+POSIX syntax of ``--add-data=source:dest`` rather than
+``--add-data=source;dest``. The latter will continue to work on Windows to avoid
+breaking backwards compatibility but is discouraged in favour of the now cross
+platform format.

--- a/tests/functional/test_basic.py
+++ b/tests/functional/test_basic.py
@@ -637,11 +637,7 @@ def test_onefile_longpath(pyi_builder, tmpdir):
     dst_filename = os.path.join(*[32 * chr(c) for c in range(ord('A'), ord('A') + 8)], 'data.txt')
     assert len(dst_filename) >= 260
     # Name for --add-data
-    if is_win:
-        add_data_name = src_filename + ';' + os.path.dirname(dst_filename)
-    else:
-        add_data_name = src_filename + ':' + os.path.dirname(dst_filename)
-
+    add_data_name = src_filename + ':' + os.path.dirname(dst_filename)
     pyi_builder.test_source(
         """
         import sys

--- a/tests/unit/test_makespec.py
+++ b/tests/unit/test_makespec.py
@@ -10,6 +10,9 @@
 #-----------------------------------------------------------------------------
 
 import os
+import argparse
+
+import pytest
 
 from PyInstaller.building import makespec
 
@@ -45,3 +48,35 @@ def test_Path_regression():
     p = makespec.Path(makespec.HOMEPATH + "-aaa", "bbb", "ccc")
     assert p.path == os.path.join(makespec.HOMEPATH + "-aaa", "bbb", "ccc")
     assert (repr(p) == repr(os.path.join(makespec.HOMEPATH + "-aaa", "bbb", "ccc")))
+
+
+def test_add_data(capsys):
+    """
+    Test CLI parsing of --add-data and --add-binary.
+    """
+    parser = argparse.ArgumentParser()
+    makespec.__add_options(parser)
+
+    assert parser.parse_args([]).datas == []
+    assert parser.parse_args(["--add-data", "/foo/bar:."]).datas == [("/foo/bar", ".")]
+    assert parser.parse_args([r"--add-data=C:\foo\bar:baz"]).datas == [(r"C:\foo\bar", "baz")]
+    assert parser.parse_args([r"--add-data=c:/foo/bar:baz"]).datas == [(r"c:/foo/bar", "baz")]
+    assert parser.parse_args([r"--add-data=/foo/:bar"]).datas == [("/foo/", "bar")]
+
+    for args in [["--add-data", "foo/bar"], ["--add-data", "C:/foo/bar"]]:
+        with pytest.raises(SystemExit):
+            parser.parse_args(args)
+        assert '--add-data: Wrong syntax, should be --add-data=SOURCE:DEST' in capsys.readouterr().err
+
+    if os.pathsep == ";":
+        assert parser.parse_args(["--add-data", "foo;."]).datas == [("foo", ".")]
+    else:
+        assert parser.parse_args(["--add-data", "foo;bar:."]).datas == [("foo;bar", ".")]
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--add-data", "foo:"])
+    assert '--add-data: You have to specify both SOURCE and DEST' in capsys.readouterr().err
+
+    options = parser.parse_args(["--add-data=a:b", "--add-data=c:d", "--add-binary=e:f"])
+    assert options.datas == [("a", "b"), ("c", "d")]
+    assert options.binaries == [("e", "f")]


### PR DESCRIPTION
I can't make up my mind which separator to use. I've done a commit for both. I don't like the look of the syntax for `=>`. `--add-data="foo=>bar"` looks like something you'd find in a perl script. And in either case, I'm not sure if allowing `\` escaping of colons is a good idea. I think we should be providing a complete syntax but it makes something like `--add-data=C:\some\folder\:.` invalid because the colon is treated literally. Any thoughts?