### PR TITLE
winutils: optimize PE headers fixup

### DIFF
--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -764,8 +764,10 @@ class EXE(Target):
         if is_win:
             # Set checksum to appease antiviral software. Also set build timestamp to current time to increase entropy
             # (but honor SOURCE_DATE_EPOCH environment variable for reproducible builds).
+            logger.info("Fixing EXE headers")
             build_timestamp = int(os.environ.get('SOURCE_DATE_EPOCH', time.time()))
-            winutils.fixup_exe_headers(build_name, build_timestamp)
+            winutils.set_exe_build_timestamp(build_name, build_timestamp)
+            winutils.update_exe_pe_checksum(build_name)
         elif is_darwin:
             # If the version of macOS SDK used to build bootloader exceeds that of macOS SDK used to built Python
             # library (and, by extension, bundled Tcl/Tk libraries), force the version declared by the frozen executable

--- a/PyInstaller/utils/win32/winutils.py
+++ b/PyInstaller/utils/win32/winutils.py
@@ -148,18 +148,19 @@ def convert_dll_name_to_str(dll_name):
         return dll_name
 
 
-def fixup_exe_headers(exe_path, timestamp=None):
+def set_exe_build_timestamp(exe_path, timestamp):
     """
-    Set executable's checksum and build timestamp in its headers.
-
-    This optional checksum is supposed to protect the executable against corruption but some anti-viral software have
-    taken to flagging anything without it set correctly as malware. See issue #5579.
+    Modifies the executable's build timestamp by updating values in the corresponding PE headers.
     """
     import pefile
-    pe = pefile.PE(exe_path, fast_load=False)  # full load because we need all headers
-    # Set build timestamp.
-    # See: https://0xc0decafe.com/malware-analyst-guide-to-pe-timestamps
-    if timestamp is not None:
+
+    with pefile.PE(exe_path, fast_load=True) as pe:
+        # Manually perform a full load. We need it to load all headers, but specifying it in the constructor triggers
+        # byte statistics gathering that takes forever with large files. So we try to go around that...
+        pe.full_load()
+
+        # Set build timestamp.
+        # See: https://0xc0decafe.com/malware-analyst-guide-to-pe-timestamps
         timestamp = int(timestamp)
         # Set timestamp field in FILE_HEADER
         pe.FILE_HEADER.TimeDateStamp = timestamp
@@ -169,7 +170,189 @@ def fixup_exe_headers(exe_path, timestamp=None):
         for debug_entry in debug_entries:
             if debug_entry.struct.TimeDateStamp:
                 debug_entry.struct.TimeDateStamp = timestamp
