### PR TITLE
ci: switch linux runners from ubuntu-latest to ubuntu-20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9, '3.10', '3.11']
-        os: ['windows-latest', 'ubuntu-latest', 'macos-11']
+        os: ['windows-latest', 'ubuntu-20.04', 'macos-11']
       fail-fast: false
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Looks like today is the day when `ubuntu-latest` becomes `ubuntu-22.04`, which is currently affected by #7197. So switch `ubuntu-latest` to `ubuntu-20.04`, and hope that Ubuntu fixes their `ldd`/`glibc` before 20.04 runners are phased out.