### PR TITLE
Remove the --key/cipher bytecode encryption.

### DIFF
--- a/PyInstaller/archive/pyz_crypto.py
+++ b/PyInstaller/archive/pyz_crypto.py
@@ -9,40 +9,8 @@
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
 
-import os
-
-from PyInstaller import log as logging
-
-BLOCK_SIZE = 16
-logger = logging.getLogger(__name__)
-
 
 class PyiBlockCipher:
-    """
-    This class is used only to encrypt Python modules.
-    """
     def __init__(self, key=None):
-        logger.log(
-            logging.DEPRECATION,
-            "Bytecode encryption will be removed in PyInstaller v6. Please remove cipher and block_cipher parameters "
-            "from your spec file to avoid breakages on upgrade. For the rationale/alternatives see "
-            "https://github.com/pyinstaller/pyinstaller/pull/6999"
-        )
-        assert type(key) is str
-        if len(key) > BLOCK_SIZE:
-            self.key = key[0:BLOCK_SIZE]
-        else:
-            self.key = key.zfill(BLOCK_SIZE)
-        assert len(self.key) == BLOCK_SIZE
-
-        import tinyaes
-        self._aesmod = tinyaes
-
-    def encrypt(self, data):
-        iv = os.urandom(BLOCK_SIZE)
-        return iv + self.__create_cipher(iv).CTR_xcrypt_buffer(data)
-
-    def __create_cipher(self, iv):
-        # The 'AES' class is stateful, and this factory method is used to re-initialize the block cipher class with
-        # each call to xcrypt().
-        return self._aesmod.AES(self.key.encode(), iv)
+        from PyInstaller.exceptions import RemovedCipherFeatureError
+        raise RemovedCipherFeatureError("Please remove cipher and block_cipher parameters from your spec file.")

--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -61,16 +61,18 @@ class PYZ(Target):
 
             name
                 A filename for the .pyz. Normally not needed, as the generated name will do fine.
-            cipher
-                The block cipher that will be used to encrypt Python bytecode.
         """
+        if kwargs.get("cipher"):
+            from PyInstaller.exceptions import RemovedCipherFeatureError
+            raise RemovedCipherFeatureError(
+                "Please remove the 'cipher' arguments to PYZ() and Analysis() in your spec file."
+            )
 
         from PyInstaller.config import CONF
 
         super().__init__()
 
         name = kwargs.get('name', None)
-        cipher = kwargs.get('cipher', None)
 
         self.name = name
         if name is None:
@@ -78,14 +80,6 @@ class PYZ(Target):
 
         # PyInstaller bootstrapping modules.
         bootstrap_dependencies = get_bootstrap_modules()
-
-        # Bundle the crypto key.
-        self.cipher = cipher
-        if cipher:
-            key_file = ('pyimod00_crypto_key', os.path.join(CONF['workpath'], 'pyimod00_crypto_key.py'), 'PYMODULE')
-            # Insert the key as the first module in the list. The key module contains just variables and does not depend
-            # on other modules.
-            bootstrap_dependencies.insert(0, key_file)
 
         # Compile the python modules that are part of bootstrap dependencies, so that they can be collected into the
         # CArchive and imported by the bootstrap script.
@@ -156,7 +150,7 @@ class PYZ(Target):
         self.code_dict = {name: strip_paths_in_code(code) for name, code in self.code_dict.items()}
 
         # Create the archive
-        ZlibArchiveWriter(self.name, archive_toc, code_dict=self.code_dict, cipher=self.cipher)
+        ZlibArchiveWriter(self.name, archive_toc, code_dict=self.code_dict)
         logger.info("Building PYZ (ZlibArchive) %s completed successfully.", self.name)
 
 

--- a/PyInstaller/building/templates.py
+++ b/PyInstaller/building/templates.py
@@ -14,7 +14,6 @@ Templates to generate .spec files.
 
 onefiletmplt = """# -*- mode: python ; coding: utf-8 -*-
 %(preamble)s
