### PR TITLE
Improve/fix compatibility with scipy 1.9.2 on Windows

### DIFF
--- a/PyInstaller/hooks/hook-scipy.py
+++ b/PyInstaller/hooks/hook-scipy.py
@@ -13,9 +13,10 @@ import glob
 import os
 
 from PyInstaller.compat import is_win
-from PyInstaller.utils.hooks import get_module_file_attribute
+from PyInstaller.utils.hooks import get_module_file_attribute, is_module_satisfies, collect_delvewheel_libs_directory
 
 binaries = []
+datas = []
 
 # Package the DLL bundle that official scipy wheels for Windows ship The DLL bundle will either be in extra-dll on
 # windows proper and in .libs if installed on a virtualenv created from MinGW (Git-Bash for example)
@@ -25,6 +26,10 @@ if is_win:
         dll_glob = os.path.join(os.path.dirname(get_module_file_attribute('scipy')), location, "*.dll")
         if glob.glob(dll_glob):
             binaries.append((dll_glob, "."))
+
+# Handle delvewheel-enabled win32 wheels, which have external scipy.libs directory (scipy >= 0.9.2)
+if is_module_satisfies("scipy >= 1.9.2") and is_win:
+    datas, binaries = collect_delvewheel_libs_directory('scipy', datas=datas, binaries=binaries)
 
 # collect library-wide utility extension modules
 hiddenimports = ['scipy._lib.%s' % m for m in ['messagestream', "_ccallback_c", "_fpumode"]]

--- a/doc/hooks.rst
+++ b/doc/hooks.rst
@@ -435,6 +435,7 @@ hooks.
 .. autofunction:: collect_entry_point
 .. autofunction:: get_homebrew_path
 .. autofunction:: include_or_exclude_file
+.. autofunction:: collect_delvewheel_libs_directory
 
 
 Support for Conda

--- a/news/7168.bugfix.rst
+++ b/news/7168.bugfix.rst
@@ -1,0 +1,3 @@
+(Windows) Improve compatibility with ``scipy`` 1.9.2, whose Windows wheels 
+switched to ``delvewheel``, and therefore have shared libraries located in 
+external .libs directory.

--- a/news/7170.feature.rst
+++ b/news/7170.feature.rst
@@ -1,0 +1,3 @@
+Implement a new hook utility function, :func:`~PyInstaller.utils.hooks.collect_delvewheel_libs_directory`,
+intended for dealing with external shared library in ``delvewheel``-enabled PyPI
+wheels for Windows.

--- a/tests/functional/test_hooks/test_scipy.py
+++ b/tests/functional/test_hooks/test_scipy.py
@@ -16,6 +16,13 @@ from PyInstaller.utils.tests import importorskip
 
 
 @importorskip('scipy')
+def test_scipy_toplevel(pyi_builder):
+    pyi_builder.test_source("""
+        import scipy
+    """)
+
+
+@importorskip('scipy')
 def test_scipy(pyi_builder):
     pyi_builder.test_source(
         """


### PR DESCRIPTION
Introduce a new helper for dealing with `delvewheel`-enabled wheels that have external shared library directory, located next to the package directory. Use the helper in the `scipy` hook to ensure that shared library directory is collected even if no `scipy` extension is found using it via binary dependency analysis. Add a top-level `scipy` import test that reproduces the scenario from #7168.

Fixes #7168.