### PR TITLE
Fix building of bootloader's test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
         run: |
           sudo apt-get update -qq
           sudo apt-get install -qq --no-install-recommends \
+            libcmocka-dev \
             libxml2-dev libxslt1-dev gfortran libatlas-base-dev \
             libespeak1 libxcb-image0 libxcb-keysyms1 libxcb-render-util0 \
             libxkbcommon-x11-0 libxcb-icccm4 libxcb1 openssl \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,17 +81,17 @@ jobs:
         run: |
           # Compile bootloader
           cd bootloader
-          CC="gcc -std=gnu90" python waf all
+          CC="gcc -std=gnu90" python waf --tests all
 
       - name: Check if bootloader is buildable with --static-zlib option
         if: startsWith(matrix.os, 'ubuntu')
-        run: cd bootloader && python waf --static-zlib all
+        run: cd bootloader && python waf --static-zlib --tests all
 
       - name: Check if bootloader is buildable for Windows ARM
         if: startsWith(matrix.os, 'windows')
         run: |
             cd bootloader
-            python waf --target-arch=64bit-arm all
+            python waf --tests --target-arch=64bit-arm all
             ls ../PyInstaller/bootloader/Windows-64bit-arm
 
       - name: Install PyInstaller
@@ -101,7 +101,7 @@ jobs:
 
           # Compile bootloader
           cd bootloader
-          python waf all
+          python waf --tests all
           cd ..
 
           # Install PyInstaller.

--- a/bootloader/src/pyi_launch.c
+++ b/bootloader/src/pyi_launch.c
@@ -53,7 +53,8 @@
  */
 
 /* Constructs the file path from given components and checks that the path exists. */
-static int
+/* NOTE: must be visible outside of this unit (i.e., non-static) due to tests! */
+int
 _format_and_check_path(char *buf, const char *fmt, ...)
 {
     va_list args;
@@ -69,7 +70,8 @@ _format_and_check_path(char *buf, const char *fmt, ...)
 }
 
 /* Splits the item in the form path:filename */
