### PR TITLE
Fix QtWebEngine with PyQt6 framework builds

### DIFF
--- a/PyInstaller/utils/hooks/qt.py
+++ b/PyInstaller/utils/hooks/qt.py
@@ -754,6 +754,8 @@ def get_qt_webengine_binaries_and_data_files(qt_library_info):
             'QtCore', 'QtWebEngineCore', 'QtQuick', 'QtQml', 'QtQmlModels', 'QtNetwork', 'QtGui', 'QtWebChannel',
             'QtPositioning'
         ]
+        if qt_library_info.qt_major == 6:
+            libraries.extend(['QtOpenGL', 'QtDBus'])
         for i in libraries:
             framework_dir = i + '.framework'
             datas += hooks.collect_system_data_files(

--- a/news/6892.bugfix.rst
+++ b/news/6892.bugfix.rst
@@ -1,0 +1,1 @@
+(macOS) The ``QtWebEngine`` hook now makes ``QtOpenGL`` and ``QtDBus`` available to the renderer process with framework installs of Qt 6.


### PR DESCRIPTION
With a PyPI-installed `PyQt6-WebEngine` (i.e., from what I understand, a framework-based install) on macOS, some libraries seem to be missing for the renderer process.

The first issue I got was that `QtWebEngineProcess` can't find `QtOpenGL` (which is [new in Qt 6 and split from QtGui](https://doc.qt.io/qt-6/opengl-changes-qt6.html)):

```
dyld: Library not loaded: @rpath/QtOpenGL.framework/Versions/A/QtOpenGL
  Referenced from: [...]/dist/test/PyQt6/Qt6/lib/QtWebEngineCore.framework/Helpers/QtWebEngineProcess.app/Contents/MacOS/QtWebEngineProcess
  Reason: image not found
```

Adding QtOpenGL to the libraries being copied in a framework build seems to help.

With that fixed (`pip install git+https://github.com/the-compiler/pyinstaller@4d6cf4b`), I'm getting a similar error about `QtDBus`, via `QtGui`:

```
dyld: Library not loaded: @rpath/QtDBus.framework/Versions/A/QtDBus
  Referenced from: [...]/dist/test/PyQt6/Qt6/lib/QtGui.framework/Versions/A/QtGui
  Reason: image not found
```

Why QtGui seems to depend on QtDBus on macOS (!) is beyond me, but whatever, let's add it as well.

With both fixes, only this is remaining:

```
Init Parameters:
  *  application-name  
  *  browser-subprocess-path [...]/dist/test/PyQt6/Qt6/lib/QtWebEngineCore.framework/Helpers/QtWebEngineProcess.app/Contents/MacOS/QtWebEngineProcess 
  *  [...]

Qt WebEngine resources not found at [...]/dist/test//Users/florian/proj/qutebrowser/qtwetest/dist/test. Trying parent directory...
Qt WebEngine resources not found at [...]/dist/test/PyQt6/Qt6. Trying application directory...
Installed Qt WebEngine locales directory not found at location /Users/florian/proj/qutebrowser/qtwetest/dist/test//Users/florian/proj/qutebrowser/qtwetest/dist/test/qtwebengine_locales. Trying application directory...
```

which seems to be non-fatal, as it seems to work in the end.