### PR TITLE
hooks: Qt: do not collect "designer" plugins with QtUiTools module

### DIFF
--- a/PyInstaller/utils/hooks/qt/_modules_info.py
+++ b/PyInstaller/utils/hooks/qt/_modules_info.py
@@ -366,9 +366,8 @@ QT_MODULES_INFO = (
         "QtDesigner", shared_lib="Designer", translation="designer", plugins=["designer"], bindings=["!PySide2"]
     ),
     _QtModuleDef("QtHelp", shared_lib="Help", translation="qt_help"),
-    # Python module is available only in PySide bindings. The "designer" plugins should also be collected alongside
-    # this module (in case we do not collect QtDesigner).
-    _QtModuleDef("QtUiTools", shared_lib="UiTools", plugins=["designer"], bindings=["PySide*"]),
+    # Python module is available only in PySide bindings.
+    _QtModuleDef("QtUiTools", shared_lib="UiTools", bindings=["PySide*"]),
 
     # *** qt/qtvirtualkeyboard ***
     # No python module; shared library -> plugins association entry.

--- a/news/7322.hooks.rst
+++ b/news/7322.hooks.rst
@@ -1,0 +1,3 @@
+Do not collect ``designer`` plugins as part of ``QtUiTools`` module in
+``PySide2`` and ``PySide6`` bindings. Instead, tie the collection of
+plugins only to the ``QtDesigner`` module.


### PR DESCRIPTION
In PySide2 and PySide6 bindings, avoid collection of "designer" plugins with QtUiTools module; instead, tie collection only to the QtDesigner module.

See #7322.