### PR TITLE
hooks: fix error in pre-safe-import gi hook when gi is missing

### DIFF
--- a/PyInstaller/hooks/pre_safe_import_module/hook-gi.py
+++ b/PyInstaller/hooks/pre_safe_import_module/hook-gi.py
@@ -27,6 +27,11 @@ def pre_safe_import_module(api):
         # NOTE: the `get_package_paths`/`get_package_all_paths` helpers read the paths from package's spec without
         # importing the (top-level) package, so they do not catch run-time path modifications. Instead, we use
         # `get_module_attribute` to import the package in isolated process and query its `__path__` attribute.
-        paths = hookutils.get_module_attribute(api.module_name, "__path__")
+        try:
+            paths = hookutils.get_module_attribute(api.module_name, "__path__")
+        except Exception:
+            # Most likely `gi` cannot be imported.
+            paths = []
+
         for path in paths:
             api.append_package_path(path)


### PR DESCRIPTION
Wrap the `get_module_attribute` call in try/except block to gracefully handle cases when `gi` cannot be imported (for example, is referenced in module graph as a conditional import that is not available in the environment).

A fix-up for #6869; the pre-safe-import hook is ran even if the module is unavailable, as seen [here](https://github.com/pyinstaller/pyinstaller-hooks-contrib/runs/6762013766?check_suite_focus=true#step:9:420).