### PR TITLE
building: assorted fixes and cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ on:
 env:
   # Colored pytest output on CI despite not having a tty
   FORCE_COLOR: 1
+  # Enable strict unpack mode to catch file duplication problems in onefile builds (at executable run-time).
+  PYINSTALLER_STRICT_UNPACK_MODE: 1
 
 permissions:
   contents: read # to fetch code (actions/checkout)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ env:
   FORCE_COLOR: 1
   # Enable strict unpack mode to catch file duplication problems in onefile builds (at executable run-time).
   PYINSTALLER_STRICT_UNPACK_MODE: 1
+  # Enable strict cpllect mode to catch file duplication problems in PKG/Carchive (onefile builds) or COLLECT
+  # (onedir builds) at build time.
+  PYINSTALLER_STRICT_COLLECT_MODE: 1
 
 permissions:
   contents: read # to fetch code (actions/checkout)

--- a/PyInstaller/archive/writers.py
+++ b/PyInstaller/archive/writers.py
@@ -347,10 +347,6 @@ class CArchiveWriter(ArchiveWriter):
             if type in ('o', 's', 'm', 'M'):
                 # Exempt options, python source script, and modules from the check
                 pass
-            elif type == 'd':
-                # Dependency; de-obfuscate the destination name.
-                _, normalized_dest = dest.split(':', 1)  # Split on first colon
-                normalized_dest = os.path.normcase(normalized_dest)
             else:
                 # Everything else; normalize the case
                 normalized_dest = os.path.normcase(dest)
@@ -363,8 +359,13 @@ class CArchiveWriter(ArchiveWriter):
                 self._collected_names.add(normalized_dest)
 
         try:
-            if type in ('o', 'd'):
+            if type == 'o':
                 return self._write_blob(b"", dest, type)
+
+            elif type == 'd':
+                # Dependency; merge source (= reference path prefix) and dest (= name) into single-string format that is
+                # parsed by bootloader.
+                return self._write_blob(b"", f"{source}:{dest}", type)
 
             if type == 's':
                 # If it is a source code file, compile it to a code object and marshal the object, so it can be

--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -246,7 +246,10 @@ class PKG(Target):
             if typ not in ('OPTION', 'DEPENDENCY') and not os.path.exists(fnm):
                 # If file is contained within python egg, it will be added with the egg.
                 if not is_path_to_egg(fnm):
-                    logger.warning("Ignoring non-existent resource %s, meant to be collected as %s", fnm, inm)
+                    if strict_collect_mode:
+                        raise ValueError(f"Non-existent resource {fnm}, meant to be collected as {inm}!")
+                    else:
+                        logger.warning("Ignoring non-existent resource %s, meant to be collected as %s", fnm, inm)
                 continue
             if typ in ('BINARY', 'EXTENSION'):
                 if self.exclude_binaries and typ == 'EXTENSION':
@@ -895,7 +898,10 @@ class COLLECT(Target):
             if typ != 'DEPENDENCY' and not os.path.exists(fnm):
                 # If file is contained within python egg, it will be added with the egg.
                 if not is_path_to_egg(fnm):
-                    logger.warning("Ignoring non-existent resource %s, meant to be collected as %s", fnm, inm)
+                    if strict_collect_mode:
+                        raise ValueError(f"Non-existent resource {fnm}, meant to be collected as {inm}!")
+                    else:
+                        logger.warning("Ignoring non-existent resource %s, meant to be collected as %s", fnm, inm)
                 continue
             # Disallow collection outside of the dist directory.
             if os.pardir in os.path.normpath(inm).split(os.sep) or os.path.isabs(inm):

--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -238,7 +238,6 @@ class PKG(Target):
 
     def assemble(self):
         logger.info("Building PKG (CArchive) %s", os.path.basename(self.name))
-        trash = []
         mytoc = []
         srctoc = []
         seen_inms = {}
@@ -308,8 +307,6 @@ class PKG(Target):
         # TODO: Think about having all modules first and then all scripts.
         CArchiveWriter(self.name, srctoc + mytoc, pylib_name=pylib_name)
 