-static int
+/* NOTE: must be visible outside of this unit (i.e., non-static) due to tests! */
+int
 _split_dependency_name(char *path, char *filename, const char *item)
 {
     char *p;

--- a/bootloader/tests/test_launch.c
+++ b/bootloader/tests/test_launch.c
@@ -20,20 +20,20 @@
 #include <setjmp.h> // required fo cmocka :-(
 #include <cmocka.h>
 
-int checkFile(char *buf, const char *fmt, ...);
+int _format_and_check_path(char *buf, const char *fmt, ...);
 
-static void test_checkFile(void **state) {
+static void test__format_and_check_path(void **state) {
     char result[PATH_MAX];
 
     // TODO: use some mocks to determine stat() output
 
     errno = 0;
-    assert_int_equal(-1, checkFile(result, "%s%s%s.pkg", "a1", "bb", "cc", "dd"));
+    assert_int_equal(-1, _format_and_check_path(result, "%s%s%s.pkg", "a1", "bb", "cc", "dd"));
     assert_int_not_equal(errno, 0); // formatting passed, stat failed
     assert_string_equal(result, "a1bbcc.pkg");
 
     errno = 0;
-    assert_int_equal(-1, checkFile(result, "%s", ""));
+    assert_int_equal(-1, _format_and_check_path(result, "%s", ""));
     assert_int_not_equal(errno, 0); // formatting passed, stat failed
     assert_string_equal(result, "");
 
@@ -42,55 +42,55 @@ static void test_checkFile(void **state) {
     // a few bytes more
     errno = 0;
     path2[PATH_MAX+8] = '\0';
-    assert_int_equal(-1, checkFile(result, "%s%s%s.pkg", "a1", path2, "ccc"));
+    assert_int_equal(-1, _format_and_check_path(result, "%s%s%s.pkg", "a1", path2, "ccc"));
     assert_int_equal(errno, 0); // formatting formatting failed
     // exact length
     errno = 0;
     path2[PATH_MAX] = '\0';
-    assert_int_equal(-1, checkFile(result, "%s", path2));
+    assert_int_equal(-1, _format_and_check_path(result, "%s", path2));
     assert_int_equal(errno, 0); // formatting formatting failed
     // one byte less
     errno = 0;
     path2[PATH_MAX-1] = '\0';
-    assert_int_equal(-1, checkFile(result, "%s", path2));
+    assert_int_equal(-1, _format_and_check_path(result, "%s", path2));
     assert_int_not_equal(errno, 0); // formatting passed, stat failed
 }
 
-int splitName(char *path, char *filename, const char *item);
+int _split_dependency_name(char *path, char *filename, const char *item);
 
-static void test_splitName(void **state) {
+static void test_split_dependency_name(void **state) {
     char path[PATH_MAX];
     char filename[PATH_MAX];
 
     // TODO: use some mocks to determine
 
-    assert_int_equal(0, splitName(path, filename, "aaa:bbb"));
+    assert_int_equal(0, _split_dependency_name(path, filename, "aaa:bbb"));
     assert_string_equal(path, "aaa");
     assert_string_equal(filename, "bbb");
 
-    assert_int_equal(-1, splitName(path, filename, ""));
-    assert_int_equal(-1, splitName(path, filename, ":"));
-    assert_int_equal(-1, splitName(path, filename, "aaa"));
-    assert_int_equal(-1, splitName(path, filename, "aaa:"));
-    assert_int_equal(-1, splitName(path, filename, ":bbb"));
+    assert_int_equal(-1, _split_dependency_name(path, filename, ""));
+    assert_int_equal(-1, _split_dependency_name(path, filename, ":"));
+    assert_int_equal(-1, _split_dependency_name(path, filename, "aaa"));
+    assert_int_equal(-1, _split_dependency_name(path, filename, "aaa:"));
+    assert_int_equal(-1, _split_dependency_name(path, filename, ":bbb"));
 
     // these cases are not expected to occur in real life
-    assert_int_equal(0, splitName(path, filename, "aaa:::"));
+    assert_int_equal(0, _split_dependency_name(path, filename, "aaa:::"));
     assert_string_equal(filename, "::");
-    assert_int_equal(-1, splitName(path, filename, ":::bbb"));
+    assert_int_equal(-1, _split_dependency_name(path, filename, ":::bbb"));
 
     char *path2 = (char *) malloc(PATH_MAX+10);
     memset(path2, 'a', PATH_MAX+8);
     path2[10] = ':';
     // a few bytes more
     path2[PATH_MAX+8] = '\0';
-    assert_int_equal(-1, splitName(path, filename, path2));
+    assert_int_equal(-1, _split_dependency_name(path, filename, path2));
     // exact length
     path2[PATH_MAX] = '\0';
-    assert_int_equal(-1, splitName(path, filename, path2));
+    assert_int_equal(-1, _split_dependency_name(path, filename, path2));
     // one byte less
     path2[PATH_MAX-1] = '\0';
-    assert_int_equal(0, splitName(path, filename, path2));
+    assert_int_equal(0, _split_dependency_name(path, filename, path2));
     assert_string_equal(path, "aaaaaaaaaa");
 }
 
@@ -101,8 +101,8 @@ int main(void)
 #endif
 {
     const struct CMUnitTest tests[] = {
-        cmocka_unit_test(test_checkFile),
-        cmocka_unit_test(test_splitName),
+        cmocka_unit_test(test__format_and_check_path),
+        cmocka_unit_test(test_split_dependency_name),
     };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/bootloader/tests/wscript
+++ b/bootloader/tests/wscript
@@ -19,9 +19,9 @@ def build(ctx):
         if ctx.env.DEST_OS == 'win32':
             # Z: inflate*()
             # ADVAPI32: ConvertStringSecurityDescriptorToSecurityDescriptorW()
-            extra_libs=['ADVAPI32', 'Z']
+            extra_libs=['ADVAPI32', 'Z', 'STATIC_ZLIB']
         else:
-            extra_libs=[]
+            extra_libs=['STATIC_ZLIB']
         ctx.program(
             source= ["test_%s.c" % name],
             target="test_%s" % name,

--- a/bootloader/tests/wscript
+++ b/bootloader/tests/wscript
@@ -11,7 +11,10 @@
 # -----------------------------------------------------------------------------
 
 def configure(ctx):
-    ctx.check_cc(lib='cmocka', mandatory=False, uselib_store='CMOCKA')
+    ctx.msg('Build tests', "enabled" if ctx.options.enable_tests else "disabled")
+    if ctx.options.enable_tests:
+        ctx.check_cc(lib='cmocka', mandatory=False, uselib_store='CMOCKA')
+
 
 def build(ctx):
 
@@ -37,6 +40,6 @@ def build(ctx):
         # be WinMain() instead of main().
         return
 
-    if "LIB_CMOCKA" in ctx.env:
+    if ctx.options.enable_tests and "LIB_CMOCKA" in ctx.env:
         test_program("path")
         test_program("launch")

--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -170,6 +170,20 @@ def options(ctx):
         'This is always done on Windows.',
         default=False,
     )
+    ctx.add_option(
+        '--tests',
+        action='store_true',
+        help='Enable cmocka-based tests if cmocka library is found. The tests are disabled by default.',
+        default=False,
+        dest='enable_tests',
+    )
+    ctx.add_option(
+        '--no-tests',
+        action='store_false',
+        help='Disable cmocka-based tests, even if cmocka library is found. The tests are disabled by default.',
+        default=False,
+        dest='enable_tests',
+    )
 
     grp = ctx.add_option_group('Linux Standard Base (LSB) compliance', 'These options have effect only on Linux.')
     grp.add_option(


### PR DESCRIPTION
Fix building of bootloader's `cmocka`-based test suite, following the renaming of tested functions in ac87b6bc19977a3a0f8bfe89c0843579f6e3f6d7 and separation of `Z` and `STATIC_ZLIB` targets in #7263.

Make the tests explicitly opt-in via `--tests` command-line argument (I would have preferred `--enable-tests`, but we already have several `--something` / `--no-something` switches...). This should minimize the damage that the potentially broken and out-of-date test suite can inflict on unsuspecting users that happen to have `cmocka` installed. And for good measure, do not even look for `cmocka` if tests are not enabled.

On the CI, opt-in to the tests, and install `libcmocka-dev` on ubuntu runner so that we have at least one place where we try to build the test suite.

Fixes #7381.