### PR TITLE
hookutils: collect_submodules: do not recurse into filtered subpackages

### DIFF
--- a/PyInstaller/utils/hooks/__init__.py
+++ b/PyInstaller/utils/hooks/__init__.py
@@ -682,7 +682,7 @@ def _collect_submodules(name, on_error):
 
     logger.debug("collect_submodules - scanning (sub)package %s", name)
 
-    modules = [name]
+    modules = []
     subpackages = []
 
     # Resolve package location(s)
@@ -700,7 +700,7 @@ def _collect_submodules(name, on_error):
         elif on_error == "raise":
             raise ImportError(f"Unable to load subpackage '{name}'.") from ex
 
-    # Do not attempt to recurse into (sub)package if it did not make it into sys.modules.
+    # Do not attempt to recurse into package if it did not make it into sys.modules.
     if name not in sys.modules:
         return modules, subpackages, on_error
 
@@ -708,6 +708,9 @@ def _collect_submodules(name, on_error):
     paths = getattr(sys.modules[name], '__path__', None) or []
     if not paths:
         return modules, subpackages, on_error
+
+    # Package was successfully imported - include it in the list of modules.
+    modules.append(name)
 
     # Iterate package contents
     logger.debug("collect_submodules - scanning (sub)package %s in location(s): %s", name, paths)

--- a/PyInstaller/utils/hooks/__init__.py
+++ b/PyInstaller/utils/hooks/__init__.py
@@ -640,6 +640,10 @@ def collect_submodules(package: str, filter: Callable[[str], bool] = lambda name
     # Skip a module which is not a package.
     if not is_package(package):
         logger.debug('collect_submodules - %s is not a package.', package)
+        # If module is importable, return its name in the list, in order to keep behavior consistent with the
+        # one we have for packages (i.e., we include the package in the list of returned names)
+        if can_import_module(package):
+            return [package]
         return []
 
     # Determine the filesystem path(s) to the specified package.

--- a/news/6846.bugfix.rst
+++ b/news/6846.bugfix.rst
@@ -1,0 +1,3 @@
+Prevent :func:`PyInstaller.utils.hooks.collect_submodules` from recursing
+into sub-packages that are excluded by the function passed via the
+``filter`` argument.

--- a/news/6850.bugfix.1.rst
+++ b/news/6850.bugfix.1.rst
@@ -1,0 +1,3 @@
+The :func:`PyInstaller.utils.hooks.collect_submodules` function now
+excludes un-importable subpackages from the returned modules list.
+

--- a/news/6850.bugfix.rst
+++ b/news/6850.bugfix.rst
@@ -1,0 +1,4 @@
+If passed a name of an importable module instead of a package, the
+:func:`PyInstaller.utils.hooks.collect_submodules` function now returns
+a list containing the module's name, same as it would for a package
+without submodules.

--- a/tests/unit/test_hookutils.py
+++ b/tests/unit/test_hookutils.py
@@ -118,9 +118,10 @@ def mod_list(monkeypatch):
 
 class TestCollectSubmodules(object):
     # A message should be emitted if a module, not a package, was passed.
+    # The module's name should be in the returned list, nevetheless.
     def test_collect_submod_module(self, caplog):
         with caplog.at_level(logging.DEBUG, logger='PyInstaller.utils.hooks'):
-            assert collect_submodules('os') == []
+            assert collect_submodules('os') == ['os']
             assert "collect_submodules - os is not a package." in caplog.records[-1].getMessage()
 
     # A TypeError should be raised if given something other than a str.

--- a/tests/unit/test_hookutils.py
+++ b/tests/unit/test_hookutils.py
@@ -138,14 +138,15 @@ class TestCollectSubmodules(object):
         assert TEST_MOD + '.pyextension' in mod_list
 
     # Check that all packages get included
+    # NOTE: the new behavior (see #6846 and #6850) is that un-importable subpackages are not included.
     def test_collect_submod_all_included(self, mod_list):
         mod_list.sort()
         assert mod_list == [
             TEST_MOD,
             # Python extensions end with '.pyd' on Windows and with  '.so' on Linux, Mac OS, and other OSes.
             TEST_MOD + '.pyextension',
-            TEST_MOD + '.raises_error_on_import_1',
-            TEST_MOD + '.raises_error_on_import_2',
+            #TEST_MOD + '.raises_error_on_import_1',
+            #TEST_MOD + '.raises_error_on_import_2',
             TEST_MOD + '.subpkg',
             TEST_MOD + '.subpkg.twelve',
             TEST_MOD + '.two'

--- a/tests/unit/test_hookutils.py
+++ b/tests/unit/test_hookutils.py
@@ -121,7 +121,7 @@ class TestCollectSubmodules(object):
     def test_collect_submod_module(self, caplog):
         with caplog.at_level(logging.DEBUG, logger='PyInstaller.utils.hooks'):
             assert collect_submodules('os') == []
-            assert "Module os is not a package." in caplog.records[-1].msg
+            assert "collect_submodules - os is not a package." in caplog.records[-1].getMessage()
 
     # A TypeError should be raised if given something other than a str.
     def test_not_a_string(self):


### PR DESCRIPTION
Reorganize the `collect_submodules` code so that each (sub)package scan step is performed separately, and the filter function is applied to the results before recursing into the child subpackages.

This ensures that we do not attempt to recurse into subpackages that are filtered out (i.e., packages that are known to be un-importable and generate a warning/error depending on the on_error setting).

Closes #6846.