### PR TITLE
depend: rework the module exclusion mechanism

### DIFF
--- a/PyInstaller/depend/analysis.py
+++ b/PyInstaller/depend/analysis.py
@@ -52,7 +52,7 @@ from PyInstaller.depend import bytecode
 from PyInstaller.depend.imphook import AdditionalFilesCache, ModuleHookCache
 from PyInstaller.depend.imphookapi import (PreFindModulePathAPI, PreSafeImportModuleAPI)
 from PyInstaller.lib.modulegraph.find_modules import get_implies
-from PyInstaller.lib.modulegraph.modulegraph import ModuleGraph
+from PyInstaller.lib.modulegraph.modulegraph import ModuleGraph, DEFAULT_IMPORT_LEVEL
 from PyInstaller.log import DEBUG, INFO, TRACE
 from PyInstaller.utils.hooks import collect_submodules, is_package
 
@@ -344,6 +344,41 @@ class PyiModuleGraph(ModuleGraph):
             # If no post-graph hooks were run, terminate iteration.
             if not hooked_module_names:
                 break
+
+    def _find_all_excluded_imports(self, module_name):
+        """
+        Collect excludedimports from the hooks of the specified module and all its parents.
+        """
+        excluded_imports = set()
+        while module_name:
+            # Gather excluded imports from hook(s) belonging to the module
+            for module_hook in self._hooks.get(module_name, []):
+                excluded_imports.update(module_hook.excludedimports)
+            # Change module name to the module's parent name
+            module_name = module_name.rpartition('.')[0]
+        return excluded_imports
+
+    def _safe_import_hook(
+        self, target_module_partname, source_module, target_attr_names, level=DEFAULT_IMPORT_LEVEL, edge_attr=None
+    ):
+        if source_module is not None:
+            # Gather all excluded imports for the referring modules, as well as its parents.
+            # For example, we want the excluded imports specified by hook for PIL to be also applied when the referring
+            # module is its submodule, PIL.Image.
+            excluded_imports = self._find_all_excluded_imports(source_module.identifier)
+            target_module_parts = target_module_partname.split('.')
+            # An excluded import that specifies a package needs to recursively applied to all that package's children.
+            for excluded_import in excluded_imports:
+                excluded_import_parts = excluded_import.split('.')
+                match = target_module_parts[:len(excluded_import_parts)] == excluded_import_parts
+                if match:
+                    logger.debug(
+                        "Suppressing import of %r from module %r due to excluded import %r specified in a hook for %r "
+                        "(or its parent package(s)).", target_module_partname, source_module.identifier,
+                        excluded_import, source_module.identifier
+                    )
+                    return []
+        return super()._safe_import_hook(target_module_partname, source_module, target_attr_names, level, edge_attr)
 
     def _safe_import_module(self, module_basename, module_name, parent_package):
         """

--- a/PyInstaller/depend/imphookapi.py
+++ b/PyInstaller/depend/imphookapi.py
@@ -427,7 +427,6 @@ class PostGraphAPI:
         current module depends.
 
         This is equivalent to appending such names to the hook-specific `excludedimports` attribute.
-
         """
         self._deleted_imports.extend(module_names)
 

--- a/PyInstaller/lib/modulegraph/modulegraph.py
+++ b/PyInstaller/lib/modulegraph/modulegraph.py
@@ -2847,7 +2847,15 @@ class ModuleGraph(ObjectGraph):
             # Graph node of the target module specified by the "from" portion
             # of this "from"-style star import (e.g., an import resembling
             # "from {target_module_name} import *") or ignored otherwise.
-            target_module = self._safe_import_hook(*import_info, **kwargs)[0]
+            target_modules = self._safe_import_hook(*import_info, **kwargs)
+            if not target_modules:
+                # If _safe_import_hook suppressed the module, quietly drop it.
+                # Do not create an ExcludedModule instance, because that might
+                # completely suppress the module whereas it might need to be
+                # included due to reference from another module (that does
+                # not exclude it via hook).
+                continue
+            target_module = target_modules[0]
 
             # If this is a "from"-style star import, process this import.
             if have_star:

--- a/doc/hooks.rst
+++ b/doc/hooks.rst
@@ -521,12 +521,6 @@ The ``hook_api`` object also offers the following methods:
    giving the fully-qualified name(s) of modules to be imported.
    This has the same effect as adding the names to the ``hiddenimports`` global.
 
-``del_imports( *names )``:
-   The ``names`` argument may be a single string or a list of strings,
-   giving the fully-qualified name(s) of modules that are not
-   to be included if they are imported only by the hooked module.
-   This has the same effect as adding names to the ``excludedimports`` global.
-
 ``add_datas( tuple_list )``:
    The ``tuple_list`` argument has the format used with the ``datas`` global
    variable. This call has the effect of adding items to that list.

