### PR TITLE
Simplify news fragment validation.

### DIFF
--- a/.github/workflows/validate-new-news.yml
+++ b/.github/workflows/validate-new-news.yml
@@ -12,25 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
-
-      - name: Get out of detached head state
-        run: |
-          git fetch origin ${{ github.base_ref }}
-          git fetch origin ${{ github.ref }}
-          git checkout FETCH_HEAD --
-      - name: Setup Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.7
 
       - name: Validate new news items
-        run: |
-          git diff --name-status origin/${{ github.base_ref }}
-          git diff --name-status origin/${{ github.base_ref }}\
-          | python scripts/verify-news-fragments.py
+        run: python scripts/verify-news-fragments.py
 
       - name: Install towncrier
         run: pip install -q -U setuptools wheel towncrier

--- a/scripts/verify-news-fragments.py
+++ b/scripts/verify-news-fragments.py
@@ -14,7 +14,7 @@ Verify that new news entries have valid filenames. Usage:
 
 .. code-block:: bash
 
-    git diff --name-status $COMMIT_ID | python verify-news-fragments.py
+    ./scripts/verify-news-fragments.py
 
 """
 
@@ -60,19 +60,10 @@ def validate_name(name):
 
 
 def main():
-    # Parse the output of `git diff --name-status COMMIT`
-    lines = sys.stdin.readlines()
-
-    for line in lines:
-        try:
-            action, filename = line.split(maxsplit=1)
-        except ValueError:
+    for file in NEWS_DIR.iterdir():
+        if file.name in ["README.txt", "_template.rst", ".gitignore"]:
             continue
-        filename = Path(filename.strip())
-
-        if action == "A" and filename.parts[0] == "news":
-            if filename.suffix == ".rst":
-                validate_name(filename)
+        validate_name(file)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Remove the elaborate git diff piping required to run the news validator script so as to make it less of a pain to use locally.
