### PR TITLE
hooks: refactor GObject introspection (gi) hooks

### DIFF
--- a/PyInstaller/hooks/hook-gi.py
+++ b/PyInstaller/hooks/hook-gi.py
@@ -8,10 +8,5 @@
 #
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
-"""
-Import hook for PyGObject https://wiki.gnome.org/PyGObject
-
-Tested with PyGObject 3.16.2 from MacPorts on Mac OS 10.10 and PyGobject 3.14.0 on Windows 7.
-"""
 
 hiddenimports = ['gi._error', 'gi._option']

--- a/PyInstaller/hooks/hook-gi.repository.Adw.py
+++ b/PyInstaller/hooks/hook-gi.repository.Adw.py
@@ -8,10 +8,9 @@
 #
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
-"""
-Import hook for PyGObject https://wiki.gnome.org/PyGObject
-"""
 
-from PyInstaller.utils.hooks.gi import get_gi_typelibs
+from PyInstaller.utils.hooks.gi import GiModuleInfo
 
-binaries, datas, hiddenimports = get_gi_typelibs('Adw', '1')
+module_info = GiModuleInfo('Adw', '1')
+if module_info.available:
+    binaries, datas, hiddenimports = module_info.collect_typelib_data()

--- a/PyInstaller/hooks/hook-gi.repository.Atk.py
+++ b/PyInstaller/hooks/hook-gi.repository.Atk.py
@@ -8,19 +8,22 @@
 #
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
-"""
-Import hook for PyGObject https://wiki.gnome.org/PyGObject
-"""
 
 from PyInstaller.utils.hooks import get_hook_config
-from PyInstaller.utils.hooks.gi import (collect_glib_translations, get_gi_typelibs)
-
-binaries, datas, hiddenimports = get_gi_typelibs('Atk', '1.0')
+from PyInstaller.utils.hooks.gi import GiModuleInfo, collect_glib_translations
 
 
 def hook(hook_api):
-    hook_datas = []
-    lang_list = get_hook_config(hook_api, "gi", "languages")
+    module_info = GiModuleInfo('Atk', '1.0')
+    if not module_info.available:
+        return
 
-    hook_datas += collect_glib_translations('atk10', lang_list)
-    hook_api.add_datas(hook_datas)
+    binaries, datas, hiddenimports = module_info.collect_typelib_data()
+
+    # Collect translations
+    lang_list = get_hook_config(hook_api, "gi", "languages")
+    datas += collect_glib_translations('atk10', lang_list)
+
+    hook_api.add_datas(datas)
+    hook_api.add_binaries(binaries)
+    hook_api.add_imports(*hiddenimports)

--- a/PyInstaller/hooks/hook-gi.repository.Champlain.py
+++ b/PyInstaller/hooks/hook-gi.repository.Champlain.py
@@ -8,10 +8,9 @@
 #
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
-"""
-Import hook for PyGObject's "gi.repository.Champlain" package.
-"""
 
-from PyInstaller.utils.hooks.gi import get_gi_typelibs
+from PyInstaller.utils.hooks.gi import GiModuleInfo
 
-binaries, datas, hiddenimports = get_gi_typelibs('Champlain', '0.12')
+module_info = GiModuleInfo('Champlain', '0.12')
+if module_info.available:
+    binaries, datas, hiddenimports = module_info.collect_typelib_data()

--- a/PyInstaller/hooks/hook-gi.repository.Clutter.py
+++ b/PyInstaller/hooks/hook-gi.repository.Clutter.py
@@ -8,10 +8,9 @@
 #
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
-"""
-Import hook for PyGObject's "gi.repository.Clutter" package.
-"""
 
-from PyInstaller.utils.hooks.gi import get_gi_typelibs
+from PyInstaller.utils.hooks.gi import GiModuleInfo
 
-binaries, datas, hiddenimports = get_gi_typelibs('Clutter', '1.0')
+module_info = GiModuleInfo('Clutter', '1.0')
+if module_info.available:
+    binaries, datas, hiddenimports = module_info.collect_typelib_data()

--- a/PyInstaller/hooks/hook-gi.repository.GIRepository.py
+++ b/PyInstaller/hooks/hook-gi.repository.GIRepository.py
@@ -8,10 +8,9 @@
 #
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
-"""
-Import hook for PyGObject https://wiki.gnome.org/PyGObject
-"""
 
-from PyInstaller.utils.hooks.gi import get_gi_typelibs
+from PyInstaller.utils.hooks.gi import GiModuleInfo
 
-binaries, datas, hiddenimports = get_gi_typelibs('GIRepository', '2.0')
+module_info = GiModuleInfo('GIRepository', '2.0')
+if module_info.available:
+    binaries, datas, hiddenimports = module_info.collect_typelib_data()

--- a/PyInstaller/hooks/hook-gi.repository.GModule.py
+++ b/PyInstaller/hooks/hook-gi.repository.GModule.py
@@ -8,15 +8,9 @@
 #
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
-"""
-Import hook for GModule https://developer.gnome.org/glib/stable/glib-Dynamic-Loading-of-Modules.html from the GLib
-library https://wiki.gnome.org/Projects/GLib introspected through PyGobject https://wiki.gnome.org/PyGObject
-via the GObject Introspection middleware layer https://wiki.gnome.org/Projects/GObjectIntrospection
 
-Tested with GLib 2.44.1, PyGObject 3.16.2, and GObject Introspection 1.44.0 on Mac OS 10.10 and
-GLib 2.42.2, PyGObject 3.14.0, and GObject Introspection 1.42 on Windows 7.
-"""
+from PyInstaller.utils.hooks.gi import GiModuleInfo
 
