### PR TITLE
Implement module collection mode setting for hooks

### DIFF
--- a/PyInstaller/building/utils.py
+++ b/PyInstaller/building/utils.py
@@ -15,6 +15,7 @@
 import fnmatch
 import glob
 import hashlib
+import importlib.util
 import marshal
 import os
 import pathlib
@@ -738,6 +739,7 @@ def compile_pymodule(name, src_path, workpath, code_cache=None):
 
     # Check if optional cache contains module entry
     code_object = code_cache.get(name, None) if code_cache else None
+    src_hash = None
 
     if code_object is None:
         _, ext = os.path.splitext(src_path)
@@ -762,6 +764,21 @@ def compile_pymodule(name, src_path, workpath, code_cache=None):
         # Unmarshal code object; this is necessary if we want to strip paths from it
         code_object = marshal.loads(pyc_data[16:])
 
+        # If this this a hash-based pyc, read the hash from it
+        flags = struct.unpack('<I', pyc_data[4:8])[0]
+        if flags & 1:
+            src_hash = pyc_data[8:16]
+
+    # If source hash is unavailable (we were dealing with timestamp-based pyc file, or the code object was retrieved
+    # from the code cache), compute it
+    if src_hash is None:
+        if os.path.isfile(src_path):
+            with open(src_path, 'rb') as fp:
+                src_bytes = fp.read()
+            src_hash = importlib.util.source_hash(src_bytes)
+        else:
+            src_hash = b'\00' * 8
+
     # Strip code paths from the code object
     code_object = strip_paths_in_code(code_object)
 
@@ -769,7 +786,7 @@ def compile_pymodule(name, src_path, workpath, code_cache=None):
     with open(pyc_path, 'wb') as fh:
         fh.write(compat.BYTECODE_MAGIC)
         fh.write(struct.pack('<I', 0b01))  # PEP-552: hash-based pyc, check_source=False
-        fh.write(b'\00' * 8)  # FIXME: what to do about the checksum?
+        fh.write(src_hash)
         marshal.dump(code_object, fh)
 
     # Return output path

--- a/PyInstaller/building/utils.py
+++ b/PyInstaller/building/utils.py
@@ -652,33 +652,6 @@ def strip_paths_in_code(co, new_filename=None):
         )
 
 
-def fake_pyc_timestamp(buf):
-    """
-    Reset the timestamp from a .pyc-file header to a fixed value.
-
-    This enables deterministic builds without having to set pyinstaller source metadata (mtime) since that changes the
-    pyc-file contents.
-
-    _buf_ must at least contain the full pyc-file header.
-    """
-    assert buf[:4] == compat.BYTECODE_MAGIC, \
-        "Expected pyc magic {}, got {}".format(compat.BYTECODE_MAGIC, buf[:4])
-    start, end = 4, 8
-    # See https://www.python.org/dev/peps/pep-0552/
-    (flags,) = struct.unpack_from(">I", buf, 4)
-    if flags & 1:
-        # We are in the future and hash-based pyc-files are used, so
-        # clear "check_source" flag, since there is no source.
-        buf[4:8] = struct.pack(">I", flags ^ 2)
-        return buf
-    else:
-        # No hash-based pyc-file, timestamp is the next field.
-        start, end = 8, 12
-
-    ts = b'pyi0'  # So people know where this comes from
-    return buf[:start] + ts + buf[end:]
-
-
 def _should_include_system_binary(binary_tuple, exceptions):
     """
     Return True if the given binary_tuple describes a system binary that should be included.

--- a/PyInstaller/depend/analysis.py
+++ b/PyInstaller/depend/analysis.py
@@ -86,6 +86,8 @@ class PyiModuleGraph(ModuleGraph):
         List of module names to be excluded when searching for dependencies.
     _additional_files_cache : AdditionalFilesCache
         Cache of all external dependencies (e.g., binaries, datas) listed in hook scripts for imported modules.
+    _module_collection_mode : dict
+        A dictionary of module/package collection mode settings set by hook scripts for their modules.
     _base_modules: list
         Dependencies for `base_library.zip` (which remain the same for every executable).
     """
