### PR TITLE
hooks: provide hooks for additional gi.repository.Gst* modules

### DIFF
--- a/PyInstaller/hooks/hook-gi.repository.GstAllocators.py
+++ b/PyInstaller/hooks/hook-gi.repository.GstAllocators.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2022, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks.gi import GiModuleInfo
+
+module_info = GiModuleInfo('GstAllocators', '1.0')
+if module_info.available:
+    binaries, datas, hiddenimports = module_info.collect_typelib_data()

--- a/PyInstaller/hooks/hook-gi.repository.GstApp.py
+++ b/PyInstaller/hooks/hook-gi.repository.GstApp.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2022, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks.gi import GiModuleInfo
+
+module_info = GiModuleInfo('GstApp', '1.0')
+if module_info.available:
+    binaries, datas, hiddenimports = module_info.collect_typelib_data()

--- a/PyInstaller/hooks/hook-gi.repository.GstBadAudio.py
+++ b/PyInstaller/hooks/hook-gi.repository.GstBadAudio.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2022, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks.gi import GiModuleInfo
+
+module_info = GiModuleInfo('GstBadAudio', '1.0')
+if module_info.available:
+    binaries, datas, hiddenimports = module_info.collect_typelib_data()

--- a/PyInstaller/hooks/hook-gi.repository.GstCheck.py
+++ b/PyInstaller/hooks/hook-gi.repository.GstCheck.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2022, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks.gi import GiModuleInfo
+
+module_info = GiModuleInfo('GstCheck', '1.0')
+if module_info.available:
+    binaries, datas, hiddenimports = module_info.collect_typelib_data()

--- a/PyInstaller/hooks/hook-gi.repository.GstCodecs.py
+++ b/PyInstaller/hooks/hook-gi.repository.GstCodecs.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2022, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks.gi import GiModuleInfo
+
+module_info = GiModuleInfo('GstCodecs', '1.0')
+if module_info.available:
+    binaries, datas, hiddenimports = module_info.collect_typelib_data()

--- a/PyInstaller/hooks/hook-gi.repository.GstController.py
+++ b/PyInstaller/hooks/hook-gi.repository.GstController.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2022, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks.gi import GiModuleInfo
+
+module_info = GiModuleInfo('GstController', '1.0')
+if module_info.available:
+    binaries, datas, hiddenimports = module_info.collect_typelib_data()

--- a/PyInstaller/hooks/hook-gi.repository.GstGL.py
+++ b/PyInstaller/hooks/hook-gi.repository.GstGL.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2022, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks.gi import GiModuleInfo
+
+module_info = GiModuleInfo('GstGL', '1.0')
+if module_info.available:
+    binaries, datas, hiddenimports = module_info.collect_typelib_data()

--- a/PyInstaller/hooks/hook-gi.repository.GstGLEGL.py
+++ b/PyInstaller/hooks/hook-gi.repository.GstGLEGL.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2022, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks.gi import GiModuleInfo
+
+module_info = GiModuleInfo('GstGLEGL', '1.0')
+if module_info.available:
+    binaries, datas, hiddenimports = module_info.collect_typelib_data()

--- a/PyInstaller/hooks/hook-gi.repository.GstGLWayland.py
+++ b/PyInstaller/hooks/hook-gi.repository.GstGLWayland.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2022, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks.gi import GiModuleInfo
+
+module_info = GiModuleInfo('GstGLWayland', '1.0')
+if module_info.available:
+    binaries, datas, hiddenimports = module_info.collect_typelib_data()

--- a/PyInstaller/hooks/hook-gi.repository.GstGLX11.py
+++ b/PyInstaller/hooks/hook-gi.repository.GstGLX11.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2022, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks.gi import GiModuleInfo
+
+module_info = GiModuleInfo('GstGLX11', '1.0')
+if module_info.available:
+    binaries, datas, hiddenimports = module_info.collect_typelib_data()

--- a/PyInstaller/hooks/hook-gi.repository.GstInsertBin.py
+++ b/PyInstaller/hooks/hook-gi.repository.GstInsertBin.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2022, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks.gi import GiModuleInfo
+
+module_info = GiModuleInfo('GstInsertBin', '1.0')
+if module_info.available:
+    binaries, datas, hiddenimports = module_info.collect_typelib_data()

--- a/PyInstaller/hooks/hook-gi.repository.GstMpegts.py
+++ b/PyInstaller/hooks/hook-gi.repository.GstMpegts.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2022, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks.gi import GiModuleInfo
+
+module_info = GiModuleInfo('GstMpegts', '1.0')
+if module_info.available:
+    binaries, datas, hiddenimports = module_info.collect_typelib_data()

