### PR TITLE
Resolve icon paths relative to specpath instead of cwd (#6759).

### DIFF
--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -468,6 +468,10 @@ class EXE(Target):
             # no value; presence means "true"
             self.toc.append(("pyi-macos-argv-emulation", "", "OPTION"))
 
+        # If the icon path is relative, make it relative to the .spec file.
+        if self.icon and self.icon != "NONE" and not os.path.isabs(self.icon):
+            self.icon = os.path.join(CONF['specpath'], self.icon)
+
         if is_win:
             if not self.exclude_binaries:
                 # onefile mode forces embed_manifest=True

--- a/PyInstaller/utils/win32/icon.py
+++ b/PyInstaller/utils/win32/icon.py
@@ -214,10 +214,7 @@ def CopyIcons(dstpath, srcpath):
     if srcext.lower() == '.ico':
         return CopyIcons_FromIco(dstpath, [srcpath])
 
-    # Single source is not .ico, presumably it is .exe (and if not, some error will occur). If relative, make it
-    # relative to the .spec file.
-    if not os.path.isabs(srcpath):
-        srcpath = os.path.join(config.CONF['specpath'], srcpath)
+    # Single source is not .ico, presumably it is .exe (and if not, some error will occur).
     if index is not None:
         logger.info("Copying icon from %s, %d", srcpath, index)
     else:

--- a/news/6759.bugfix.rst
+++ b/news/6759.bugfix.rst
@@ -1,0 +1,2 @@
+Restore the pre PyInstaller 5.0 behavior of resolving relative paths to icons as
+relative to the spec file rather than the current working directory.

--- a/tests/functional/test_basic.py
+++ b/tests/functional/test_basic.py
@@ -387,6 +387,7 @@ def test_set_icon(pyi_builder, data_dir):
         args = ['--windowed', '--icon', os.path.join(data_dir.strpath, 'pyi_icon.icns')]
     else:
         pytest.skip('option --icon works only on Windows and Mac OS X')
+    os.chdir(os.path.expanduser("~"))
     pyi_builder.test_source("print('Hello Python!')", pyi_args=args)
 
 


### PR DESCRIPTION
Interpreting `./foo.ico` as `$SPECPATH/foo.ico` was the original behaviour before #6697 accidentally changed it to `$PWD/foo.ico`. For the most part, this breakage went unnoticed because the spec file is typically placed in the current working directory.

Fixes #6759.