### PR TITLE
Couple of fixes for the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9, '3.10']
-        os: ['windows-latest', 'ubuntu-latest', 'macos-10.15', 'macos-11']
+        os: ['windows-latest', 'ubuntu-latest', 'macos-11']
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,11 @@ on:
       - develop
       - v4
 
+env:
+  # Prevent setuptools from replacing distutils with its vendored version. There seem to be issues
+  # between setuptools-provided distutils and pip 22.2 on python < 3.10, which results in failure
+  # of the "Test Packaging" step.
+  SETUPTOOLS_USE_DISTUTILS: not-today
 
 jobs:
   run:


### PR DESCRIPTION
Looks like every time we don't run the CI for couple of days, something horrible happens...

Currently, we are in the middle of a brown-out for `macos-10.15` runners to remind us that they are deprecated and planned to be removed at the end of August. So avoid prolonging the misery by removing them now. We *could* enable `macos-12` instead, but I don't think there's enough difference between Big Sur and Monterey from PyInstaller's point of view to warrant that (we could switch `macos-11` to `macos-12`, though).

The issues between `setuptools`-provided `distutils` and `pip` 22.2 on python < 3.10 that we worked around in the "ci" workflow in #6970 now needs to be also applied to the "lint" workflow due to "Test packaging step": https://github.com/pyinstaller/pyinstaller/runs/7543307689?check_suite_focus=true#step:8:1843