### PR TITLE
Fix for 7086

### DIFF
--- a/PyInstaller/building/toc_conversion.py
+++ b/PyInstaller/building/toc_conversion.py
@@ -108,10 +108,6 @@ class DependencyProcessor:
                 and not dist._pyinstaller_info['zip-safe']
             ):
                 # this is a un-zipped, not-zip-safe egg
-                toplevel = dist.get_metadata('top_level.txt').strip()
-                basedir = dist.location
-                if toplevel:
-                    os.path.join(basedir, toplevel)
                 tree = Tree(dist.location, excludes=PY_IGNORE_EXTENSIONS)
                 toc.extend(tree)
         return toc
@@ -146,17 +142,12 @@ class DependencyProcessor:
         logger.debug('Looking for egg data files...')
         for dist in self._distributions:
             if dist._pyinstaller_info['egg']:
-                # TODO: check in docs if top_level.txt always exists
-                toplevel = dist.get_metadata('top_level.txt').strip()
                 if dist._pyinstaller_info['zipped']:
                     # this is a zipped egg
                     tree = self.__collect_data_files_from_zip(dist.location)
                     toc.extend(tree)
                 elif dist._pyinstaller_info['zip-safe']:
                     # this is an un-zipped, zip-safe egg
-                    basedir = dist.location
-                    if toplevel:
-                        os.path.join(basedir, toplevel)
                     tree = Tree(dist.location, excludes=PY_IGNORE_EXTENSIONS)
                     toc.extend(tree)
                 else:

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -1,41 +1,65 @@
 How to Install PyInstaller
 ===============================
 
-PyInstaller is a normal Python package.
-You can download the archive from PyPi_,
-but it is easier to install using pip_ where is is available,
-for example::
+PyInstaller is available as a regular Python package.
+The source archives for released versions are available from PyPi_,
+but it is easier to install the latest version using pip_::
 
     pip install pyinstaller
 
-or upgrade to a newer version::
+To upgrade existing PyInstaller installation to the latest version, use::
 
     pip install --upgrade pyinstaller
 
-To install the current development version use::
+To install the current development version, use::
 
     pip install https://github.com/pyinstaller/pyinstaller/tarball/develop
 
+To install directly using pip's built-in git checkout support, use::
 
-Installing from the archive
+    pip install git+https://github.com/pyinstaller/pyinstaller
+
+or to install specific branch (e.g., ``develop``)::
+
+    pip install git+https://github.com/pyinstaller/pyinstaller@develop
+
+Installing from the source archive
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If pip is not available, download the compressed archive from PyPI_.
-If you are asked to test a problem using the latest development code,
-download the compressed archive from the *develop* branch of
-`PyInstaller Downloads`_ page.
+The source code archive for released versions of PyInstaller are
+available at PyPI_ and on `PyInstaller Downloads`_ page.
 
-Expand the archive.
-Inside is a script named ``setup.py``.
-Execute ``python setup.py install``
-with administrator privilege to install or upgrade PyInstaller.
+.. Note::
+    Even though the source archive provides the ``setup.py`` script,
+    installation via ``python setup.py install`` has been deprecated
+    and should not be used anymore. Instead, run ``pip install .`` from
+    the unpacked source directory, as described below.
+
+The installation procedure is:
+    1. Unpack the source archive.
+
+    2. Move into the unpacked source directory.
+
+    3. Run ``pip install .`` from the unpacked source directory. If
+       installing into system-wide python installation, administrator
+       privilege is required.
+
+The same procedure applies to installing from manual git checkout::
+
+    git clone https://github.com/pyinstaller/pyinstaller
+    cd pyinstaller
+    pip install .
+
+If you intend to make changes to the source code and want them to take
+effect immediately, without re-installing the package each time, you
+can install it in editable mode::
+
+    pip install -e .
 
 For platforms other than Windows, GNU/Linux and macOS, you must first
-build a bootloader program for your platform: see :ref:`Building the Bootloader`.
-After the bootloader has been created,
-use ``python setup.py install`` with administrator privileges
+build the bootloader for your platform: see :ref:`Building the Bootloader`.
+After the bootloader has been built, use the ``pip install .`` command
 to complete the installation.
-
 
 
 Verifying the installation
@@ -63,6 +87,15 @@ the proper directory:
 To display the current path in Windows the command is ``echo %path%``
 and in other systems, ``echo $PATH``.
 
