### PR TITLE
hooks: qt6: collect multimedia plugins for QtMultimedia >= 6.4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
             libxcb-shape0-dev libxcb-xkb-dev xvfb \
             libopengl0 libegl1 \
             libpulse0 libpulse-mainloop-glib0 \
-            libgstreamer-plugins-base1.0-0 libgstreamer-gl1.0-0 \
+            gstreamer1.0-plugins-base libgstreamer-gl1.0-0 \
             gir1.2-gtk-3.0 libgirepository1.0-dev
 
       - name: Download AppImage tool

--- a/PyInstaller/utils/hooks/qt/_modules_info.py
+++ b/PyInstaller/utils/hooks/qt/_modules_info.py
@@ -285,7 +285,9 @@ QT_MODULES_INFO = (
         "QtMultimedia",
         shared_lib="Multimedia",
         translation="qtmultimedia",
-        plugins=["video/gstvideorenderer", "video/videonode"],
+        # `multimedia` plugins are available as of Qt6 >= 6.4.0; earlier versions had `video/gstvideorenderer` and
+        # `video/videonode` plugins.
+        plugins=["multimedia", "video/gstvideorenderer", "video/videonode"],
         bindings=["PySide6", "PyQt6"]
     ),
     _QtModuleDef("QtMultimediaWidgets", shared_lib="MultimediaWidgets"),

--- a/news/7352.hooks.rst
+++ b/news/7352.hooks.rst
@@ -1,0 +1,2 @@
+Collect ``multimedia`` plugins that are required by ``QtMultimedia``
+module starting with Qt6 v6.4.0.

--- a/tests/functional/test_qt.py
+++ b/tests/functional/test_qt.py
@@ -468,6 +468,21 @@ def test_Qt_QtWebEngineQuick_PySide6(pyi_builder):
     _test_Qt_QtWebEngineQuick(pyi_builder, 'PySide6')
 
 
+# QtMultimedia test that triggers error when the module's plugins are missing (#7352).
+@QtPyLibs
+def test_Qt_QtMultimedia_player_init(pyi_builder, QtPyLib):
+    pyi_builder.test_source(
+        """
+        import sys
+
+        from {0} import QtCore, QtMultimedia
+
+        app = QtCore.QCoreApplication(sys.argv)
+        player = QtMultimedia.QMediaPlayer(app)
+        """.format(QtPyLib), **USE_WINDOWED_KWARG
+    )
+
+
 # QtMultimedia test that also uses PySide's true_property, which triggers hidden dependency on QtMultimediaWidgets
 # python module.
 # See:


### PR DESCRIPTION
In Qt6 6.4.0, QtMultimedia replaced `video/gstvideorenderer` and `video/videonode` plugins with `multimedia` plugins. Update the module information to ensure that the plugins are collected.

Fixes #7352.