### PR TITLE
Add support for setuptools-provided distutils

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,6 @@ on:
       - '!pyup/**'
 
 env:
-  # Prevent setuptools from replacing distutils with its vendored version, as our test suite is not
-  # ready for that. There also seem to be issues with setuptools-provided distutils and pip 22.2
-  # on python < 3.10.
-  SETUPTOOLS_USE_DISTUTILS: not-today
-
   # Colored pytest output on CI despite not having a tty
   FORCE_COLOR: 1
 
@@ -141,7 +136,6 @@ jobs:
       - run: docker build -f alpine.dockerfile -t foo .
       - run: >
           docker run
-          -e SETUPTOOLS_USE_DISTUTILS='not-today'
           foo
           pytest
           -n 3 --maxfail 3 --durations 10 tests/unit tests/functional

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,12 +6,6 @@ on:
       - develop
       - v4
 
-env:
-  # Prevent setuptools from replacing distutils with its vendored version. There seem to be issues
-  # between setuptools-provided distutils and pip 22.2 on python < 3.10, which results in failure
-  # of the "Test Packaging" step.
-  SETUPTOOLS_USE_DISTUTILS: not-today
-
 jobs:
   run:
     runs-on: ubuntu-latest

--- a/PyInstaller/hooks/hook-setuptools.py
+++ b/PyInstaller/hooks/hook-setuptools.py
@@ -25,7 +25,13 @@ if is_unix or is_darwin:
 # setuptools >= 39.0.0 is "vendoring" its own direct dependencies from "_vendor" to "extern". This also requires
 # 'pre_safe_import_module/hook-setuptools.extern.six.moves.py' to make the moves defined in 'setuptools._vendor.six'
 # importable under 'setuptools.extern.six'.
-hiddenimports.extend(collect_submodules('setuptools._vendor'))
+_excluded_submodules = (
+    # Prevent recursing into setuptools._vendor.pyparsing.diagram, which typically fails to be imported due to
+    # missing dependencies (railroad, pyparsing (?), jinja2) and generates a warning... As the module is usually
+    # unimportable, it is likely not to be used by setuptools.
+    'setuptools._vendor.pyparsing.diagram',
+)
+hiddenimports.extend(collect_submodules('setuptools._vendor', filter=lambda name: name not in _excluded_submodules))
 
 # As of setuptools >= 60.0, we need to collect the vendored version of distutils via hiddenimports. The corresponding
 # pyi_rth_setuptools runtime hook ensures that the _distutils_hack is installed at the program startup, which allows

--- a/PyInstaller/hooks/hook-setuptools.py
+++ b/PyInstaller/hooks/hook-setuptools.py
@@ -10,7 +10,7 @@
 #-----------------------------------------------------------------------------
 
 from PyInstaller.compat import is_darwin, is_unix
