### PR TITLE
hooks: gi: set custom version from hooks config

### DIFF
--- a/PyInstaller/utils/hooks/gi.py
+++ b/PyInstaller/utils/hooks/gi.py
@@ -34,9 +34,9 @@ class GiModuleInfo:
         if hook_api is not None:
             module_versions = get_hook_config(hook_api, 'gi', 'module-versions')
             if module_versions:
-                version = module_versions.get(module, version)
+                self.version = module_versions.get(module, version)
 
-        logger.debug("Gathering GI module info for %s %s", module, version)
+        logger.debug("Gathering GI module info for %s %s", module, self.version)
 
         @isolated.decorate
         def _get_module_info(module, version):

--- a/tests/unit/test_hookutils_gi.py
+++ b/tests/unit/test_hookutils_gi.py
@@ -1,0 +1,31 @@
+from PyInstaller.utils.hooks.gi import GiModuleInfo
+
+
+def test_module_info():
+    module_info = GiModuleInfo("MyModule", "1.0")
+
+    assert module_info.name == "MyModule"
+    assert module_info.version == "1.0"
+
+
+def test_module_info_with_versions():
+    hook_api = hook_api_for_module_version("MyModule", "2.0")
+
+    module_info = GiModuleInfo("MyModule", "1.0", hook_api)
+
+    assert module_info.name == "MyModule"
+    assert module_info.version == "2.0"
+
+
+def hook_api_for_module_version(module, version):
+    class hook_api_stub:
+        class analysis:
+            hooksconfig = {
+                "gi": {
+                    "module-versions": {
+                        module: version,
+                    }
+                }
+            }
+
+    return hook_api_stub


### PR DESCRIPTION
In `hooksconfig.gi.module-versions` you can set what version to use for GI (gobject-introspection) based modules.

The version was not recorded correctly, which caused modules like GtkSource(View) to collect the wrong resources from their share/ folder.

This PR fixes this.

See also https://github.com/gaphor/gaphor/issues/2017.