### PR TITLE
Suppress `invalid nullptr parameter` warning during `QSslSocket.supportsSsl()`

### DIFF
--- a/PyInstaller/utils/hooks/qt/__init__.py
+++ b/PyInstaller/utils/hooks/qt/__init__.py
@@ -588,6 +588,11 @@ class QtLibraryInfo:
         def _ssl_enabled(package):
             import importlib
 
+            # Create QCoreApplication instance (to suppress warnings)
+            # equivalent to: from package import QtCore
+            QtCore = importlib.import_module('.QtCore', package)
+            QtCore.QCoreApplication()
+
             # Import the Qt-based package
             # equivalent to: from package.QtNetwork import QSslSocket
             QtNetwork = importlib.import_module('.QtNetwork', package)

--- a/PyInstaller/utils/hooks/qt/__init__.py
+++ b/PyInstaller/utils/hooks/qt/__init__.py
@@ -588,15 +588,17 @@ class QtLibraryInfo:
         def _ssl_enabled(package):
             import importlib
 
-            # Create QCoreApplication instance (to suppress warnings)
-            # equivalent to: from package import QtCore
-            QtCore = importlib.import_module('.QtCore', package)
-            QtCore.QCoreApplication()
-
             # Import the Qt-based package
+            # equivalent to: from package.QtCore import QCoreApplication
+            QtCore = importlib.import_module('.QtCore', package)
+            QCoreApplication = QtCore.QCoreApplication
             # equivalent to: from package.QtNetwork import QSslSocket
             QtNetwork = importlib.import_module('.QtNetwork', package)
             QSslSocket = QtNetwork.QSslSocket
+
+            # Instantiate QCoreApplication to suppress warnings
+            app = QCoreApplication([])  # noqa: F841
+
             return QSslSocket.supportsSsl()
 
         if not _ssl_enabled(self.namespace):


### PR DESCRIPTION
In #7415, I "documented" how to fix a warning regarding `qt.tlsbackend.ossl`, and was pointed to the fact that this warning was emitted by Qt. I therefore filed https://bugreports.qt.io/browse/PYSIDE-2216 to find out why the other warning was emitted.

Turns out, 
> The warning is printed when no instance of Q(Core)Application is present.

So we create this instance to suppress the warning.