### PR TITLE
bootloader: remove superfluous argument to pyi_arch_status_new() call

### DIFF
--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -99,7 +99,7 @@ pyi_main(int argc, char * argv[])
 
     VS("PyInstaller Bootloader 3.x\n");
 
-    archive_status = pyi_arch_status_new(archive_status);
+    archive_status = pyi_arch_status_new();
     if (archive_status == NULL) {
         return -1;
     }

--- a/news/6742.bootloader.rst
+++ b/news/6742.bootloader.rst
@@ -1,0 +1,2 @@
+Remove superfluous argument to ``pyi_arch_status_new`` call in ``pyi_main.c``
+to allow building with compilers that enable ``-Wunprototyped-calls``.


### PR DESCRIPTION
The function call should take no arguments, but it seems that only some particular compilers (or their settings) take an issue with the superfluous argument. Fixes #6742.