### PR TITLE
building: force the runtime hook execution order based on filenames

### DIFF
--- a/news/7012.feature.rst
+++ b/news/7012.feature.rst
@@ -1,0 +1,4 @@
+Make runtime hook execution order deterministic, based on the runtime
+hook filenames. This change affects only the runtime hooks tied to
+the imported modules; the custom runtime hooks are still executed
+first and in the order that they are specified.


### PR DESCRIPTION
Force the execution order of runtime hooks that are tied to imported modules and packages by sorting them by their filename (basename). This gives us stable and predictable execution order; up until now, the order depended on the order modules appeared in the module graph, i.e., on the order of imports made in the program.

It also gives us the ability to force execution of some hooks before other hooks, and conversely, force execution of some hooks
after all other hooks, by giving them appropriate names.

For example, a runtime hook named `pyi_rth_000_00_mymod_early.py` should be executed first (right after custom runtime hooks), while the one named `pyi_rth_zzz_00_mymod_late.py` should be executed last; regardless of the names used by potential 3rd party runtime hooks, as long as they adhere to the `pyi_rth_` prefix.