### PR TITLE
loader: remove deprecated PEP-302 functionality from FrozenImporter

### DIFF
--- a/news/7344.breaking.rst
+++ b/news/7344.breaking.rst
@@ -1,0 +1,6 @@
+The deprecated ``PEP-302`` ``find_module()`` and ``load_module()``
+methods have been removed from PyInstaller's ``FrozenImporter``. These
+methods have not been used by python's import machinery since
+python 3.4 and ``PEP-451``, and were effectively left untested and
+unmaintained. The removal affects 3rd party code that still relies
+on ``PEP-302`` finder/loader methods instead of the ``PEP-451`` ones.

--- a/news/7344.moduleloader.rst
+++ b/news/7344.moduleloader.rst
@@ -1,0 +1,3 @@
+Remove deprecated ``PEP-302`` functionality from ``FrozenImporter``.
+The ``find_module()`` and ``load_module()`` methods are deprecated
+since python 3.4 in favor of ``PEP-451`` loader.


### PR DESCRIPTION
Remove `find_module()` and `load_module()` from `FrozenImporter`. As per comments in these two methods, they are deprecated since python 3.4 in favor of PEP-451 loader, which is used by import machinery under contemporary python versions.

Also remove the `FrozenPackageImporter` class which was used only from `FrozenImporter.load_module()`.