-from PyInstaller.utils.hooks.gi import get_gi_typelibs
-
-binaries, datas, hiddenimports = get_gi_typelibs('GModule', '2.0')
+module_info = GiModuleInfo('GModule', '2.0')
+if module_info.available:
+    binaries, datas, hiddenimports = module_info.collect_typelib_data()

--- a/PyInstaller/hooks/hook-gi.repository.GObject.py
+++ b/PyInstaller/hooks/hook-gi.repository.GObject.py
@@ -8,17 +8,10 @@
 #
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
-"""
-Import hook for GObject https://developer.gnome.org/gobject/stable from the GLib
-library https://wiki.gnome.org/Projects/GLib introspected through PyGobject https://wiki.gnome.org/PyGObject
-via the GObject Introspection middleware layer https://wiki.gnome.org/Projects/GObjectIntrospection
 
-Tested with GLib 2.44.1, PyGObject 3.16.2, and GObject Introspection 1.44.0 on Mac OS 10.10 and
-GLib 2.42.2, PyGObject 3.14.0, and GObject Introspection 1.42 on Windows 7.
-"""
+from PyInstaller.utils.hooks.gi import GiModuleInfo
 
-from PyInstaller.utils.hooks.gi import get_gi_typelibs
-
-binaries, datas, hiddenimports = get_gi_typelibs('GObject', '2.0')
-
-hiddenimports += ['gi._gobject']
+module_info = GiModuleInfo('GObject', '2.0')
+if module_info.available:
+    binaries, datas, hiddenimports = module_info.collect_typelib_data()
+    hiddenimports += ['gi._gobject']

--- a/PyInstaller/hooks/hook-gi.repository.GdkPixbuf.py
+++ b/PyInstaller/hooks/hook-gi.repository.GdkPixbuf.py
@@ -8,140 +8,134 @@
 #
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
-"""
-Import hook for PyGObject's "gi.repository.GdkPixbuf" package.
-"""
 
 import glob
 import os
-from shutil import which
+import shutil
 
-from PyInstaller.compat import exec_command_stdout, is_darwin, is_linux, is_win
-from PyInstaller.config import CONF
+from PyInstaller import compat
+from PyInstaller.config import CONF  # workpath
 from PyInstaller.utils.hooks import get_hook_config, logger
-from PyInstaller.utils.hooks.gi import (collect_glib_translations, get_gi_libdir, get_gi_typelibs)
+from PyInstaller.utils.hooks.gi import GiModuleInfo, collect_glib_translations
 
-loaders_path = os.path.join('gdk-pixbuf-2.0', '2.10.0', 'loaders')
+LOADERS_PATH = os.path.join('gdk-pixbuf-2.0', '2.10.0', 'loaders')
+LOADER_MODULE_DEST_PATH = "lib/gdk-pixbuf/loaders"
+LOADER_CACHE_DEST_PATH = "lib/gdk-pixbuf"  # NOTE: some search & replace code depends on / being used on all platforms.
 
-destpath = "lib/gdk-pixbuf/loaders"
-cachedest = "lib/gdk-pixbuf"
 
-# If the "gdk-pixbuf-query-loaders" command is not in the current ${PATH}, or is not in the GI lib path, GDK and thus
-# GdkPixbuf is unavailable. Return with a non-fatal warning.
-gdk_pixbuf_query_loaders = None
-
-try:
-    libdir = get_gi_libdir('GdkPixbuf', '2.0')
-except ValueError:
-    logger.warning('"hook-gi.repository.GdkPixbuf" ignored, since GdkPixbuf library not found')
-    libdir = None
-
-if libdir:
+def _find_gdk_pixbuf_query_loaders_executable(libdir):
     # Distributions either package gdk-pixbuf-query-loaders in the GI libs directory (not on the path), or on the path
-    # with or without a -x64 suffix depending on the architecture
+    # with or without a -x64 suffix, depending on the architecture.
     cmds = [
-        os.path.join(libdir, 'gdk-pixbuf-2.0/gdk-pixbuf-query-loaders'),
+        os.path.join(libdir, 'gdk-pixbuf-2.0', 'gdk-pixbuf-query-loaders'),
         'gdk-pixbuf-query-loaders-64',
         'gdk-pixbuf-query-loaders',
     ]
 
     for cmd in cmds:
-        gdk_pixbuf_query_loaders = which(cmd)
-        if gdk_pixbuf_query_loaders is not None:
-            break
+        cmd_fullpath = shutil.which(cmd)
+        if cmd_fullpath is not None:
+            return cmd_fullpath
 
-    if gdk_pixbuf_query_loaders is None:
-        logger.warning(
-            '"hook-gi.repository.GdkPixbuf" ignored, since "gdk-pixbuf-query-loaders" is not in $PATH or gi lib dir.'
-        )
+    return None
 
-    # Else, GDK is available. Let's do this.
-    else:
-        binaries, datas, hiddenimports = get_gi_typelibs('GdkPixbuf', '2.0')
 
-        # To add support for a new platform, add a new "elif" branch below with the proper is_<platform>() test and glob
-        # for finding loaders on that platform.
-        if is_win:
-            ext = "*.dll"
-        elif is_darwin or is_linux:
-            ext = "*.so"
+def _collect_loaders(libdir):
+    # Assume loader plugins have .so library suffix on all non-Windows platforms
+    lib_ext = "*.dll" if compat.is_win else "*.so"
 