--- a/news/7066.feature.rst
+++ b/news/7066.feature.rst
@@ -1,0 +1,7 @@
+Rework the module exclusion mechanism. The excluded module entries,
+specified via ``excludedimports`` list in the hooks, are now used to
+suppress module imports from corresponding nodes *during modulegraph
+construction*, rather than to remove the nodes from the graph as a
+post-processing step. This should make the module exclusion more robust,
+but the main benefit is that we avoid running (potentially many and
+potentially costly) hooks for modules that would end up excluded anyway.

--- a/tests/functional/modules/pyi_module_exclusion/hooks/hook-mymodule_feature1.py
+++ b/tests/functional/modules/pyi_module_exclusion/hooks/hook-mymodule_feature1.py
@@ -1,0 +1,1 @@
+# This hook does nothing, and exists only for completeness sake.

--- a/tests/functional/modules/pyi_module_exclusion/hooks/hook-mymodule_feature2.py
+++ b/tests/functional/modules/pyi_module_exclusion/hooks/hook-mymodule_feature2.py
@@ -1,0 +1,5 @@
+# This hook should not be loaded at all.
+# `mymodule_feature2` is imported by `mymodule_main`, but the hook for `mymodule_main` explicitly excludes
+# `mymodule_feature2`. Therefore, if exclusion is applied correctly during processing of modules' imports (as opposed to
+# a post-processing step), this hook will not be loaded.
+raise RuntimeError("This hook should not have been loaded!")

--- a/tests/functional/modules/pyi_module_exclusion/hooks/hook-mymodule_feature3.py
+++ b/tests/functional/modules/pyi_module_exclusion/hooks/hook-mymodule_feature3.py
@@ -1,0 +1,6 @@
+# This hook should not be loaded at all.
+# `mymodule_feature3` is imported by `mymodule_main.submodule_feature3` via import of ˙mymodule_feature3.submodule1`,
+# but the hook for `mymodule_main` explicitly excludes `mymodule_feature3`. Therefore, if exclusion is applied correctly
+# during processing of modules' imports (as opposed to a post-processing step), and if exclusion rules are applied in
+# recursive way, this hook will not be loaded.
+raise RuntimeError("This hook should not have been loaded!")

--- a/tests/functional/modules/pyi_module_exclusion/hooks/hook-mymodule_main.py
+++ b/tests/functional/modules/pyi_module_exclusion/hooks/hook-mymodule_main.py
@@ -1,0 +1,2 @@
+# This hook attempts to exclude mymodule_feature2 and mymodule_feature3 from being collected.
+excludedimports = ['mymodule_feature2', 'mymodule_feature3']

--- a/tests/functional/modules/pyi_module_exclusion/modules/mymodule_feature1/__init__.py
+++ b/tests/functional/modules/pyi_module_exclusion/modules/mymodule_feature1/__init__.py
@@ -1,0 +1,1 @@
+# Nothing to do here.

--- a/tests/functional/modules/pyi_module_exclusion/modules/mymodule_feature2/__init__.py
+++ b/tests/functional/modules/pyi_module_exclusion/modules/mymodule_feature2/__init__.py
@@ -1,0 +1,1 @@
+# Nothing to do here.

--- a/tests/functional/modules/pyi_module_exclusion/modules/mymodule_main/__init__.py
+++ b/tests/functional/modules/pyi_module_exclusion/modules/mymodule_main/__init__.py
@@ -1,0 +1,21 @@
+from . import submodule_feature3
+
+# Try importing two other custom top-level modules, and provide boolean flags indicating their availability.
+# Feature #1
+feature1_available = False
+try:
+    import mymodule_feature1  # noqa: F401
+    feature1_available = True
+except ImportError:
+    pass
+
+# Feature #2
+feature2_available = False
+try:
+    import mymodule_feature2  # noqa: F401
+    feature2_available = True
+except ImportError:
+    pass
+
+# Feature #3: imported via sub-module from this pacakge, which in turn tries to import submodule from mymodule_feature3.
+feature3_available = submodule_feature3.feature3_available

--- a/tests/functional/modules/pyi_module_exclusion/modules/mymodule_main/submodule_feature3.py
+++ b/tests/functional/modules/pyi_module_exclusion/modules/mymodule_main/submodule_feature3.py
@@ -1,0 +1,7 @@
+# Feature #3: attempt to import submodule from mymodule_feature3
+feature3_available = False
+try:
+    import mymodule_feature3.submodule1  # noqa: F401
+    feature3_available = True
+except ImportError:
+    pass

--- a/tests/functional/test_hooks/test_pil.py
+++ b/tests/functional/test_hooks/test_pil.py
@@ -17,15 +17,14 @@ which retains the same Python package `PIL`.
 
 import pytest
 
-from PyInstaller.utils.tests import importorskip, skip
+from PyInstaller.utils.tests import importorskip
 from PyInstaller.utils.hooks import can_import_module
 
 
-# "excludedimports" support is currently non-deterministic and hence cannot be marked as @xfail. If this test was
-# marked as @xfail but succeeded, py.test would record this test as an XPASS failure (i.e., an unexpected success).
+# The tkinter module may be available for import, but not actually importable due to missing shared libraries.
+# Therefore, we need to use `can_import_module`-based skip decorator instead of `@importorskip`.
 @importorskip('PIL')
