### PR TITLE
Add support for GObject introspection from RHEL/Fedora RPMs

### DIFF
--- a/PyInstaller/hooks/pre_safe_import_module/hook-gi.py
+++ b/PyInstaller/hooks/pre_safe_import_module/hook-gi.py
@@ -1,0 +1,32 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2022, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+from PyInstaller import compat
+from PyInstaller.utils import hooks as hookutils
+
+
+def pre_safe_import_module(api):
+    if compat.is_linux:
+        # RHEL/Fedora RPM package for GObject introspection is known to split the `gi` package into two locations:
+        #  - /usr/lib64/python3.x/site-packages/gi
+        #  - /usr/lib/python3.x/site-packages/gi
+        # The `__init__.py` is located in the first directory, while `repository` and `overrides` are located in
+        # the second, and `__init__.py` dynamically extends the `__path__` during package import, using
+        #  `__path__ = pkgutil.extend_path(__path__, __name__)`.
+        # The modulegraph has no way of knowing this, so we need extend the package path in this hook. Otherwise,
+        # only the first location is scanned, and the `gi.repository` ends up missing.
+        #
+        # NOTE: the `get_package_paths`/`get_package_all_paths` helpers read the paths from package's spec without
+        # importing the (top-level) package, so they do not catch run-time path modifications. Instead, we use
+        # `get_module_attribute` to import the package in isolated process and query its `__path__` attribute.
+        paths = hookutils.get_module_attribute(api.module_name, "__path__")
+        for path in paths:
+            api.append_package_path(path)

--- a/news/6780.bugfix.rst
+++ b/news/6780.bugfix.rst
@@ -1,0 +1,3 @@
+(Linux) Fix the missing ``gi.repository`` error in an application frozen on
+RHEL/Fedora linux with GObject introspection installed from the distrubtion's 
+RPM package.


### PR DESCRIPTION
Fixes #6780. Fedora's `python3-gobject-base` RPM places splits the `gi` package in `/usr/lib64/python3.10/site-packages/gi` and `/usr/lib/python3.10/site-packages/gi`. The `__init__.py` is located in the first directory, while `repository` and `overrides` are located in the second. At import time, the package's `__init__.py` modifies its `__path__` using:
```python
# support overrides in different directories than our gi module
from pkgutil import extend_path
__path__ = extend_path(__path__, __name__)
```
The module graph has no way of knowing this, so we end up searching only the first directory, and end up missing `gi.repository`. But we can work around this using a pre-safe-import-module for `gi` in which we extend the modulegraph's paths for the package. 

This, however, requires a new helper that imports the given package in isolated subprocess and queries its `__path__` attribute, in contrast to existing helpers that are based on the package spec retrieved via `importlib` machinery.