+.. Note::
+    If you cannot use the ``pyinstaller`` command due to the scripts
+    directory not being in ``PATH``, you can instead invoke the
+    ``PyInstaller`` module, by running ``python -m PyInstaller``
+    (pay attention to the module name, which is case sensitive).
+    This form of invocation is also useful when you have PyInstaller
+    installed in multiple python environments, and you cannot be sure
+    from which installation the ``pyinstaller`` command will be ran.
+
 
 Installed commands
 ~~~~~~~~~~~~~~~~~~~~
@@ -83,15 +116,8 @@ The complete installation places these commands on the execution path:
 * ``pyi-grab_version`` is used to extract a version resource from a Windows
   executable.  See :ref:`Capturing Windows Version Data`.
 
-If you do not perform a complete installation
-(installing via ``pip`` or executing ``setup.py``),
-these commands will not be installed as commands.
-However, you can still execute all the functions documented below
-by running Python scripts found in the distribution folder.
-The equivalent of the ``pyinstaller`` command is
-:file:`{PyInstaller-folder}/pyinstaller.py`.
-The other commands are found in :file:`{PyInstaller-folder}/cliutils/`
-with meaningful names (``makespec.py``, etc.)
+* ``pyi-set_version`` can be used to apply previously-extracted version
+  resource to an existing Windows executable.
 
 
 .. include:: _common_definitions.txt

--- a/news/7086.bugfix.rst
+++ b/news/7086.bugfix.rst
@@ -1,0 +1,2 @@
+Fix spurious attempt at reading the ``top_level.txt`` metadata from
+packages installed in egg form.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,5 +81,5 @@ blank_line_before_nested_class_or_def = false
 # which has issues with unicode paths.
 requires = [
 	"wheel",
-	"setuptools",
+	"setuptools >= 42.0.0",
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ keywords =
 	pyinstaller, cxfreeze, freeze, py2exe, py2app, bbfreeze
 
 license = GPLv2-or-later with a special exception which allows to use PyInstaller to build and distribute non-free programs (including commercial ones)
-license_file = COPYING.txt
+license_files = COPYING.txt
 
 classifiers =
     Development Status :: 6 - Mature
@@ -59,7 +59,7 @@ include_package_data = False
 python_requires = >=3.7, <3.12
 ## IMPORTANT: Keep aligned with requirements.txt
 install_requires =
-    setuptools
+    setuptools >= 42.0.0
     altgraph
     pefile >= 2022.5.30 ; sys_platform == 'win32'
     pywin32-ctypes >= 0.2.0 ; sys_platform == 'win32'

--- a/setup.py
+++ b/setup.py
@@ -250,6 +250,28 @@ class bdist_wheels(Command):
 
 #--
 
+# --- Prevent `python setup.py install` from building and installing eggs ---
+
+if "bdist_egg" not in sys.argv:
+    from setuptools.command.bdist_egg import bdist_egg
+
+    class bdist_egg_disabled(bdist_egg):
+        """
+        Disabled version of bdist_egg, which prevents `setup.py install` from performing setuptools' default
+        easy_install, which is deprecated and should be avoided.
+        """
+        def run(self):
+            raise SystemExit(
+                "Error: Aborting implicit building of eggs. To install from source, use `pip install .` instead of "
+                "`python setup.py install`."
+            )
+
+    bdist_egg_override = {'bdist_egg': bdist_egg_disabled}
+else:
+    bdist_egg_override = {}
+
+#--
+
 setup(
     setup_requires=["setuptools >= 42.0.0"],
     cmdclass={
@@ -257,6 +279,7 @@ setup(
         'build': MyBuild,
         **wheel_commands,
         'bdist_wheels': bdist_wheels,
+        **bdist_egg_override,
     },
     packages=find_packages(include=["PyInstaller", "PyInstaller.*"]),
     package_data={

--- a/setup.py
+++ b/setup.py
@@ -251,7 +251,7 @@ class bdist_wheels(Command):
 #--
 
 setup(
-    setup_requires=["setuptools >= 39.2.0"],
+    setup_requires=["setuptools >= 42.0.0"],
     cmdclass={
         'build_bootloader': build_bootloader,
         'build': MyBuild,


### PR DESCRIPTION
Remove the attempt at reading `top_level.txt` metadata from egg-installed packages. The obtained top-level path is not used anywhere, and the attempt at reading it triggers #7086 when `top_level.txt` is unavailable. Fixes #7086.

Update the installation instructions to discourage bad practices and reduce the amount of misinformation.