### PR TITLE
isolated: introduce time-out in the wait for the child subprocess to exit

### DIFF
--- a/news/7290.bugfix.rst
+++ b/news/7290.bugfix.rst
@@ -1,0 +1,4 @@
+Prevent isolated-subprocess calls from indefinitely blocking in their
+clean-up codepath when the subprocess fails to exit. After the grace
+period of 5 seconds, we now attempt to terminate such subprocess in
+order to prevent hanging of the build process.


### PR DESCRIPTION
Prevent isolated-subprocess calls from indefinitely blocking in their clean-up codepath when the subprocess fails to exit. After the grace period of 5 seconds, we now attempt to terminate such subprocess in order to prevent hanging of the build process.

For the purposes of our CI, introduce a strict mode (by default controlled by the ˙compat.strict_collect_mode˙ and its backing environment variable), which raises an error instead of just printing the warning.

Fixes #7290. 
Likely fixes #7269 (which probably has a similar of not the same underlying problem).