### PR TITLE
Hooks: Add gi.repository.freetype2 hook, remove gi._gobject import warning

### DIFF
--- a/PyInstaller/hooks/hook-gi.repository.GObject.py
+++ b/PyInstaller/hooks/hook-gi.repository.GObject.py
@@ -8,10 +8,12 @@
 #
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
-
+from PyInstaller.utils.hooks import is_module_satisfies
 from PyInstaller.utils.hooks.gi import GiModuleInfo
 
 module_info = GiModuleInfo('GObject', '2.0')
 if module_info.available:
     binaries, datas, hiddenimports = module_info.collect_typelib_data()
-    hiddenimports += ['gi._gobject']
+    # gi._gobject removed from PyGObject in version 3.25.1
+    if is_module_satisfies('PyGObject < 3.25.1'):
+        hiddenimports += ['gi._gobject']

--- a/PyInstaller/hooks/hook-gi.repository.freetype2.py
+++ b/PyInstaller/hooks/hook-gi.repository.freetype2.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2022, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks.gi import GiModuleInfo
+
+module_info = GiModuleInfo('freetype2', '2.0')
+if module_info.available:
+    binaries, datas, hiddenimports = module_info.collect_typelib_data()

--- a/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.freetype2.py
+++ b/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.freetype2.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2022, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+
+def pre_safe_import_module(api):
+    # PyGObject modules loaded through the gi repository are marked as MissingModules by modulegraph, so we convert them
+    # to RuntimeModules in order for their hooks to be loaded and executed.
+    api.add_runtime_module(api.module_name)

--- a/news/6951.hooks.rst
+++ b/news/6951.hooks.rst
@@ -1,0 +1,2 @@
+Add PyGObject hook for ``gi.repository.freetype2``. Remove warning for
+hidden import not found for gi._gobject with PyGObject 3.25.1+.


### PR DESCRIPTION
The latest gvsbuild is importing freetype2 when HarfBuzz is imported. This PR adds a hook for freetype2, which removes a warning for `gi.repository.freetype2` hidden import not found when using GTK3 on Windows. Additionally, it removes a warning for hidden import not found for `gi._gobject` with PyGObject 3.25.1+.

Fixes #6957.