### PR TITLE
hookutils: conda: have collect_dynamic_libs collect only shared libs

### DIFF
--- a/news/7248.bugfix.1.rst
+++ b/news/7248.bugfix.1.rst
@@ -1,0 +1,4 @@
+(Anaconda) Fix the problem with Anaconda python 3.10 on linux and macOS, 
+where all content of the environment's ``lib`` directory would end up 
+collected as data  due to additional symbolic link pointing from ``python3.1`` 
+to ``python3.10``.

--- a/news/7248.bugfix.rst
+++ b/news/7248.bugfix.rst
@@ -1,0 +1,6 @@
+(Anaconda) Fix the ``PyInstaller.utils.hooks.conda.collect_dynamic_libs`` 
+hook utility function to collect only dynamic libraries, by introducing 
+an additional type check (to exclude directories and symbolic links to 
+directories) and additional suffix check (to include only files whose 
+name matches the following patterns: ``*.dll``, ``*.dylib``, ``*.so``, 
+and ``*.so.*``).


### PR DESCRIPTION
Implement additional checks when collecting shared libraries using `PyInstaller.utils.hooks.conda.collect_dynamic_libs`: check that "file" is in fact a file and not a directory or a symbolic link pointing to a directory. Also check that the suffix matches one of the following: `*.dll`, `*.dylib`, `*.so`, `*.so.*`.

Preventing directory paths from being returned fixes a problem where mysterious directories named "31", "32", "33", etc. appear in the application's top-level directory when building on macOS. These are sub-directories of the `lib/terminfo` directory, which is collected as part of `numpy`'s depdendency tree; and because the destination parameter is set to ".", we collect its  contents into top-level application directory.

The "python" distribution for Anaconda's python 3.10 contains a symbolic link `/path/to/conda/env/lib/python3.1 -> python3.10`, which causes the contents of `/path/to/conda/env/lib/python3.10` to be collected into top-level application directory (including whole python stdlib in source form and the `site-packages` directory).

Lastly, enforcing the shared libs suffices prevents collection of additional files, such as static libraries (`*.a`) or assorted data files that also seem to dwell in the `lib` directory.