### PR TITLE
hooks: fix gi .so files not found without version suffix

### DIFF
--- a/PyInstaller/building/splash.py
+++ b/PyInstaller/building/splash.py
@@ -448,7 +448,7 @@ class Splash(Target):
         if self.minify_script:
             # Remove any documentation, empty lines and unnecessary spaces
             script = '\n'.join(
-                line for line in map(lambda l: l.strip(), script.splitlines())
+                line for line in map(lambda line: line.strip(), script.splitlines())
                 if not line.startswith('#')  # documentation
                 and line  # empty lines
             )

--- a/PyInstaller/utils/hooks/gi.py
+++ b/PyInstaller/utils/hooks/gi.py
@@ -11,6 +11,7 @@
 import os
 import re
 
+from PyInstaller.depend.utils import _resolveCtypesImports
 from PyInstaller.utils.hooks import collect_submodules, collect_system_data_files, get_hook_config
 from PyInstaller import isolated
 from PyInstaller import log as logging
@@ -112,11 +113,10 @@ class GiModuleInfo:
             raise ValueError(f"Module {self.name} {self.version} is unavailable!")
 
         # Find shared libraries
-        for lib in self.sharedlibs:
-            lib_path = findSystemLibrary(lib)
-            if lib_path:
-                logger.debug('Collecting shared library %s at %s', lib, lib_path)
-                binaries.append((lib_path, '.'))
+        resolved_libs = _resolveCtypesImports(self.sharedlibs)
+        for resolved_lib in resolved_libs:
+            logger.debug("Collecting shared library %s at %s", resolved_lib[0], resolved_lib[1])
+            binaries.append((resolved_lib[1], "."))
 
         # Find and collect .typelib file. Run it through the `gir_library_path_fix` to fix the library path, if
         # necessary.

--- a/news/7278.bugfix.rst
+++ b/news/7278.bugfix.rst
@@ -1,0 +1,3 @@
+(GNU/Linux) Fixes an issue with gi shared libraries not being packaged if they don't
+have version suffix and are in a special location set by ``LD_LIBRARY_PATH`` instead of
+a typical library path.


### PR DESCRIPTION
Fixes #7277. If a shared library on Linux doesn't have a version suffix and is in a location set by LD_LIBRARY_PATH, it isn't being packaged as a binary file properly.

Another option is, we could update the regexp directly to allow for 0 or 1 numbers with periods by adding a ? at the end:

```
def _library_matcher(name):
    return re.compile(name + r"[0-9]*\.?").match
```