### PR TITLE
Re-license PyInstaller.isolated + its tests under MIT.

### DIFF
--- a/COPYING.txt
+++ b/COPYING.txt
@@ -46,7 +46,19 @@ Version 2.0.
 Run-time Hooks are in the directory
 ./PyInstaller/hooks/rthooks
 
- 
+
+The PyInstaller.isolated submodule
+----------------------------------
+
+By request, the PyInstaller.isolated submodule and its corresponding tests are
+additionally licensed with the MIT license so that it may be reused outside of
+PyInstaller under GPL 2.0 or MIT terms and conditions -- whichever is the most
+suitable to the recipient downstream project. Affected files/directories are:
+
+./PyInstaller/isolated/
+./tests/unit/test_isolation.py
+
+
 About the PyInstaller Development Team
 --------------------------------------
 
@@ -600,3 +612,25 @@ Apache License 2.0
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+===========
+MIT License
+===========
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/PyInstaller/isolated/__init__.py
+++ b/PyInstaller/isolated/__init__.py
@@ -2,11 +2,11 @@
 # Copyright (c) 2021-2023, PyInstaller Development Team.
 #
 # Distributed under the terms of the GNU General Public License (version 2
-# or later) with exception for distributing the bootloader.
+# or later) or, at the user's discretion, the MIT License.
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #
-# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception OR MIT)
 # -----------------------------------------------------------------------------
 """
 PyInstaller hooks typically will need to import the package which they are written for but doing so may manipulate

--- a/PyInstaller/isolated/_child.py
+++ b/PyInstaller/isolated/_child.py
@@ -2,11 +2,11 @@
 # Copyright (c) 2021-2023, PyInstaller Development Team.
 #
 # Distributed under the terms of the GNU General Public License (version 2
-# or later) with exception for distributing the bootloader.
+# or later) or, at the user's discretion, the MIT License.
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #
-# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception OR MIT)
 # -----------------------------------------------------------------------------
 """
 The child process to be invoked by IsolatedPython().

--- a/PyInstaller/isolated/_parent.py
+++ b/PyInstaller/isolated/_parent.py
@@ -2,11 +2,11 @@
 # Copyright (c) 2021-2023, PyInstaller Development Team.
 #
 # Distributed under the terms of the GNU General Public License (version 2
-# or later) with exception for distributing the bootloader.
+# or later) or, at the user's discretion, the MIT License.
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #
-# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception OR MIT)
 # -----------------------------------------------------------------------------
 
 import os

--- a/tests/unit/test_isolation.py
+++ b/tests/unit/test_isolation.py
@@ -2,11 +2,11 @@
 # Copyright (c) 2021-2023, PyInstaller Development Team.
 #
 # Distributed under the terms of the GNU General Public License (version 2
-# or later) with exception for distributing the bootloader.
+# or later) or, at the user's discretion, the MIT License.
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #
-# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception OR MIT)
 #-----------------------------------------------------------------------------
 
 import os


### PR DESCRIPTION
It has been requested that `PyInstaller.isolated` be made reusable by other, permissively licensed projects. (#7386)

That portion of the codebase has so far only picked up two contributors and can therefore be re-licensed with just the consent of those two.