-        for item in trash:
-            os.remove(item)
         logger.info("Building PKG (CArchive) %s completed successfully.", os.path.basename(self.name))
 
 

--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -429,14 +429,33 @@ class EXE(Target):
 
         self.toc = TOC()
 
+        _deps_toc = TOC()  # See the note below
+
         for arg in args:
             if isinstance(arg, TOC):
                 self.toc.extend(arg)
             elif isinstance(arg, Target):
                 self.toc.append((os.path.basename(arg.name), arg.name, arg.typ))
-                self.toc.extend(arg.dependencies)
+                # See the note below (and directly extend self.toc once this workaround is not necessary anymore).
+                # self.toc.extend(arg.dependencies)
+                for entry in arg.dependencies:
+                    if entry[2] in ('EXTENSION', 'BINARY', 'DATA'):
+                        _deps_toc.append(entry)
+                    else:
+                        self.toc.append(entry)
             else:
                 self.toc.extend(arg)
+
+        # NOTE: this is an ugly work-around that ensures that when MERGE is used, the EXE's TOC is first populated with
+        # MERGE'd `binaries` and `datas` entries (which should be DEPENDENCY references for shared resources, and BINARY
+        # or DATA entries for non-shared resources), and that `PYZ.dependencies` is merged last. The latter may contain
+        # entries for `_struct` and `zlib` extensions, and if they end up in the TOC first, they will block the
+        # corresponding DEPENDENCY entries (if they are available) from being added to TOC. Which will in turn result in
+        # missing extensions with certain onefile/onedir referencing combinations. And even if not, the result would be
+        # but sub-optimal, as the extensions could be shared via DEPENDENCY mechanism. This work-around can be removed
+        # once we replace the TOC class with mechanism that implements a typecode-based priority system for the entries.
+        self.toc.extend(_deps_toc)
+        del _deps_toc
 
         if self.runtime_tmpdir is not None:
             self.toc.append(("pyi-runtime-tmpdir " + self.runtime_tmpdir, "", "OPTION"))

--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -242,7 +242,8 @@ class PKG(Target):
         # 'fnm'  - absolute filename as it is on the file system.
         for inm, fnm, typ in self.toc:
             # Ensure that the source file exists, if neccessary. Skip the check for OPTION entries, where 'fnm' is None.
-            if typ != 'OPTION' and not os.path.exists(fnm):
+            # Also skip DEPENDENCY entries due to special contents of 'inm' and/or 'fnm'.
+            if typ not in ('OPTION', 'DEPENDENCY') and not os.path.exists(fnm):
                 # If file is contained within python egg, it will be added with the egg.
                 if not is_path_to_egg(fnm):
                     logger.warning("Ignoring non-existent resource %s, meant to be collected as %s", fnm, inm)
@@ -868,8 +869,9 @@ class COLLECT(Target):
         _make_clean_directory(self.name)
         logger.info("Building COLLECT %s", self.tocbasename)
         for inm, fnm, typ in self.toc:
-            # Ensure that the source file exists, if neccessary.
-            if not os.path.exists(fnm):
+            # Ensure that the source file exists, if necessary. Skip the check for DEPENDENCY entries due to special
+            # contents of 'inm' and/or 'fnm'.
+            if typ != 'DEPENDENCY' and not os.path.exists(fnm):
                 # If file is contained within python egg, it will be added with the egg.
                 if not is_path_to_egg(fnm):
                     logger.warning("Ignoring non-existent resource %s, meant to be collected as %s", fnm, inm)

--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -897,16 +897,10 @@ class COLLECT(Target):
                     strict_arch_validation=(typ == 'EXTENSION'),
                 )
             if typ != 'DEPENDENCY':