-        # If loader detection is supported on this platform, bundle all detected loaders and an updated loader cache.
-        if ext:
-            loader_libs = []
+    # Find all loaders
+    loader_libs = []
+    pattern = os.path.join(libdir, LOADERS_PATH, lib_ext)
+    for f in glob.glob(pattern):
+        loader_libs.append(f)
 
-            # Bundle all found loaders with this user application.
-            pattern = os.path.join(libdir, loaders_path, ext)
-            for f in glob.glob(pattern):
-                binaries.append((f, destpath))
-                loader_libs.append(f)
+    # Sometimes the loaders are stored in a different directory from the library (msys2)
+    if not loader_libs:
+        pattern = os.path.join(libdir, '..', 'lib', LOADERS_PATH, lib_ext)
+        for f in glob.glob(pattern):
+            loader_libs.append(f)
 
-            # Sometimes the loaders are stored in a different directory from the library (msys2)
-            if not loader_libs:
-                pattern = os.path.join(libdir, '..', 'lib', loaders_path, ext)
-                for f in glob.glob(pattern):
-                    binaries.append((f, destpath))
-                    loader_libs.append(f)
+    return loader_libs
 
-            # Filename of the loader cache to be written below.
-            cachefile = os.path.join(CONF['workpath'], 'loaders.cache')
 
-            # Run the "gdk-pixbuf-query-loaders" command and capture its standard output providing an updated loader
-            # cache; then write this output to the loader cache bundled with this frozen application. On all platforms,
-            # we also move the package structure to point to lib/gdk-pixbuf instead of lib/gdk-pixbuf-2.0/2.10.0 in
-            # order to make compatible for OSX application signing.
-            #
-            # On Mac OS we use @executable_path to specify a path relative to the generated bundle. However, on
-            # non-Windows, we need to rewrite the loader cache because it is not relocatable by default. See
-            # https://bugzilla.gnome.org/show_bug.cgi?id=737523
-            #
-            # To make it easier to rewrite, we just always write @executable_path, since its significantly easier to
-            # find/replace at runtime. :)
-            #
-            # To permit string munging, decode the encoded bytes output by this command (i.e., enable the
-            # "universal_newlines" option).
-            #
-            # On Fedora, the default loaders cache is /usr/lib64, but the libdir is actually /lib64. To get around this,
-            # we pass the path to the loader command, and it will create a cache with the right path.
-            #
-            # On Windows, the loaders lib directory is relative, starts with 'lib', and uses \\ as path separators
-            # (escaped \).
-            cachedata = exec_command_stdout(gdk_pixbuf_query_loaders, *loader_libs)
+def _generate_loader_cache(gdk_pixbuf_query_loaders, libdir, loader_libs):
+    # Run the "gdk-pixbuf-query-loaders" command and capture its standard output providing an updated loader
+    # cache; then write this output to the loader cache bundled with this frozen application. On all platforms,
+    # we also move the package structure to point to lib/gdk-pixbuf instead of lib/gdk-pixbuf-2.0/2.10.0 in
+    # order to make compatible for OSX application signing.
+    #
+    # On Mac OS we use @executable_path to specify a path relative to the generated bundle. However, on
+    # non-Windows, we need to rewrite the loader cache because it is not relocatable by default. See
+    # https://bugzilla.gnome.org/show_bug.cgi?id=737523
+    #
+    # To make it easier to rewrite, we just always write @executable_path, since its significantly easier to
+    # find/replace at runtime. :)
+    #
+    # To permit string munging, decode the encoded bytes output by this command (i.e., enable the
+    # "universal_newlines" option).
+    #
+    # On Fedora, the default loaders cache is /usr/lib64, but the libdir is actually /lib64. To get around this,
+    # we pass the path to the loader command, and it will create a cache with the right path.
+    #
+    # On Windows, the loaders lib directory is relative, starts with 'lib', and uses \\ as path separators
+    # (escaped \).
+    cachedata = compat.exec_command_stdout(gdk_pixbuf_query_loaders, *loader_libs)
 
-            cd = []
-            prefix = '"' + os.path.join(libdir, 'gdk-pixbuf-2.0', '2.10.0')
-            plen = len(prefix)
+    output_lines = []
+    prefix = '"' + os.path.join(libdir, 'gdk-pixbuf-2.0', '2.10.0')
+    plen = len(prefix)
 
-            win_prefix = '"' + '\\\\'.join(['lib', 'gdk-pixbuf-2.0', '2.10.0'])
-            win_plen = len(win_prefix)
+    win_prefix = '"' + '\\\\'.join(['lib', 'gdk-pixbuf-2.0', '2.10.0'])
+    win_plen = len(win_prefix)
 
-            # For each line in the updated loader cache...
-            for line in cachedata.splitlines():
-                if line.startswith('#'):
-                    continue
-                if line.startswith(prefix):
-                    line = '"@executable_path/' + cachedest + line[plen:]
-                elif line.startswith(win_prefix):
-                    line = '"' + cachedest.replace('/', '\\\\') + line[win_plen:]
-                cd.append(line)
+    # For each line in the updated loader cache...
+    for line in cachedata.splitlines():
+        if line.startswith('#'):
+            continue
+        if line.startswith(prefix):
+            line = '"@executable_path/' + LOADER_CACHE_DEST_PATH + line[plen:]
+        elif line.startswith(win_prefix):
+            line = '"' + LOADER_CACHE_DEST_PATH.replace('/', '\\\\') + line[win_plen:]
+        output_lines.append(line)
 
