### PR TITLE
bindepend: get_python_library_path: resolve symlinks during libdir search

### DIFF
--- a/PyInstaller/depend/bindepend.py
+++ b/PyInstaller/depend/bindepend.py
@@ -854,8 +854,15 @@ def get_python_library_path():
         for libdir in libdirs:
             for name in compat.PYDYLIB_NAMES:
                 full_path = os.path.join(libdir, name)
-                if os.path.exists(full_path):
-                    return full_path
+                if not os.path.exists(full_path):
+                    continue
+                # Resolve potential symbolic links to achieve consistent results with linker-based search; e.g., on
+                # POSIX systems, linker resolves unversioned library names (python3.X.so) to versioned ones
+                # (libpython3.X.so.1.0) due to former being symbolic linkes to the latter. See #6831.
+                full_path = os.path.realpath(full_path)
+                if not os.path.exists(full_path):
+                    continue
+                return full_path
         return None
 
     # If this is Microsoft App Store Python, check the compat.base_path first. While compat.python_executable resolves

--- a/news/6831.bugfix.rst
+++ b/news/6831.bugfix.rst
@@ -1,0 +1,5 @@
+(Linux) Fix potential mismatch between the collected python shared
+library name and the name expected by the bootloader when using
+Anaconda environment. The mismatch would occur on some attempts to
+freeze a program that uses an extension that is also linked against
+the python shared library.


### PR DESCRIPTION
When searching for python shared library via libdir search (i.e, using `_find_lib_in_libdirs()` helper), resolve the potential symbolic links. This ensures that unversioned .so names (e.g., `libpython3.x.so`) are resolved as versioned .so names (e.g., `libpython3.x.so.1`), which is the behavior of linker-based search codepath.

Having the bootloader expect an unversioned .so name results in a missing library error when the versioned .so library is already
collected for whatever reason (e.g., due to being link-time dependency of a collected extension), because such cases preclude
collection of the unversioned .so name.

In practice, the above issue manifests only under Anaconda on linux, because regular linux codepath uses linker-based search, which already resolves unversioned .so name to the versioned one.

Fixes #6831.