--- a/PyInstaller/hooks/hook-gi.repository.GstNet.py
+++ b/PyInstaller/hooks/hook-gi.repository.GstNet.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2022, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks.gi import GiModuleInfo
+
+module_info = GiModuleInfo('GstNet', '1.0')
+if module_info.available:
+    binaries, datas, hiddenimports = module_info.collect_typelib_data()

--- a/PyInstaller/hooks/hook-gi.repository.GstPlay.py
+++ b/PyInstaller/hooks/hook-gi.repository.GstPlay.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2022, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks.gi import GiModuleInfo
+
+module_info = GiModuleInfo('GstPlay', '1.0')
+if module_info.available:
+    binaries, datas, hiddenimports = module_info.collect_typelib_data()

--- a/PyInstaller/hooks/hook-gi.repository.GstPlayer.py
+++ b/PyInstaller/hooks/hook-gi.repository.GstPlayer.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2022, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks.gi import GiModuleInfo
+
+module_info = GiModuleInfo('GstPlayer', '1.0')
+if module_info.available:
+    binaries, datas, hiddenimports = module_info.collect_typelib_data()

--- a/PyInstaller/hooks/hook-gi.repository.GstRtp.py
+++ b/PyInstaller/hooks/hook-gi.repository.GstRtp.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2022, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks.gi import GiModuleInfo
+
+module_info = GiModuleInfo('GstRtp', '1.0')
+if module_info.available:
+    binaries, datas, hiddenimports = module_info.collect_typelib_data()

--- a/PyInstaller/hooks/hook-gi.repository.GstRtsp.py
+++ b/PyInstaller/hooks/hook-gi.repository.GstRtsp.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2022, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks.gi import GiModuleInfo
+
+module_info = GiModuleInfo('GstRtsp', '1.0')
+if module_info.available:
+    binaries, datas, hiddenimports = module_info.collect_typelib_data()

--- a/PyInstaller/hooks/hook-gi.repository.GstRtspServer.py
+++ b/PyInstaller/hooks/hook-gi.repository.GstRtspServer.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2022, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks.gi import GiModuleInfo
+
+module_info = GiModuleInfo('GstRtspServer', '1.0')
+if module_info.available:
+    binaries, datas, hiddenimports = module_info.collect_typelib_data()

--- a/PyInstaller/hooks/hook-gi.repository.GstSdp.py
+++ b/PyInstaller/hooks/hook-gi.repository.GstSdp.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2022, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks.gi import GiModuleInfo
+
+module_info = GiModuleInfo('GstSdp', '1.0')
+if module_info.available:
+    binaries, datas, hiddenimports = module_info.collect_typelib_data()

--- a/PyInstaller/hooks/hook-gi.repository.GstTranscoder.py
+++ b/PyInstaller/hooks/hook-gi.repository.GstTranscoder.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2022, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks.gi import GiModuleInfo
+
+module_info = GiModuleInfo('GstTranscoder', '1.0')
+if module_info.available:
+    binaries, datas, hiddenimports = module_info.collect_typelib_data()

--- a/PyInstaller/hooks/hook-gi.repository.GstVulkan.py
+++ b/PyInstaller/hooks/hook-gi.repository.GstVulkan.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2022, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks.gi import GiModuleInfo
+
+module_info = GiModuleInfo('GstVulkan', '1.0')
+if module_info.available:
+    binaries, datas, hiddenimports = module_info.collect_typelib_data()

--- a/PyInstaller/hooks/hook-gi.repository.GstVulkanWayland.py
+++ b/PyInstaller/hooks/hook-gi.repository.GstVulkanWayland.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2022, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks.gi import GiModuleInfo
+
+module_info = GiModuleInfo('GstVulkanWayland', '1.0')
+if module_info.available:
+    binaries, datas, hiddenimports = module_info.collect_typelib_data()

--- a/PyInstaller/hooks/hook-gi.repository.GstVulkanXCB.py
+++ b/PyInstaller/hooks/hook-gi.repository.GstVulkanXCB.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2022, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks.gi import GiModuleInfo
+
+module_info = GiModuleInfo('GstVulkanXCB', '1.0')
+if module_info.available:
+    binaries, datas, hiddenimports = module_info.collect_typelib_data()

--- a/PyInstaller/hooks/hook-gi.repository.GstWebRTC.py
+++ b/PyInstaller/hooks/hook-gi.repository.GstWebRTC.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2022, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks.gi import GiModuleInfo
+
+module_info = GiModuleInfo('GstWebRTC', '1.0')
+if module_info.available:
+    binaries, datas, hiddenimports = module_info.collect_typelib_data()

