### PR TITLE
hooks: setuptools: do not enable distutils hack for setuptools < 60.0

### DIFF
--- a/PyInstaller/hooks/rthooks/pyi_rth_setuptools.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_setuptools.py
@@ -9,13 +9,27 @@
 # SPDX-License-Identifier: Apache-2.0
 #-----------------------------------------------------------------------------
 
+
 # This runtime hook performs the equivalent of the distutils-precedence.pth from the setuptools package;
 # it registers a special meta finder that diverts import of distutils to setuptools._distutils, if
 # available.
-try:
+def _install_setuptools_distutils_hack():
     import os
-    if os.environ.get("SETUPTOOLS_USE_DISTUTILS", "local") == "local":
+    import setuptools
+
+    # We need to query setuptools version at runtime, because the default value for SETUPTOOLS_USE_DISTUTILS
+    # has changed at version 60.0 from "stdlib" to "local", and we want to mimic that behavior.
+    setuptools_major = int(setuptools.__version__.split('.')[0])
+    default_value = "stdlib" if setuptools_major < 60 else "local"
+
+    if os.environ.get("SETUPTOOLS_USE_DISTUTILS", default_value) == "local":
         import _distutils_hack
         _distutils_hack.add_shim()
+
+
+try:
+    _install_setuptools_distutils_hack()
 except Exception:
     pass
+
+del _install_setuptools_distutils_hack

--- a/news/7172.bugfix.rst
+++ b/news/7172.bugfix.rst
@@ -1,0 +1,6 @@
+Prevent PyInstaller runtime hook for ``setuptools`` from attempting to
+override ``distutils`` with ``setuptools``-provided version when
+``setuptools`` is collected and its version is lower than 60.0. This
+both mimics the unfrozen behavior and prevents errors on versions
+between 50.0 and 60.0, where we do not explicitly collect
+``setuptools._distutils``.


### PR DESCRIPTION
In the `setuptools` runtime hook, do not attempt to enable the `distutils` override if `setuptools` version is less than 60.0. In other words, perform runtime version check, and set the default value for `SETUPTOOLS_USE_DISTUTILS` based on the major version; "stdlib" for `setuptools` < 60.0 and "local" for `setuptools` >= 60.0.

This both attempts to mimic the unfrozen behavior (the `distutils` override was enabled by default in 60.0), but also fixes the error in frozen application with `setuptools` >= 50.0 and < 60.0, where our runtime hook would attempt to enable `_distutils_hack` (due to default value for `SETUPTOOLS_USE_DISTUTILS` being "local", regardless of the version), but our standard hook forces collection of `setuptools.distutils˙ only from version 60.0 on.