-            cachedata = '\n'.join(cd)
-
-            # Write the updated loader cache to this file.
-            with open(cachefile, 'w') as fp:
-                fp.write(cachedata)
-
-            # Bundle this loader cache with this frozen application.
-            datas.append((cachefile, cachedest))
-        # Else, loader detection is unsupported on this platform.
-        else:
-            logger.warning('GdkPixbuf loader bundling unsupported on your platform.')
+    return '\n'.join(output_lines)
 
 
 def hook(hook_api):
-    hook_datas = []
-    lang_list = get_hook_config(hook_api, "gi", "languages")
+    module_info = GiModuleInfo('GdkPixbuf', '2.0')
+    if not module_info.available:
+        return
 
-    if libdir and gdk_pixbuf_query_loaders is not None:
-        hook_datas += collect_glib_translations('gdk-pixbuf', lang_list)
-    hook_api.add_datas(hook_datas)
+    binaries, datas, hiddenimports = module_info.collect_typelib_data()
+
+    libdir = module_info.get_libdir()
+
+    # Collect GdkPixbuf loaders and generate loader cache file
+    gdk_pixbuf_query_loaders = _find_gdk_pixbuf_query_loaders_executable(libdir)
+    logger.debug("gdk-pixbuf-query-loaders executable: %s", gdk_pixbuf_query_loaders)
+    if not gdk_pixbuf_query_loaders:
+        logger.warning("gdk-pixbuf-query-loaders executable not found in GI library directory or in PATH!")
+    else:
+        # Find all GdkPixbuf loader modules
+        loader_libs = _collect_loaders(libdir)
+
+        # Collect discovered loaders
+        for lib in loader_libs:
+            binaries.append((lib, LOADER_MODULE_DEST_PATH))
+
+        # Generate loader cache; we need to store it to CONF['workpath'] so we can collect it as a data file.
+        cachedata = _generate_loader_cache(gdk_pixbuf_query_loaders, libdir, loader_libs)
+        cachefile = os.path.join(CONF['workpath'], 'loaders.cache')
+        with open(cachefile, 'w') as fp:
+            fp.write(cachedata)
+        datas.append((cachefile, LOADER_CACHE_DEST_PATH))
+
+    # Collect translations
+    lang_list = get_hook_config(hook_api, "gi", "languages")
+    if gdk_pixbuf_query_loaders:
+        datas += collect_glib_translations('gdk-pixbuf', lang_list)
+
+    hook_api.add_datas(datas)
+    hook_api.add_binaries(binaries)
+    hook_api.add_imports(*hiddenimports)

--- a/PyInstaller/hooks/hook-gi.repository.Gio.py
+++ b/PyInstaller/hooks/hook-gi.repository.Gio.py
@@ -8,58 +8,56 @@
 #
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
-"""
-Import hook for Gio https://developer.gnome.org/gio/stable from the GLib library https://wiki.gnome.org/Projects/GLib
-introspected through PyGobject https://wiki.gnome.org/PyGObject via the GObject Introspection middleware layer
-https://wiki.gnome.org/Projects/GObjectIntrospection
-
-Tested with GLib 2.44.1, PyGObject 3.16.2, GObject Introspection 1.44.0 on Mac OS 10.10.5 and
-GLib 2.42.2, PyGObject 3.14.0, and GObject Introspection 1.42 on Windows 7.
-"""
 
 import glob
 import os
 
+from PyInstaller import compat
 import PyInstaller.log as logging
-from PyInstaller.compat import base_prefix, is_darwin, is_linux, is_win
-from PyInstaller.utils.hooks.gi import get_gi_libdir, get_gi_typelibs
+from PyInstaller.utils.hooks.gi import GiModuleInfo
 
 logger = logging.getLogger(__name__)
 
-binaries, datas, hiddenimports = get_gi_typelibs('Gio', '2.0')
+module_info = GiModuleInfo('Gio', '2.0')
+if module_info.available:
+    binaries, datas, hiddenimports = module_info.collect_typelib_data()
 
-libdir = get_gi_libdir('Gio', '2.0')
-path = None
+    # Find Gio modules
+    libdir = module_info.get_libdir()
+    modules_pattern = None
 
-if is_win:
-    pattern = os.path.join(libdir, 'gio', 'modules', '*.dll')
-elif is_darwin or is_linux:
-    gio_libdir = os.path.join(libdir, 'gio', 'modules')
-    if not os.path.exists(gio_libdir):
-        # homebrew installs the files elsewhere..
-        gio_libdir = os.path.join(os.path.commonprefix([base_prefix, gio_libdir]), 'lib', 'gio', 'modules')
+    if compat.is_win:
+        modules_pattern = os.path.join(libdir, 'gio', 'modules', '*.dll')
+    else:
+        gio_libdir = os.path.join(libdir, 'gio', 'modules')
+        if not os.path.exists(gio_libdir):
+            # homebrew installs the files elsewhere...
+            gio_libdir = os.path.join(os.path.commonprefix([compat.base_prefix, gio_libdir]), 'lib', 'gio', 'modules')
 
-    pattern = os.path.join(gio_libdir, '*.so')
+        if os.path.exists(gio_libdir):
+            modules_pattern = os.path.join(gio_libdir, '*.so')
+        else:
+            logger.warning('Could not determine Gio modules path!')
 
-if pattern:
-    for f in glob.glob(pattern):
-        binaries.append((f, 'gio_modules'))
-else:
-    # To add a new platform add a new elif above with the proper is_<platform> and proper pattern for finding the Gio
-    # modules on your platform.
-    logger.warning('Bundling Gio modules is currently not supported on your platform.')
+    if modules_pattern:
+        for f in glob.glob(modules_pattern):
+            binaries.append((f, 'gio_modules'))
+    else:
+        # To add a new platform add a new elif above with the proper is_<platform> and proper pattern for finding the
+        # Gio modules on your platform.
+        logger.warning('Bundling Gio modules is not supported on your platform.')
 
