### PR TITLE
Bugfix/prevent site collection (closes #6785)

### DIFF
--- a/PyInstaller/utils/hooks/__init__.py
+++ b/PyInstaller/utils/hooks/__init__.py
@@ -686,6 +686,11 @@ def collect_dynamic_libs(package, destdir=None):
     if not isinstance(package, compat.string_types):
         raise TypeError('package must be a str')
 
+    # Skip a module which is not a package.
+    if not is_package(package):
+        logger.warning("collect_dynamic_libs - skipping library collection for module '%s' as it is not a package.", package)
+        return []
+
     pkg_base, pkg_dir = get_package_paths(package)
     # Walk through all file in the given package, looking for dynamic libraries.
     dylibs = []
@@ -740,6 +745,11 @@ def collect_data_files(package, include_py_files=False, subdir=None, excludes=No
     # Accept only strings as packages.
     if not isinstance(package, compat.string_types):
         raise TypeError('package must be a str')
+
+    # Skip a module which is not a package.
+    if not is_package(package):
+        logger.warning("collect_data_files - skipping data collection for module '%s' as it is not a package.", package)
+        return []
 
     # Compute the root path for the provided patckage.
     pkg_base, pkg_dir = get_package_paths(package)

--- a/PyInstaller/utils/hooks/__init__.py
+++ b/PyInstaller/utils/hooks/__init__.py
@@ -688,7 +688,9 @@ def collect_dynamic_libs(package, destdir=None):
 
     # Skip a module which is not a package.
     if not is_package(package):
-        logger.warning("collect_dynamic_libs - skipping library collection for module '%s' as it is not a package.", package)
+        logger.warning(
+            "collect_dynamic_libs - skipping library collection for module '%s' as it is not a package.", package
+        )
         return []
 
     pkg_base, pkg_dir = get_package_paths(package)

--- a/PyInstaller/utils/hooks/__init__.py
+++ b/PyInstaller/utils/hooks/__init__.py
@@ -680,11 +680,12 @@ def collect_dynamic_libs(package, destdir=None):
 
     :param destdir: Relative path to ./dist/APPNAME where the libraries should be put.
     """
+    logger.debug('Collecting dynamic libraries for %s' % package)
+
     # Accept only strings as packages.
     if not isinstance(package, compat.string_types):
         raise TypeError('package must be a str')
 
-    logger.debug('Collecting dynamic libraries for %s' % package)
     pkg_base, pkg_dir = get_package_paths(package)
     # Walk through all file in the given package, looking for dynamic libraries.
     dylibs = []

--- a/news/6789.bugfix.rst
+++ b/news/6789.bugfix.rst
@@ -1,1 +1,1 @@
-Prevent collection of an entire Python site for single-file modules
+Prevent collection of an entire Python site when using `collect_data_files` or `collect_dynamic_libs` for single-file modules

--- a/news/6789.bugfix.rst
+++ b/news/6789.bugfix.rst
@@ -1,0 +1,1 @@
+Prevent collection of an entire Python site for single-file modules

--- a/news/6789.bugfix.rst
+++ b/news/6789.bugfix.rst
@@ -1,1 +1,1 @@
-Prevent collection of an entire Python site when using `collect_data_files` or `collect_dynamic_libs` for single-file modules
+Prevent collection of an entire Python site when using :func:`~PyInstaller.utils.hooks.collect_data_files` or :func:`~PyInstaller.utils.hooks.collect_dynamic_libs` for single-file modules


### PR DESCRIPTION
This PR adds an `is_package()` check to the data/binary collection routines to prevent duplicating the entire site of the host interpreter when called for single-file libraries, see #6785 