### PR TITLE
make --icon option repeatable

### DIFF
--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -481,8 +481,17 @@ class EXE(Target):
             self.toc.append(("pyi-macos-argv-emulation", "", "OPTION"))
 
         # If the icon path is relative, make it relative to the .spec file.
-        if self.icon and self.icon != "NONE" and not os.path.isabs(self.icon):
-            self.icon = os.path.join(CONF['specpath'], self.icon)
+        def makeabs(path):
+            if os.path.isabs(path):
+                return path
+            else:
+                return os.path.join(CONF['specpath'], path)
+
+        if self.icon and self.icon != "NONE":
+            if isinstance(self.icon, list):
+                self.icon = [makeabs(ic) for ic in self.icon]
+            else:
+                self.icon = [makeabs(self.icon)]
 
         if is_win:
             if not self.exclude_binaries:

--- a/PyInstaller/building/makespec.py
+++ b/PyInstaller/building/makespec.py
@@ -452,13 +452,14 @@ def __add_options(parser):
     g.add_argument(
         "-i",
         "--icon",
+        action='append',
         dest="icon_file",
         metavar='<FILE.ico or FILE.exe,ID or FILE.icns or Image or "NONE">',
         help="FILE.ico: apply the icon to a Windows executable. FILE.exe,ID: extract the icon with ID from an exe. "
         "FILE.icns: apply the icon to the .app bundle on Mac OS. If an image file is entered that isn't in the "
         "platform format (ico on Windows, icns on Mac), PyInstaller tries to use Pillow to translate the icon into "
         "the correct format (if Pillow is installed). Use \"NONE\" to not apply any icon, thereby making the OS show "
-        "some default (default: apply PyInstaller's icon)",
+        "some default (default: apply PyInstaller's icon). This option can be used multiple times.",
     )
     g.add_argument(
         "--disable-windowed-traceback",
@@ -680,10 +681,13 @@ def main(
     if icon_file:
         # Icon file for Windows.
         # On Windows, the default icon is embedded in the bootloader executable.
-        exe_options += "\n    icon='%s'," % escape_win_filepath(icon_file)
+        if icon_file[0] == 'NONE':
+            exe_options += "\n    icon='NONE',"
+        else:
+            exe_options += "\n    icon=[%s]," % ','.join("'%s'" % escape_win_filepath(ic) for ic in icon_file)
         # Icon file for Mac OS.
         # We need to encapsulate it into apostrofes.
-        icon_file = "'%s'" % icon_file
+        icon_file = "'%s'" % icon_file[0]
     else:
         # On Mac OS, the default icon has to be copied into the .app bundle.
         # The the text value 'None' means - use default icon.

--- a/PyInstaller/utils/win32/icon.py
+++ b/PyInstaller/utils/win32/icon.py
@@ -188,16 +188,12 @@ def CopyIcons(dstpath, srcpath):
 
     if len(srcpath) > 1:
         # More than one icon source given. We currently handle multiple icons by calling CopyIcons_FromIco(), which only
-        # allows .ico. In principle we could accept a mix of .ico and .exe, but it would complicate things. If you need
-        # it, submit a pull request.
+        # allows .ico, but will convert to that format if needed.
         #
         # Note that a ",index" on a .ico is just ignored in the single or multiple case.
         srcs = []
         for s in srcpath:
-            e = os.path.splitext(s[0])[1]
-            if e.lower() != '.ico':
-                raise ValueError('Multiple icons supported only from .ico files')
-            srcs.append(s[0])
+            srcs.append(normalize_icon_type(s[0], ("ico",), "ico", config.CONF["workpath"]))
         return CopyIcons_FromIco(dstpath, srcs)
 
     # Just one source given.

--- a/news/7103.feature.rst
+++ b/news/7103.feature.rst
@@ -1,0 +1,1 @@
+(Windows) Support embedding multiple icons in the executable.


### PR DESCRIPTION
In Windows it is possible to embed multiple icon resources in the executable, and utils/win32/icon.py can handle it. Adjust the rest of the code to be able to do that.

Fixes pyinstaller#3086