### PR TITLE
building: extend DLL search paths when searching for binary deps

### DIFF
--- a/news/6924.bugfix.rst
+++ b/news/6924.bugfix.rst
@@ -1,0 +1,4 @@
+(Windows) Attempt to extend DLL search paths with directories found in
+the `PATH` environment variable and by tracking calls to the
+`os.add_dll_directory` function during import of the packages in
+the isolated sub-process that performs the binary dependency scanning.


### PR DESCRIPTION
As part of depdendency analysis, we search for binary dependencies (shared libraries) of the collected binaries, which is done by
running the `find_binary_dependencies` helper function in an isolated sub-process.

In that helper, we already import all collected top-level packages; the aim was to ensure that library search paths, which may be
modified during packages' initialization, are up to date. In practice, however, just importing the packages has little effect on search paths - at least on Windows, where we still consider only the binary's parent directory.

Therefore, we now try to explicitly extend the search paths on Windows, obtaining extra DLL search directories:
 - from the PATH environment variable once all packages are imported
 - by tracking calls to `os.add_dll_directory` calls during package imports by monkey-patching that call

Fixes #6924.

Fixes https://github.com/pyinstaller/pyinstaller-hooks-contrib/issues/317.
Fixes https://github.com/pyinstaller/pyinstaller/issues/6482.
Fixes https://github.com/pyinstaller/pyinstaller/issues/6960.