-    # Set PE checksum
-    pe.OPTIONAL_HEADER.CheckSum = pe.generate_checksum()
-    pe.close()
-    pe.write(exe_path)
+
+        # Generate updated EXE data
+        data = pe.write()
+
+    # Rewrite the exe
+    with open(exe_path, 'wb') as fp:
+        fp.write(data)
+
+
+def update_exe_pe_checksum(exe_path):
+    """
+    Compute the executable's PE checksum, and write it to PE headers.
+
+    This optional checksum is supposed to protect the executable against corruption but some anti-viral software have
+    taken to flagging anything without it set correctly as malware. See issue #5579.
+    """
+    import pefile
+
+    # Compute checksum using our equivalent of the MapFileAndCheckSumW - for large files, it is significantly faster
+    # than pure-pyton pefile.PE.generate_checksum(). However, it requires the file to be on disk (i.e., cannot operate
+    # on a memory buffer).
+    try:
+        checksum = compute_exe_pe_checksum(exe_path)
+    except Exception as e:
+        raise RuntimeError("Failed to compute PE checksum!") from e
+
+    # Update the checksum
+    with pefile.PE(exe_path, fast_load=True) as pe:
+        pe.OPTIONAL_HEADER.CheckSum = checksum
+
+        # Generate updated EXE data
+        data = pe.write()
+
+    # Rewrite the exe
+    with open(exe_path, 'wb') as fp:
+        fp.write(data)
+
+
+def compute_exe_pe_checksum(exe_path):
+    """
+    This is a replacement for the MapFileAndCheckSumW function. As noted in MSDN documentation, the Microsoft's
+    implementation of MapFileAndCheckSumW internally calls its ASCII variant (MapFileAndCheckSumA), and therefore
+    cannot handle paths that contain characters that are not representable in the current code page.
+    See: https://docs.microsoft.com/en-us/windows/win32/api/imagehlp/nf-imagehlp-mapfileandchecksumw
+
+    This function is based on Wine's implementation of MapFileAndCheckSumW, and due to being based entirely on
+    the pure widechar-API functions, it is not limited by the current code page.
+    """
+    # ctypes bindings for relevant win32 API functions
+    import ctypes
+    from ctypes import windll, wintypes
+
+    INVALID_HANDLE = wintypes.HANDLE(-1).value
+
+    GetLastError = ctypes.windll.kernel32.GetLastError
+    GetLastError.argtypes = ()
+    GetLastError.restype = wintypes.DWORD
+
+    CloseHandle = windll.kernel32.CloseHandle
+    CloseHandle.argtypes = (
+        wintypes.HANDLE,  # hObject
+    )
+    CloseHandle.restype = wintypes.BOOL
+
+    CreateFileW = windll.kernel32.CreateFileW
+    CreateFileW.argtypes = (
+        wintypes.LPCWSTR,  # lpFileName
+        wintypes.DWORD,  # dwDesiredAccess
+        wintypes.DWORD,  # dwShareMode
+        wintypes.LPVOID,  # lpSecurityAttributes
+        wintypes.DWORD,  # dwCreationDisposition
+        wintypes.DWORD,  # dwFlagsAndAttributes
+        wintypes.HANDLE,  # hTemplateFile
+    )
+    CreateFileW.restype = wintypes.HANDLE
+
+    CreateFileMappingW = windll.kernel32.CreateFileMappingW
+    CreateFileMappingW.argtypes = (
+        wintypes.HANDLE,  # hFile
+        wintypes.LPVOID,  # lpSecurityAttributes
+        wintypes.DWORD,  # flProtect
+        wintypes.DWORD,  # dwMaximumSizeHigh
+        wintypes.DWORD,  # dwMaximumSizeLow
+        wintypes.LPCWSTR,  # lpName
+    )
+    CreateFileMappingW.restype = wintypes.HANDLE
+
+    MapViewOfFile = windll.kernel32.MapViewOfFile
+    MapViewOfFile.argtypes = (
+        wintypes.HANDLE,  # hFileMappingObject
+        wintypes.DWORD,  # dwDesiredAccess
+        wintypes.DWORD,  # dwFileOffsetHigh
+        wintypes.DWORD,  # dwFileOffsetLow
+        wintypes.DWORD,  # dwNumberOfBytesToMap
+    )
+    MapViewOfFile.restype = wintypes.LPVOID
+
+    UnmapViewOfFile = windll.kernel32.UnmapViewOfFile
+    UnmapViewOfFile.argtypes = (
+        wintypes.LPCVOID,  # lpBaseAddress
+    )
+    UnmapViewOfFile.restype = wintypes.BOOL
+
+    GetFileSizeEx = windll.kernel32.GetFileSizeEx
+    GetFileSizeEx.argtypes = (
+        wintypes.HANDLE,  # hFile
+        wintypes.PLARGE_INTEGER,  # lpFileSize
+    )
+
+    CheckSumMappedFile = windll.imagehlp.CheckSumMappedFile
+    CheckSumMappedFile.argtypes = (
+        wintypes.LPVOID,  # BaseAddress
+        wintypes.DWORD,  # FileLength
+        wintypes.PDWORD,  # HeaderSum
+        wintypes.PDWORD,  # CheckSum
+    )
+    CheckSumMappedFile.restype = wintypes.LPVOID
+
+    # Open file
+    hFile = CreateFileW(
+        ctypes.c_wchar_p(exe_path),
+        0x80000000,  # dwDesiredAccess = GENERIC_READ
+        0x00000001 | 0x00000002,  # dwShareMode = FILE_SHARE_READ | FILE_SHARE_WRITE,
+        None,  # lpSecurityAttributes = NULL
+        3,  # dwCreationDisposition = OPEN_EXISTING
+        0x80,  # dwFlagsAndAttributes = FILE_ATTRIBUTE_NORMAL
+        None  # hTemplateFile = NULL
+    )
+    if hFile == INVALID_HANDLE:
+        err = GetLastError()
+        raise RuntimeError(f"Failed to open file {exe_path}! Error code: {err}")
+
+    # Query file size
+    fileLength = wintypes.LARGE_INTEGER(0)
+    if GetFileSizeEx(hFile, fileLength) == 0:
+        err = GetLastError()
+        CloseHandle(hFile)
+        raise RuntimeError(f"Failed to query file size file! Error code: {err}")
+    fileLength = fileLength.value
+    if fileLength > (2**32 - 1):
+        raise RuntimeError("Executable size exceeds maximum allowed executable size on Windows (4 GiB)!")
+
+    # Map the file
+    hMapping = CreateFileMappingW(
+        hFile,
+        None,  # lpFileMappingAttributes = NULL
+        0x02,  # flProtect = PAGE_READONLY
+        0,  # dwMaximumSizeHigh = 0
+        0,  # dwMaximumSizeLow = 0
+        None  # lpName = NULL
+    )
+    if not hMapping:
+        err = GetLastError()
+        CloseHandle(hFile)
+        raise RuntimeError(f"Failed to map file! Error code: {err}")
+
+    # Create map view
+    baseAddress = MapViewOfFile(
+        hMapping,
+        4,  # dwDesiredAccess = FILE_MAP_READ
+        0,  # dwFileOffsetHigh = 0
+        0,  # dwFileOffsetLow = 0
+        0  # dwNumberOfBytesToMap = 0
+    )
+    if baseAddress == 0:
+        err = GetLastError()
+        CloseHandle(hMapping)
+        CloseHandle(hFile)
+        raise RuntimeError(f"Failed to create map view! Error code: {err}")
+
+    # Finally, compute the checksum
+    headerSum = wintypes.DWORD(0)
+    checkSum = wintypes.DWORD(0)
+    ret = CheckSumMappedFile(baseAddress, fileLength, ctypes.byref(headerSum), ctypes.byref(checkSum))
+    if ret is None:
+        err = GetLastError()
+
+    # Cleanup
+    UnmapViewOfFile(baseAddress)
+    CloseHandle(hMapping)
+    CloseHandle(hFile)
+
+    if ret is None:
+        raise RuntimeError(f"CheckSumMappedFile failed! Error code: {err}")
+
+    return checkSum.value

