### PR TITLE
Bump required pyinstaller-hooks-contrib version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@
 
 setuptools
 altgraph
-pyinstaller-hooks-contrib >= 2020.11
+pyinstaller-hooks-contrib >= 2021.4
 pefile; sys_platform == 'win32'
 pywin32-ctypes; sys_platform == 'win32'
 macholib; sys_platform == 'darwin'

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,7 +63,7 @@ install_requires =
     pefile >= 2017.8.1 ; sys_platform == 'win32'
     pywin32-ctypes >= 0.2.0 ; sys_platform == 'win32'
     macholib >= 1.8 ; sys_platform == 'darwin'
-    pyinstaller-hooks-contrib >= 2020.6
+    pyinstaller-hooks-contrib >= 2021.4
     importlib-metadata ; python_version < '3.8'
 
 [options.extras_require]


### PR DESCRIPTION
For `PyInstaller` 5.x, we need `pyinstaller-hooks-contrib` >= `v2021.4` to have a working `pydantic` hook.

In an ideal world, people would have the latest version installed anyway, but #6816 shows us that this is not the case...