### PR TITLE
depend: limit DLL parent path preservation to site-packages

### DIFF
--- a/news/7155.bugfix.rst
+++ b/news/7155.bugfix.rst
@@ -1,0 +1,5 @@
+(Windows) Limit the DLL parent path preservation behavior from :issue:``
+to files collected from site-packages directories (as returned by
+``site.getsitepackages`` and ``site.getusersitepackages``) instead of all paths
+in ``sys.path``, to avoid unintended behavior in corner cases, such as
+``sys.path`` containing the drive root or user's home directory.


### PR DESCRIPTION
Limit the DLL parent path preservation only to files that are collected from site-packages directories, as returned by `site` `getsitepackages()`  and `getusersitepackages()`.

The initial implementation using all paths from `sys.path` has proven to be problematic due to our lack of control over `sys.path`. The latter may end up containing a drive root, causing all DLLs collected from that drive that are not explicitly rooted in some other directory also in `sys.path` to be collected with its whole directory structure preserved.

The DLL parent path preservation is primarily intended for PyPI wheels that ship and install their own copies of DLLs along with the package. As both are typically installed into site-packages directory, limiting the DLL parent path preservation to only site-packages directories should be both sufficient for our use case and safe, as it has no effect on the outside paths.

Fixes #7155.