--- a/news/6874.bugfix.rst
+++ b/news/6874.bugfix.rst
@@ -1,0 +1,2 @@
+(Windows) Optimize EXE PE headers fix-up process in an attempt to reduce
+the processing time and the memory footprint with large onefile builds.


### PR DESCRIPTION
Attempt to optimize PE headers fix-up from both time- and memory-intensity perspective.

First, avoid specifying `fast_load=False` in `pefile.PE` constructor, because that triggers the bytes statistics collection
https://github.com/erocarrera/pefile/blob/v2022.5.30/pefile.py#L2862-L2876
which takes a long time for large files. Instead, we can obtain full headers (required for build timestamp modification) by calling `pe.full_load()` ourselves.

Second, use (an equivalent of) `MapFileAndCheckSumW` to compute the PE checksum. For large files, it is orders of magnitude faster than its pure-python `pefile.PE.compute_checksum` equivalent.

The downside is that `MapFileAndCheckSumW` requires an on-disk file as opposed to a memory buffer, so we need to split the
PE headers fixup into two separate steps, with each modifying the corresponding PE headers and (re)writing the whole file. Even so, this brings the fix-up process for a 700MB executable down to seconds instead of minutes.

In addition, as noted on MSDN, `MapFileAndCheckSumW` internally calls its ASCII variant (`MapFileAndCheckSumA`), so it cannot handle file paths that contain characters that are not representable in the current code page. Therefore, we implement our own equivalent using `ctypes` and pure widechar-based win32 API functions.

Closes #6874.