### PR TITLE
setup: Move package discovery and package data options to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -54,6 +54,7 @@ classifiers =
     Topic :: Utilities
 
 [options]
+packages = find:
 zip_safe = False
 include_package_data = False
 python_requires = >=3.7, <3.12
@@ -66,6 +67,20 @@ install_requires =
     macholib >= 1.8 ; sys_platform == 'darwin'
     pyinstaller-hooks-contrib >= 2021.4
     importlib-metadata >= 1.4 ; python_version < '3.8'
+
+[options.packages.find]
+include =
+    PyInstaller
+    PyInstaller.*
+
+[options.package_data]
+PyInstaller =
+    # Include all bootloaders in wheels by default.
+    bootloader/*/*
+    # These files need to be explicitly included as well.
+    fake-modules/*.py
+    hooks/rthooks.dat
+    lib/README.rst
 
 [options.extras_require]
 ; for 3rd-party packages testing their hooks in their CI:

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ import os
 import subprocess
 from typing import Type
 
-from setuptools import setup, find_packages
+from setuptools import setup
 
 #-- plug-in building the bootloader
 
@@ -282,16 +282,5 @@ setup(
         **wheel_commands,
         'bdist_wheels': bdist_wheels,
         **bdist_egg_override,
-    },
-    packages=find_packages(include=["PyInstaller", "PyInstaller.*"]),
-    package_data={
-        "PyInstaller": [
-            # Include all bootloaders in wheels by default.
-            "bootloader/*/*",
-            # These files need to be explicitly included as well.
-            "fake-modules/*.py",
-            "hooks/rthooks.dat",
-            "lib/README.rst",
-        ],
     },
 )


### PR DESCRIPTION
When digging into an issue with pipenv (pypa/pipenv#5360) - it was failing to install/lock
pyinstaller from source, I was able to extract the following exception traceback [1].
It led me to investigate why could setuptools say that,
and mixed use of `setup.cfg` and `setup()` seems to be causing issues for setuptools as used by pipenv...

<details><summary>[1] - traceback</summary>

```
  File "/var/home/ievgenp/src/pipenv/pipenv/vendor/requirementslib/models/setup_info.py", line 1107, in parse_setup_cfg
    parsed = setuptools_parse_setup_cfg(self.setup_cfg.as_posix())
  File "/var/home/ievgenp/src/pipenv/pipenv/vendor/requirementslib/models/setup_info.py", line 499, in setuptools_parse_setup_cfg
    parsed = read_configuration(path)
  File "/var/home/ievgenp/.pyenv/versions/3.7.9/lib/python3.7/site-packages/setuptools/config/setupcfg.py", line 65, in read_configuration
    handlers = _apply(dist, filepath, filenames, ignore_option_errors)
  File "/var/home/ievgenp/.pyenv/versions/3.7.9/lib/python3.7/site-packages/setuptools/config/setupcfg.py", line 98, in _apply
    dist, dist.command_options, ignore_option_errors=ignore_option_errors
  File "/var/home/ievgenp/.pyenv/versions/3.7.9/lib/python3.7/site-packages/setuptools/config/setupcfg.py", line 175, in parse_configuration
    meta.parse()
  File "/var/home/ievgenp/.pyenv/versions/3.7.9/lib/python3.7/site-packages/setuptools/config/setupcfg.py", line 508, in parse
    section_parser_method(section_options)
  File "/var/home/ievgenp/.pyenv/versions/3.7.9/lib/python3.7/site-packages/setuptools/config/setupcfg.py", line 482, in parse_section
    self[name] = value
  File "/var/home/ievgenp/.pyenv/versions/3.7.9/lib/python3.7/site-packages/setuptools/config/setupcfg.py", line 290, in __setitem__
    value = parser(value)
  File "/var/home/ievgenp/.pyenv/versions/3.7.9/lib/python3.7/site-packages/setuptools/config/setupcfg.py", line 614, in _parse_version
    return expand.version(self._parse_attr(value, self.package_dir, self.root_dir))
  File "/var/home/ievgenp/.pyenv/versions/3.7.9/lib/python3.7/site-packages/setuptools/config/setupcfg.py", line 423, in _parse_attr
    package_dir.update(self.ensure_discovered.package_dir)
  File "/var/home/ievgenp/.pyenv/versions/3.7.9/lib/python3.7/_collections_abc.py", line 720, in __iter__
    yield from self._mapping
  File "/var/home/ievgenp/.pyenv/versions/3.7.9/lib/python3.7/site-packages/setuptools/config/expand.py", line 462, in __iter__
    return iter(self._target())
  File "/var/home/ievgenp/.pyenv/versions/3.7.9/lib/python3.7/site-packages/setuptools/config/expand.py", line 452, in _target
    self._value = self._obtain()
  File "/var/home/ievgenp/.pyenv/versions/3.7.9/lib/python3.7/site-packages/setuptools/config/expand.py", line 422, in _get_package_dir
    self()
  File "/var/home/ievgenp/.pyenv/versions/3.7.9/lib/python3.7/site-packages/setuptools/config/expand.py", line 412, in __call__
    self._dist.set_defaults(name=False)  # Skip name, we can still be parsing
  File "/var/home/ievgenp/.pyenv/versions/3.7.9/lib/python3.7/site-packages/setuptools/discovery.py", line 341, in __call__
    self._analyse_package_layout(ignore_ext_modules)
  File "/var/home/ievgenp/.pyenv/versions/3.7.9/lib/python3.7/site-packages/setuptools/discovery.py", line 374, in _analyse_package_layout
    or self._analyse_flat_layout()
  File "/var/home/ievgenp/.pyenv/versions/3.7.9/lib/python3.7/site-packages/setuptools/discovery.py", line 431, in _analyse_flat_layout
    return self._analyse_flat_packages() or self._analyse_flat_modules()
  File "/var/home/ievgenp/.pyenv/versions/3.7.9/lib/python3.7/site-packages/setuptools/discovery.py", line 437, in _analyse_flat_packages
    self._ensure_no_accidental_inclusion(top_level, "packages")
  File "/var/home/ievgenp/.pyenv/versions/3.7.9/lib/python3.7/site-packages/setuptools/discovery.py", line 467, in _ensure_no_accidental_inclusion
    raise PackageDiscoveryError(cleandoc(msg))
  setuptools.errors.PackageDiscoveryError: Multiple top-level packages discovered in a flat-layout: ['icons', 'release', 'bootloader', 'PyInstaller'].

  To avoid accidental inclusion of unwanted files or directories,
  setuptools will not proceed with this build.

  If you are trying to create a single distribution with multiple packages
  on purpose, you should not rely on automatic discovery.
  Instead, consider the following options:

  1. set up custom discovery (`find` directive with `include` or `exclude`)
  2. use a `src-layout`
  3. explicitly set `py_modules` or `packages` with a list of names

  To find more information, look for "package discovery" on setuptools docs.
  Traceback (most recent call last):
    File "/var/home/ievgenp/src/pipenv/pipenv/patched/pip/_vendor/packaging/specifiers.py", line 634, in __init__
      parsed.add(Specifier(specifier))
    File "/var/home/ievgenp/src/pipenv/pipenv/patched/pip/_vendor/packaging/specifiers.py", line 98, in __init__
      raise InvalidSpecifier(f"Invalid specifier: '{spec}'")
  pipenv.patched.pip._vendor.packaging.specifiers.InvalidSpecifier: Invalid specifier: '==attr: PyInstaller.__version__'
```
</details>

P.S. Now, I must confess, I did not dig very deep, and it may even be an issue with setuptools... but this is as far as I can go today :)