### PR TITLE
Remove `$pythonprefix/bin` from `sys.path` when launched from console script.

### DIFF
--- a/PyInstaller/__main__.py
+++ b/PyInstaller/__main__.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import argparse
 import os
 import platform
+import sys
 from collections import defaultdict
 
 from PyInstaller import __version__
@@ -183,6 +184,14 @@ def run(pyi_args: list | None = None, pyi_config: dict | None = None):
     except RecursionError:
         from PyInstaller import _recursion_too_deep_message
         _recursion_too_deep_message.raise_with_msg()
+
+
+def _console_script_run():
+    # Python prepends the main script's parent directory to sys.path. When PyInstaller is ran via the usual
+    # `pyinstaller` CLI entry point, this directory is $pythonprefix/bin which should not be in sys.path.
+    if os.path.basename(sys.path[0]) in ("bin", "Scripts"):
+        sys.path.pop(0)
+    run()
 
 
 if __name__ == '__main__':

--- a/news/7120.bugfix.rst
+++ b/news/7120.bugfix.rst
@@ -1,0 +1,4 @@
+Prevent ``$pythonprefix/bin`` from being added to :data:`sys.path` when
+PyInstaller is invoked using ``pyinstaller your-code.py`` but not using
+``python -m PyInstaller your-code.py``. This prevents collection mismatch when
+a library has the same name as console script.

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ author = Hartmut Goebel, Giovanni Bajo, David Vierra, David Cortesi, Martin Zibr
 
 keywords =
     packaging, app, apps, bundle, convert, standalone, executable
-	pyinstaller, cxfreeze, freeze, py2exe, py2app, bbfreeze
+    pyinstaller, cxfreeze, freeze, py2exe, py2app, bbfreeze
 
 license = GPLv2-or-later with a special exception which allows to use PyInstaller to build and distribute non-free programs (including commercial ones)
 license_file = COPYING.txt
@@ -78,7 +78,7 @@ encryption =
 
 [options.entry_points]
 console_scripts =
-	pyinstaller = PyInstaller.__main__:run
+    pyinstaller = PyInstaller.__main__:_console_script_run
     pyi-archive_viewer = PyInstaller.utils.cliutils.archive_viewer:run
     pyi-bindepend = PyInstaller.utils.cliutils.bindepend:run
     pyi-grab_version = PyInstaller.utils.cliutils.grab_version:run


### PR DESCRIPTION
Python prepends the main script's parent directory to sys.path. When PyInstaller is ran via the usual `pyinstaller` CLI entry point, this directory is `$pythonprefix/bin` which should not be in `sys.path`.

Removing it prevents collection mismatch when a library has the same name as console script.