-# Bundle the mime cache -- might not be needed on Windows
-# -> this is used for content type detection (also used by GdkPixbuf)
-# -> gio/xdgmime/xdgmime.c looks for mime/mime.cache in the users home directory, followed by XDG_DATA_DIRS if specified
-#    in the environment, otherwise it searches /usr/local/share/ and /usr/share/
-if not is_win:
-    _mime_searchdirs = ['/usr/local/share', '/usr/share']
-    if 'XDG_DATA_DIRS' in os.environ:
-        _mime_searchdirs.insert(0, os.environ['XDG_DATA_DIRS'])
+    # Bundle the mime cache -- might not be needed on Windows
+    # -> this is used for content type detection (also used by GdkPixbuf)
+    # -> gio/xdgmime/xdgmime.c looks for mime/mime.cache in the users home directory, followed by XDG_DATA_DIRS if
+    #    specified in the environment, otherwise it searches /usr/local/share/ and /usr/share/
+    if not compat.is_win:
+        _mime_searchdirs = ['/usr/local/share', '/usr/share']
+        if 'XDG_DATA_DIRS' in os.environ:
+            _mime_searchdirs.insert(0, os.environ['XDG_DATA_DIRS'])
 
-    for sd in _mime_searchdirs:
-        spath = os.path.join(sd, 'mime', 'mime.cache')
-        if os.path.exists(spath):
-            datas.append((spath, 'share/mime'))
-            break
+        for sd in _mime_searchdirs:
+            spath = os.path.join(sd, 'mime', 'mime.cache')
+            if os.path.exists(spath):
+                datas.append((spath, 'share/mime'))
+                break

--- a/PyInstaller/hooks/hook-gi.repository.Graphene.py
+++ b/PyInstaller/hooks/hook-gi.repository.Graphene.py
@@ -8,10 +8,9 @@
 #
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
-"""
-Import hook for PyGObject https://wiki.gnome.org/PyGObject
-"""
 
-from PyInstaller.utils.hooks.gi import get_gi_typelibs
+from PyInstaller.utils.hooks.gi import GiModuleInfo
 
-binaries, datas, hiddenimports = get_gi_typelibs('Graphene', '1.0')
+module_info = GiModuleInfo('Graphene', '1.0')
+if module_info.available:
+    binaries, datas, hiddenimports = module_info.collect_typelib_data()

--- a/PyInstaller/hooks/hook-gi.repository.Gsk.py
+++ b/PyInstaller/hooks/hook-gi.repository.Gsk.py
@@ -8,10 +8,9 @@
 #
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
-"""
-Import hook for PyGObject https://wiki.gnome.org/PyGObject
-"""
 
-from PyInstaller.utils.hooks.gi import get_gi_typelibs
+from PyInstaller.utils.hooks.gi import GiModuleInfo
 
-binaries, datas, hiddenimports = get_gi_typelibs('Gsk', '4.0')
+module_info = GiModuleInfo('Gsk', '4.0')
+if module_info.available:
+    binaries, datas, hiddenimports = module_info.collect_typelib_data()

--- a/PyInstaller/hooks/hook-gi.repository.Gst.py
+++ b/PyInstaller/hooks/hook-gi.repository.Gst.py
@@ -8,14 +8,6 @@
 #
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
-"""
-Import hook for Gst (GStreamer) http://gstreamer.freedesktop.org introspected through
-PyGobject https://wiki.gnome.org/PyGObject via the GObject Introspection middleware
-layer https://wiki.gnome.org/Projects/GObjectIntrospection
-
-Tested with GStreamer 1.4.5, gst-python 1.4.0, PyGObject 3.16.2, and GObject Introspection 1.44.0 on Mac OS 10.10 and
-GStreamer 1.4.5, gst-python 1.4.0, PyGObject 3.14.0, and GObject Introspection 1.42 on Windows 7.
-"""
 
 # GStreamer contains a lot of plugins. We need to collect them and bundle them with the exe file. We also need to
 # resolve binary dependencies of these GStreamer plugins.
@@ -24,33 +16,15 @@ import glob
 import os
 
 from PyInstaller.utils.hooks import get_hook_config
+import PyInstaller.log as logging
 from PyInstaller import isolated
-from PyInstaller.utils.hooks.gi import (collect_glib_share_files, collect_glib_translations, get_gi_typelibs)
+from PyInstaller.utils.hooks.gi import GiModuleInfo, collect_glib_share_files, collect_glib_translations
 
-binaries, datas, hiddenimports = get_gi_typelibs('Gst', '1.0')
-
-datas += collect_glib_share_files('gstreamer-1.0')
-
-hiddenimports += ["gi.repository.Gio"]
+logger = logging.getLogger(__name__)
 
 
-def hook(hook_api):
-    hook_datas = []
-    lang_list = get_hook_config(hook_api, "gi", "languages")
-
-    for prog in [
-        'gst-plugins-bad-1.0',
-        'gst-plugins-base-1.0',
-        'gst-plugins-good-1.0',
-        'gst-plugins-ugly-1.0',
-        'gstreamer-1.0',
-    ]:
-        hook_datas += collect_glib_translations(prog, lang_list)
-    hook_api.add_datas(hook_datas)
-
-
-@isolated.call
-def plugin_path():
+@isolated.decorate
+def _get_gst_plugin_path():
     import os
     import gi
     gi.require_version('Gst', '1.0')
@@ -62,8 +36,42 @@ def plugin_path():
     return os.path.dirname(path)
 
 
