### PR TITLE
hooks: PySide6: add PySide6.support.deprecated to hidden imports

### DIFF
--- a/PyInstaller/hooks/hook-PySide6.py
+++ b/PyInstaller/hooks/hook-PySide6.py
@@ -9,11 +9,17 @@
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
 
+from PyInstaller.utils.hooks import is_module_satisfies
 from PyInstaller.utils.hooks.qt import get_qt_binaries, pyside6_library_info
 
 # Only proceed if PySide6 can be imported.
 if pyside6_library_info.version is not None:
     hiddenimports = ['shiboken6', 'inspect']
+
+    # Starting with PySide6 6.4.0, we need to collect PySide6.support.deprecated for | and & operators to work with
+    # Qt key and key modifiers enums. See #7249.
+    if is_module_satisfies("PySide6 >= 6.4.0"):
+        hiddenimports += ['PySide6.support.deprecated']
 
     # Collect required Qt binaries.
     binaries = get_qt_binaries(pyside6_library_info)

--- a/news/7249.bugfix.rst
+++ b/news/7249.bugfix.rst
@@ -1,0 +1,4 @@
+Ensure that ``PySide6.support.deprecated`` module is collected for
+``PySide6`` 6.4.0 and later in order to enable continued support for
+``|`` and ``&`` operators between Qt key and key modifier enum values
+(e.g., ``QtCore.Qt.Key_D`` and ``QtCore.Qt.AltModifier``).

--- a/tests/functional/test_qt.py
+++ b/tests/functional/test_qt.py
@@ -486,3 +486,15 @@ def test_Qt_QtMultimedia_with_true_property(pyi_builder, QtPyLib):
         app = QtCore.QCoreApplication()
         """.format(QtPyLib), **USE_WINDOWED_KWARG
     )
+
+
+# In PySide6 >= 6.4.0, we need to collect `PySide6.support.deprecated` module for logical operators between Qt key and
+# key modifier enums to work. See #7249.
+@requires('PySide6')
+def test_Qt_PySide6_key_enums(pyi_builder):
+    pyi_builder.test_source(
+        """
+        from PySide6 import QtCore
+        key = QtCore.Qt.AltModifier | QtCore.Qt.Key_D
+        """
+    )


### PR DESCRIPTION
Add `PySide6.support.deprecated` to hidden imports for PySide6 6.4.0 or later. Required to continue supporting and/or operators between Qt key and key modifier enum values.

Likely related to the new enum system and its "forgiveness mode": https://www.qt.io/blog/qt-for-python-release-6.4-is-finally-here

Fixes #7249.