### PR TITLE
building: disallow empty source path in binaries/datas tuples

### DIFF
--- a/PyInstaller/building/utils.py
+++ b/PyInstaller/building/utils.py
@@ -509,6 +509,13 @@ def format_binaries_and_datas(binaries_or_datas, workingdir=None):
     toc_datas = set()
 
     for src_root_path_or_glob, trg_root_dir in binaries_or_datas:
+        # Disallow empty source path. Those are typically result of errors, and result in implicit collection of the
+        # whole current working directory, which is never a good idea.
+        if not src_root_path_or_glob:
+            raise SystemExit(
+                "Empty SRC is not allowed when adding binary and data files, as it would result in collection of the "
+                "whole current working directory."
+            )
         if not trg_root_dir:
             raise SystemExit(
                 "Empty DEST not allowed when adding binary and data files. Maybe you want to used %r.\nCaused by %r." %

--- a/news/7384.bugfix.rst
+++ b/news/7384.bugfix.rst
@@ -1,0 +1,6 @@
+Disallow empty source path in the ``binaries`` and ``datas`` tuples
+that are returned from the hooks and sanitized in the
+``PyInstaller.building.utils.format_binaries_and_datas``. The empty
+source path is usually result of an error in the hook's path retrieval
+code, and causes implicit collection of the whole current working
+directory. This is never the intended behavior, so raise a ``SystemExit``.

--- a/tests/unit/test_building_utils.py
+++ b/tests/unit/test_building_utils.py
@@ -25,6 +25,14 @@ def test_format_binaries_and_datas_not_found_raises_error(tmpdir):
         utils.format_binaries_and_datas(datas, str(tmpdir))
 
 
+def test_format_binaries_and_datas_empty_src(tmpdir):
+    # `format_binaries_and_datas()` must disallow empty src in `binaries`/`datas` tuples, as those result in implicit
+    # collection of the whole current working directory .
+    datas = [('', '.')]
+    with pytest.raises(SystemExit, match="Empty SRC is not allowed"):
+        utils.format_binaries_and_datas(datas, str(tmpdir))
+
+
 def test_format_binaries_and_datas_1(tmpdir):
     def _(path):
         return os.path.join(*path.split('/'))


### PR DESCRIPTION
Disallow empty source path in the `binaries` and `datas` tuples that are returned from the hooks and sanitized in the ``PyInstaller.building.utils.format_binaries_and_datas``.

The empty source path is usually result of an error in the hook's path retrieval code, and causes implicit collection of the whole current working directory. This is never the intended behavior, so raise a ``SystemExit``.