### PR TITLE
docs: Update note on running with admin privileges

### DIFF
--- a/doc/operating-mode.rst
+++ b/doc/operating-mode.rst
@@ -242,13 +242,15 @@ stored in the executable, and the bootloader will create the
 
 .. Note::
 
-    Do *not* give administrator privileges to a one-file executable
-    (setuid root in Unix/Linux, or the "Run this program as an administrator"
-    property in Windows 7).
+    Do *not* give administrator privileges to a one-file executable on Windows
+    ("Run this program as an administrator").
     There is an unlikely but not impossible way in which a malicious attacker could
     corrupt one of the shared libraries in the temp folder
     while the bootloader is preparing it.
-    Distribute a privileged program in one-folder mode instead.
+    When distributing a privileged program in general, ensure that file
+    permissions prevent shared libraries or executables from being tampered with.
+    Otherwise, an unelevated process which has write access to these files may
+    escalate privileges by modifying them.
 
 .. Note::
     Applications that use `os.setuid()` may encounter permissions errors.


### PR DESCRIPTION
This updates the documentation in accordance with the discussion at https://github.com/pyinstaller/pyinstaller/issues/6842. While `setuid` binaries are not an issue on Linux due to `700` permissions of the temporary directory, security issues may arise on Windows, where an unelevated process running under the same identity as a PyInstaller executable may gain elevated privileges by modifying the shared libraries or the executable itself.

Closes #6842.