### PR TITLE
Fix PyInstaller under Cygwin

### DIFF
--- a/PyInstaller/building/utils.py
+++ b/PyInstaller/building/utils.py
@@ -33,7 +33,7 @@ from PyInstaller.depend import dylib
 from PyInstaller.depend.bindepend import match_binding_redirect
 from PyInstaller.utils import misc
 
-if is_win or is_cygwin:
+if is_win:
     from PyInstaller.utils.win32 import versioninfo, winmanifest, winresource
 
 if is_darwin:
@@ -235,7 +235,7 @@ def checkCache(
             return cachedfile
 
     # Optionally change manifest and its dependencies to private assemblies.
-    if fnm.lower().endswith(".manifest") and (is_win or is_cygwin):
+    if fnm.lower().endswith(".manifest") and is_win:
         manifest = winmanifest.Manifest()
         manifest.filename = fnm
         with open(fnm, "rb") as f:
@@ -267,7 +267,7 @@ def checkCache(
                 strict_arch_validation=strict_arch_validation,
             )
         # We need to avoid using UPX with Windows DLLs that have Control Flow Guard enabled, as it breaks them.
-        if (is_win or is_cygwin) and versioninfo.pefile_check_control_flow_guard(fnm):
+        if is_win and versioninfo.pefile_check_control_flow_guard(fnm):
             logger.info('Disabling UPX for %s due to CFG!', fnm)
         elif misc.is_file_qt_plugin(fnm):
             logger.info('Disabling UPX for %s due to it being a Qt plugin!', fnm)
@@ -305,7 +305,7 @@ def checkCache(
             pass
     os.chmod(cachedfile, 0o755)
 
-    if os.path.splitext(fnm.lower())[1] in (".pyd", ".dll") and (is_win or is_cygwin):
+    if os.path.splitext(fnm.lower())[1] in (".pyd", ".dll") and is_win:
         # When shared assemblies are bundled into the app, they may optionally be changed into private assemblies.
         try:
             res = winmanifest.GetManifestResources(os.path.abspath(cachedfile))

--- a/PyInstaller/utils/hooks/tcl_tk.py
+++ b/PyInstaller/utils/hooks/tcl_tk.py
@@ -139,12 +139,12 @@ def find_tcl_tk_shared_libs(tkinter_ext_file):
     _tkinter_imports = bindepend.getImports(tkinter_ext_file)
 
     def _get_library_path(lib):
-        if not compat.is_win and not compat.is_cygwin:
-            # Non-Windows systems return the path of the library.
-            path = lib
-        else:
-            # We need to find the library.
+        if compat.is_win:
+            # On Windows, we need to resolve full path to the library.
             path = bindepend.getfullnameof(lib)
+        else:
+            # Non-Windows systems (including Cygwin) already return full path to the library.
+            path = lib
         return path
 
     for lib in _tkinter_imports:

--- a/news/7382.bugfix.rst
+++ b/news/7382.bugfix.rst
@@ -1,0 +1,3 @@
+(Cygwin) Avoid using Windows-specific codepaths that require
+``pywin32-ctypes`` functionality that is not available in Cygwin
+environment.


### PR DESCRIPTION
When running under Cygwin, avoid using Windows-specific codepaths that require `pywin32-ctypes` functionality that is not available in Cygwin environment.

Fixes the first part of #7382 (missing `PyInstaller.compat.win32api` when running under Cygwin). The second part of the issue seems to be caused by Cygwin's `ldd` freezing, and is not specific to PyInstaller.