-# Use a pattern of libgst* as all GStreamer plugins that conform to GStreamer standards start with libgst, and we may
-# have mixed plugin extensions, e.g., .so and .dylib.
-for pattern in ['libgst*.dll', 'libgst*.dylib', 'libgst*.so']:
-    pattern = os.path.join(plugin_path, pattern)
-    binaries += [(f, os.path.join('gst_plugins')) for f in glob.glob(pattern)]
+def hook(hook_api):
+    module_info = GiModuleInfo('Gst', '1.0')
+    if not module_info.available:
+        return
+
+    binaries, datas, hiddenimports = module_info.collect_typelib_data()
+    hiddenimports += ["gi.repository.Gio"]
+
+    # Collect data files
+    datas += collect_glib_share_files('gstreamer-1.0')
+
+    # Translations
+    lang_list = get_hook_config(hook_api, "gi", "languages")
+    for prog in [
+        'gst-plugins-bad-1.0',
+        'gst-plugins-base-1.0',
+        'gst-plugins-good-1.0',
+        'gst-plugins-ugly-1.0',
+        'gstreamer-1.0',
+    ]:
+        datas += collect_glib_translations(prog, lang_list)
+
+    # Plugins
+    try:
+        plugin_path = _get_gst_plugin_path()
+    except Exception as e:
+        logger.warning("Failed to determine gstreamer plugin path: %s", e)
+        plugin_path = None
+
+    if plugin_path:
+        # Use a pattern of libgst* as all GStreamer plugins that conform to GStreamer standards start with libgst, and
+        # we may have mixed plugin extensions, e.g., .so and .dylib.
+        for lib_pattern in ['libgst*.dll', 'libgst*.dylib', 'libgst*.so']:
+            pattern = os.path.join(plugin_path, lib_pattern)
+            binaries += [(f, os.path.join('gst_plugins')) for f in glob.glob(pattern)]
+
+    hook_api.add_datas(datas)
+    hook_api.add_binaries(binaries)
+    hook_api.add_imports(*hiddenimports)

--- a/PyInstaller/hooks/hook-gi.repository.GstAudio.py
+++ b/PyInstaller/hooks/hook-gi.repository.GstAudio.py
@@ -8,12 +8,9 @@
 #
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
-"""
-Import hook for Gst (GStreamer) http://gstreamer.freedesktop.org introspected through
-PyGobject https://wiki.gnome.org/PyGObject via the GObject Introspection middleware
-layer https://wiki.gnome.org/Projects/GObjectIntrospection
-"""
 
-from PyInstaller.utils.hooks.gi import get_gi_typelibs
+from PyInstaller.utils.hooks.gi import GiModuleInfo
 
-binaries, datas, hiddenimports = get_gi_typelibs('GstAudio', '1.0')
+module_info = GiModuleInfo('GstAudio', '1.0')
+if module_info.available:
+    binaries, datas, hiddenimports = module_info.collect_typelib_data()

--- a/PyInstaller/hooks/hook-gi.repository.GstBase.py
+++ b/PyInstaller/hooks/hook-gi.repository.GstBase.py
@@ -8,12 +8,9 @@
 #
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
-"""
-Import hook for Gst (GStreamer) http://gstreamer.freedesktop.org introspected through
-PyGobject https://wiki.gnome.org/PyGObject via the GObject Introspection middleware
-layer https://wiki.gnome.org/Projects/GObjectIntrospection
-"""
 
-from PyInstaller.utils.hooks.gi import get_gi_typelibs
+from PyInstaller.utils.hooks.gi import GiModuleInfo
 
-binaries, datas, hiddenimports = get_gi_typelibs('GstBase', '1.0')
+module_info = GiModuleInfo('GstBase', '1.0')
+if module_info.available:
+    binaries, datas, hiddenimports = module_info.collect_typelib_data()

--- a/PyInstaller/hooks/hook-gi.repository.GstPbutils.py
+++ b/PyInstaller/hooks/hook-gi.repository.GstPbutils.py
@@ -8,12 +8,9 @@
 #
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
-"""
-Import hook for Gst (GStreamer) http://gstreamer.freedesktop.org introspected through
-PyGobject https://wiki.gnome.org/PyGObject via the GObject Introspection middleware
-layer https://wiki.gnome.org/Projects/GObjectIntrospection
-"""
 
-from PyInstaller.utils.hooks.gi import get_gi_typelibs
+from PyInstaller.utils.hooks.gi import GiModuleInfo
 
-binaries, datas, hiddenimports = get_gi_typelibs('GstPbutils', '1.0')
+module_info = GiModuleInfo('GstPbutils', '1.0')
+if module_info.available:
+    binaries, datas, hiddenimports = module_info.collect_typelib_data()

--- a/PyInstaller/hooks/hook-gi.repository.GstTag.py
+++ b/PyInstaller/hooks/hook-gi.repository.GstTag.py
@@ -8,12 +8,9 @@
 #
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
-"""
-Import hook for Gst (GStreamer) http://gstreamer.freedesktop.org introspected through
-PyGobject https://wiki.gnome.org/PyGObject via the GObject Introspection middleware
-layer https://wiki.gnome.org/Projects/GObjectIntrospection
-"""
 
-from PyInstaller.utils.hooks.gi import get_gi_typelibs
+from PyInstaller.utils.hooks.gi import GiModuleInfo
 
-binaries, datas, hiddenimports = get_gi_typelibs('GstTag', '1.0')
+module_info = GiModuleInfo('GstTag', '1.0')
+if module_info.available:
+    binaries, datas, hiddenimports = module_info.collect_typelib_data()

