### PR TITLE
Propagate log level to isolated subprocesses.

### DIFF
--- a/news/7235.bugfix.rst
+++ b/news/7235.bugfix.rst
@@ -1,0 +1,2 @@
+Fix the log level (provided via :option:`--log-level`) being ignored by some
+build steps.

--- a/news/7235.feature.rst
+++ b/news/7235.feature.rst
@@ -1,0 +1,2 @@
+Allow controlling the build log level (:option:`--log-level`) via a
+``PYI_LOG_LEVEL`` environment variable.


### PR DESCRIPTION
The few usages of `PyInstaller.isolated` which used logging would import and use PyInstaller's logger without setting its level. This meant that someone using `--log-level=WARN` would still see INFO messages from subprocesses.

To avoid each usage of PyInstaller.isolated having to manually juggle logging levels in its parameterisation or to avoid the overhead of initialising the logger automatically at the start of each subprocess, this approach allows the logging level to also be controlled by an environment variable `PYI_LOG_LEVEL` which `--log-level` sets, subprocesses inherit and those importing PyInstaller's logger act on implicitly.

I wanted to have a test in here but pytest's own logging caturing is getting in the way. 