### PR TITLE
hookutils: fix regression in get_gi_typelibs behavior

### DIFF
--- a/PyInstaller/utils/hooks/gi.py
+++ b/PyInstaller/utils/hooks/gi.py
@@ -68,7 +68,12 @@ def get_gi_typelibs(module, version):
             'deps': get_deps(module) or []
         }
 
-    typelibs_data = _gi_typelibs(module, version)
+    try:
+        typelibs_data = _gi_typelibs(module, version)
+    except Exception as e:
+        logger.warning("Failed to query files for %s %s: %s", module, version, e)
+        return binaries, datas, hiddenimports
+
     logger.debug("Adding files for %s %s", module, version)
 
     if typelibs_data['sharedlib']:

--- a/news/6897.bugfix.rst
+++ b/news/6897.bugfix.rst
@@ -1,0 +1,4 @@
+Fix regression in ``gi`` hooks where an import of a non-existent package
+(for example, an optional dependency) in the program causes a build-time
+error and aborts the build process. Instead, display a warning and
+continue, which was the behavior in PyInstaller v4.

--- a/tests/functional/test_hooks/test_gi.py
+++ b/tests/functional/test_hooks/test_gi.py
@@ -63,3 +63,13 @@ def test_gi_repository(pyi_builder, repository_name, version):
         print({repository_name})
         """.format(repository_name=repository_name, version=version)
     )
+
+
+# Test behavior of get_gi_typelibs() when the specified package/typelib does not exist. Due to the way the function is
+# used in hooks, it should return empty lists and display a warning instead of raising an exception.
+def test_gi_get_gi_typelibs_nonexistant():
+    from PyInstaller.utils.hooks.gi import get_gi_typelibs
+    binaries, datas, hiddenimports = get_gi_typelibs("PackageThatSurelyDoesNotExist", "1.0")
+    assert binaries == []
+    assert datas == []
+    assert hiddenimports == []


### PR DESCRIPTION
Due to the way the `get_gi_typelibs` function is used in the `gi` hooks, it should not raise an exception when the package cannot be found, but rather display a warning and return empty lists (which is the behavior in PyInstaller 4.x). Otherwise, a missing optional dependency causes build-time error and aborts the build.

Fixes #6897.