### PR TITLE
Make incompatible stdlib back-port error message more specific.

### DIFF
--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -750,15 +750,15 @@ def check_requirements():
 
     for name in ["enum34", "typing"]:
         try:
-            distribution(name)
+            dist = distribution(name)
         except PackageNotFoundError:
-            pass
-        else:
-            raise SystemExit(
-                f"The '{name}' package is an obsolete backport of a standard library package and is "
-                f"incompatible with PyInstaller. Please "
-                f"`{'conda remove' if is_conda else 'pip uninstall'} {name}` then try again."
-            )
+            continue
+        remove = "conda remove" if is_conda else f'"{sys.executable}" -m pip uninstall {name}'
+        raise SystemExit(
+            f"The '{name}' package is an obsolete backport of a standard library package and is incompatible with "
+            f"PyInstaller. Please remove this package (located in {dist.locate_file('')}) using\n    {remove}\n"
+            "then try again."
+        )
 
     # Bail out if binutils is not installed.
     if is_linux and shutil.which("objdump") is None:

--- a/news/7221.feature.rst
+++ b/news/7221.feature.rst
@@ -1,0 +1,3 @@
+Add the package's location and exact interpreter path to the error message for
+the check for obsolete and PyInstaller-incompatible standard library back-port
+packages (``enum34`` and ``typing``).


### PR DESCRIPTION
We've had several invalid bug reports from users on the wrong side of xkcd 1987. Include some full paths in the message to attempt to prevent this.
