### PR TITLE
Update usage.rst

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -117,7 +117,7 @@ Is equivalent to:
 
 .. code-block:: shell
 
-    pyinstaller my_script.py --onefile --windowed
+    pyinstaller my_script.py --onefile -w
 
 
 Using UPX


### PR DESCRIPTION
Changed `pyinstaller my_script.py --onefile --windowed` to `pyinstaller my_script.py --onefile -w`.

Both achieve the same result, the second way is just easier to read and write. 