--- a/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GstAllocators.py
+++ b/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GstAllocators.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2022, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+
+def pre_safe_import_module(api):
+    # PyGObject modules loaded through the gi repository are marked as MissingModules by modulegraph, so we convert them
+    # to RuntimeModules in order for their hooks to be loaded and executed.
+    api.add_runtime_module(api.module_name)

--- a/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GstApp.py
+++ b/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GstApp.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2022, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+
+def pre_safe_import_module(api):
+    # PyGObject modules loaded through the gi repository are marked as MissingModules by modulegraph, so we convert them
+    # to RuntimeModules in order for their hooks to be loaded and executed.
+    api.add_runtime_module(api.module_name)

--- a/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GstBadAudio.py
+++ b/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GstBadAudio.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2022, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+
+def pre_safe_import_module(api):
+    # PyGObject modules loaded through the gi repository are marked as MissingModules by modulegraph, so we convert them
+    # to RuntimeModules in order for their hooks to be loaded and executed.
+    api.add_runtime_module(api.module_name)

--- a/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GstCheck.py
+++ b/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GstCheck.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2022, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+
+def pre_safe_import_module(api):
+    # PyGObject modules loaded through the gi repository are marked as MissingModules by modulegraph, so we convert them
+    # to RuntimeModules in order for their hooks to be loaded and executed.
+    api.add_runtime_module(api.module_name)

--- a/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GstCodecs.py
+++ b/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GstCodecs.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2022, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+
+def pre_safe_import_module(api):
+    # PyGObject modules loaded through the gi repository are marked as MissingModules by modulegraph, so we convert them
+    # to RuntimeModules in order for their hooks to be loaded and executed.
+    api.add_runtime_module(api.module_name)

--- a/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GstController.py
+++ b/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GstController.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2022, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+
+def pre_safe_import_module(api):
+    # PyGObject modules loaded through the gi repository are marked as MissingModules by modulegraph, so we convert them
+    # to RuntimeModules in order for their hooks to be loaded and executed.
+    api.add_runtime_module(api.module_name)

--- a/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GstGL.py
+++ b/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GstGL.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2022, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+
+def pre_safe_import_module(api):
+    # PyGObject modules loaded through the gi repository are marked as MissingModules by modulegraph, so we convert them
+    # to RuntimeModules in order for their hooks to be loaded and executed.
+    api.add_runtime_module(api.module_name)

--- a/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GstGLEGL.py
+++ b/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GstGLEGL.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2022, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+
+def pre_safe_import_module(api):
+    # PyGObject modules loaded through the gi repository are marked as MissingModules by modulegraph, so we convert them
+    # to RuntimeModules in order for their hooks to be loaded and executed.
+    api.add_runtime_module(api.module_name)

--- a/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GstGLWayland.py
+++ b/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GstGLWayland.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2022, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+
+def pre_safe_import_module(api):
+    # PyGObject modules loaded through the gi repository are marked as MissingModules by modulegraph, so we convert them
+    # to RuntimeModules in order for their hooks to be loaded and executed.
+    api.add_runtime_module(api.module_name)

--- a/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GstGLX11.py
+++ b/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GstGLX11.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2022, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+
+def pre_safe_import_module(api):
+    # PyGObject modules loaded through the gi repository are marked as MissingModules by modulegraph, so we convert them
+    # to RuntimeModules in order for their hooks to be loaded and executed.
+    api.add_runtime_module(api.module_name)

--- a/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GstInsertBin.py
+++ b/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GstInsertBin.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2022, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+
+def pre_safe_import_module(api):
+    # PyGObject modules loaded through the gi repository are marked as MissingModules by modulegraph, so we convert them
+    # to RuntimeModules in order for their hooks to be loaded and executed.
+    api.add_runtime_module(api.module_name)

--- a/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GstMpegts.py
+++ b/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GstMpegts.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2022, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+
+def pre_safe_import_module(api):
+    # PyGObject modules loaded through the gi repository are marked as MissingModules by modulegraph, so we convert them
+    # to RuntimeModules in order for their hooks to be loaded and executed.
+    api.add_runtime_module(api.module_name)

--- a/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GstNet.py
+++ b/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GstNet.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2022, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+
+def pre_safe_import_module(api):
+    # PyGObject modules loaded through the gi repository are marked as MissingModules by modulegraph, so we convert them
+    # to RuntimeModules in order for their hooks to be loaded and executed.
+    api.add_runtime_module(api.module_name)

--- a/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GstPlay.py
+++ b/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GstPlay.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2022, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+
+def pre_safe_import_module(api):
+    # PyGObject modules loaded through the gi repository are marked as MissingModules by modulegraph, so we convert them
+    # to RuntimeModules in order for their hooks to be loaded and executed.
+    api.add_runtime_module(api.module_name)

