### PR TITLE
hooks: pickle: exclude doctest

### DIFF
--- a/PyInstaller/hooks/hook-PyQt5.py
+++ b/PyInstaller/hooks/hook-PyQt5.py
@@ -17,7 +17,9 @@ if pyqt5_library_info.version is not None:
         # PyQt5.10 and earlier uses sip in an separate package;
         'sip',
         # PyQt5.11 and later provides SIP in a private package. Support both.
-        'PyQt5.sip'
+        'PyQt5.sip',
+        # Imported via __import__ in PyQt5/__init__.py
+        'pkgutil',
     ]
 
     # Collect required Qt binaries.

--- a/PyInstaller/hooks/hook-PyQt6.py
+++ b/PyInstaller/hooks/hook-PyQt6.py
@@ -13,7 +13,11 @@ from PyInstaller.utils.hooks.qt import get_qt_binaries, pyqt6_library_info
 
 # Only proceed if PyQt6 can be imported.
 if pyqt6_library_info.version is not None:
-    hiddenimports = ['PyQt6.sip']
+    hiddenimports = [
+        'PyQt6.sip',
+        # Imported via __import__ in PyQt6/__init__.py
+        'pkgutil',
+    ]
 
     # Collect required Qt binaries.
     binaries = get_qt_binaries(pyqt6_library_info)

--- a/PyInstaller/hooks/hook-PySide2.py
+++ b/PyInstaller/hooks/hook-PySide2.py
@@ -13,7 +13,10 @@ from PyInstaller.utils.hooks.qt import get_qt_binaries, pyside2_library_info
 
 # Only proceed if PySide2 can be imported.
 if pyside2_library_info.version is not None:
-    hiddenimports = ['shiboken2']
+    hiddenimports = ['shiboken2', 'inspect']
+    if pyside2_library_info.version < [5, 15]:
+        # The shiboken2 bootstrap in earlier releases requires __future__ in addition to inspect
+        hiddenimports += ['__future__']
 
     # Collect required Qt binaries.
     binaries = get_qt_binaries(pyside2_library_info)

--- a/PyInstaller/hooks/hook-PySide6.py
+++ b/PyInstaller/hooks/hook-PySide6.py
@@ -13,7 +13,7 @@ from PyInstaller.utils.hooks.qt import get_qt_binaries, pyside6_library_info
 
 # Only proceed if PySide6 can be imported.
 if pyside6_library_info.version is not None:
-    hiddenimports = ['shiboken6']
+    hiddenimports = ['shiboken6', 'inspect']
 
     # Collect required Qt binaries.
     binaries = get_qt_binaries(pyside6_library_info)

--- a/PyInstaller/hooks/hook-pickle.py
+++ b/PyInstaller/hooks/hook-pickle.py
@@ -10,7 +10,4 @@
 #-----------------------------------------------------------------------------
 
 # Only required when run as `__main__`
-excludedimports = ["argparse"]
-
-# pickle also imports `doctest`, which also is only used when run an `__main__`. Anyway, excluding it made some Qt
-# related tests fail terribly with "ModuleNotFoundError: No module named '__future__'" when running the executable.
+excludedimports = ["argparse", "doctest"]

--- a/news/6797.hooks.rst
+++ b/news/6797.hooks.rst
@@ -1,0 +1,3 @@
+Exclude ``doctest`` in the ``pickle`` hook. Update ``PySide2``, ``PySide6``, 
+``PyQt5``, and ``PyQt6`` hooks with hidden imports that were previously
+pulled in by ``doctest`` (that was in turn pulled in by ``pickle``).


### PR DESCRIPTION
Exclude `doctest` in `pickle` hook. As already noted there, it is needed only when running the module as `__main__` (same as
already-excluded `argparse`).

The `doctest` module pulls in several other modules that are hidden imports in PySide and PyQt packages. Specifically:
- `PySide2` and `PySide6` require `inspect` module
- `PySide2` prior to 5.15 requires `__future__` module
- `PyQt5` and `PyQt6` require `pkgutil` module

So add these as hidden imports to corresponding hooks.