### PR TITLE
Make modulegraph EXTENDED_ARG opcode aware (#7055).

### DIFF
--- a/PyInstaller/lib/modulegraph/util.py
+++ b/PyInstaller/lib/modulegraph/util.py
@@ -136,7 +136,9 @@ def iterate_instructions(code_object):
     Yields `dis.Instruction`. After each code-block (`co_code`), `None` is
     yielded to mark the end of the block and to interrupt the steam.
     """
-    yield from get_instructions(code_object)
+    # The arg extension the EXTENDED_ARG opcode represents is automatically handled by get_instructions() but the
+    # instruction is left in. Get rid of it to make subsequent parsing easier/safer.
+    yield from (i for i in get_instructions(code_object) if i.opname != "EXTENDED_ARG")
 
     yield None
 

--- a/news/7055.bugfix.rst
+++ b/news/7055.bugfix.rst
@@ -1,0 +1,3 @@
+Fix :class:`AssertionError` during build when analysing a ``.pyc`` file
+containing more that 255 variable names followed by an import statement all in
+the same namespace.

--- a/tests/unit/test_modulegraph/test_imports.py
+++ b/tests/unit/test_modulegraph/test_imports.py
@@ -531,5 +531,16 @@ class TestInvalidAsyncFunction (unittest.TestCase):
                 self.fail("%r is not an instance of %r"%(value, types))
 
 
+def test_extended_args_import():
+    source = "".join(f"dummy_var{i} = {i}\n" for i in range(300)) + "import os\n"
+    code = compile(source, "", "exec")
+    node = modulegraph.Node("dummy_module")
+    node._deferred_imports = []
+    node.code = code
+    graph = modulegraph.ModuleGraph()
+    graph._scan_bytecode(node, code, True)
+    assert node._deferred_imports[0][1][0] == "os"
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fix `AssertionError` during build when analysing a ``.pyc`` file containing more that 255 variable names followed by an import statement all in the same namespace.

Fixes #7055.
