### PR TITLE
Update Qt hooks for PySide6/PyQt6 6.3 support

### DIFF
--- a/PyInstaller/hooks/hook-PyQt5.py
+++ b/PyInstaller/hooks/hook-PyQt5.py
@@ -9,7 +9,7 @@
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
 
-from PyInstaller.utils.hooks.qt import get_qt_binaries, get_qt_conf_file, pyqt5_library_info
+from PyInstaller.utils.hooks.qt import get_qt_binaries, pyqt5_library_info
 
 # Only proceed if PyQt5 can be imported.
 if pyqt5_library_info.version is not None:
@@ -19,9 +19,6 @@ if pyqt5_library_info.version is not None:
         # PyQt5.11 and later provides SIP in a private package. Support both.
         'PyQt5.sip'
     ]
-
-    # Collect the ``qt.conf`` file.
-    datas = get_qt_conf_file(pyqt5_library_info)
 
     # Collect required Qt binaries.
     binaries = get_qt_binaries(pyqt5_library_info)

--- a/PyInstaller/hooks/hook-PyQt6.py
+++ b/PyInstaller/hooks/hook-PyQt6.py
@@ -9,14 +9,11 @@
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
 
-from PyInstaller.utils.hooks.qt import get_qt_binaries, get_qt_conf_file, pyqt6_library_info
+from PyInstaller.utils.hooks.qt import get_qt_binaries, pyqt6_library_info
 
 # Only proceed if PyQt6 can be imported.
 if pyqt6_library_info.version is not None:
     hiddenimports = ['PyQt6.sip']
-
-    # Collect the ``qt.conf`` file.
-    datas = get_qt_conf_file(pyqt6_library_info)
 
     # Collect required Qt binaries.
     binaries = get_qt_binaries(pyqt6_library_info)

--- a/PyInstaller/hooks/hook-PySide2.py
+++ b/PyInstaller/hooks/hook-PySide2.py
@@ -9,14 +9,11 @@
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
 
-from PyInstaller.utils.hooks.qt import get_qt_binaries, get_qt_conf_file, pyside2_library_info
+from PyInstaller.utils.hooks.qt import get_qt_binaries, pyside2_library_info
 
 # Only proceed if PySide2 can be imported.
 if pyside2_library_info.version is not None:
     hiddenimports = ['shiboken2']
-
-    # Collect the ``qt.conf`` file.
-    datas = get_qt_conf_file(pyside2_library_info)
 
     # Collect required Qt binaries.
     binaries = get_qt_binaries(pyside2_library_info)

--- a/PyInstaller/hooks/hook-PySide6.py
+++ b/PyInstaller/hooks/hook-PySide6.py
@@ -9,14 +9,11 @@
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
 
-from PyInstaller.utils.hooks.qt import get_qt_binaries, get_qt_conf_file, pyside6_library_info
+from PyInstaller.utils.hooks.qt import get_qt_binaries, pyside6_library_info
 
 # Only proceed if PySide6 can be imported.
 if pyside6_library_info.version is not None:
     hiddenimports = ['shiboken6']
-
-    # Collect the ``qt.conf`` file.
-    datas = get_qt_conf_file(pyside6_library_info)
 
     # Collect required Qt binaries.
     binaries = get_qt_binaries(pyside6_library_info)

--- a/PyInstaller/utils/hooks/qt.py
+++ b/PyInstaller/utils/hooks/qt.py
@@ -703,19 +703,6 @@ def get_qt_qml_files(qt_library_info):
     return binaries, datas
 
 
-# Collect the ``qt.conf`` file.
-def get_qt_conf_file(qt_library_info):
-    # No-op if requested Qt-based package is not available.
-    if qt_library_info.version is None:
-        return []
-    # Find ``qt.conf`` in location['PrefixPath'].
-    datas = [
-        x for x in hooks.collect_system_data_files(qt_library_info.location['PrefixPath'], qt_library_info.qt_rel_dir)
-        if os.path.basename(x[0]) == 'qt.conf'
-    ]
-    return datas
-
-
 # Collect QtWebEngine helper process executable, translations, and resources.
 def get_qt_webengine_binaries_and_data_files(qt_library_info):
     binaries = []
@@ -794,6 +781,12 @@ def get_qt_webengine_binaries_and_data_files(qt_library_info):
             os.path.relpath(qt_library_info.location['LibraryExecutablesPath'], qt_library_info.location['PrefixPath'])
         )
         binaries.append((os.path.join(qt_library_info.location['LibraryExecutablesPath'], 'QtWebEngineProcess*'), dest))
+
+        # The helper QtWebEngineProcess executable should have an accompanying qt.conf file that helps it locate the
+        # Qt shared libraries. Try collecting it as well
+        qt_conf_file = os.path.join(qt_library_info.location['LibraryExecutablesPath'], 'qt.conf')
+        if os.path.isfile(qt_conf_file):
+            datas.append((qt_conf_file, dest))
 
     # Add Linux-specific libraries.
     if compat.is_linux:

--- a/news/6769.hooks.rst
+++ b/news/6769.hooks.rst
@@ -1,0 +1,4 @@
+Update PySide6 and PyQt6 hooks for compatibility with Qt 6.3. ``QtWebEngine`` 
+on Windows and Linux does not provide the ``qt.conf`` file for the helper 
+executable anymore, so we generate our own version of the file in order for 
+``QtWebengine`` -based frozen applications to work.

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -38,14 +38,17 @@ pygments==2.11.2
 PyGObject==3.42.0; sys_platform == 'linux'
 pyside2==5.15.2.1
 # pyside6 6.2.2 wheel is incompatible with python < 3.8 on macOS
+# pyside6 6.3 wheels are incompatible with python < 3.8 on linux
+# see https://bugreports.qt.io/browse/PYSIDE-1797
 pyside6==6.2.1; sys_platform == 'darwin' and python_version < '3.8'  # pyup: ignore
-pyside6==6.2.4; sys_platform != 'darwin' or python_version >= '3.8'
+pyside6==6.2.4; sys_platform == 'linux' and python_version < '3.8'  # pyup: ignore
+pyside6==6.3; (sys_platform != 'darwin' and sys_platform != 'linux') or python_version >= '3.8'
 pyqt5==5.15.6; python_version < '3.10'
 pyqtwebengine==5.15.5; python_version < '3.10'
-pyqt6==6.2.3  # PyQt6 Qt6 bindings
-pyqt6-qt6==6.2.4  # Qt6 binaries (keep in sync with pyqt6 version!)
-pyqt6-webengine==6.2.1  # PyQt6 QtWebEngine bindings
-pyqt6-webengine-qt6==6.2.4  # Qt6 QtWebEngine binaries
+pyqt6==6.3  # PyQt6 Qt6 bindings
+pyqt6-qt6==6.3  # Qt6 binaries (keep in sync with pyqt6 version!)
+pyqt6-webengine==6.3  # PyQt6 QtWebEngine bindings
+pyqt6-webengine-qt6==6.3  # Qt6 QtWebEngine binaries
 python-dateutil==2.8.2
 pytz==2022.1
 requests==2.27.1


### PR DESCRIPTION
In Qt6 6.3, the `QtWebEngine` seems to have dropped the `qt.conf` file used by the helper `QtWebEngineProcess` executable on Windows and Linux. This file is likely redundant for the PySide6/PyQt6 (the base prefix of Qt6 is likely correctly inferred from the location of shared libs), but we need it in the frozen bundle due to shared libs being relocated to _MEIPASS. 

So until we stop relocating those shared libs, we need to generate our own version of `qt.conf` file.