### PR TITLE
hookutils: qt: compatibility fix for PySide6 6.4.0

### DIFF
--- a/PyInstaller/utils/hooks/qt.py
+++ b/PyInstaller/utils/hooks/qt.py
@@ -727,7 +727,13 @@ def get_qt_qml_files(qt_library_info):
     #
     # https://github.com/pyinstaller/pyinstaller/pull/3229#issuecomment-359735031
     # https://github.com/pyinstaller/pyinstaller/issues/3864
-    qmldir = qt_library_info.location['Qml2ImportsPath']
+    #
+    # In Qt 6, Qml2ImportsPath was deprecated in favor of QmlImportsPath. The former is not available in PySide6
+    # 6.4.0 anymore (but is in PyQt6 6.4.
+    if 'QmlImportsPath' in qt_library_info.location:
+        qmldir = qt_library_info.location['QmlImportsPath']
+    else:
+        qmldir = qt_library_info.location['Qml2ImportsPath']
     if not qmldir or not os.path.exists(qmldir):
         logger.warning(
             'QML directory for %s, %r, does not exist. QML files not packaged.', qt_library_info.namespace, qmldir

--- a/news/7164.bugfix.rst
+++ b/news/7164.bugfix.rst
@@ -1,0 +1,3 @@
+Fix compatibility with ``PySide6`` 6.4.0, where the deprecated
+``Qml2ImportsPath`` location key is not available anymore; use the
+new ``QmlImportsPath`` key when it is available.

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -37,18 +37,11 @@ pandas==1.5.0; python_version >= '3.8'
 pygments==2.13.0
 PyGObject==3.42.2; sys_platform == 'linux'
 pyside2==5.15.2.1
-# pyside6 6.2.2 wheel is incompatible with python < 3.8 on macOS
-# pyside6 6.3 wheels are incompatible with python < 3.8 on linux
-# see https://bugreports.qt.io/browse/PYSIDE-1797
-pyside6==6.2.1; sys_platform == 'darwin' and python_version < '3.8'  # pyup: ignore
-pyside6==6.2.4; sys_platform == 'linux' and python_version < '3.8'  # pyup: ignore
-pyside6==6.3.2; (sys_platform != 'darwin' and sys_platform != 'linux') or python_version >= '3.8'
-pyqt5==5.15.7; python_version < '3.10'
-pyqtwebengine==5.15.6; python_version < '3.10'
-pyqt6==6.4.0  # PyQt6 Qt6 bindings
-pyqt6-qt6==6.4.0  # Qt6 binaries (keep in sync with pyqt6 version!)
-pyqt6-webengine==6.4.0  # PyQt6 QtWebEngine bindings
-pyqt6-webengine-qt6==6.4.0  # Qt6 QtWebEngine binaries
+pyside6==6.4.0
+pyqt5==5.15.7
+pyqtwebengine==5.15.6
+pyqt6==6.4.0
+pyqt6-webengine==6.4.0
 python-dateutil==2.8.2
 pytz==2022.4
 requests==2.28.1


### PR DESCRIPTION
In Qt6, `Qml2ImportsPath` location is deprecated in favor of `QmlImportsPath`, and in `PySide6` 6.4.0, the former is not available anymore. So use the new `QmlImportsPath` if it is available, otherwise fall back to `Qml2ImportsPath`.

Fixes #7164.