--- a/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GstPlayer.py
+++ b/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GstPlayer.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2022, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+
+def pre_safe_import_module(api):
+    # PyGObject modules loaded through the gi repository are marked as MissingModules by modulegraph, so we convert them
+    # to RuntimeModules in order for their hooks to be loaded and executed.
+    api.add_runtime_module(api.module_name)

--- a/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GstRtp.py
+++ b/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GstRtp.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2022, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+
+def pre_safe_import_module(api):
+    # PyGObject modules loaded through the gi repository are marked as MissingModules by modulegraph, so we convert them
+    # to RuntimeModules in order for their hooks to be loaded and executed.
+    api.add_runtime_module(api.module_name)

--- a/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GstRtsp.py
+++ b/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GstRtsp.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2022, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+
+def pre_safe_import_module(api):
+    # PyGObject modules loaded through the gi repository are marked as MissingModules by modulegraph, so we convert them
+    # to RuntimeModules in order for their hooks to be loaded and executed.
+    api.add_runtime_module(api.module_name)

--- a/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GstRtspServer.py
+++ b/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GstRtspServer.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2022, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+
+def pre_safe_import_module(api):
+    # PyGObject modules loaded through the gi repository are marked as MissingModules by modulegraph, so we convert them
+    # to RuntimeModules in order for their hooks to be loaded and executed.
+    api.add_runtime_module(api.module_name)

--- a/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GstSdp.py
+++ b/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GstSdp.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2022, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+
+def pre_safe_import_module(api):
+    # PyGObject modules loaded through the gi repository are marked as MissingModules by modulegraph, so we convert them
+    # to RuntimeModules in order for their hooks to be loaded and executed.
+    api.add_runtime_module(api.module_name)

--- a/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GstTranscoder.py
+++ b/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GstTranscoder.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2022, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+
+def pre_safe_import_module(api):
+    # PyGObject modules loaded through the gi repository are marked as MissingModules by modulegraph, so we convert them
+    # to RuntimeModules in order for their hooks to be loaded and executed.
+    api.add_runtime_module(api.module_name)

--- a/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GstVulkan.py
+++ b/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GstVulkan.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2022, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+
+def pre_safe_import_module(api):
+    # PyGObject modules loaded through the gi repository are marked as MissingModules by modulegraph, so we convert them
+    # to RuntimeModules in order for their hooks to be loaded and executed.
+    api.add_runtime_module(api.module_name)

--- a/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GstVulkanWayland.py
+++ b/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GstVulkanWayland.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2022, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+
+def pre_safe_import_module(api):
+    # PyGObject modules loaded through the gi repository are marked as MissingModules by modulegraph, so we convert them
+    # to RuntimeModules in order for their hooks to be loaded and executed.
+    api.add_runtime_module(api.module_name)

--- a/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GstVulkanXCB.py
+++ b/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GstVulkanXCB.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2022, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+
+def pre_safe_import_module(api):
+    # PyGObject modules loaded through the gi repository are marked as MissingModules by modulegraph, so we convert them
+    # to RuntimeModules in order for their hooks to be loaded and executed.
+    api.add_runtime_module(api.module_name)

--- a/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GstWebRTC.py
+++ b/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GstWebRTC.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2022, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+
+def pre_safe_import_module(api):
+    # PyGObject modules loaded through the gi repository are marked as MissingModules by modulegraph, so we convert them
+    # to RuntimeModules in order for their hooks to be loaded and executed.
+    api.add_runtime_module(api.module_name)

--- a/news/7074.hooks.rst
+++ b/news/7074.hooks.rst
@@ -1,0 +1,10 @@
+Provide hooks for additional ``gstreamer`` modules provided via
+GObject introspection (``gi``) bindings: ``gi.repository.GstAllocators``,
+``gi.repository.GstApp``, ``gi.repository.GstBadAudio``, ``gi.repository.GstCheck``,
+``gi.repository.GstCodecs``, ``gi.repository.GstController``, ``gi.repository.GstGL``,
+``gi.repository.GstGLEGL``, ``gi.repository.GstGLWayland``, ``gi.repository.GstGLX11``,
+``gi.repository.GstInsertBin``, ``gi.repository.GstMpegts``, ``gi.repository.GstNet``,
+``gi.repository.GstPlay``, ``gi.repository.GstPlayer``, ``gi.repository.GstRtp``,
+``gi.repository.GstRtsp``, ``gi.repository.GstRtspServer``, ``gi.repository.GstSdp``,
+``gi.repository.GstTranscoder``, ``gi.repository.GstVulkan``, ``gi.repository.GstVulkanWayland``,
+``gi.repository.GstVulkanXCB``, and ``gi.repository.GstWebRTC``.


### PR DESCRIPTION
Based on `Gst*` GI typelibs that are currently available on my Fedora linux.

Fixes #7070.