### PR TITLE
hooks: disable QtWebEngine sandboxing for Qt6 on macOS

### DIFF
--- a/PyInstaller/hooks/rthooks/pyi_rth_pyqt6webengine.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_pyqt6webengine.py
@@ -27,3 +27,9 @@ if sys.platform == 'darwin':
     )
     if os.path.exists(process_path):
         os.environ['QTWEBENGINEPROCESS_PATH'] = process_path
+
+        # As of Qt 6.3.1, we need to disable sandboxing to make QtWebEngineProcess to work at all with the way
+        # PyInstaller currently collects libraries from Qt .framework bundles.
+        # This runtime hook should avoid importing PyQt6, so we have no way of querying the version, and always disable
+        # sandboxing.
+        os.environ['QTWEBENGINE_DISABLE_SANDBOX'] = '1'

--- a/PyInstaller/hooks/rthooks/pyi_rth_pyside6webengine.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_pyside6webengine.py
@@ -23,3 +23,9 @@ if sys.platform == 'darwin':
     )
     if os.path.exists(process_path):
         os.environ['QTWEBENGINEPROCESS_PATH'] = process_path
+
+        # As of Qt 6.3.1, we need to disable sandboxing to make QtWebEngineProcess to work at all with the way
+        # PyInstaller currently collects libraries from Qt .framework bundles.
+        # This runtime hook should avoid importing PySide6, so we have no way of querying the version, and always
+        # disable sandboxing.
+        os.environ['QTWEBENGINE_DISABLE_SANDBOX'] = '1'

--- a/news/6903.hooks.rst
+++ b/news/6903.hooks.rst
@@ -1,0 +1,8 @@
+(macOS) Disable ``QtWebEngine`` sandboxing for Qt6 in the corresponding
+``PySide6`` and ``PyQt6`` run-time hooks as a work-around for the
+``QtWebEngineProcess`` helper process crashing. This is required as of
+Qt 6.3.1 due to the way PyInstaller collects Qt libraries, but is applied
+regardless of the used Qt6 version. If you are using an older version of
+Qt6 and would like to keep the sandboxing, reset the
+``QTWEBENGINE_DISABLE_SANDBOX`` environment variable at the start of your
+program, before importing Qt packages.


### PR DESCRIPTION
The `QtWebEngine` sandboxing in Qt 6.3.1 is apparently stricter than in earlier versions, and the way PyInstaller currently collects
shared libraries from .framework bundles prevents the helper process from running.

So disable the sandboxing until we come up with proper solution.