### PR TITLE
building: EXE: load version info structure before comparing guts

### DIFF
--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -431,6 +431,20 @@ class EXE(Target):
         else:
             self.upx = False
 
+        # Catch and clear options that are unsupported on specific platforms.
+        if self.versrsrc and not is_win:
+            logger.warning('Ignoring version information; supported only on Windows!')
+            self.versrsrc = None
+        if self.manifest and not is_win:
+            logger.warning('Ignoring manifest; supported only on Windows!')
+            self.manifest = None
+        if self.resources and not is_win:
+            logger.warning('Ignoring resources; supported only on Windows!')
+            self.resources = []
+        if self.icon and not (is_win or is_darwin):
+            logger.warning('Ignoring icon; supported only on Windows and macOS!')
+            self.icon = None
+
         # Old .spec format included in 'name' the path where to put created app. New format includes only exename.
         #
         # Ignore fullpath in the 'name' and prepend DISTPATH or WORKPATH.
@@ -608,12 +622,6 @@ class EXE(Target):
 
         if Target._check_guts(self, data, last_build):
             return True
-
-        if (data['versrsrc'] or data['resources']) and not is_win:
-            # todo: really ignore :-)
-            logger.warning('Ignoring version, manifest and resources; platform not supported!')
-        if data['icon'] and not (is_win or is_darwin):
-            logger.warning('Ignoring icon; platform not supported!')
 
         mtm = data['mtm']
         if mtm != miscutils.mtime(self.name):

--- a/PyInstaller/utils/cliutils/grab_version.py
+++ b/PyInstaller/utils/cliutils/grab_version.py
@@ -36,13 +36,13 @@ def run():
     args = parser.parse_args()
 
     try:
-        import PyInstaller.utils.win32.versioninfo
-        vs = PyInstaller.utils.win32.versioninfo.decode(args.exe_file)
-        if not vs:
+        from PyInstaller.utils.win32 import versioninfo
+        info = versioninfo.read_version_info_from_executable(args.exe_file)
+        if not info:
             raise SystemExit("Error: VersionInfo resource not found in exe")
         with codecs.open(args.out_filename, 'w', 'utf-8') as fp:
-            fp.write(str(vs))
-        print('Version info written to: %s' % args.out_filename)
+            fp.write(str(info))
+        print(f"Version info written to: {args.out_filename!r}")
     except KeyboardInterrupt:
         raise SystemExit("Aborted by user request.")
 

--- a/PyInstaller/utils/cliutils/set_version.py
+++ b/PyInstaller/utils/cliutils/set_version.py
@@ -31,9 +31,10 @@ def run():
     exe_file = os.path.abspath(args.exe_file)
 
     try:
-        import PyInstaller.utils.win32.versioninfo
-        PyInstaller.utils.win32.versioninfo.SetVersion(exe_file, info_file)
-        print(('Version info set in: %s' % exe_file))
+        from PyInstaller.utils.win32 import versioninfo
+        info = versioninfo.load_version_info_from_text_file(info_file)
+        versioninfo.write_version_info_to_executable(exe_file, info)
+        print(f"Version info written to: {exe_file!r}")
     except KeyboardInterrupt:
         raise SystemExit("Aborted by user request.")
 

--- a/news/7338.bugfix.rst
+++ b/news/7338.bugfix.rst
@@ -1,0 +1,2 @@
+(Windows) Changes in the version info file now trigger rebuild of the
+executable file.

--- a/tests/unit/test_miscutils.py
+++ b/tests/unit/test_miscutils.py
@@ -74,7 +74,8 @@ def test_versioninfo_str(tmp_path):
     # "Serialize" to string. This is what grab_version.py utility does to write VsVersionInfo to output text file.
     vs_info_str = str(vsinfo)
 
-    # "Deserialize" via eval. This is what versioninfo.SetVersion() does to read VsVersionInfo from text file.
+    # "Deserialize" via eval. This is what `versioninfo.load_version_info_from_text_file` does to read `VsVersionInfo`
+    # from text file.
     vsinfo2 = eval(vs_info_str)
 
     assert vsinfo == vsinfo2
@@ -126,7 +127,7 @@ def test_versioninfo_written_to_exe(tmp_path):
     shutil.copyfile(bootloader_file, test_file)
 
     # Embed version info
-    versioninfo.SetVersion(test_file, vsinfo)
+    versioninfo.write_version_info_to_executable(test_file, vsinfo)
 
     # Read back the values from the string table.
     def read_file_version_info(filename, *attributes):


### PR DESCRIPTION
The first commit is a left-over from my previous cleanup in the `PyInstaller.building` module; we move the check for platform-unsupported properties in `EXE` from guts change check to the constructor. This way, we always clear the unsupported properties, and we also emit the warning on every build instead of only on repeated builds during cached state comparison. I guess that resolves the TODO that has been lurking in that part fo the code.

In the second commit, we load the version info structure in the `EXE` constructor. That way, the guts change check is performed on the actual version info data instead of the version info filename. Fixes #7338. Due to this change the `PyInstaller.utils.win32.versioninfo.SetVersion` had to be split into loading/deserialization function and writing function.