### PR TITLE
hooks: fix error raised by pyi_rth_win32comgenpy

### DIFF
--- a/PyInstaller/hooks/rthooks/pyi_rth_win32comgenpy.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_win32comgenpy.py
@@ -18,6 +18,7 @@
 
 import atexit
 import os
+import sys
 import shutil
 import tempfile
 
@@ -35,6 +36,17 @@ try:
     atexit.register(shutil.rmtree, supportdir, ignore_errors=True)
 except OSError:
     pass
+
+# The following block of code is necessary because currently we have no guarantee that the pyi_rth_win32api run-time
+# hook is ran before this one. Similarly to that runtime hook, we need to set path to pywintypes3X.dll and import
+# pywintypes module, which results in pywintypes3X.dll being loaded. This in turn ensures that when win32api extension
+# module is loaded,  pywintypes3X.dll is already resolved and loaded (in this case, win32com imports win32api).
+pywin32_system32_path = os.path.join(sys._MEIPASS, 'pywin32_system32')
+if os.path.isdir(pywin32_system32_path) and pywin32_system32_path not in sys.path:
+    sys.path.append(pywin32_system32_path)
+del pywin32_system32_path
+
+import pywintypes  # noqa: F401, E402
 
 # Override the default path to gen_py cache.
 import win32com  # noqa: E402

--- a/news/7079.bugfix.rst
+++ b/news/7079.bugfix.rst
@@ -1,0 +1,2 @@
+(Windows) Fix run-time error raised by ``pyi_rth_win32comgenpy``, the run-time
+hook for ``win32com``.


### PR DESCRIPTION
In `pyi_rth_win32comgenpy`, we import `win32com`, which in turn imports `win32api`. The `win32api` extension module depends on `pywintypes3X.dll`. Because we now collect `pywintypes3X.dll` and `pythoncom3X.dll` into `pywin32_system32` sub-directory to preserve the original layout, the `win32api.pyd`, upon being loaded,  cannot find the DLL anymore. The `pyi_rth_win32api` runtime hook fixes this by ensuring that the `pywin32_system32` sub-directory is in `sys.path`, then imports the `pywintypes` module. This loads the `pywintypes3X.dll` and ensures that it is resolvable by extension modules that are linked against it.

However, when `pyi_rth_win32comgenpy` is ran, we currently cannot ensure that `pyi_rth_win32api` has been ran yet. Therefore, we need to duplicate its work-around to prevent error upon import of `win32com` (and its import of `win32api`).