@@ -111,6 +113,7 @@ class PyiModuleGraph(ModuleGraph):
         """
         self._top_script_node = None
         self._additional_files_cache = AdditionalFilesCache()
+        self._module_collection_mode = dict()
         # Command line, Entry Point, and then builtin hook dirs.
         self._user_hook_dirs = [*user_hook_dirs, os.path.join(PACKAGEPATH, 'hooks')]
         # Hook-specific lookup tables. These need to reset when reusing cached PyiModuleGraph to avoid hooks to refer to
@@ -328,6 +331,9 @@ class PyiModuleGraph(ModuleGraph):
                     # Cache all external dependencies listed by this script after running this hook, which could add
                     # dependencies.
                     self._additional_files_cache.add(module_name, module_hook.binaries, module_hook.datas)
+
+                    # Update package collection mode settings.
+                    self._module_collection_mode.update(module_hook.module_collection_mode)
 
                 # Prevent this module's hooks from being run again.
                 hooked_module_names.add(module_name)

--- a/PyInstaller/depend/analysis.py
+++ b/PyInstaller/depend/analysis.py
@@ -848,10 +848,10 @@ def get_bootstrap_modules():
     # NOTE:These modules should be kept simple without any complicated dependencies.
     loader_mods += [
         ('struct', os.path.abspath(mod_struct.__file__), 'PYMODULE'),
-        ('pyimod01_os_path', os.path.join(loaderpath, 'pyimod01_os_path.pyc'), 'PYMODULE'),
-        ('pyimod02_archive', os.path.join(loaderpath, 'pyimod02_archive.pyc'), 'PYMODULE'),
-        ('pyimod03_importers', os.path.join(loaderpath, 'pyimod03_importers.pyc'), 'PYMODULE'),
-        ('pyimod04_ctypes', os.path.join(loaderpath, 'pyimod04_ctypes.pyc'), 'PYMODULE'),
+        ('pyimod01_os_path', os.path.join(loaderpath, 'pyimod01_os_path.py'), 'PYMODULE'),
+        ('pyimod02_archive', os.path.join(loaderpath, 'pyimod02_archive.py'), 'PYMODULE'),
+        ('pyimod03_importers', os.path.join(loaderpath, 'pyimod03_importers.py'), 'PYMODULE'),
+        ('pyimod04_ctypes', os.path.join(loaderpath, 'pyimod04_ctypes.py'), 'PYMODULE'),
         ('pyiboot01_bootstrap', os.path.join(loaderpath, 'pyiboot01_bootstrap.py'), 'PYSOURCE'),
     ]
     return loader_mods

--- a/PyInstaller/depend/imphookapi.py
+++ b/PyInstaller/depend/imphookapi.py
@@ -304,6 +304,9 @@ class PostGraphAPI:
     _added_binaries : list
         List of the `(name, path)` 2-tuples or TOC objects of all external C extensions imported by the current hook,
         defaulting to the empty list. This is equivalent to the global `binaries` hook attribute.
+    _module_collection_mode : dict
+        Dictionary of package/module names and their corresponding collection mode strings. This is equivalent to the
+        global `module_collection_mode` hook attribute.
     """
     def __init__(self, module_name, module_graph, analysis):
         # Mutable attributes.
@@ -329,6 +332,7 @@ class PostGraphAPI:
         self._added_datas = []
         self._added_imports = []
         self._deleted_imports = []
+        self._module_collection_mode = {}
 
     # Immutable properties. No corresponding setters are defined.
     @property
@@ -450,3 +454,16 @@ class PostGraphAPI:
             self._added_datas.extend(i[:2] for i in list_of_tuples)
         else:
             self._added_datas.extend(format_binaries_and_datas(list_of_tuples))
