### PR TITLE
Hooks: Add GTK4 support

### DIFF
--- a/PyInstaller/hooks/hook-gi.repository.Graphene.py
+++ b/PyInstaller/hooks/hook-gi.repository.Graphene.py
@@ -13,22 +13,5 @@ Import hook for PyGObject https://wiki.gnome.org/PyGObject
 """
 
 from PyInstaller.utils.hooks.gi import get_gi_typelibs
-from PyInstaller.utils.hooks import get_hook_config, logger
 
-
-def hook(hook_api):
-    module_versions = get_hook_config(hook_api, 'gi', 'module-versions')
-    if module_versions:
-        version = module_versions.get('Gdk')
-        if not version:
-            version = module_versions.get('Gtk', '3.0')
-    else:
-        version = '3.0'
-    logger.info(f'Gdk version is {version}')
-
-    binaries, datas, hiddenimports = get_gi_typelibs('Gdk', version)
-    hiddenimports += ['gi._gi_cairo', 'gi.repository.cairo']
-
-    hook_api.add_datas(datas)
-    hook_api.add_binaries(binaries)
-    hook_api.add_imports(*hiddenimports)
+binaries, datas, hiddenimports = get_gi_typelibs('Graphene', '1.0')

--- a/PyInstaller/hooks/hook-gi.repository.Gsk.py
+++ b/PyInstaller/hooks/hook-gi.repository.Gsk.py
@@ -13,22 +13,5 @@ Import hook for PyGObject https://wiki.gnome.org/PyGObject
 """
 
 from PyInstaller.utils.hooks.gi import get_gi_typelibs
-from PyInstaller.utils.hooks import get_hook_config, logger
 
-
-def hook(hook_api):
-    module_versions = get_hook_config(hook_api, 'gi', 'module-versions')
-    if module_versions:
-        version = module_versions.get('Gdk')
-        if not version:
-            version = module_versions.get('Gtk', '3.0')
-    else:
-        version = '3.0'
-    logger.info(f'Gdk version is {version}')
-
-    binaries, datas, hiddenimports = get_gi_typelibs('Gdk', version)
-    hiddenimports += ['gi._gi_cairo', 'gi.repository.cairo']
-
-    hook_api.add_datas(datas)
-    hook_api.add_binaries(binaries)
-    hook_api.add_imports(*hiddenimports)
+binaries, datas, hiddenimports = get_gi_typelibs('Gsk', '4.0')

--- a/PyInstaller/hooks/hook-gi.repository.Gtk.py
+++ b/PyInstaller/hooks/hook-gi.repository.Gtk.py
@@ -16,16 +16,23 @@ import os
 import os.path
 
 from PyInstaller.compat import is_win
-from PyInstaller.utils.hooks import get_hook_config
+from PyInstaller.utils.hooks import get_hook_config, logger
 from PyInstaller.utils.hooks.gi import \
     collect_glib_etc_files, collect_glib_share_files, collect_glib_translations, get_gi_typelibs
 
-binaries, datas, hiddenimports = get_gi_typelibs('Gtk', '3.0')
-
-datas += collect_glib_share_files('fontconfig')
-
 
 def hook(hook_api):
+    module_versions = get_hook_config(hook_api, 'gi', 'module-versions')
+    if module_versions:
+        version = module_versions.get('Gtk', '3.0')
+    else:
+        version = '3.0'
+    logger.info(f'Gtk version is {version}')
+
+    binaries, datas, hiddenimports = get_gi_typelibs('Gtk', version)
+
+    datas += collect_glib_share_files('fontconfig')
+
     hook_datas = []
 
     icon_list = get_hook_config(hook_api, "gi", "icons")
@@ -44,13 +51,16 @@ def hook(hook_api):
     else:
         hook_datas += collect_glib_share_files('themes')
 
-    hook_datas += collect_glib_translations('gtk30', lang_list)
+    hook_datas += collect_glib_translations(f'gtk{version[0]}0', lang_list)
 
     hook_api.add_datas(hook_datas)
 
+    # these only seem to be required on Windows
+    if is_win:
+        datas += collect_glib_etc_files('fonts')
+        datas += collect_glib_etc_files('pango')
+        datas += collect_glib_share_files('fonts')
 
-# these only seem to be required on Windows
-if is_win:
-    datas += collect_glib_etc_files('fonts')
-    datas += collect_glib_etc_files('pango')
-    datas += collect_glib_share_files('fonts')
+    hook_api.add_datas(datas)
+    hook_api.add_binaries(binaries)
+    hook_api.add_imports(*hiddenimports)

--- a/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.Graphene.py
+++ b/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.Graphene.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2022, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+
+def pre_safe_import_module(api):
+    # PyGObject modules loaded through the gi repository are marked as MissingModules by modulegraph, so we convert them
+    # to RuntimeModules in order for their hooks to be loaded and executed.
+    api.add_runtime_module(api.module_name)

--- a/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.Gsk.py
+++ b/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.Gsk.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2022, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+
+def pre_safe_import_module(api):
+    # PyGObject modules loaded through the gi repository are marked as MissingModules by modulegraph, so we convert them
+    # to RuntimeModules in order for their hooks to be loaded and executed.
+    api.add_runtime_module(api.module_name)

--- a/doc/hooks-config.rst
+++ b/doc/hooks-config.rst
@@ -98,7 +98,7 @@ version 3.0 of Gtk and version 4 of GtkSource:
         ...,
     )
 
-.. note:: Currently only the ``module-versions`` configuration is available for ``GtkSource``.
+.. note:: Currently the ``module-versions`` configuration is available only for ``GtkSource``, ``Gtk``, and ``Gdk``.
 
 .. _matplotlib hook options:
 

--- a/news/6834.hooks.rst
+++ b/news/6834.hooks.rst
@@ -1,0 +1,3 @@
+Add support for GTK4 by adding dependencies and updating ``gi.repository.Gtk``
+and ``gi.repository.Gdk`` to work with ``module-versions`` in hooksconfig for
+``gi``.


### PR DESCRIPTION
I built off of https://github.com/pyinstaller/pyinstaller/pull/6267 by updating the ``gi.repository.Gtk`` and ``gi.repository.Gdk`` to work with ``module-versions`` in hooksconfig for ``gi`` and also adding dependencies.

GTK4 can be enabled by simply adding an entry for Gtk in hooksconfig like below.

```
a = Analysis(
    ["program.py"],
    ...,
    hooksconfig={
        "gi": {
            "module-versions": {
                "Gtk": "4.0"
            }
        },
    },
    ...,
)
```

I have confirmed this update to work on Debian Testing, MinGW on Windows 11, and macOS Monterey.