### PR TITLE
Detect mislabelled icon files via their file header.

### DIFF
--- a/news/6870.feature.rst
+++ b/news/6870.feature.rst
@@ -1,0 +1,3 @@
+Detect if an icon file (``.ico`` or ``.icns``) is of another image type but has
+been mislabelled as a native icon type via its file suffix then either normalise
+to a genuinely native image type if ``pillow`` is installed or raise an error.

--- a/tests/unit/test_normalize_icon_type.py
+++ b/tests/unit/test_normalize_icon_type.py
@@ -63,10 +63,11 @@ def test_normalize_icon_pillow(tmp_path):
 
     # A .ico which is really a mislabelled .png: should be detected and normalised
 
-    png = shutil.copy(icon, str(tmp_path / "png-in-disguise.ico"))
-    normalised = normalize_icon_type(png, ("exe", "ico"), "ico", workpath)
-    assert normalised != png
-    assert normalize_icon_type(normalised, ("exe", "ico"), "ico", workpath) == normalised
+    for (i, suffix) in enumerate(["ico", "ICO"]):
+        png = shutil.copy(icon, str(tmp_path / f"png-in-disguise-{i}.{suffix}"))
+        normalised = normalize_icon_type(png, ("exe", "ico"), "ico", workpath)
+        assert normalised != png
+        assert normalize_icon_type(normalised, ("exe", "ico"), "ico", workpath) == normalised
 
     # Some random non-image file: Raises an image conversion error
 

--- a/tests/unit/test_normalize_icon_type.py
+++ b/tests/unit/test_normalize_icon_type.py
@@ -11,6 +11,7 @@
 
 import os
 import sys
+import shutil
 from pathlib import Path
 
 import pytest
@@ -59,6 +60,13 @@ def test_normalize_icon_pillow(tmp_path):
     _, ret_filetype = os.path.splitext(ret)
     if ret_filetype != ".ico":
         pytest.fail("icon validation didn't convert to the right format", False)
+
+    # A .ico which is really a mislabelled .png: should be detected and normalised
+
+    png = shutil.copy(icon, str(tmp_path / "png-in-disguise.ico"))
+    normalised = normalize_icon_type(png, ("exe", "ico"), "ico", workpath)
+    assert normalised != png
+    assert normalize_icon_type(normalised, ("exe", "ico"), "ico", workpath) == normalised
 
     # Some random non-image file: Raises an image conversion error
 


### PR DESCRIPTION
In addition to checking an icon's suffix to see if it is of the correct native type, check the first few bytes of the icon to guard against a naive user just renaming a .png to a .ico or .icns.

I'm not entirely sure why I'm bothering with this. It might have shortened #6845's long path to nowhere.