--- a/PyInstaller/hooks/hook-gi.repository.GstVideo.py
+++ b/PyInstaller/hooks/hook-gi.repository.GstVideo.py
@@ -8,12 +8,9 @@
 #
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
-"""
-Import hook for Gst (GStreamer) http://gstreamer.freedesktop.org introspected through
-PyGobject https://wiki.gnome.org/PyGObject via the GObject Introspection middleware
-layer https://wiki.gnome.org/Projects/GObjectIntrospection
-"""
 
-from PyInstaller.utils.hooks.gi import get_gi_typelibs
+from PyInstaller.utils.hooks.gi import GiModuleInfo
 
-binaries, datas, hiddenimports = get_gi_typelibs('GstVideo', '1.0')
+module_info = GiModuleInfo('GstVideo', '1.0')
+if module_info.available:
+    binaries, datas, hiddenimports = module_info.collect_typelib_data()

--- a/PyInstaller/hooks/hook-gi.repository.GtkChamplain.py
+++ b/PyInstaller/hooks/hook-gi.repository.GtkChamplain.py
@@ -8,10 +8,9 @@
 #
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
-"""
-Import hook for PyGObject's "gi.repository.GtkChamplain" package.
-"""
 
-from PyInstaller.utils.hooks.gi import get_gi_typelibs
+from PyInstaller.utils.hooks.gi import GiModuleInfo
 
-binaries, datas, hiddenimports = get_gi_typelibs('GtkChamplain', '0.12')
+module_info = GiModuleInfo('GtkChamplain', '0.12')
+if module_info.available:
+    binaries, datas, hiddenimports = module_info.collect_typelib_data()

--- a/PyInstaller/hooks/hook-gi.repository.GtkClutter.py
+++ b/PyInstaller/hooks/hook-gi.repository.GtkClutter.py
@@ -8,10 +8,9 @@
 #
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
-"""
-Import hook for PyGObject's "gi.repository.GtkClutter" package.
-"""
 
-from PyInstaller.utils.hooks.gi import get_gi_typelibs
+from PyInstaller.utils.hooks.gi import GiModuleInfo
 
-binaries, datas, hiddenimports = get_gi_typelibs('GtkClutter', '1.0')
+module_info = GiModuleInfo('GtkClutter', '1.0')
+if module_info.available:
+    binaries, datas, hiddenimports = module_info.collect_typelib_data()

--- a/PyInstaller/hooks/hook-gi.repository.GtkSource.py
+++ b/PyInstaller/hooks/hook-gi.repository.GtkSource.py
@@ -9,21 +9,23 @@
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
 
-from PyInstaller.utils.hooks.gi import (collect_glib_share_files, get_gi_typelibs)
-from PyInstaller.utils.hooks import (get_hook_config, logger)
+from PyInstaller.utils.hooks.gi import GiModuleInfo, collect_glib_share_files
 
 
 def hook(hook_api):
-    module_versions = get_hook_config(hook_api, 'gi', 'module-versions')
-    if module_versions:
-        version = module_versions.get('GtkSource', '3.0')
-    else:
-        version = '3.0'
-    logger.info(f'GtkSource version is {version}')
+    module_info = GiModuleInfo('GtkSource', '3.0', hook_api=hook_api)  # Pass hook_api to read version from hook config
+    if not module_info.available:
+        return
 
-    binaries, datas, hiddenimports = get_gi_typelibs('GtkSource', version)
+    binaries, datas, hiddenimports = module_info.collect_typelib_data()
 
-    datas += collect_glib_share_files(f'gtksourceview-{version}')
+    # Collect data files
+    # The data directory name contains verbatim version, e.g.:
+    #   * GtkSourceView-3.0 -> /usr/share/gtksourceview-3.0
+    #   * GtkSourceView-4 -> /usr/share/gtksourceview-4
+    #   * GtkSourceView-5 -> /usr/share/gtksourceview-5
+    datas += collect_glib_share_files(f'gtksourceview-{module_info.version}')
+
     hook_api.add_datas(datas)
     hook_api.add_binaries(binaries)
     hook_api.add_imports(*hiddenimports)

--- a/PyInstaller/hooks/hook-gi.repository.GtkosxApplication.py
+++ b/PyInstaller/hooks/hook-gi.repository.GtkosxApplication.py
@@ -8,12 +8,11 @@
 #
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
-"""
-Import hook for PyGObject https://wiki.gnome.org/PyGObject
-"""
 
 from PyInstaller.compat import is_darwin
-from PyInstaller.utils.hooks.gi import get_gi_typelibs
+from PyInstaller.utils.hooks.gi import GiModuleInfo
 
 if is_darwin:
-    binaries, datas, hiddenimports = get_gi_typelibs('GtkosxApplication', '1.0')
+    module_info = GiModuleInfo('GtkosxApplication', '1.0')
+    if module_info.available:
+        binaries, datas, hiddenimports = module_info.collect_typelib_data()

--- a/PyInstaller/hooks/hook-gi.repository.HarfBuzz.py
+++ b/PyInstaller/hooks/hook-gi.repository.HarfBuzz.py
@@ -8,10 +8,9 @@
 #
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
-"""
-Import hook for PyGObject https://wiki.gnome.org/PyGObject
-"""
 
-from PyInstaller.utils.hooks.gi import get_gi_typelibs
+from PyInstaller.utils.hooks.gi import GiModuleInfo
 
-binaries, datas, hiddenimports = get_gi_typelibs('HarfBuzz', '0.0')
+module_info = GiModuleInfo('HarfBuzz', '0.0')
+if module_info.available:
+    binaries, datas, hiddenimports = module_info.collect_typelib_data()