-                if os.path.isdir(fnm):
-                    # Because shutil.copy2() is the default copy function for shutil.copytree, this will also copy file
-                    # metadata.
-                    shutil.copytree(fnm, tofnm)
-                else:
-                    shutil.copy(fnm, tofnm)
-                try:
-                    shutil.copystat(fnm, tofnm)
-                except OSError:
-                    logger.warning("failed to copy flags of %s", fnm)
+                # At this point, fnm should be a valid file
+                if not os.path.isfile(fnm):
+                    raise ValueError("Resource %r is not a valid file!", fnm)
+                shutil.copy2(fnm, tofnm)  # Use copy2 to (attempt to) preserve metadata
             if typ in ('EXTENSION', 'BINARY'):
                 os.chmod(tofnm, 0o755)
         logger.info("Building COLLECT %s completed successfully.", self.tocbasename)

--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -28,7 +28,7 @@ from PyInstaller.building.datastruct import TOC, Target, _check_guts_eq
 from PyInstaller.building.utils import (
     _check_guts_toc, _make_clean_directory, _rmtree, checkCache, get_code_object, strip_paths_in_code, compile_pymodule
 )
-from PyInstaller.compat import (is_cygwin, is_darwin, is_linux, is_win)
+from PyInstaller.compat import is_cygwin, is_darwin, is_linux, is_win, strict_collect_mode
 from PyInstaller.depend import bindepend
 from PyInstaller.depend.analysis import get_bootstrap_modules
 from PyInstaller.depend.utils import is_path_to_egg
@@ -903,6 +903,9 @@ class COLLECT(Target):
                 # At this point, fnm should be a valid file
                 if not os.path.isfile(fnm):
                     raise ValueError("Resource %r is not a valid file!", fnm)
+                # If strict collection mode is enabled, the destination should not exist yet.
+                if strict_collect_mode and os.path.exists(tofnm):
+                    raise ValueError(f"Attempting to collect a duplicated file into COLLECT: {inm} (type: {typ})")
                 shutil.copy2(fnm, tofnm)  # Use copy2 to (attempt to) preserve metadata
             if typ in ('EXTENSION', 'BINARY'):
                 os.chmod(tofnm, 0o755)

--- a/PyInstaller/building/datastruct.py
+++ b/PyInstaller/building/datastruct.py
@@ -31,7 +31,7 @@ def unique_name(entry):
     unique_name: str
     """
     name, path, typecode = entry
-    if typecode in ('BINARY', 'DATA'):
+    if typecode in ('BINARY', 'DATA', 'EXTENSION', 'DEPENDENCY'):
         name = os.path.normcase(name)
 
     return name

--- a/PyInstaller/building/osx.py
+++ b/PyInstaller/building/osx.py
@@ -15,7 +15,7 @@ import shutil
 
 from PyInstaller.building.api import COLLECT, EXE
 from PyInstaller.building.datastruct import TOC, Target, logger
-from PyInstaller.building.utils import (_check_path_overlap, _rmtree, add_suffix_to_extension, checkCache)
+from PyInstaller.building.utils import _check_path_overlap, _rmtree, checkCache
 from PyInstaller.compat import is_darwin
 from PyInstaller.building.icon import normalize_icon_type
 
@@ -174,8 +174,6 @@ class BUNDLE(Target):
         links = []
         _QT_BASE_PATH = {'PySide2', 'PySide6', 'PyQt5', 'PySide6'}
         for inm, fnm, typ in self.toc:
-            # Adjust name for extensions, if applicable
-            inm, fnm, typ = add_suffix_to_extension(inm, fnm, typ)
             # Copy files from cache. This ensures that are used files with relative paths to dynamic library
             # dependencies (@executable_path)
             base_path = inm.split('/', 1)[0]

--- a/PyInstaller/building/osx.py
+++ b/PyInstaller/building/osx.py
@@ -200,16 +200,14 @@ class BUNDLE(Target):
             if relocate_file:
                 links.append((inm, fnm))
             else:
+                # At this point, fnm should be a valid file
+                if not os.path.isfile(fnm):
+                    raise ValueError("Resource %r is not a valid file!", fnm)
                 tofnm = os.path.join(self.name, "Contents", "MacOS", inm)
                 todir = os.path.dirname(tofnm)
                 if not os.path.exists(todir):
                     os.makedirs(todir)
-                if os.path.isdir(fnm):
-                    # Because shutil.copy2() is the default copy function for shutil.copytree, this will also copy file
-                    # metadata.
-                    shutil.copytree(fnm, tofnm)
-                else:
-                    shutil.copy(fnm, tofnm)
+                shutil.copy2(fnm, tofnm)  # Use copy2 to (attempt to) preserve metadata
 
         logger.info('Moving BUNDLE data files to Resource directory')
 
@@ -218,16 +216,14 @@ class BUNDLE(Target):
         bin_dir = os.path.join(self.name, 'Contents', 'MacOS')
         res_dir = os.path.join(self.name, 'Contents', 'Resources')
         for inm, fnm in links:
+            # At this point, fnm should be a valid file
+            if not os.path.isfile(fnm):
+                raise ValueError("Resource %r is not a valid file!", fnm)
             tofnm = os.path.join(res_dir, inm)
             todir = os.path.dirname(tofnm)
             if not os.path.exists(todir):
                 os.makedirs(todir)
-            if os.path.isdir(fnm):
-                # Because shutil.copy2() is the default copy function for shutil.copytree, this will also copy file
-                # metadata.
-                shutil.copytree(fnm, tofnm)
-            else:
-                shutil.copy(fnm, tofnm)
+            shutil.copy2(fnm, tofnm)  # Use copy2 to (attempt to) preserve metadata
             base_path = os.path.split(inm)[0]
             if base_path:
                 if not os.path.exists(os.path.join(bin_dir, inm)):

--- a/PyInstaller/building/utils.py
+++ b/PyInstaller/building/utils.py
@@ -88,29 +88,26 @@ def _check_guts_toc(attr, old, toc, last_build, pyc=0):
 
 def add_suffix_to_extension(inm, fnm, typ):
     """
