### PR TITLE
depend: prevent get_code_using() from returning None code objects

### DIFF
--- a/PyInstaller/depend/analysis.py
+++ b/PyInstaller/depend/analysis.py
@@ -662,6 +662,10 @@ class PyiModuleGraph(ModuleGraph):
                 if identifier == module or identifier.startswith(module + '.'):
                     # Skip self references or references from `modules`'s own submodules.
                     continue
+                # The code object may be None if referrer ends up shadowed by eponymous directory that ends up treated
+                # as a namespace package. See #6873 for an example.
+                if r.code is None:
+                    continue
                 co_dict[r.identifier] = r.code
         return co_dict
 


### PR DESCRIPTION
In addition to all other checks and restrictions imposed in the `analysis.get_code_using`, also check that code object is not None.

This seems to happen in #6873, with a directory named `packaging` placed next to entry point script seems to be treated as a namespace package, and mistaken for a referrer of `pkg_resources`, whereas the original referrer is likely the vendored version of `packaging` from the `pkg_resources` itself.

Fixes #6873.