### PR TITLE
CI and tests update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
         run: >
             pytest
             -n 3 --maxfail 3 --durations 10 tests/unit tests/functional
-            --force-flaky --no-flaky-report --reruns 3 --reruns-delay 10
+            --force-flaky --no-flaky-report
 
       # hooksample is installed as part of tests/requirements-libraries.txt, so run this step only if we
       # installed all libraries.
@@ -169,7 +169,7 @@ jobs:
           foo
           pytest
           -n 3 --maxfail 3 --durations 10 tests/unit tests/functional
-          --force-flaky --no-flaky-report --reruns 3 --reruns-delay 10
+          --force-flaky --no-flaky-report
 
       # Verify that installing from sdist works. This is mostly just a verification that the MANIFEST.in contains
       # all the extras needed to compile the bootloader.

--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -2,7 +2,7 @@ name: Lock Closed Threads
 
 on:
   schedule:
-    - cron: '0 * * * *'
+    - cron: '0 12 * * *'
   workflow_dispatch:
 
 permissions:

--- a/tests/requirements-tools.txt
+++ b/tests/requirements-tools.txt
@@ -20,12 +20,12 @@ pytest-xdist
 
 # Plugin to abort hanging tests.
 pytest-timeout >= 2.0.0
-# allows specifying order without duplicates
+
+# Allows specifying order without duplicates
 pytest-drop-dup-tests
-# reruns failed flaky tests
-# Pin pytest-rerunfailures to 11.0 due to problems with 11.1:
-# https://github.com/pytest-dev/pytest-rerunfailures/issues/206
-pytest-rerunfailures==11.0
+
+# Ability to retry a failed test
+flaky
 
 # Better subprocess alternative with implemented timeout.
 psutil
@@ -40,6 +40,3 @@ lxml; python_version < '3.11'
 
 # crypto support (`--key` option)
 tinyaes ~= 1.0; python_version < '3.11'
-
-# Ability to retry a failed test
-flaky


### PR DESCRIPTION
- run the `lock-threads` workflow only once per day
- do not install and use `pytest-rerunfailures`; try sticking with `flaky` for now, as per https://github.com/pyinstaller/pyinstaller/pull/7439#issuecomment-1427113403