### PR TITLE
Update usage.rst

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -118,7 +118,10 @@ Is equivalent to:
 .. code-block:: shell
 
     pyinstaller my_script.py --onefile --windowed
+or
 
+.. code-block:: shell
+    pyinstaller my_script.py --onefile -w 
 
 Using UPX
 ~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Added a code block showing another way to make it so that there is no window.

Previously the documentation had  `pyinstaller my_script.py --onefile --windowed`. However, another way to accomplish this for more experienced users is, `pyinstaller my_script.py --onefile -w`.

Both commands will achieve the same result. A more experienced user may choose the second command due to its simplicity. 