### PR TITLE
loader: Windows: provide run-time override for ctypes.util.find_library

### DIFF
--- a/news/7097.bugfix.rst
+++ b/news/7097.bugfix.rst
@@ -1,0 +1,2 @@
+(Windows) Provide run-time override for ``ctypes.util.find_library`` that
+searches ``sys._MEIPASS`` in addition to directories specified in ``PATH``.


### PR DESCRIPTION
On Windows, provide run-time override for `ctypes.util.find_library` that searches `sys._MEIPASS` in addition to directories specified in `PATH`. This fixes the Windows-specific problem of code using `ctypes.util.find_library` not being able to discover shared libraries that are collected into frozen application's top-level directory.

Fixes the run-time discovery part of #7065.