### PR TITLE
Docs: Assorted README updates.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,11 +45,9 @@ Main Advantages
 - Fully multi-platform, and uses the OS support to load the dynamic libraries,
   thus ensuring full compatibility.
 - Correctly bundles the major Python packages such as numpy, PyQt5,
-  PySide2, Django, wxPython, matplotlib and others out-of-the-box.
+  PySide2, PyQt6, PySide6, wxPython, matplotlib and others out-of-the-box.
 - Compatible with many 3rd-party packages out-of-the-box. (All the required
   tricks to make external packages work are already integrated.)
-- Libraries like PyQt5, PySide2, wxPython, matplotlib or Django are fully
-  supported, without having to handle plugins or external data files manually.
 - Works with code signing on macOS.
 - Bundles MS Visual C++ DLLs on Windows.
 
@@ -65,34 +63,39 @@ PyInstaller is available on PyPI. You can install it through `pip`::
 Requirements and Tested Platforms
 ---------------------------------
 
-- Python: 
-
- - 3.7-3.10
- - tinyaes_ 1.0+ (only if using bytecode encryption).
-   Instead of installing tinyaes, ``pip install pyinstaller[encryption]`` instead.
-
+- Python:
+    - 3.7-3.10. Note that Python 3.10.0 contains a bug making it unsupportable by
+      PyInstaller. PyInstaller will also not work with beta releases of Python
+      3.11.
+    - tinyaes_ 1.0+ (only if using bytecode encryption). Instead of installing
+      tinyaes, ``pip install pyinstaller[encryption]`` instead.
 - Windows (32bit/64bit):
-
- - PyInstaller should work on Windows 7 or newer, but we only officially support Windows 8+.
-
- - Support for Python installed from the Windows store without using virtual
-   environments requires PyInstaller 4.4 or later.
-    
-- GNU/Linux (32bit/64bit)
-
- - ldd: Console application to print the shared libraries required
-   by each program or shared library. This typically can be found in
-   the distribution-package `glibc` or `libc-bin`.
- - objdump: Console application to display information from 
-   object files. This typically can be found in the
-   distribution-package `binutils`.
- - objcopy: Console application to copy and translate object files.
-   This typically can be found in the distribution-package `binutils`,
-   too.
-
-- macOS (64bit):
-
- - macOS 10.15 (Catalina) or newer.
+    - PyInstaller should work on Windows 7 or newer, but we only officially support Windows 8+.
+    - Support for Python installed from the Windows store without using virtual
+      environments requires PyInstaller 4.4 or later.
+    - Note that Windows on ``arm64`` is not yet supported. If you have such a
+      device and want to help us add ``arm64`` support then please let us know on
+      our issue tracker.
+- Linux:
+    - GNU libc based distributions on architectures ``x86_64``, ``aarch64``,
+      ``i686``, ``ppc64le``, ``s390x``.
+    - musl libc based distributions on architectures ``x86_64``, ``aarch64``.
+    - ldd: Console application to print the shared libraries required
+      by each program or shared library. This typically can be found in
+      the distribution-package `glibc` or `libc-bin`.
+    - objdump: Console application to display information from
+      object files. This typically can be found in the
+      distribution-package `binutils`.
+    - objcopy: Console application to copy and translate object files.
+      This typically can be found in the distribution-package `binutils`,
+      too.
+    - Raspberry Pi users on ``armv5``-``armv7`` should `add piwheels as an extra
+      index url <https://www.piwheels.org/>`_ then ``pip install pyinstaller``
+      as usual.
+- macOS (``x86_64`` or ``arm64``):
+    - macOS 10.15 (Catalina) or newer.
+    - Supports building ``universal2`` applications provided that your installation
+      of Python and all your dependencies are also compiled ``universal2``.
 
 
 Usage
@@ -112,42 +115,30 @@ The following platforms have been contributed and any feedback or
 enhancements on these are welcome.
 
 - FreeBSD
-
- - ldd
-
+    - ldd
 - Solaris
-
- - ldd
- - objdump
-
+    - ldd
+    - objdump
 - AIX
-
- - AIX 6.1 or newer. PyInstaller will not work with statically
-   linked Python libraries.
- - ldd
-
-- PowerPC GNU/Linux (Debian)
-
+    - AIX 6.1 or newer. PyInstaller will not work with statically
+      linked Python libraries.
+    - ldd
+- Linux on any other libc implementation/architecture combination not listed
+  above.
 
 Before using any contributed platform, you need to build the PyInstaller
-bootloader, as we do not ship binary packages. Download PyInstaller
-source, and build the bootloader::
-     
-        cd bootloader
-        python ./waf all
-
-Then install PyInstaller::
-
-        python setup.py install
-        
-or simply use it directly from the source (pyinstaller.py).
+bootloader. This will happen automatically when you ``pip install
+pyinstaller`` provided that you have an appropriate C compiler (typically
+either ``gcc`` or ``clang``) and zlib's development headers already installed.
 
 
 Support
 -------
 
-See http://www.pyinstaller.org/support.html for how to find help as well as
-for commercial support.
+- Official debugging guide: https://pyinstaller.org/en/stable/when-things-go-wrong.html
+- Assorted user contributed help topics: https://github.com/pyinstaller/pyinstaller/wiki
+- Web based Q&A forums: https://github.com/pyinstaller/pyinstaller/discussions
+- Email based Q&A forums: https://groups.google.com/g/pyinstaller
 
 
 Changes in this Release
@@ -158,5 +149,5 @@ in the `Changelog`_ section of the manual.
 
 
 .. _tinyaes: https://github.com/naufraghi/tinyaes-py
-.. _`manual`: https://pyinstaller.readthedocs.io/en/v5.0.1/
-.. _`Changelog`: https://pyinstaller.readthedocs.io/en/v5.0.1/CHANGES.html
+.. _`manual`: https://pyinstaller.readthedocs.io/en/v5.3/
+.. _`Changelog`: https://pyinstaller.readthedocs.io/en/v5.3/CHANGES.html


### PR DESCRIPTION
* Mark the Linux flavours we ship wheels for as officially supported.
* Update macOS architectures (addinf `universal2` and dropping 32 bit support).
* Remove advise to use the now deprecated `setup.py install` command.
* Update outdated/broken URLs to docs and getting help (fixes #7043).
* Remove the laughably untrue claim that PyInstaller works with Django out of the box.
* Fix GitHub's rst parser misinterpreting nested lists as quote blocks.

See it rendered here: https://github.com/bwoodsend/pyinstaller/tree/7043