### PR TITLE
Fix current issues with the tests and CI

### DIFF
--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -11,6 +11,6 @@ jobs:
       actions: write # to cancel/stop running workflows (styfle/cancel-workflow-action)
     runs-on: ubuntu-latest
     steps:
-    - uses: styfle/cancel-workflow-action@0.8.0
+    - uses: styfle/cancel-workflow-action@0.11.0
       with:
         workflow_id: ${{ github.event.workflow.id }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,10 @@ jobs:
         os: ['windows-latest', 'ubuntu-latest', 'macos-11']
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -65,7 +65,7 @@ jobs:
 
       - name: Fetch cache
         id: cache-target
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ env.pip_cache_dir }}
           key: ${{ runner.os }}-${{ matrix.python-version }}
@@ -146,7 +146,7 @@ jobs:
   test-alpine:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: docker build -f alpine.dockerfile -t foo .
       - run: >
           docker run

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
   run:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
@@ -21,7 +21,7 @@ jobs:
         git fetch origin ${{ github.ref }}
         git checkout FETCH_HEAD --
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
 

--- a/.github/workflows/validate-new-news.yml
+++ b/.github/workflows/validate-new-news.yml
@@ -11,7 +11,7 @@ jobs:
   run:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
@@ -22,7 +22,7 @@ jobs:
           git fetch origin ${{ github.ref }}
           git checkout FETCH_HEAD --
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.7
 

--- a/.github/workflows/wheel-builder.yml
+++ b/.github/workflows/wheel-builder.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
 
@@ -26,7 +26,7 @@ jobs:
           python -m twine check dist/*
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: wheels
           path: dist/*


### PR DESCRIPTION
Replaces the problematic `psutil.test` package in `test_pkgutil_iter_modules` with stdlib package (˙xml.dom˙). Similarly, replace `altgraph` with stdlib `json` to avoid relying on 3rd party package.

Bump the versions of actions we use in the github workflows to the versions that switched to Node 16, to avoid deprecation warnings about actions that use Node 12.