### PR TITLE
Fix Dockerfile zlib download path

### DIFF
--- a/bootloader/Dockerfile
+++ b/bootloader/Dockerfile
@@ -39,7 +39,7 @@ ARG ZLIB_VERSION=1.2.11
 
 # Download and unpack zlib.
 WORKDIR /home/
-RUN curl -s https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz | tar xfz -
+RUN curl -s https://zlib.net/fossils/zlib-${ZLIB_VERSION}.tar.gz | tar xfz -
 
 ENV CC=${CC:-gcc}
 


### PR DESCRIPTION
Fix Dockerfile zlib download path.
The path for 1.2.11 has changed. Also, 1.2.12 seems to have some compile errors.

Quick fix was to change the path for 1.2.11.