-    Take a TOC entry (inm, fnm, typ) and adjust the inm for EXTENSION or DEPENDENCY to include the full library suffix.
+    Take a TOC entry (inm, fnm, typ) and adjust the inm for EXTENSION to include the full library suffix.
     """
-    if typ == 'EXTENSION':
-        if fnm.endswith(inm):
-            # If inm completely fits into end of the fnm, it has already been processed.
-            return inm, fnm, typ
-        # Change the dotted name into a relative path. This places C extensions in the Python-standard location.
-        inm = inm.replace('.', os.sep)
-        # In some rare cases extension might already contain a suffix. Skip it in this case.
-        if os.path.splitext(inm)[1] not in EXTENSION_SUFFIXES:
-            # Determine the base name of the file.
-            base_name = os.path.basename(inm)
-            assert '.' not in base_name
-            # Use this file's existing extension. For extensions such as ``libzmq.cp36-win_amd64.pyd``, we cannot use
-            # ``os.path.splitext``, which would give only the ```.pyd`` part of the extension.
-            inm = inm + os.path.basename(fnm)[len(base_name):]
+    # No-op for non-extension
+    if typ != 'EXTENSION':
+        return inm, fnm, typ
 
-    elif typ == 'DEPENDENCY':
-        # Use the suffix from the filename.
-        # TODO: verify what extensions are by DEPENDENCIES.
-        binext = os.path.splitext(fnm)[1]
-        if not os.path.splitext(inm)[1] == binext:
-            inm = inm + binext
+    # If inm completely fits into end of the fnm, it has already been processed.
+    if fnm.endswith(inm):
+        return inm, fnm, typ
+
+    # Change the dotted name into a relative path. This places C extensions in the Python-standard location.
+    inm = inm.replace('.', os.sep)
+    # In some rare cases extension might already contain a suffix. Skip it in this case.
+    if os.path.splitext(inm)[1] not in EXTENSION_SUFFIXES:
+        # Determine the base name of the file.
+        base_name = os.path.basename(inm)
+        assert '.' not in base_name
+        # Use this file's existing extension. For extensions such as ``libzmq.cp36-win_amd64.pyd``, we cannot use
+        # ``os.path.splitext``, which would give only the ```.pyd`` part of the extension.
+        inm = inm + os.path.basename(fnm)[len(base_name):]
 
     return inm, fnm, typ
 

--- a/PyInstaller/building/utils.py
+++ b/PyInstaller/building/utils.py
@@ -158,11 +158,6 @@ def checkCache(
     if not strip and not upx and not is_darwin and not is_win:
         return fnm
 
-    if dist_nm is not None and ":" in dist_nm:
-        # A file embedded in another PyInstaller build via multipackage.
-        # No actual file exists to process.
-        return fnm
-
     if strip:
         strip = True
     else:

--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -27,6 +27,9 @@ import shutil
 from PyInstaller._shared_with_waf import _pyi_machine
 from PyInstaller.exceptions import ExecCommandFailed
 
+# Strict collect mode, which raises error when trying to collect duplicate files into PKG/CArchive or COLLECT.
+strict_collect_mode = os.environ.get("PYINSTALLER_STRICT_COLLECT_MODE", "0") != "0"
+
 # Copied from https://docs.python.org/3/library/platform.html#cross-platform.
 is_64bits: bool = sys.maxsize > 2**32
 

--- a/PyInstaller/depend/analysis.py
+++ b/PyInstaller/depend/analysis.py
@@ -44,6 +44,7 @@ from copy import deepcopy
 from PyInstaller import HOMEPATH, PACKAGEPATH
 from PyInstaller import log as logging
 from PyInstaller.building.datastruct import TOC
+from PyInstaller.building.utils import add_suffix_to_extension
 from PyInstaller.compat import (
     BAD_MODULE_TYPES, BINARY_MODULE_TYPES, MODULE_TYPES_TO_TOC_DICT, PURE_PYTHON_MODULE_TYPES, PY3_BASE_MODULES,
     VALID_MODULE_TYPES, importlib_load_source, is_win
@@ -879,7 +880,7 @@ def get_bootstrap_modules():
             if os.path.basename(os.path.dirname(mod_file)) == 'lib-dynload':
                 # Divert extensions originating from python's lib-dynload directory, to match behavior of #5604.
                 mod_name = os.path.join('lib-dynload', mod_name)
-            loader_mods.append((mod_name, mod_file, 'EXTENSION'))
+            loader_mods.append(add_suffix_to_extension(mod_name, mod_file, 'EXTENSION'))
     loader_mods.append(('struct', os.path.abspath(mod_struct.__file__), 'PYMODULE'))
     # Loader/bootstrap modules.
     # NOTE: These modules should be kept simple without any complicated dependencies.

--- a/bootloader/src/pyi_launch.c
+++ b/bootloader/src/pyi_launch.c
@@ -258,7 +258,10 @@ _extract_dependency(ARCHIVE_STATUS *archive_pool[], const char *item)
 
         if (extractDependencyFromArchive(status, filename) == -1) {
             FATALERROR("Error extracting %s\n", filename);
-            pyi_arch_status_free(status);
+            /* Do not free the archive ("status") here, because its
+             * pointer is stored in the archive pool that is cleaned up
+             * by the caller.
+             */
             return -1;
         }
     }
@@ -316,7 +319,7 @@ pyi_launch_extract_binaries(ARCHIVE_STATUS *archive_status, SPLASH_STATUS *splas
     TOC * ptoc = archive_status->tocbuff;
 
     /* Clean memory for archive_pool list. */
-    memset(&archive_pool, 0, _MAX_ARCHIVE_POOL_LEN * sizeof(ARCHIVE_STATUS *));
+    memset(archive_pool, 0, _MAX_ARCHIVE_POOL_LEN * sizeof(ARCHIVE_STATUS *));
 
     /* Current process is the 1st item. */
     archive_pool[0] = archive_status;

--- a/doc/spec-files.rst
+++ b/doc/spec-files.rst
@@ -643,7 +643,8 @@ Following this you can copy the ``PYZ``, ``EXE`` and ``COLLECT`` statements from
 the original three spec files,
 substituting the unique names of the Analysis objects
 where the original spec files have ``a.``
-Modify the EXE statements to pass in ``Analysis.dependencies.``
+Modify the EXE statements to pass in ``Analysis.dependencies``, in addition
+to all other arguments that are passed in the original EXE statements.
 For example::
 
     foo_pyz = PYZ(foo_a.pure)
@@ -654,11 +655,11 @@ For example::
 
 Save the combined spec file as ``foobarzap.spec`` and then build it::
 
-    pyi-build foobarzap.spec
+    pyinstaller foobarzap.spec
 
 The output in the :file:`dist` folder will be all three apps, but
 the apps :file:`dist/bar` and :file:`dist/zap` will refer to
-the contents of :file:`dist/foo/` for shared dependencies.
+the contents of :file:`dist/foo` for shared dependencies.
 
 Remember that a spec file is executable Python.
 You can use all the Python facilities (``for`` and ``with``

--- a/news/7273.bugfix.1.rst
+++ b/news/7273.bugfix.1.rst
@@ -1,0 +1,5 @@
+Fix the problem with ``MERGE`` not properly cleaning up passed
+``Analysis.binaries`` and ``Analysis.datas`` TOCs due to changes made to
+``TOC`` class in PyInstaller 5.0. This effectively broke the supposed
+de-duplication functionality of ``MERGE`` and multi-package bundles,
+which should be restored now.

--- a/news/7273.bugfix.rst
+++ b/news/7273.bugfix.rst
@@ -1,0 +1,7 @@
+Fix potential duplication of python extension modules in ``onefile``
+builds, which happened when an extension was collected both as an
+``EXTENSION`` and as a ``DATA`` (or a ``BINARY``) TOC type. This
+resulted in run-time warnings about files already existing; the
+most notorious example being ``WARNING: file already exists but
+should not: C:\Users\user\AppData\Local\Temp\MEI1234567\torch\_C.cp39-win_amd64.pyd``
+when building ``onefile`` applications that use ``torch``.


### PR DESCRIPTION
This branch was intended as a preliminary clean-up step that would make rebasing my symlinks branch back onto `develop` a bit easier. However, the clean-up endeavor quickly morphed into attempts to fix various forms of file duplication that occur under certain build conditions.

One such problem is that in the current implementation, `EXTENSION` TOC entries keep their module-like name until the very end, when they need to be collected. This means that all codepaths need to deal with extension file name adjustment; even worse, it also means that from the TOC's perspective, the following two entries are different and are thus not de-duplicated when they should be:
```
    ('torch._C',
       '...\\site-packages\\torch\\_C.cp39-win_amd64.pyd',
       'EXTENSION'),
    ('torch\\_C.cp39-win_amd64.pyd',
       '...\\site-pakages\\torch\\_C.cp39-win_amd64.pyd',
       'DATA'),
```
So when building a onefile `torch` program, the user ends up with a
```
WARNING: file already exists but should not: C:\Users\user\AppData\Local\Temp\MEI1234567\torch\_C.cp39-win_amd64.pyd
```

As part of the cleanup/fix, we push the `EXTENSION` name resolving into analysis stage, which should take care of this problem, as well as simplify the code because now the name handling needs to be done in only one place.

Due to the planned deprecation of `TOC` class and removal of its use from the codebase, the idea was to implement extra checks that would ensure that no file duplication is introduced during the process. So we now have optional run-time and build-time checks for duplication (for onefile `PKG` extraction at run-time, and during `PKG` and `COLLECT` assembly at build-time) and all are enabled on our CI to ensure we are aware of any duplication issues.

These extra checks revealed that `MERGE` has been broken since PyInstaller v5.0 as it is not removing entries from passed `Analysis.binaries` and `Analysis.datas`, due to 14949d3 changing the way `toc[i] = (None, None, None)` works. So trying to use `MERGE` correctly fails to yield any de-duplication at all. Therefore, the second part of the PR tries to deal with `MERGE` and introduce some sanity in the related parts of the codebase.

Closes #7215 - the documentation issue part is partly addressed by #7236 and party here, and the lack of de-duplication is addressed here.