### PR TITLE
CI/CD: Automatically lock closed issues after a measure of inactivity.

### DIFF
--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -1,0 +1,23 @@
+name: Lock Closed Threads
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: lock
+
+jobs:
+  action:
+    if: github.repository_owner == 'pyinstaller'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v3
+        with:
+          issue-inactive-days: 60
+          pr-inactive-days: 60


### PR DESCRIPTION
Almost always, messages on old resolved issues are either off-topic or people claiming to have "the exact same issue" as some ancient bug report on an obsolete version of Python but after verbal ping pong reveal that their problem has nothing in common with the original issue.

Forcing people to go through the process of creating a new issue with the issue template and filling in their various platform specs should hopefully dissuade the former and save us time teasing out the details in the second.
