### PR TITLE
docs: Fix a few typos

### DIFF
--- a/PyInstaller/hooks/rthooks/pyi_rth_pkgres.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_pkgres.py
@@ -95,7 +95,7 @@ _toc_tree_cache = {}
 
 class PyiFrozenProvider(pkg_resources.NullProvider):
     """
-    Custom pkg_resourvces provider for FrozenImporter.
+    Custom pkg_resources provider for FrozenImporter.
     """
     def __init__(self, module):
         super().__init__(module)

--- a/PyInstaller/utils/win32/winmanifest.py
+++ b/PyInstaller/utils/win32/winmanifest.py
@@ -21,7 +21,7 @@
 # http://msdn.microsoft.com/en-us/library/dd408052%28VS.85%29.aspx
 #
 # Changelog:
-# 2009-12-17  fix: small glitch in toxml / toprettyxml methods (xml declaration wasn't replaced when a different encodig
+# 2009-12-17  fix: small glitch in toxml / toprettyxml methods (xml declaration wasn't replaced when a different encoding
 #                  than UTF-8 was used)
 #             chg: catch xml.parsers.expat.ExpatError and re-raise as ManifestXMLParseError
 #             chg: support initialize option in parse method also

--- a/PyInstaller/utils/win32/winmanifest.py
+++ b/PyInstaller/utils/win32/winmanifest.py
@@ -21,8 +21,8 @@
 # http://msdn.microsoft.com/en-us/library/dd408052%28VS.85%29.aspx
 #
 # Changelog:
-# 2009-12-17  fix: small glitch in toxml / toprettyxml methods (xml declaration wasn't replaced when a different encoding
-#                  than UTF-8 was used)
+# 2009-12-17  fix: small glitch in toxml / toprettyxml methods (xml declaration wasn't replaced when a different
+#                  encoding than UTF-8 was used)
 #             chg: catch xml.parsers.expat.ExpatError and re-raise as ManifestXMLParseError
 #             chg: support initialize option in parse method also
 #


### PR DESCRIPTION
There are small typos in:
- PyInstaller/hooks/rthooks/pyi_rth_pkgres.py
- PyInstaller/utils/win32/winmanifest.py

Fixes:
- Should read `resources` rather than `resourvces`.
- Should read `encoding` rather than `encodig`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md