### PR TITLE
Deprecate bytecode encryption (for #6999).

### DIFF
--- a/PyInstaller/archive/pyz_crypto.py
+++ b/PyInstaller/archive/pyz_crypto.py
@@ -11,7 +11,10 @@
 
 import os
 
+from PyInstaller import log as logging
+
 BLOCK_SIZE = 16
+logger = logging.getLogger(__name__)
 
 
 class PyiBlockCipher:
@@ -19,6 +22,12 @@ class PyiBlockCipher:
     This class is used only to encrypt Python modules.
     """
     def __init__(self, key=None):
+        logger.log(
+            logging.DEPRECATION,
+            "Bytecode encryption will be removed in PyInstaller v6. Please remove cipher and block_cipher parameters "
+            "from your spec file to avoid breakages on upgrade. For the rationale/alternatives see "
+            "https://github.com/pyinstaller/pyinstaller/pull/6999"
+        )
         assert type(key) is str
         if len(key) > BLOCK_SIZE:
             self.key = key[0:BLOCK_SIZE]

--- a/PyInstaller/building/makespec.py
+++ b/PyInstaller/building/makespec.py
@@ -91,6 +91,15 @@ def make_variable_path(filename, conversions=path_conversions):
     return None, filename
 
 
+def deprecated_key_option(x):
+    logger.log(
+        logging.DEPRECATION,
+        "Bytecode encryption will be removed in PyInstaller v6. Please remove your --key=xxx argument to avoid "
+        "breakages on upgrade. For the rationale/alternatives see https://github.com/pyinstaller/pyinstaller/pull/6999"
+    )
+    return x
+
+
 # An object used in place of a "path string", which knows how to repr() itself using variable names instead of
 # hard-coded paths.
 class Path:
@@ -346,7 +355,8 @@ def __add_options(parser):
     g.add_argument(
         '--key',
         dest='key',
-        help='The key used to encrypt Python bytecode.',
+        help=argparse.SUPPRESS,
+        type=deprecated_key_option,
     )
     g.add_argument(
         '--splash',

--- a/PyInstaller/log.py
+++ b/PyInstaller/log.py
@@ -12,7 +12,7 @@
 Logging module for PyInstaller.
 """
 
-__all__ = ['getLogger', 'INFO', 'WARN', 'DEBUG', 'TRACE', 'ERROR', 'FATAL']
+__all__ = ['getLogger', 'INFO', 'WARN', 'DEBUG', 'TRACE', 'ERROR', 'FATAL', 'DEPRECATION']
 
 import os
 import logging
@@ -20,7 +20,9 @@ from logging import DEBUG, ERROR, FATAL, INFO, WARN, getLogger
 
 TRACE = logging.TRACE = DEBUG - 5
 logging.addLevelName(TRACE, 'TRACE')
-LEVELS = ('TRACE', 'DEBUG', 'INFO', 'WARN', 'ERROR', 'CRITICAL')
+DEPRECATION = WARN + 5
+logging.addLevelName(DEPRECATION, 'DEPRECATION')
+LEVELS = ('TRACE', 'DEBUG', 'INFO', 'WARN', 'DEPRECATION', 'ERROR', 'CRITICAL')
 
 FORMAT = '%(relativeCreated)d %(levelname)s: %(message)s'
 _env_level = os.environ.get("PYI_LOG_LEVEL", "INFO")

--- a/README.rst
+++ b/README.rst
@@ -69,8 +69,6 @@ Requirements and Tested Platforms
     - 3.7-3.11. Note that Python 3.10.0 contains a bug making it unsupportable by
       PyInstaller. PyInstaller will also not work with beta releases of Python
       3.12.
-    - tinyaes_ 1.0+ (only if using bytecode encryption). Instead of installing
-      tinyaes, ``pip install pyinstaller[encryption]`` instead.
 - Windows (32bit/64bit):
     - PyInstaller should work on Windows 7 or newer, but we only officially support Windows 8+.
     - Support for Python installed from the Windows store without using virtual
@@ -151,7 +149,5 @@ Changes in this Release
 You can find a detailed list of changes in this release
 in the `Changelog`_ section of the manual.
 
-
-.. _tinyaes: https://github.com/naufraghi/tinyaes-py
 .. _`manual`: https://pyinstaller.org/en/v5.6.2/
 .. _`Changelog`: https://pyinstaller.org/en/v5.6.2/CHANGES.html

--- a/doc/_common_definitions.txt
+++ b/doc/_common_definitions.txt
@@ -37,7 +37,6 @@
 .. _pip: http://www.pip-installer.org/
 .. _pip-Win: https://sites.google.com/site/pydatalog/python/pip-for-windows
 .. _plistlib: https://docs.python.org/3/library/plistlib.html
-.. _tinyaes: https://github.com/naufraghi/tinyaes-py
 .. _`PyInstaller at GitHub`: https://github.com/pyinstaller/pyinstaller
 .. _`PyInstaller code signing recipe`: https://github.com/pyinstaller/pyinstaller/wiki/Recipe-OSX-Code-Signing
 .. _`PyInstaller Downloads`:  https://github.com/pyinstaller/pyinstaller/releases

--- a/doc/development/changelog-entries.rst
+++ b/doc/development/changelog-entries.rst
@@ -24,6 +24,7 @@ few simple rules:
   ``feature``,
   ``bugfix``,
   ``breaking`` (breaking changes),
+  ``deprecation``,
   ``hooks`` (all hook-related changes),
   ``bootloader``,
   ``moduleloader``,

--- a/doc/development/quickstart.rst
+++ b/doc/development/quickstart.rst
@@ -22,7 +22,7 @@ Quickstart
   for more information.
 
   Reformatting code without functional changes will generally not be accepted
-  (for rational see :issue:`2727`).
+  (for rationale see :issue:`2727`).
 
 * Write meaningful commit messages.
 

--- a/doc/operating-mode.rst
+++ b/doc/operating-mode.rst
@@ -298,12 +298,6 @@ the C to machine language.
 PyInstaller can follow import statements that refer to
 Cython C object modules and bundle them.
 
-Additionally, Python bytecode can be obfuscated with AES256 by specifying
-an encryption key on PyInstaller's command line. Please note that it is still
-very easy to extract the key and get back the original bytecode, but it
-should prevent most forms of "casual" tampering.
-See :ref:`encrypting python bytecode` for details.
-
 
 .. include:: _common_definitions.txt
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -196,26 +196,6 @@ For example, to exclude Qt5 DLLs from the PySide2 package, use
 from the PySide2 package, use ``--upx-exclude "PySide2\*.pyd"``.
 
 
-.. _encrypting python bytecode:
-
-Encrypting Python Bytecode
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-To encrypt the Python bytecode modules stored in the bundle,
-pass the :option:`--key`\ =\ *key-string*  argument on
-the command line.
-
-For this to work, you need to run::
-
-    pip install pyinstaller[encryption]
-
-The *key-string* is a string of 16 characters which is used to
-encrypt each file of Python byte-code before it is stored in
-the archive inside the executable file.
-
-This feature uses the tinyaes_ module internally for the encryption.
-
-
 .. _splash screen:
 
 Splash Screen *(Experimental)*

--- a/news/6999.deprecation.rst
+++ b/news/6999.deprecation.rst
@@ -1,0 +1,1 @@
+Deprecate bytecode encryption (the ``--key`` option), to be removed in PyInstaller v6.0.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,11 @@
 		showcontent = true
 
 	[[tool.towncrier.type]]
+		directory = "deprecation"
+		name = "Deprecations"
+		showcontent = true
+
+	[[tool.towncrier.type]]
 		directory = "hooks"
 		name = "Hooks"
 		showcontent = true

--- a/scripts/verify-news-fragments.py
+++ b/scripts/verify-news-fragments.py
@@ -28,7 +28,8 @@ CHANGELOG_GUIDE = (
 )
 
 CHANGE_TYPES = {
-    'bootloader', 'breaking', 'bugfix', 'build', 'core', 'doc', 'feature', 'hooks', 'moduleloader', 'process', 'tests'
+    'bootloader', 'breaking', 'bugfix', 'build', 'core', 'doc', 'feature', 'hooks', 'moduleloader', 'process', 'tests',
+    'deprecation'
 }
 
 NEWS_PATTERN = re.compile(r"(\d+)\.(\w+)\.(?:(\d+)\.)?rst")


### PR DESCRIPTION
* Add a new log level called DEPRECATION with higher priority than WARNING in the hopes that it'll be more visisble.
* Add deprecation log commands to instantiating pyi_crypto.PyiBlockCipher() and the --key option. This puts the warning near the top when running both with or without a spec.
* Add a deprecation category to the changelog.