-@importorskip('tkinter')
-@skip(reason='"excludedimports" support is non-deterministically broken.')
+@pytest.mark.skipif(not can_import_module("tkinter"), reason="tkinter cannot be imported.")
 def test_pil_no_tkinter(pyi_builder):
     """
     Ensure that the Tkinter package excluded by `PIL` package hooks is unimportable by frozen applications explicitly

--- a/tests/functional/test_module_exclusion.py
+++ b/tests/functional/test_module_exclusion.py
@@ -1,0 +1,51 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2021-2022, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+import os
+
+import pytest
+
+# Directory with testing modules used in some tests.
+_MODULES_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'modules')
+
+
+# Test module exclusion; ensure that excluded modules are not collected. When exclusion is performed via hooks, also
+# test that hooks for excluded modules are not ran (by having hooks raise exceptions).
+@pytest.mark.parametrize(
+    "exclude_args,exclude_hooks", (
+        pytest.param(True, False, id='args'),
+        pytest.param(False, True, id='hooks'),
+        pytest.param(True, True, id='args-and-hooks'),
+    )
+)
+def test_module_exclusion(exclude_args, exclude_hooks, pyi_builder):
+    pyi_args = ['--paths', os.path.join(_MODULES_DIR, 'pyi_module_exclusion', 'modules')]
+    if exclude_args:
+        pyi_args += ['--exclude', 'mymodule_feature2', '--exclude', 'mymodule_feature3']
+    if exclude_hooks:
+        pyi_args += ['--additional-hooks-dir', os.path.join(_MODULES_DIR, 'pyi_module_exclusion', 'hooks')]
+
+    pyi_builder.test_source(
+        """
+        import mymodule_main
+
+        # Feature #1 module should be included, and thus available
+        assert mymodule_main.feature1_available == True
+
+        # Feature #2 module should be excluded, and thus unavailable
+        assert mymodule_main.feature2_available == False
+
+        # Feature #3 module should be excluded, and thus unavailable
+        assert mymodule_main.feature3_available == False
+        """,
+        pyi_args=pyi_args,
+        run_from_path=True
+    )


### PR DESCRIPTION
Rework the module exclusion mechanism to immediately suppress excluded modules during modulegraph's construction (module analysis), rather as a post-processing modulegraph step. Preventing modules from being included in the modulegraph in the first place should be more reliable than trying to remove the nodes and connections from the graph later on. But most importantly, it ensures that we do not run (potentially many and potentially costly) hooks for modules that later end up excluded anyway.

Following suggestion from a FIXME at https://github.com/pyinstaller/pyinstaller/blob/v5.3/PyInstaller/depend/imphook.py#L497-L519, this is done by overriding `ModuleGraph._safe_import_hook()` to obtain the set of excluded imports from the hooks for the referring module and its parent package(s). The target module's name is then matched against the excluded imports, where each excluded import entry is treated as a name prefix. This ensures that the exclusion rules are recursive in both relevant "directions":
* excluded imports specified in a hook for a package are also applied to   all submodules and subpackages from that package (and each of those   may specify additional excluded imports via their own hook)
* if excluded import is a package, we suppress the import of all its submodules and subpackages.

The import is suppressed by our `_safe_import_hook()` override returning an empty list. We cannot return an `ExcludedModule` entry, because that would preclude proper collection of corresponding module when that module is available via another different import chain. Returning an empty list requires a modification of the original modulegraph code, but only in one place. In other places where `_safe_import_hook()` is called, the source module is not passed to it, and therefore the modified codepath cannot
be triggered there.

The "basic" modulegraph caching that we perform in order to speed up our test suite requires that the modulegraph, along with its hooks cache, is fully serializable via pickle, so that a deep copy can be performed. Unfortunately, we now load some of our hooks during the analysis of those basic modules, and the loaded module objects cannot be pickled.

To work around this, the hook loading is modified to not keep the references to the loaded modules by default. If loaded due to a magic attribute look up (i.e., during the modulegraph analysis for excluded imports), the hook loads the module and copies the attributes from it. In the post-processing graph step, the hooks are loaded again, this time keeping the reference to the module, which is necessary for running the "post-graph API" hook function, if available. In order to avoid unnecessarily reloading the module that does not have a hook function, we check for its presence during the first load, and then reload the hook module during post-graph step only if the hook function is available.

Consequently, the hooks without hook function are loaded only once, but hooks with hook function may be loaded twice. However, as the hooks that provide the hook function should perform heavy lifting within the hook function, this should have a minimal performance impact.

The post-graph operation step remains, but the code related to removal of excluded imports has been removed, as it is now unnecessary. Therefore, post-graph function only updates the magic attributes with values from the Post-graph API object, stores `binaries` and `datas` to the global list of files to be collected, and performs analysis of additional modules specified by the `hiddenimports`. Eventually, the whole post-graph operation should be merged into base modulegraph's module analysis, but that is beyond the scope of changes here, and is probably better left for when try to replace/rewrite the modulegraph itself.