### PR TITLE
RFC: Treat all pytest warnings as errors

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -133,14 +133,15 @@ norecursedirs:
    tests/unit/test_modulegraph/testpkg-*
 
 filterwarnings =
-;  in unit/test_altgraph/test_graph.py
-   ignore:Please use assertEqual instead.:DeprecationWarning
-; tests/unit/test_modulegraph/test_modulegraph.py::TestFunctions::test_os_listdir
-   ignore:Use zipio.listdir instead of os_listdir:DeprecationWarning:
-; Enable Python's improperly closed file handle detection...
-   error::ResourceWarning:
-; ... and force pytest to raise an error if the ResourceWarning is emitted during test cleanup.
-   error::pytest.PytestUnraisableExceptionWarning:
+    error
+    # https://github.com/pyinstaller/pyinstaller/issues/4536
+    ignore:the imp module is deprecated in favour of importlib:DeprecationWarning
+    # PyInstaller.utils.tests
+    ignore:The distutils package is deprecated:DeprecationWarning
+    ignore:The distutils\.sysconfig module is deprecated
+    # depend.analysis
+    ignore:FileFinder\.find_loader\(\) is deprecated:DeprecationWarning
+    ignore:the load_module\(\) method is deprecated:DeprecationWarning
 
 # Display summary info for (s)skipped, (X)xpassed, (x)xfailed, (f)failed and (e)errored tests
 # Skip doctest text files

--- a/tests/unit/test_modulegraph/test_modulegraph.py
+++ b/tests/unit/test_modulegraph/test_modulegraph.py
@@ -12,6 +12,7 @@ from PyInstaller.utils.tests import importorskip
 import textwrap
 import pickle
 
+import pytest
 from importlib._bootstrap_external import SourceFileLoader, ExtensionFileLoader
 from zipimport import zipimporter
 
@@ -150,6 +151,8 @@ class TestFunctions (unittest.TestCase):
         finally:
             pkg_resources.WorkingSet = saved_ws
 
+    @pytest.mark.filterwarnings(
+        "ignore:Use zipio.listdir instead of os_listdir:DeprecationWarning")
     def test_os_listdir(self):
         root = os.path.join(
                 os.path.dirname(os.path.abspath(__file__)), 'testdata')


### PR DESCRIPTION
What do you think about this? In my opinion, it's a good idea to treat warnings as errors by default, so that any non-fatal issues are uncovered as part of CI runs.

If this seems sensible, I'd be happy to go through the CI logs and see what other issues pop up there.