### PR TITLE
Bootstrap: Detect the if executable has been moved/deleted. (#6856)

### DIFF
--- a/PyInstaller/loader/pyimod02_archive.py
+++ b/PyInstaller/loader/pyimod02_archive.py
@@ -287,9 +287,15 @@ class ZlibArchiveReader(ArchiveReader):
         (typ, pos, length) = self.toc.get(name, (0, None, 0))
         if pos is None:
             return None
-        with self.lib:
-            self.lib.seek(self.start + pos)
-            obj = self.lib.read(length)
+        try:
+            with self.lib:
+                self.lib.seek(self.start + pos)
+                obj = self.lib.read(length)
+        except FileNotFoundError:
+            raise SystemExit(
+                f"{self.path} appears to have been moved or deleted since this application was launched. "
+                "Continouation from this state is impossible. Exiting now."
+            )
         try:
             if self.cipher:
                 obj = self.cipher.decrypt(obj)

--- a/news/6856.feature.rst
+++ b/news/6856.feature.rst
@@ -1,0 +1,3 @@
+Exit gracefully with an explainatory :class:`SystemExit` if the user moves or
+deletes the application whilst it's still running. Note that this is only
+detected on trying to load a module which has not already been loaded.

--- a/tests/functional/test_import.py
+++ b/tests/functional/test_import.py
@@ -673,3 +673,23 @@ def test_pkg_without_hook_for_pkg(pyi_builder, script_dir):
 def test_app_with_plugin(pyi_builder, data_dir, monkeypatch):
     datas = os.pathsep.join(('data/*/static_plugin.py', os.curdir))
     pyi_builder.test_script('pyi_app_with_plugin.py', pyi_args=['--add-data', datas])
+
+
+def test_app_has_moved_error(pyi_builder, tmpdir):
+    """
+    Test graceful exit from the user moving/deleting the application whilst it's still running.
+    """
+    pyi_builder.test_source(
+        f"""
+        import os
+        import sys
+        os.rename(sys.executable, {repr(str(tmpdir/ "something-else"))})
+        try:
+            # Import some non-builtin module which hasn't already been loaded.
+            import csv
+        except SystemExit:
+            pass
+        else:
+            assert 0, "A system exit should have been raised."
+        """
+    )


### PR DESCRIPTION
If, during an import which would normally be loaded from the PYZ archive, it transpires that the archive is no longer there, catch the resultant FileNotFoundError and translate it into a more descriptive system exit.

Whilst this scenario is 100% user self inflicted, autonomous bug reports led to a mystery exception taking 5 years to track down (https://github.com/spesmilo/electrum/issues/4072).
