### PR TITLE
Update minimum supported version of pefile.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -60,7 +60,7 @@ python_requires = >=3.7, <3.11
 install_requires =
     setuptools
     altgraph
-    pefile >= 2017.8.1 ; sys_platform == 'win32'
+    pefile >= 2022.5.30 ; sys_platform == 'win32'
     pywin32-ctypes >= 0.2.0 ; sys_platform == 'win32'
     macholib >= 1.8 ; sys_platform == 'darwin'
     pyinstaller-hooks-contrib >= 2021.4


### PR DESCRIPTION
A slight ammendment to 41483cb9e6d5086416c8fea6ad6781782c091c60, it turns out that the change to make pefile.PE() a context manager was only released two weeks ago so we need to ensure that users upgrading PyInstaller will implicitly upgrade pefile.
