### PR TITLE
rhtooks: multiprocessing: use class-wide lock to prevent race conditions

### DIFF
--- a/news/7410.bugfix.rst
+++ b/news/7410.bugfix.rst
@@ -1,0 +1,3 @@
+(non-Windows) Fix race condition in environment modification done by
+``multiprocessing`` runtime hook when multiple threads concurrently
+spawn processes using the ``spawn`` method.


### PR DESCRIPTION
Use class-wide lock in the `FrozenSupportMixIn` constructor in `multiprocessing` run-time hook to  prevent race conditions between `os.putenv` and `os.unsetenv` calls when processes are spawned concurrently from multiple threads. This essentially serializes process spawning and its associated environment modifications (which are done in main process and inherited by child ones).

Fixes #7410.

Also get rid of redunant check for `sys.frozen`.