### PR TITLE
building: prepend sys.base_prefix to DLL search paths on Windows

### DIFF
--- a/PyInstaller/building/build_main.py
+++ b/PyInstaller/building/build_main.py
@@ -146,12 +146,13 @@ def find_binary_dependencies(binaries, binding_redirects, import_packages):
     from PyInstaller.building.build_main import logger
     from PyInstaller import compat
 
-    # In the case of MS App Store python, add compat.base_prefix to extra library search paths. In addition to
-    # python38.dll (that we manage to resolve by other means, if necessary), this directory also contains
-    # python3.dll that might be required by some 3rd-party extension modules, and would otherwise end up missing
-    # during the dependency analysis.
+    # Extra library search paths (used on Windows to resolve DLL paths).
+    #
+    # Always search `sys.base_prefix`, and search it first. This ensures that we resolve the correct version of
+    # `python3X.dll` and `python3.dll` (a PEP-0384 stable ABI stub that forwards symbols to the fully versioned
+    # `python3X.dll`), regardless of other python installations that might be present in the PATH.
     extra_libdirs = []
-    if compat.is_ms_app_store:
+    if compat.is_win:
         extra_libdirs.append(compat.base_prefix)
 
     # On Windows with python >= 3.8, attempt to track calls to os.add_dll_directory() to obtain DLL search paths that

--- a/news/7102.bugfix.rst
+++ b/news/7102.bugfix.rst
@@ -1,0 +1,4 @@
+(Windows) Fix a regression introduced in PyInstaller 5.4 (:issue:`#6925`),
+where incorrect copy of ``python3.dll`` (and consequently an additional,
+incorrect copy of ``python3X.dll`` from the same directory) is collected
+when additional python installations are present in ``PATH``.


### PR DESCRIPTION
On Windows, when extending the DLL search paths for binary dependency analysis, always search `sys.base_prefix` first. This ensures that the correct version of `python3.dll` is picked up, regardless of other python installations that might be present in the `PATH`.

Fixes #7102.