+
+    def set_module_collection_mode(self, name, mode):
+        """"
+        Set the package/module collection mode for the specified module
+        name. If `name` is `None`, the hooked module/package name is used.
+        Valid values for `mode` are: `'pyc'`, `'py'`, and `None`.
+        """
+        if name is None:
+            name = self.__name__
+        if mode is None:
+            self._module_collection_mode.pop(name)
+        else:
+            self._module_collection_mode[name] = mode

--- a/PyInstaller/depend/imphookapi.py
+++ b/PyInstaller/depend/imphookapi.py
@@ -457,9 +457,9 @@ class PostGraphAPI:
 
     def set_module_collection_mode(self, name, mode):
         """"
-        Set the package/module collection mode for the specified module
-        name. If `name` is `None`, the hooked module/package name is used.
-        Valid values for `mode` are: `'pyc'`, `'py'`, and `None`.
+        Set the package/module collection mode for the specified module name. If `name` is `None`, the hooked
+        module/package name is used. `mode` can be one of valid mode strings (`'pyz'`, `'pyc'`, ˙'py'˙, `'pyz+py'`,
+        ˙'py+pyz'`) or `None`, which clears the setting for the module/package - but only  within this hook's context!
         """
         if name is None:
             name = self.__name__

--- a/bootloader/src/pyi_pythonlib.c
+++ b/bootloader/src/pyi_pythonlib.c
@@ -617,16 +617,15 @@ pyi_pylib_import_modules(ARCHIVE_STATUS *status)
 
             VS("LOADER: extracted %s\n", ptoc->name);
 
-            /* Unmarshall code object for module; we need to skip
-               the pyc header */
-            co = PI_PyMarshal_ReadObjectFromString((const char *) modbuf + 16, ptoc->ulen - 16);
+            /* Unmarshal the stored code object */
+            co = PI_PyMarshal_ReadObjectFromString((const char *) modbuf, ptoc->ulen);
 
             if (co != NULL) {
                 VS("LOADER: running unmarshalled code object for %s...\n", ptoc->name);
                 mod = PI_PyImport_ExecCodeModule(ptoc->name, co);
             }
             else {
-                VS("LOADER: failed to unmarshall code object for %s!\n", ptoc->name);
+                VS("LOADER: failed to unmarshal code object for %s!\n", ptoc->name);
                 mod = NULL;
             }
 

--- a/doc/hooks.rst
+++ b/doc/hooks.rst
@@ -259,12 +259,25 @@ applies them to the bundle being created.
    When set to a string, the variable controls the collection mode for
    the hooked package/module. Valid values are:
 
-   * ``'pyc'``: collect byte-compiled modules, typically into the embedded
-     PYZ archive. This is the default behavior when no collection mode
-     is specified.
+   * ``'pyz'``: collect byte-compiled modules into the embedded PYZ
+     archive. This is the default behavior when no collection mode is
+     specified. If the ``noarchive`` flag is used with ``Analysis``,
+     the PYZ archive is not used, and ``pyz`` collection mode is
+     automatically turned into ``pyc`` one.
 
-   * ``'py'``: collect source .py files as external data files, and do
-     not collect byte-compiled modules into the PYZ archive.
+   * ``'pyc'``: collect byte-compiled modules as external data files
+     (as opposed to collecting them into the PYZ archive).
+
+   * ``'py'``: collect source .py files as external data files. Do not
+     collect byte-compiled modules.
+
+   * ``'pyz+py'`` or ``'py+pyz'``: collect byte-compiled modules into
+     the embedded PYZ archive and collect corresponding source .py files
+     as external data files.
+
+     If ``noarchive`` flag is in effect, the byte-compiled modules are
+     collected as external data files, which causes python to ignore
+     them due to the source files being placed next to them.
 
    The setting is applied to all child modules and subpackages, unless
    overridden by the setting in their corresponding hook.