-from PyInstaller.utils.hooks import collect_submodules
+from PyInstaller.utils.hooks import collect_submodules, is_module_satisfies
 
 hiddenimports = [
     # Test case import/test_zipimport2 fails during importing pkg_resources or setuptools when module not present.
@@ -26,3 +26,10 @@ if is_unix or is_darwin:
 # 'pre_safe_import_module/hook-setuptools.extern.six.moves.py' to make the moves defined in 'setuptools._vendor.six'
 # importable under 'setuptools.extern.six'.
 hiddenimports.extend(collect_submodules('setuptools._vendor'))
+
+# As of setuptools >= 60.0, we need to collect the vendored version of distutils via hiddenimports. The corresponding
+# pyi_rth_setuptools runtime hook ensures that the _distutils_hack is installed at the program startup, which allows
+# setuptools to override the stdlib distutils with its vendored version, if necessary.
+if is_module_satisfies("setuptools >= 60.0"):
+    hiddenimports += ["_distutils_hack"]
+    hiddenimports += collect_submodules("setuptools._distutils")

--- a/PyInstaller/hooks/pre_find_module_path/hook-distutils.py
+++ b/PyInstaller/hooks/pre_find_module_path/hook-distutils.py
@@ -11,15 +11,17 @@
 """
 `distutils`-specific pre-find module path hook.
 
-When run from within a venv (virtual environment), this hook changes the `__path__` of the `distutils` package to
-that of the system-wide rather than venv-specific `distutils` package. While the former is suitable for freezing,
-the latter is intended for use _only_ from within venvs.
+When run from within a virtual environment, this hook changes the `__path__` of the `distutils` package to
+that of the system-wide rather than virtual-environment-specific `distutils` package. While the former is suitable for
+freezing, the latter is intended for use _only_ from within virtual environments.
+
+NOTE: this behavior seems to be specific to virtual environments created by (an old?) version of `virtualenv`; it is not
+applicable to virtual environments created by the `venv`.
 """
 
-import distutils
-import os
+import pathlib
 
-from PyInstaller.utils.hooks import logger
+from PyInstaller.utils.hooks import logger, get_module_file_attribute
 
 
 def pre_find_module_path(api):
@@ -28,11 +30,17 @@ def pre_find_module_path(api):
     # opcode is not a virtualenv module, so we can use it to find the stdlib. Technique taken from virtualenv's
     # "distutils" package detection at
     # https://github.com/pypa/virtualenv/blob/16.3.0/virtualenv_embedded/distutils-init.py#L5
-    import opcode
+    # As opcode is a module, stdlib path corresponds to the parent directory of its ``__file__`` attribute.
+    stdlib_path = pathlib.Path(get_module_file_attribute('opcode')).parent.resolve()
+    # As distutils is a package, we need to consider the grandparent directory of its ``__file__`` attribute.
+    distutils_path = pathlib.Path(get_module_file_attribute('distutils')).parent.parent.resolve()
 
-    system_module_path = os.path.normpath(os.path.dirname(opcode.__file__))
-    loaded_module_path = os.path.normpath(os.path.dirname(distutils.__file__))
-    if system_module_path != loaded_module_path:
-        # Find this package in its parent directory.
-        api.search_dirs = [system_module_path]
-        logger.info('distutils: retargeting to non-venv dir %r', system_module_path)
+    if distutils_path.name == 'setuptools':
+        logger.debug("distutils: provided by setuptools")
+    elif distutils_path == stdlib_path:
+        logger.debug("distutils: provided by stdlib")
+    else:
+        # Find this package in stdlib.
+        stdlib_path = str(stdlib_path)
+        logger.debug("distutils: virtualenv shim - retargeting to stdlib dir %r", stdlib_path)
+        api.search_dirs = [stdlib_path]

--- a/PyInstaller/hooks/rthooks.dat
+++ b/PyInstaller/hooks/rthooks.dat
@@ -25,5 +25,6 @@
     'win32api':   ['pyi_rth_win32api.py'],
     'win32com':   ['pyi_rth_win32comgenpy.py'],
     'multiprocessing': ['pyi_rth_multiprocessing.py'],
+    'setuptools': ['pyi_rth_setuptools.py'],
     'subprocess': ['pyi_rth_subprocess.py'],
 }

--- a/PyInstaller/hooks/rthooks/pyi_rth_setuptools.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_setuptools.py
@@ -1,0 +1,21 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2022, PyInstaller Development Team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: Apache-2.0
+#-----------------------------------------------------------------------------
+
+# This runtime hook performs the equivalent of the distutils-precedence.pth from the setuptools package;
+# it registers a special meta finder that diverts import of distutils to setuptools._distutils, if
+# available.
+try:
+    import os
+    if os.environ.get("SETUPTOOLS_USE_DISTUTILS", "local") == "local":
+        import _distutils_hack
+        _distutils_hack.add_shim()
+except Exception:
+    pass

--- a/news/7075.feature.rst
+++ b/news/7075.feature.rst
@@ -1,0 +1,2 @@
+Add support for ``setuptools``-provided ``distutils``, available since
+``setuptools >= 60.0``.

--- a/tests/functional/test_libraries.py
+++ b/tests/functional/test_libraries.py
@@ -413,3 +413,10 @@ def test_pywin32ctypes(pyi_builder, submodule):
     pyi_builder.test_source("""
         from win32ctypes.pywin32 import {0}
         """.format(submodule))
+
+
+@importorskip('setuptools')
+def test_setuptools(pyi_builder):
+    pyi_builder.test_source("""
+        import setuptools
+        """)


### PR DESCRIPTION
Add support for `setuptools`-provided `distutils`, available in `setuptools >= 60.0`.

Fixes #6911.

While the initial version of this PR (#6866) tried to go out of its way to collect only one variant of distutils, we now collect both of them, because in general we have no control over environment variables available in runtime environment, and so the `SETUPTOOLS_USE_DISTUTILS` setting may differ between the build and runtime environments.