### PR TITLE
bootloader: improve signal handling in POSIX codepath

### DIFF
--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -414,6 +414,10 @@ pyi_main(int argc, char * argv[])
         }
         pyi_arch_status_free(archive_status);
 
+        /* Re-raise child's signal, if necessary (non-Windows only) */
+#ifndef _WIN32
+        pyi_utils_reraise_child_signal();
+#endif
     }
     return rc;
 }

--- a/bootloader/src/pyi_utils.c
+++ b/bootloader/src/pyi_utils.c
@@ -967,13 +967,20 @@ pyi_utils_get_child_pid()
 static void
 _ignoring_signal_handler(int signum)
 {
-    VS("LOADER: Ignoring signal %d\n", signum);
+    /* Ignore the signal. Avoid generating debug messages as per
+     * explanation in _signal_handler().
+     */
+    (void)signum;  /* Supress unused argument warnings */
 }
 
 static void
 _signal_handler(int signum)
 {
-    VS("LOADER: Forwarding signal %d to child pid %d\n", signum, child_pid);
+    /* Forward signal to the child. Avoid generating debug messages, as
+     * functions involved are generally not signal safe. Furthermore, it
+     * may result in endless spamming of SIGPIPE, as reported and
+     * diagnosed in #5270.
+     */
     kill(child_pid, signum);
 }
 

--- a/bootloader/src/pyi_utils.h
+++ b/bootloader/src/pyi_utils.h
@@ -57,6 +57,7 @@ int pyi_utils_create_child(const char *thisfile, const ARCHIVE_STATUS *status,
                            const int argc, char *const argv[]);
 #ifndef _WIN32
 pid_t pyi_utils_get_child_pid();
+void pyi_utils_reraise_child_signal();
 #endif
 int pyi_utils_set_environment(const ARCHIVE_STATUS *status);
 

--- a/news/2379.bugfix.rst
+++ b/news/2379.bugfix.rst
@@ -1,0 +1,6 @@
+(non-Windows) If the child process of a ``onefile`` frozen application
+is terminated by a signal, delay re-raising of the signal in the parent
+process until after the clean up has been performed. This prevents
+``onefile`` frozen applications from leaving behind their unpacked
+temporary directories when either the parent or the child process is
+sent the ``SIGTERM`` signal.

--- a/news/5270.bugfix.rst
+++ b/news/5270.bugfix.rst
@@ -1,0 +1,4 @@
+(non-Windows) Avoid generating debug messages in POSIX signal handlers,
+as the functions involved are generally not signal-safe. Should also
+fix the endless spam of ``SIGPIPE`` that ocurrs under certain conditions
+when shutting down the frozen application on linux.


### PR DESCRIPTION
If the child process in the `onefile` mode is terminated by a signal, delay re-raising of the signal in the POSIX codepath of the parent process until after the cleanup. Re-raising it immediately after the child exits means that clean up is never reached, and the unpacked temporary directory is left behind by the terminated frozen application.

Terminating a onefile frozen application by sending `SIGTERM` to either the parent or the child process should now clean up
the application's temporary directory. This applies only to the POSIX codepath, i.e., OSes other than Windows.

Fixes #2379.

I have also removed the generation of debug messages from signal handlers, which should prevent #5270. I haven't been able to reproduce that issue, but the explanation in https://github.com/pyinstaller/pyinstaller/issues/5270#issuecomment-896466360 seems plausible. Besides, using functions that are not signal-safe in signal handlers is iffy anyway...

Fixes #5270.