--- a/PyInstaller/hooks/hook-gi.repository.Pango.py
+++ b/PyInstaller/hooks/hook-gi.repository.Pango.py
@@ -8,10 +8,9 @@
 #
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
-"""
-Import hook for PyGObject https://wiki.gnome.org/PyGObject
-"""
 
-from PyInstaller.utils.hooks.gi import get_gi_typelibs
+from PyInstaller.utils.hooks.gi import GiModuleInfo
 
-binaries, datas, hiddenimports = get_gi_typelibs('Pango', '1.0')
+module_info = GiModuleInfo('Pango', '1.0')
+if module_info.available:
+    binaries, datas, hiddenimports = module_info.collect_typelib_data()

--- a/PyInstaller/hooks/hook-gi.repository.PangoCairo.py
+++ b/PyInstaller/hooks/hook-gi.repository.PangoCairo.py
@@ -8,10 +8,9 @@
 #
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
-"""
-Import hook for PyGObject https://wiki.gnome.org/PyGObject
-"""
 
-from PyInstaller.utils.hooks.gi import get_gi_typelibs
+from PyInstaller.utils.hooks.gi import GiModuleInfo
 
-binaries, datas, hiddenimports = get_gi_typelibs('PangoCairo', '1.0')
+module_info = GiModuleInfo('PangoCairo', '1.0')
+if module_info.available:
+    binaries, datas, hiddenimports = module_info.collect_typelib_data()

--- a/PyInstaller/hooks/hook-gi.repository.cairo.py
+++ b/PyInstaller/hooks/hook-gi.repository.cairo.py
@@ -8,10 +8,9 @@
 #
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
-"""
-Import hook for PyGObject https://wiki.gnome.org/PyGObject
-"""
 
-from PyInstaller.utils.hooks.gi import get_gi_typelibs
+from PyInstaller.utils.hooks.gi import GiModuleInfo
 
-binaries, datas, hiddenimports = get_gi_typelibs('cairo', '1.0')
+module_info = GiModuleInfo('cairo', '1.0')
+if module_info.available:
+    binaries, datas, hiddenimports = module_info.collect_typelib_data()

--- a/PyInstaller/hooks/hook-gi.repository.xlib.py
+++ b/PyInstaller/hooks/hook-gi.repository.xlib.py
@@ -8,10 +8,9 @@
 #
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
-"""
-Import hook for PyGObject https://wiki.gnome.org/PyGObject
-"""
 
-from PyInstaller.utils.hooks.gi import get_gi_typelibs
+from PyInstaller.utils.hooks.gi import GiModuleInfo
 
-binaries, datas, hiddenimports = get_gi_typelibs('xlib', '2.0')
+module_info = GiModuleInfo('xlib', '2.0')
+if module_info.available:
+    binaries, datas, hiddenimports = module_info.collect_typelib_data()

--- a/news/6897.bugfix.rst
+++ b/news/6897.bugfix.rst
@@ -1,0 +1,3 @@
+Fix regression in PyInstaller v5 where an import of a non-existent
+GObject introspection (`gi`) module (for example, an optional dependency)
+in the program causes a build-time error and aborts the build process.

--- a/news/6901.hooks.1.rst
+++ b/news/6901.hooks.1.rst
@@ -1,0 +1,3 @@
+Refactor the GObject introspection (``gi``) hooks so that the processing
+is performed only in hook loading stage or in the ``hook()`` function,
+but not in the mixture of two.

--- a/news/6901.hooks.rst
+++ b/news/6901.hooks.rst
@@ -1,0 +1,10 @@
+Update the GObject introspection (``gi``) hooks to use newly-introduced
+``GiModuleInfo`` object to:
+ * check for module availability
+ * perform typelib data collection; equivalent of old ``get_gi_typelibs`
+   function call
+ * obtain associated shared library path, equivalent of old ``get_gi_libdir``
+   function call
+The ``get_gi_typelibs` and ``get_gi_libdir`` functions now internally
+use ``GiModuleInfo`` to provide backwards-compatibility for external
+users.


### PR DESCRIPTION
The modules imported from `gi.repository` are marked as runtime modules by their corresponding pre-safe-import-module hooks. Therefore, their standard hooks are always loaded and executed, regardless of whether the modue is actually importable or not.

In PyInstaller v5, this behavior triggers errors in hooks for GI modules that are not importable, because the new `isolated` framework propagates the errors instead of swallowing them. While these errors could be caught and demoted to warnings
to match the old behavior, it would be better if hooks checked whether module is importable before doing any processing at all.

To that end, we introduce new class, `GiModuleInfo` that, as part of its initialization, allows us to:
 - perform availability check
 - obtain data previously returned by `get_gi_typelibs`
 - obtain data previously returned by `get_gi_libdir`
 
using a single isolated import attempt (instead of one being performed in each of those steps).

In  addition, if passed `hook_api` as an optional argument, the `GiModuleInfo` can use hook configuration API to override the GI module version to be collected (which allows the standard use pattern to be removed from the hook itself).

The old `get_gi_typelibs` and `get_gi_libdir` functions now internally use `GiModuleInfo` to provide backward compatible behavior to (potential) external user.

All `gi` hooks are ported to the `GiModuleInfo` and now become no-op if the module is not available.

In addition, hooks are cleaned up/refactored so that all processing is performed either in the loading stage ("simple" hooks that do not require access to hook configuration API) or in the `hook()` function (hooks that require access to hook configuration API), but not in the mixture of the two.

Fixes #6897.