-%(cipher_init)s
 
 a = Analysis(
     %(scripts)s,
@@ -28,10 +27,9 @@ a = Analysis(
     excludes=%(excludes)s,
     win_no_prefer_redirects=%(win_no_prefer_redirects)s,
     win_private_assemblies=%(win_private_assemblies)s,
-    cipher=block_cipher,
     noarchive=%(noarchive)s,
 )
-pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+pyz = PYZ(a.pure, a.zipped_data)
 %(splash_init)s
 exe = EXE(
     pyz,
@@ -58,7 +56,6 @@ exe = EXE(
 
 onedirtmplt = """# -*- mode: python ; coding: utf-8 -*-
 %(preamble)s
-%(cipher_init)s
 
 a = Analysis(
     %(scripts)s,
@@ -72,10 +69,9 @@ a = Analysis(
     excludes=%(excludes)s,
     win_no_prefer_redirects=%(win_no_prefer_redirects)s,
     win_private_assemblies=%(win_private_assemblies)s,
-    cipher=block_cipher,
     noarchive=%(noarchive)s,
 )
-pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+pyz = PYZ(a.pure, a.zipped_data)
 %(splash_init)s
 exe = EXE(
     pyz,
@@ -104,14 +100,6 @@ coll = COLLECT(
     upx_exclude=%(upx_exclude)s,
     name='%(name)s',
 )
-"""
-
-cipher_absent_template = """
-block_cipher = None
-"""
-
-cipher_init_template = """
-block_cipher = pyi_crypto.PyiBlockCipher(key=%(key)r)
 """
 
 bundleexetmplt = """app = BUNDLE(

--- a/PyInstaller/exceptions.py
+++ b/PyInstaller/exceptions.py
@@ -28,3 +28,9 @@ class ImportErrorWhenRunningHook(HookError):
             "exists and whether the hook is compatible with your version of {1}: You might want to read more about "
             "hooks in the manual and provide a pull-request to improve PyInstaller.".format(self.args[0], self.args[1])
         )
+
+
+class RemovedCipherFeatureError(SystemExit):
+    def __str__(self):
+        return f"Bytecode encryption was removed in PyInstaller v6.0. {self.args[0]}" \
+               " For the rationale and alternatives see https://github.com/pyinstaller/pyinstaller/pull/6999"

--- a/doc/spec-files.rst
+++ b/doc/spec-files.rst
@@ -73,7 +73,6 @@ the ``pyinstaller`` command executes the spec file as code.
 Your bundled application is created by the execution of the spec file.
 The following is a shortened example of a spec file for a minimal, one-folder app::
 
-    block_cipher = None
     a = Analysis(['minimal.py'],
              pathex=['/Developer/PItests/minimal'],
              binaries=None,
@@ -81,10 +80,8 @@ The following is a shortened example of a spec file for a minimal, one-folder ap
              hiddenimports=[],
              hookspath=None,
              runtime_hooks=None,
-             excludes=None,
-             cipher=block_cipher)
-    pyz = PYZ(a.pure, a.zipped_data,
-             cipher=block_cipher)
+             excludes=None)
+    pyz = PYZ(a.pure, a.zipped_data)
     exe = EXE(pyz,... )
     coll = COLLECT(...)
 

--- a/news/6999.breaking.rst
+++ b/news/6999.breaking.rst
@@ -1,0 +1,1 @@
+Remove bytecode encryption (``--key`` and ``cipher`` options).

--- a/setup.cfg
+++ b/setup.cfg
@@ -87,8 +87,6 @@ hook_testing =
     pytest >= 2.7.3
     execnet >= 1.5.0
     psutil
-encryption =
-    tinyaes>=1.0.0
 
 [options.entry_points]
 console_scripts =

--- a/tests/functional/test_basic.py
+++ b/tests/functional/test_basic.py
@@ -157,38 +157,6 @@ def test_email(pyi_builder):
     )
 
 
-@importorskip('tinyaes')
-def test_feature_crypto(pyi_builder):
-    pyi_builder.test_source(
-        """
-        from pyimod00_crypto_key import key
-        from pyimod01_archive import CRYPT_BLOCK_SIZE
-
-        # Test against issue #1663: importing a package in the bootstrap
-        # phase should not interfere with subsequent imports.
-        import tinyaes
-
-        assert type(key) is str
-        # The test runner uses 'test_key' as key.
-        assert key == 'test_key'.zfill(CRYPT_BLOCK_SIZE)
-        """,
-        pyi_args=['--key=test_key']
-    )
-
-
-def test_feature_nocrypto(pyi_builder):
-    pyi_builder.test_source(
-        """
-        try:
-            import pyimod00_crypto_key
-
-            raise AssertionError('The pyimod00_crypto_key module must NOT be there if crypto is disabled.')
-        except ImportError:
-            pass
-        """
-    )
-
-
 def test_filename(pyi_builder):
     pyi_builder.test_script('pyi_filename.py')
 

--- a/tests/requirements-tools.txt
+++ b/tests/requirements-tools.txt
@@ -37,6 +37,3 @@ ruff
 pywin32; sys_platform == 'win32'
 
 lxml; python_version < '3.11'
-
-# crypto support (`--key` option)
-tinyaes ~= 1.0; python_version < '3.11'


### PR DESCRIPTION
Bytecode encryption, given that the decryption key has to be stored somewhere in the built application for the application to be able to function, was only ever a mild deterrent against prying eyes. It could be cracked by anyone willing to dig around PyInstaller's source code for the exact layout of the executable archive and a quick hexdump to get the key once you know where to look.

These days however, PyInstaller reverse engineering tools like [PyExtractor](https://github.com/Rdimo/PyExtractor/) have this all built in. For example, in the steps below, our would be prying user doesn't even need to know that the application they are trying to break open is encrypted, let alone have to do anything clever to decrypt it.

    git clone https://github.com/Rdimo/PyExtractor.git
    cd PyExtractor
    pip install -r requirements.txt
    python main.py some/pyinstaller/application

So since the knowledge barrier to reverse engineer an encrypted build is now identical to that of a regular one, and because users are being misled into thinking that an encrypted PyInstaller build is a safe place to put things like API keys, and since adding further code obfuscation will eventually lead to the same outcome, remove the encryption feature entirely.

Users looking for a replacement should look for code obfuscation methods that don't require lossless de-obfuscation at runtime in order for the code to be runable. This means PyArmour or any DIY bytecode encryption scheme should be avoided for the same reasons that this feature is  being dropped. Instead, you can use [pyminifier's obfuscation feature](http://liftoff.github.io/pyminifier/obfuscate.html) which mangles variable names or if (and only if) you understand the perils of Linux ABI compatibility, are aware of the macOS deployment target and understand that PyInstaller can't detect imports made by C extensions (i.e. you will need to use `--hidden-import`/`--collect-submodules` a lot) then you may consider running Cython on the more confidential Python files in your project.
