### PR TITLE
Add scripts used to streamline releasing PyInstaller. [skip-ci]

### DIFF
--- a/release/README.rst
+++ b/release/README.rst
@@ -1,0 +1,60 @@
+Releasing PyInstaller
+---------------------
+
+*How to put PyInstaller on PyPI*
+
+
+Prerequisites
+.............
+
+* It's assumed that you are running in a UNIX like environment with tools like
+  ``bash`` and ``perl`` available.
+
+* It's also assumed that your Python environment is suitably de-`xkcd-1987
+  <https://xkcd.com/1987>`_-ified. i.e ``which python`` points to a sensible,
+  non-EOL version of Python 3 with user-writable ``site-packages`` directory and
+  ``which pip`` points to that same environment.
+
+* You need to install and be running `fish <https://fishshell.com/>`_. (Just
+  entering ``fish`` into a terminal is enough, no need to ``chsh``).
+
+* You need ``docker`` with ``qemu`` (cross architecture emulation). These are
+  typically just called ``docker`` and ``qemu`` on Linux repositories. Windows and
+  macOS can get them via docker desktop. To test your setup run:
+
+  .. code-block:: bash
+
+      $ docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+      ... lots of noise ...
+      $ docker run --rm --platform=ppc64le alpine uname -m
+      ... some more noise ...
+      ppc64le
+
+
+To release PyInstaller to PyPI
+..............................
+
+The steps to do a release are below. Note that only explicitly typing the
+commands ``pyi_upload_to_pypi`` or ``pyi_github_release`` or a ``git push`` will
+make persistent online changes. All other steps are harmless in that they apply
+changes locally only and can be undone by running ``git reset --hard
+origin/develop``. It *should* be impossible to accidentally create a release or
+other irreversible change just by monkeying around.
+
+#.  Ensure that you are on the ``develop`` branch, your working directory is
+    clean and you have pulled the latest upstream changes.
+
+#.  ``cd`` to the root of this repo and enter fish:
+
+    .. code-block:: bash
+
+        $ fish
+
+#.  Source the ``release.fish`` script.
+
+    .. code-block:: fish
+
+        > source release/release.fish
+
+    That script should prompt you for everything you need to do from there on.
+

--- a/release/build-manylinux
+++ b/release/build-manylinux
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -e
+
+platforms=( \
+    manylinux2014_x86_64 musllinux_1_1_x86_64\
+    manylinux2014_i686 musllinux_1_1_i686 \
+    manylinux2014_aarch64 musllinux_1_1_aarch64 \
+    manylinux2014_ppc64le musllinux_1_1_ppc64le \
+    manylinux2014_s390x musllinux_1_1_s390x \
+)
+
+docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+
+for platform in "${platforms[@]}"
+do
+    docker build -t pyi-$platform --build-arg BASE=quay.io/pypa/$platform ./bootloader
+    docker run -v "$PWD:/io" -t pyi-$platform
+done

--- a/release/release.fish
+++ b/release/release.fish
@@ -1,0 +1,82 @@
+#!/usr/bin/env fish
+
+if not status is-interactive
+    echo 'This script must be sourced from a fish shell' ; exit 1
+end
+for command in python pip git perl nano bash grep gh
+    if not which $command > /dev/null 2>&1
+        echo Missing dependency: Please install (set_color $fish_color_command)$command(set_color normal) and ensure it\'s in PATH before running this script.
+        exit 1
+    end
+end
+
+open https://readthedocs.org/projects/pyinstaller/builds/
+if not test (read -n1 -P 'Are the most recent "version latest" readthedocs builds passing? (y/N) ') = y
+    echo 'Do not attempt to do a release whilst readthedocs is in an unstable state! Create and merge a pull request to fix whatever\'s broken then restart the release process.'
+    exit 1;
+end
+
+set -x PYINSTALLER_DO_RELEASE 1
+pip install -q -r doc/requirements.txt
+pip install -Uq twine
+
+read -n1 -P 'nano is about to be opened so that you can edit PyInstaller\'s version. When it does, write the new version then save and quit. Press any key to proceed: '
+nano +21 PyInstaller/__init__.py
+towncrier --yes
+sh -c 'cd doc && make man'
+
+# Insert a section for this release into the credits file.
+set header (head -n7 doc/CREDITS.rst)
+set footer (tail -n +7 doc/CREDITS.rst)
+printf '%s\n' $header > doc/CREDITS.rst
+set title 'Contributions to PyInstaller '(python setup.py --version)
+echo $title >> doc/CREDITS.rst
+echo $title | perl -pe 's/./-/g' >> doc/CREDITS.rst
+echo '' >> doc/CREDITS.rst
+git shortlog -ns (git tag -l)[-1].. | grep -v -w bot | perl -pe 's/^\s+\d+\s+/* /g' >> doc/CREDITS.rst
+printf '%s\n' $footer >> doc/CREDITS.rst
+
+# Update docs versions in the README.
+perl -pe 's&https?://pyinstaller.readthedocs.io&https://pyinstaller.org&g' -i README.rst
+perl -pe 's&(https://pyinstaller.org/en/)[^/]+/&$1'v(python setup.py --version)'/&g' -i README.rst
+
+sh -c 'cd doc; make clean html'
+open doc/_build/html/CHANGES.html
+open doc/_build/html/CREDITS.html
+while not test (read -n1 -P 'Do the two opened docs pages look OK? Check for formatting/spelling errors. If yes, type \'y\', otherwise edit the rst source files then type anything else to trigger a rebuild: ') = y
+    sh -c 'cd doc; make clean html'
+end
+
+read -P 'If the bootloaders need to be rebuilt, now is the time to do it. Hit return if they don\'t need rebuilding or once you have rebuilt and copied the '(set_color --bold)'Windows and macOS bootloaders only'(set_color normal)' into PyInstaller/bootloaders: '
+
+echo 'Building bootloaders for Linux. If this is the first time you\'ve done so on this machine then this will take a while.'
+./release/build-manylinux || exit 1
+
+function pyi_build_wheels
+    rm -rf build dist pyinstaller.egg-info
+    python setup.py bdist_wheels
+    python setup.py -qqq sdist
+    twine check dist/* || return 1
+end
+
+function pyi_upload_to_pypi
+    echo 'API tokens can be created at https://pypi.org/manage/account/token/'
+    twine upload -u __token__ dist/*
+end
+
+function pyi_commit
+    git add -u
+    git commit -m 'Release v'(python setup.py --version)'. [skip ci]'
+    git tag v(python setup.py --version)
+    echo 'A commit and tag for this release has been made. When you\'re ready run:'
+    echo -s '    ' (set_color $fish_color_command) 'git push; sleep 60; git push --tags' (set_color normal)
+    echo 'Note that the dumb delay is required to avoid hitting readthedocs\'s concurrent build limit.'
+end
+
+function pyi_github_release
+    gh release create v(python setup.py --version) --notes 'Please see the [v'(python setup.py --version)' section of the changelog](https://pyinstaller.org/en/v'(python setup.py --version)'/CHANGES.html#id1) for a list of the changes since '(git tag -l --sort=version:refname)[-2]'.'
+end
+
+printf 'Commands '
+printf (set_color $fish_color_command)'%s'(set_color normal)', ' pyi_build_wheels pyi_upload_to_pypi pyi_commit pyi_github_release
+echo 'have been defined. When you\'re ready, run each of those (in that order).'


### PR DESCRIPTION
These are the scripts I've been using/cobbling together to _mostly automate_ the release process. As the readme says, you should be able to give almost all of it a shot locally without actually creating a release.