### PR TITLE
Add pypi.org/project/pathlib to the list of prohibited stdlib back-ports.

### DIFF
--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -751,7 +751,7 @@ def check_requirements():
     else:
         from importlib_metadata import distribution, PackageNotFoundError
 
-    for name in ["enum34", "typing"]:
+    for name in ["enum34", "typing", "pathlib"]:
         try:
             dist = distribution(name)
         except PackageNotFoundError:


### PR DESCRIPTION
Would theoretically have prevented #7380.