### PR TITLE
rthooks: glib: prepend XDG_DATA_PATH instead of overwriting it

### DIFF
--- a/PyInstaller/hooks/rthooks/pyi_rth_glib.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_glib.py
@@ -12,4 +12,20 @@
 import os
 import sys
 
-os.environ['XDG_DATA_DIRS'] = os.path.join(sys._MEIPASS, 'share')
+# Prepend the frozen application's data dir to XDG_DATA_DIRS. We need to avoid overwriting the existing paths in order
+# to allow the frozen application to run system-installed applications (for example, launch a web browser via the
+# webbrowser module on Linux). Should the user desire complete isolation of the frozen application from the system,
+# they need to clean up XDG_DATA_DIRS at the start of their program (i.e., remove all entries but first).
+pyi_data_dir = os.path.join(sys._MEIPASS, 'share')
+
+xdg_data_dirs = os.environ.get('XDG_DATA_DIRS', None)
+if xdg_data_dirs:
+    if pyi_data_dir not in xdg_data_dirs:
+        xdg_data_dirs = pyi_data_dir + os.pathsep + xdg_data_dirs
+else:
+    xdg_data_dirs = pyi_data_dir
+os.environ['XDG_DATA_DIRS'] = xdg_data_dirs
+
+# Cleanup aux variables
+del xdg_data_dirs
+del pyi_data_dir

--- a/news/3668.bugfix.rst
+++ b/news/3668.bugfix.rst
@@ -1,0 +1,6 @@
+(Linux) Have ``glib`` runtime hook prepend the frozen application's data
+dir to the ``XDG_DATA_DIRS`` environment variable instead of completely
+overwriting it. This should fix the case when ``xdg-open`` is used to
+launch a system-installed application (for example, opening an URL in a
+web browser via the ``webbrowser`` module) and no registered applications
+being found.


### PR DESCRIPTION
Prepend the frozen application's data path (`_MEIPASS/share`) to `XDG_DATA_PATH` instead of overwriting it in the `glib` runtime hook.

The most common example where `XDG_DATA_PATH` is needed is when system-installed programs are being spawned via `xdg-open` (for example, opening a web browser via `webbrowser` module on Linux), and in that case, limiting `XDG_DATA_PATH` to bundle's data path results in no registered applications being found.

By modifying `XDG_DATA_PATH` instead of overwriting it, we now allow discovery of applications that are installed on system as well as part of the bundle (if any?), to cover the most use cases. Should users wish to completely isolate their bundle from the system for whatever reason (i.e., previous behavior), they need to clean up `XDG_DATA_PATH` (keep only the first entry) at the start of their program.

Closes #3668.