### PR TITLE
Add basic tests for macOS app bundle codesigning

### DIFF
--- a/PyInstaller/building/osx.py
+++ b/PyInstaller/building/osx.py
@@ -263,7 +263,11 @@ class BUNDLE(Target):
         try:
             osxutils.sign_binary(self.name, self.codesign_identity, self.entitlements_file, deep=True)
         except Exception as e:
-            logger.warning("Error while signing the bundle: %s", e)
-            logger.warning("You will need to sign the bundle manually!")
+            # Display a warning or re-raise the error, depending on the environment-variable setting.
+            if os.environ.get("PYINSTALLER_STRICT_BUNDLE_CODESIGN_ERROR", "0") == "0":
+                logger.warning("Error while signing the bundle: %s", e)
+                logger.warning("You will need to sign the bundle manually!")
+            else:
+                raise RuntimeError("Failed to codesign the bundle!") from e
 
         logger.info("Building BUNDLE %s completed successfully.", self.tocbasename)

--- a/news/7184.bugfix.rst
+++ b/news/7184.bugfix.rst
@@ -1,0 +1,2 @@
+(macOS) Fix regression in macOS app bundle signing caused by a typo made
+in :issue:`7180`.

--- a/tests/functional/test_macos_bundle_signing.py
+++ b/tests/functional/test_macos_bundle_signing.py
@@ -1,0 +1,73 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2022, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+#
+# Basic tests for macOS app bundle data relocation and code signing.
+
+import pytest
+
+from PyInstaller.utils.tests import importorskip
+
+
+# Test that collected metadata is properly relocated to avoid codesign errors due to directory containing dots in name.
+@pytest.mark.darwin
+@importorskip('psutil')
+@pytest.mark.parametrize('pyi_builder', ['onedir'], indirect=True)  # Run only in onedir mode.
+def test_macos_bundle_signing_metadata(pyi_builder, monkeypatch):
+    # Have codesign errors terminate the build instead of generating a warning.
+    monkeypatch.setenv("PYINSTALLER_STRICT_BUNDLE_CODESIGN_ERROR", "1")
+
+    pyi_builder.test_source("""
+        import psutil
+        """, pyi_args=['--windowed', '--copy-metadata', 'psutil'])
+
+
+# Test that the bundle signing works even if we collect a package as source .py files, which we do not relocate.
+@pytest.mark.darwin
+@importorskip('psutil')
+@pytest.mark.parametrize('pyi_builder', ['onedir'], indirect=True)  # Run only in onedir mode.
+def test_macos_bundle_signing_py_files(pyi_builder, monkeypatch):
+    # Have codesign errors terminate the build instead of generating a warning.
+    monkeypatch.setenv("PYINSTALLER_STRICT_BUNDLE_CODESIGN_ERROR", "1")
+
+    # Override Analysis so that we can set package collection mode without having to use .spec file.
+    def AnalysisOverride(*args, **kwargs):
+        kwargs['module_collection_mode'] = {'psutil': 'py'}
+        return Analysis(*args, **kwargs)
+
+    import PyInstaller.building.build_main
+    Analysis = PyInstaller.building.build_main.Analysis
+    monkeypatch.setattr('PyInstaller.building.build_main.Analysis', AnalysisOverride)
+
+    pyi_builder.test_source("""
+        import psutil
+        """, pyi_args=['--windowed'])
+
+
+# Test that the codesigning works even if we collect a package as .pyc files, which we do not relocate.
+@pytest.mark.darwin
+@importorskip('psutil')
+@pytest.mark.parametrize('pyi_builder', ['onedir'], indirect=True)  # Run only in onedir mode.
+def test_macos_bundle_signing_pyc_files(pyi_builder, monkeypatch):
+    # Have codesign errors terminate the build instead of generating a warning.
+    monkeypatch.setenv("PYINSTALLER_STRICT_BUNDLE_CODESIGN_ERROR", "1")
+
+    # Override Analysis so that we can set package collection mode without having to use .spec file.
+    def AnalysisOverride(*args, **kwargs):
+        kwargs['module_collection_mode'] = {'psutil': 'pyc'}
+        return Analysis(*args, **kwargs)
+
+    import PyInstaller.building.build_main
+    Analysis = PyInstaller.building.build_main.Analysis
+    monkeypatch.setattr('PyInstaller.building.build_main.Analysis', AnalysisOverride)
+
+    pyi_builder.test_source("""
+        import psutil
+        """, pyi_args=['--windowed'])


### PR DESCRIPTION
Implement basic tests for macOS app bundle signing, to hopefully prevent regressions in basic relocation functionality, like the one caused by typo in #7180 (see #7184, #7185).

Add an option to turn the codesign error when signing the generated app bundle into fatal error, so we can catch it on the CI.

Add basic tests that:
 - involve collection of the metadata, which should be reallocated
 - involve collection of package as source .py files, which we do not relocate as of #7180.
 - involve collection of package as .pyc files, which we do not relocate as of #7180.

Also sneak in a news fragment for #7184, so that the changelog for hotfix release will make note of it.