### PR TITLE
Remove timeout on UPX subprocesses (#6722).

### DIFF
--- a/PyInstaller/building/utils.py
+++ b/PyInstaller/building/utils.py
@@ -20,7 +20,9 @@ import pathlib
 import platform
 import shutil
 import struct
+import subprocess
 import sys
+import textwrap
 
 from PyInstaller import compat
 from PyInstaller import log as logging
@@ -362,9 +364,13 @@ def checkCache(
                                     raise
 
     if cmd:
-        logger.info("Executing - " + ' '.join(cmd))
-        # terminates if execution fails
-        compat.exec_command(*cmd)
+        logger.info("Executing - " + "".join(cmd))
+        p = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, universal_newlines=True)
+        if p.returncode:
+            raise SystemExit(
+                f"The subprocess:\n    {''.join(cmd)}\nexited with error {p.returncode} and error "
+                "output:\n" + textwrap.indent(p.stdout, "    ")
+            )
 
     # update cache index
     cache_index[basenm] = digest

--- a/news/6722.bugfix.rst
+++ b/news/6722.bugfix.rst
@@ -1,0 +1,2 @@
+Remove the hard-coded 60 second timeout on UPX subprocesses which causes UPX
+applied to large files to fail unnecessarily.


### PR DESCRIPTION
The unneeded timeout causes the build to abort if it is given a large enough file to UPX-compress. Fixes #6722.