@@ -298,11 +311,11 @@ applies them to the bundle being created.
 
       # hook-mypackage.py
 
-      # Collect whole package as source except for a signle sub-package
+      # Collect whole package as source except for a single sub-package
       # (without creating a hook for the sub-package).
       module_collection_mode = {
          'mypackage': 'py',
-         'mypackage.bin_subpackage': 'pyc'
+         'mypackage.bin_subpackage': 'pyz'
       }
 
    Example::
@@ -525,11 +538,12 @@ The ``hook_api`` object also offers the following methods:
 
 ``set_module_collection_mode ( name, mode )``:
    Set the `package collection mode`_ for the specified package/module name.
-   Valid values for ``mode`` are: ``'pyc'``, ``'py'``, and ``None``
-   (which clears/resets the setting for the given package/module name).
-   The collection mode may be set for the hooked package, its sub-module
-   or sub-package, or for other packages. If ``name`` is ``None``, it
-   is substituted with the hooked package/module name.
+   Valid values for ``mode`` are: ``'pyz'``, ``'pyc'``, ``'py'``,
+   ``'pyz+py'``, ``'py+pyz'`` and ``None``. ``None`` clears/resets the
+   setting for the given package/module name - but only within the
+   current hook's context! The collection mode may be set for the hooked
+   package, its sub-module or sub-package, or for other packages. If ``name``
+   is ``None``, it is substituted with the hooked package/module name.
 
 The ``hook()`` function can add, remove or change included files using the
 above methods of ``hook_api``.

--- a/news/6591.bugfix.1.rst
+++ b/news/6591.bugfix.1.rst
@@ -1,0 +1,3 @@
+When building with ``noarchive=True`` (e.g., ``--debug noarchive`` or
+``--debug all``), the source paths are now stripped from the collected
+.pyc modules, same as if PYZ archive was used.

--- a/news/6591.bugfix.rst
+++ b/news/6591.bugfix.rst
@@ -1,0 +1,4 @@
+When building with ``noarchive=True`` (e.g., ``--debug noarchive`` or
+``--debug all``), PyInstaller no longer pollutes user-writable source
+locations with its ``.pyc`` or ``.pyo`` files written next to the
+corresponding source files.

--- a/news/6945.feature.rst
+++ b/news/6945.feature.rst
@@ -1,0 +1,6 @@
+Implement a mechanism for controlling the collection mode of modules and
+packages, with granularity ranging from top-level packages to individual
+sub-modules. Therefore, the hooks can now specify whether the hooked
+package should be collected as byte-compiled .pyc modules into embedded
+PYZ archive (the default behavior), or as source .py files collected as
+external data files (without corresponding modules in the PYZ archive).


### PR DESCRIPTION
Implement a mechanism for controlling the collection mode of modules and packages, with granularity ranging from top-level packages to individual sub-modules. Therefore, the hooks can now specify whether the hooked package should be collected as
byte-compiled .pyc modules into embedded PYZ archive (the default behavior), or as source .py files collected as external data files (without corresponding modules in the PYZ archive).

The latter option should let us avoid unnecessary .pyc module collection when the source files are required by the code, or
work around the situations where having a .pyc module in PYZ archive causes issues due to FrozenImporter's incompatibility with sys.path manipulation that some packages attempt to perform.

This feature adds a new optional global hook variable, called `module_collection_mode`. The value can be either a string ("py" or "pyc") or a dictionary of module names and setting strings.

In the case of a string, the setting affects the hooked module or a package, and is applied recursively to all sub-packages and sub-modules, unless another hook overrides it.

The dictionary setting allows a hook to specify different settings for the package and it subpackages, or even different settings for other packages.

A corresponding `set_module_collection_mode` method has been added to the `hook_api` object for adjusting the collection mode from within the `hook()` function.

The `Analysis` object can now also be passed a dictionary via an optional `module_collection_mode` argument; the corresponding settings are applied last, which allows advanced users to both supplement and override the settings made by the hooks.