### PR TITLE
building: BUNDLE: exempt collected .py/.pyc files from relocation

### DIFF
--- a/PyInstaller/building/osx.py
+++ b/PyInstaller/building/osx.py
@@ -192,7 +192,12 @@ class BUNDLE(Target):
                     strict_arch_validation=(typ == 'EXTENSION'),
                 )
             # Add most data files to a list for symlinking later.
-            if typ == 'DATA' and base_path not in _QT_BASE_PATH:
+            # Exempt python source files from this relocation, because their real path might need to resolve
+            # to the directory that also contains the extension module.
+            relocate_file = type == 'DATA' and base_path not in _QT_BASE_PATH
+            if relocate_file and os.path.splitext(inm)[1].lower() in {'.py', '.pyc'}:
+                relocate_file = False
+            if relocate_file:
                 links.append((inm, fnm))
             else:
                 tofnm = os.path.join(self.name, "Contents", "MacOS", inm)

--- a/news/7180.breaking.rst
+++ b/news/7180.breaking.rst
@@ -1,0 +1,6 @@
+(macOS) In generated macOS .app bundles, the collected source .py files
+are not relocated from ``Contents/MacOS`` to ``Contents/Resources``
+anymore, to avoid issues when the path to a .py file is supposed to
+resolve to the same directory as adjacent binary extensions. On the
+other hand, this change might result in regressions w.r.t. bundle
+signing and/or notarization.

--- a/news/7180.bugfix.rst
+++ b/news/7180.bugfix.rst
@@ -1,0 +1,2 @@
+(macOS) Fix OpenCV (``cv2``) loader error in generated macOS .app
+bundles, caused by the relocation of package's source .py files.


### PR DESCRIPTION
In macOS .app bundles, exempt the .py and .pyc files that are collected as DATA files from being relocated from Contents/MacOS to Contents/Resources (and then symlinked back).

In certain scenarios (such as OpenCV loader's code), the path to a .py file needs to resolve to the directory that contains the adjacent binary extensions; i.e., the original directory in Contents/MacOS, beaucse the extensions are not relocated.

This might introduce regressions with bundle signing and notarization that we cannot test, hence the breaking change news entry. But to my knowledge, the main source of problems with that are dots in the directory names, which should not be the problem with directory- and base names of the collected .py/.pyc files.

 Fixes #7128.