### PR TITLE
Windows: attempt to preserve DLL parent directory structure

### DIFF
--- a/PyInstaller/hooks/rthooks/pyi_rth_win32api.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_win32api.py
@@ -15,4 +15,18 @@
 # https://github.com/mhammond/pywin32/commit/71afa71e11e6631be611ca5cb57cda526
 # As a work-around, import pywintypes prior to win32api.
 
-import pywintypes  # noqa: F401
+# Unfortunately, __import_pywin32_system_module__ from pywintype module assumes that in a frozen application, the
+# pythoncom3X.dll and pywintypes3X.dll that are normally found in site-packages/pywin32_system32, are located
+# directly in the sys.path, without bothering to check first if they are actually available in the standard location.
+# This obviously runs afoul of our attempts at preserving the directory layout and placing them in the pywin32_system32
+# sub-directory instead of the top-level application directory. So as a work-around, add the sub-directory to sys.path
+# to keep pywintypes happy...
+import sys
+import os
+
+pywin32_system32_path = os.path.join(sys._MEIPASS, 'pywin32_system32')
+if os.path.isdir(pywin32_system32_path) and pywin32_system32_path not in sys.path:
+    sys.path.append(pywin32_system32_path)
+del pywin32_system32_path
+
+import pywintypes  # noqa: F401, E402

--- a/news/7028.breaking.rst
+++ b/news/7028.breaking.rst
@@ -1,0 +1,6 @@
+(Windows) PyInstaller now attempts to preserve parent directory structure
+of DLLs that are collected from python packages (e.g., bundled with
+packages in PyPI wheels) instead of collecting them to the top-level
+application directory. This behavior might be incompatible with 3rd
+party hooks that assume the old behavior, and may result in duplication
+of DLL files or missing DLLs in hook-provided runtime search paths.

--- a/news/7028.feature.rst
+++ b/news/7028.feature.rst
@@ -1,0 +1,8 @@
+(Windows) When collecting a DLL that was discovered via link-time
+dependency analysis of a collected binary/extension, attempt to preserve
+its parent directory structure instead of collecting it into application's
+top-level directory. This aims to preserve the parent directory structure
+of DLLs bundled with python packages in PyPI wheels, while the DLLs
+collected from system directories (as well as from ``Library\bin``
+directory of the Anaconda's environment) are still collected into
+top-level application directory.


### PR DESCRIPTION
When collecting a DLL that was discovered via link-time dependency analysis of a collected binary/extension, attempt to preserve
its parent directory structure instead of collecting it into application's top-level directory. 

This aims to preserve the parent directory structure of DLLs bundled with python packages in PyPI wheels, while the DLLs
collected from system directories (as well as from `Library\bin` directory of the Anaconda's environment) are still collected into
top-level application directory (because there is no directory structure to preserve there).

Ultimately, this behavior should be fixed on all OSes, but for macOS and linux, we need to first implement support for symbolic
links. On Windows, we won't be using symbolic links anyway, so we can make the change in advance and see (and fix) the fallout this causes. 

Besides, our hand is kind of forced by #6924 and the fix for it, #6925. There, we improve the tracking of DLL search paths for binary dependency analysis in order to be able to find more DLLs. Previously, similar problems were handled by hooks that collected those "unreachable" DLLs, and the hooks typically preserved the DLLs parent directory structure. On the other hand, prior to this PR, binary dependency analysis always collected the discovered DLLs into top-level directory. So a DLL discovered and collected via both mechanisms ended up duplicated; and because more DLLs can be discovered by binary dependency analysis due to #6925, this leads to duplication. But, after changes in this PR, both mechanisms should collect into the original sub-directory, and the duplication will be handled on the TOC level.

This *does* introduce another type of DLL duplication, if multiple packages bundle a copy of the same DLL (e.g., `vcruntime140.dll`). I suppose if this becomes a problem, we could refine the mechanism to collect well-known-and-common DLLs into top-level directory again. But on the other hand, such duplication might already happen when DLL collection is done by a hook, and in some cases, the package expects to find that particular DLL copy in its library (sub)directory anyway (e.g., packages using [`delvewheel`](https://github.com/pyinstaller/pyinstaller-hooks-contrib/issues/421) on python 3.7 due to loading via load order file).