### PR TITLE
hooks: robustify importlib_resources hook

### DIFF
--- a/PyInstaller/hooks/hook-importlib_resources.py
+++ b/PyInstaller/hooks/hook-importlib_resources.py
@@ -12,19 +12,11 @@
 `importlib_resources` is a backport of the 3.9+ module `importlib.resources`
 """
 
-import os
+from PyInstaller.utils.hooks import is_module_satisfies, collect_data_files
 
-from PyInstaller.utils.hooks import get_module_file_attribute, is_module_satisfies
-
-if is_module_satisfies("importlib_resources >= 1.2.0"):
-    # since 1.2.0 importlib.metadata is used which PyInstaller knows how to handle.
-    pass
-else:
-    # include the version.txt file, used to set __version__
-    res_loc = os.path.dirname(get_module_file_attribute('importlib_resources'))
-    datas = [
-        (os.path.join(res_loc, 'version.txt'), 'importlib_resources'),
-    ]
+# Prior to v1.2.0, a `version.txt` file is used to set __version__. Later versions use `importlib.metadata`.
+if is_module_satisfies("importlib_resources < 1.2.0"):
+    datas = collect_data_files("importlib_resources", includes=["version.txt"])
 
 if is_module_satisfies("importlib_resources >= 1.3.1"):
     hiddenimports = ['importlib_resources.trees']


### PR DESCRIPTION
Robustify the `importlib_resources` hook by replacing manual attempt at collecting `version.txt` file with the `collect_data_files` hook utility.

This is based on the traceback from #7293. Switching to `collect_data_files` ensures that we do not raise an error in abnormal cases when either
 * the `importlib_resources` is not importable (although in that case, I don't think the hook could even be fired)
 * the `importlib_resources` has no `__file__` attribute; the only way I can think of this happening is if there was a eponymous directory shadowing the actual package, and thus would appear to be a namespace package
 * the `version.txt` file does not exist for whatever other reason
 
In addition, the inverted version check also ensures that we do not attempt to collect the data if `importlib_resources` is not a valid dist (for example, if the hook was triggered by user's eponymous (namespace) package).

As far as I'm concerned, this closes #7293 (although the actual underlying reason for the error probably lies the user's environment).