### PR TITLE
hookutils: qt: ensure ANGLE DLLs are collected from Anaconda Qt5

### DIFF
--- a/news/7029.bugfix.rst
+++ b/news/7029.bugfix.rst
@@ -1,0 +1,2 @@
+(Windows) Ensure that ANGLE DLLs (``libEGL.dll`` and ``libGLESv2.dll``)
+are collected when using Anaconda-installed ``PyQt5`` and ``Qt5``.


### PR DESCRIPTION
Anaconda's Qt5 ships ANGLE DLLs (`libEGL.dll` and `libGLESv2.dll`) but does not seem to provide the `d3dcompiler_XY.dll`. Therefore, we need to adjust the extra Qt DLL collection to consider the latter an optional dependency whose absence does not preclude the collection of the ANGLE DLL group.

Rework the `get_qt_binaries` hook utility function and its `_find_all_or_none` helper to peform collection based on a list
of mandatory and a list of optional patterns, instead of a single list and number of expected matches (since up until now, all matches were always expected to be found).