### PR TITLE
building: resolve spec path, workpath, and distpath to absolute paths

### DIFF
--- a/PyInstaller/utils/win32/icon.py
+++ b/PyInstaller/utils/win32/icon.py
@@ -95,15 +95,13 @@ class GRPICONDIRENTRY(Structure):
 class IconFile:
     def __init__(self, path):
         self.path = path
-        if not os.path.isabs(path):
-            self.path = os.path.join(config.CONF['specpath'], path)
         try:
             # The path is from the user parameter, don't trust it.
             file = open(self.path, "rb")
         except OSError:
             # The icon file can't be opened for some reason. Stop the
             # program with an informative message.
-            raise SystemExit('Unable to open icon file {}'.format(path))
+            raise SystemExit(f'Unable to open icon file {self.path}!')
         with file:
             self.entries = []
             self.images = []

--- a/news/6788.bugfix.1.rst
+++ b/news/6788.bugfix.1.rst
@@ -1,0 +1,3 @@
+The user-provided spec file path and paths provided via :option:`--workpath`
+and :option:`--distpath` are now resolved to absolute full paths before being
+passed to PyInstaller's internals.

--- a/news/6788.bugfix.rst
+++ b/news/6788.bugfix.rst
@@ -1,0 +1,2 @@
+(Windows) Fix the regression causing the (relative) spec path ending up
+prepended to relative icon path twice, resulting in icon not being found.


### PR DESCRIPTION
Ensure that the spec filename (and later spec path) as well as user-provided `workpath` and `distpath` are absolute paths before they are stored in the `PyInstaller.config.CONF dictionary`.

Fixes #6788 - the issue with relative icon path being prepended spec path twice in two different places due to spec path itself being relative.

The second commit removes a redundant check for absolute icon file path; the calling code from `building.api.EXE` should already ensure that this is the case (and this second call was, in fact, responsible for the relative spec path being prepended to relative icon path twice).