### PR TITLE
hookutils: conda: do not collect "python" conda distribution

### DIFF
--- a/PyInstaller/utils/hooks/conda.py
+++ b/PyInstaller/utils/hooks/conda.py
@@ -212,6 +212,13 @@ def walk_dependency_tree(initial: str, excludes: Iterable[str] | None = None):
     while names_to_do:
         # Grab a distribution name from the to-do list.
         name = names_to_do.pop()
+        # Skip the base "python" distribution and its dependencies. These should be collected as a part of the regular
+        # build process, lest we end up with defunct build when no hook uses these conda hook utility functions.
+        # In python 3.10, the "python" distribution on linux and macOS includes a symbolic link
+        #  /path/to/conda/env/lib/python3.1 -> python3.10
+        # which causes all content of the environment's lib directory to be collected as data.
+        if name == 'python':
+            continue
         try:
             # Collect and save it's metadata.
             done[name] = distribution = Distribution.from_name(name)


### PR DESCRIPTION
When collecting extra data based on conda distribution information, avoid collecting "python" conda distribution and its dependencies. These should already be collected as a part of regular build process, otherwise we would end up with defunct build when no hook is called that uses these conda utility functions.

More importantly, the "python" distribution for python 3.10 on macOS and linux includes a symbolic link
  `/path/to/conda/env/lib/python3.1 -> python3.10`
which causes all content of the environment's lib directory to be collected as data.

This has been observed in https://github.com/pyinstaller/pyinstaller/issues/4764#issuecomment-1314540780 and https://github.com/pyinstaller/pyinstaller/issues/7165#issuecomment-1281364341 and verified with the following snippet:
```python
import pprint
from PyInstaller.utils.hooks import conda_support
pprint.pprint(conda_support.collect_dynamic_libs('python', dependencies=False))
```

with python 3.9:
```
[('/Users/rok/miniconda3/envs/pyi-testenv-3.9/lib/libpython3.9.dylib', '.')]
```

and with python 3.10:

```
[('/Users/rok/miniconda3/envs/pyi-testenv-3.10/lib/libpython3.10.dylib', '.'),
 ('/Users/rok/miniconda3/envs/pyi-testenv-3.10/lib/python3.1', '.')]
```

and

```
$ ls -l /Users/rok/miniconda3/envs/pyi-testenv-3.10/lib/python3.1
lrwxr-xr-x  1 rok  staff  10 15 nov 11:51 /Users/rok/miniconda3/envs/pyi-testenv-3.10/lib/python3.1 -> python3.10
```

I think in the linked reports, the issue was triggered due to use of `numpy`, whose hook tries to collect all conda-based dependencies:
https://github.com/pyinstaller/pyinstaller/blob/f6eea916adbaa205c57c04daaf7cfebfc3b21fe0/PyInstaller/hooks/hook-numpy.py#L31-L35
