### PR TITLE
Hooks: Remove pkg_resources hidden imports that aren't available

### DIFF
--- a/PyInstaller/hooks/hook-pkg_resources.py
+++ b/PyInstaller/hooks/hook-pkg_resources.py
@@ -17,7 +17,8 @@ hiddenimports = collect_submodules('pkg_resources._vendor')
 
 # pkg_resources v45.0 dropped support for Python 2 and added this module printing a warning. We could save some bytes if
 # we would replace this by a fake module.
-hiddenimports.append('pkg_resources.py2_warn')
+if is_module_satisfies('setuptools >= 45.0.0, < 49.1.1'):
+    hiddenimports.append('pkg_resources.py2_warn')
 
 excludedimports = ['__main__']
 

--- a/PyInstaller/hooks/hook-pkg_resources.py
+++ b/PyInstaller/hooks/hook-pkg_resources.py
@@ -9,11 +9,19 @@
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
 
-from PyInstaller.utils.hooks import collect_submodules, is_module_satisfies
+from PyInstaller.utils.hooks import collect_submodules, is_module_satisfies, can_import_module
 
 # pkg_resources keeps vendored modules in its _vendor subpackage, and does sys.meta_path based import magic to expose
 # them as pkg_resources.extern.*
-hiddenimports = collect_submodules('pkg_resources._vendor')
+
+# The `railroad` package is an optional requirement for `pyparsing`. `pyparsing.diagrams` depends on `railroad`, so
+# filter it out when `railroad` is not available.
+if can_import_module('railroad'):
+    hiddenimports = collect_submodules('pkg_resources._vendor')
+else:
+    hiddenimports = collect_submodules(
+        'pkg_resources._vendor', filter=lambda name: 'pkg_resources._vendor.pyparsing.diagram' not in name
+    )
 
 # pkg_resources v45.0 dropped support for Python 2 and added this module printing a warning. We could save some bytes if
 # we would replace this by a fake module.

--- a/PyInstaller/hooks/hook-pkg_resources.py
+++ b/PyInstaller/hooks/hook-pkg_resources.py
@@ -24,11 +24,8 @@ excludedimports = ['__main__']
 
 # Some more hidden imports. See:
 # https://github.com/pyinstaller/pyinstaller-hooks-contrib/issues/15#issuecomment-663699288 `packaging` can either be
-# its own package, or embedded in `pkg_resources._vendor.packaging`, or both. Assume the worst and include both if
-# present.
+# its own package, or embedded in `pkg_resources._vendor.packaging`, or both.
 hiddenimports += collect_submodules('packaging')
-
-hiddenimports += ['pkg_resources.markers']
 
 # As of v60.7, setuptools vendored jaraco and has pkg_resources use it. Currently, the pkg_resources._vendor.jaraco
 # namespace package cannot be automatically scanned due to limited support for pure namespace packages in our hook

--- a/news/6952.hooks.rst
+++ b/news/6952.hooks.rst
@@ -1,0 +1,2 @@
+Remove ``pkg_resources`` hidden imports that aren't available including
+``py2_warn``, ``markers``, and ``_vendor.pyparsing.diagram``.


### PR DESCRIPTION
The pkg_resources has a few warnings that don't represent actual errors, this PR resolves #6849 including fixing warnings for:

- `pkg_resources.py2_warn`, which was removed in version 49.1.1 of setuptools
- `pkg_resources.markers`, which I don't think was an actual module name
- `pkg_resources._vendor.pyparsing.diagram`, when the railroad dependency isn't available