### PR TITLE
Add detection for leaked file handles in tests.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Run tests
         run: >
             pytest
-            -n 3 --maxfail 3 --durations 10 tests/unit tests/functional
+            --maxfail 3 --durations 10 tests/unit tests/functional
             --force-flaky --no-flaky-report --reruns 3 --reruns-delay 10
 
       - name: Run hooksample tests
@@ -149,7 +149,7 @@ jobs:
           -e SETUPTOOLS_USE_DISTUTILS='not-today'
           foo
           pytest
-          -n 3 --maxfail 3 --durations 10 tests/unit tests/functional
+          --maxfail 3 --durations 10 tests/unit tests/functional
           --force-flaky --no-flaky-report --reruns 3 --reruns-delay 10
 
       # Verify that installing from sdist works. This is mostly just a verification that the MANIFEST.in contains

--- a/PyInstaller/utils/conftest.py
+++ b/PyInstaller/utils/conftest.py
@@ -579,3 +579,21 @@ def pyi_windowed_builder(pyi_builder: AppBuilder):
 
     pyi_builder._run_executable_ = _run_executable_
     yield pyi_builder
+
+
+@pytest.fixture(autouse=True)
+def check_for_file_handle_leaks():
+    """Close all open Qt Windows before and after each test."""
+
+    p = psutil.Process()
+
+    def _state():
+        return (p.open_files(), p.connections(), p.num_handles() if is_win else p.num_fds())
+
+    before = _state()
+    yield
+    after = _state()
+
+    assert before[0] == after[0]
+    assert before[1] == after[1]
+    assert before[2] == after[2]

--- a/tests/requirements-tools.txt
+++ b/tests/requirements-tools.txt
@@ -18,9 +18,6 @@ execnet >= 1.5.0
 # Testing framework.
 pytest >= 2.7.3
 
-# Plugin allowing running tests in parallel.
-pytest-xdist
-
 # Plugin to abort hanging tests.
 pytest-timeout >= 2.0.0
 # allows specifying order without duplicates


### PR DESCRIPTION
Add a pytest fixture applied to all tests which compares the handles open before and after each test and raises an error if they differ. This will hopefully identify our mystery Windows + Python 3.8 and 3.9 exceeding file handle limit on CI/CD.
