### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -4,8 +4,11 @@ on:
     workflows: ["CI"]
     types:
       - requested
+permissions: {}
 jobs:
   cancel:
+    permissions:
+      actions: write # to cancel/stop running workflows (styfle/cancel-workflow-action)
     runs-on: ubuntu-latest
     steps:
     - uses: styfle/cancel-workflow-action@0.8.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ env:
   # Colored pytest output on CI despite not having a tty
   FORCE_COLOR: 1
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   tests:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/wheel-builder.yml
+++ b/.github/workflows/wheel-builder.yml
@@ -3,6 +3,9 @@ on: workflow_dispatch
 name: Wheel Builder
 
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.