### PR TITLE
Prevent pyinstaller-hooks-contrib *randomly* shadowing hooks from packages.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,6 @@ jobs:
           pip install --progress-bar=off --upgrade --requirement tests/requirements-tools.txt
 
       - name: Install test dependencies (libraries)
-        id: install_libraries
         if: ${{ !endsWith(matrix.python-version, '-dev') }}
         run: |
           pip install --progress-bar=off --upgrade --requirement tests/requirements-libraries.txt
@@ -147,10 +146,19 @@ jobs:
             -n 3 --maxfail 3 --durations 10 tests/unit tests/functional
             --force-flaky --no-flaky-report
 
-      # hooksample is installed as part of tests/requirements-libraries.txt, so run this step only if we
-      # installed all libraries.
+      # Install and test PyInstaller Hook Sample, to ensure that tests declared in
+      # entry-points are discovered.
+      - name: Install hooksample
+        run: pip install "https://github.com/pyinstaller/hooksample/archive/v4.0rc1.zip"
+
+      - name: Inject bogus hook
+        shell: python
+        run: |
+          from _pyinstaller_hooks_contrib.hooks.stdhooks import __path__ as path
+          with open(path[0] + "/hook-pyi_hooksample.py", "w") as f:
+              f.write('assert 0, "Wrong hook! Use the pyi_hooksample copy instead!"\n')
+
       - name: Run hooksample tests
-        if: steps.install_libraries.outcome == 'success'
         run: |
           # The ``run_tests`` script is invoked with the ``-c`` option to
           # specify a ``pytest.ini``, rather than allowing pytest to find

--- a/PyInstaller/building/build_main.py
+++ b/PyInstaller/building/build_main.py
@@ -108,6 +108,8 @@ def discover_hook_directories():
     from PyInstaller.log import logger
 
     entry_points = pkg_resources.iter_entry_points('pyinstaller40', 'hook-dirs')
+    # Ensure that pyinstaller_hooks_contrib comes last so that hooks from packages providing their own take priority.
+    entry_points = sorted(entry_points, key=lambda x: x.module_name == "_pyinstaller_hooks_contrib.hooks")
 
     hook_directories = []
     for entry_point in entry_points:

--- a/PyInstaller/depend/imphook.py
+++ b/PyInstaller/depend/imphook.py
@@ -116,7 +116,8 @@ class ModuleHookCache(dict):
                 module_name = os.path.basename(hook_filename)[5:-3]
                 if module_name in self:
                     logger.warning(
-                        "Several hooks defined for module %r. Please take care they do not conflict.", module_name
+                        "Several hooks defined for module %r. Using %r.", module_name,
+                        self[module_name][0].hook_filename
                     )
 
                 # Lazily loadable hook object.

--- a/news/7456.feature.rst
+++ b/news/7456.feature.rst
@@ -1,0 +1,1 @@
+Choose :ref:`hooks provided by packages <provide hooks with package>` over hooks from `pyinstaller-hooks-contrib<github.com/pyinstaller/pyinstaller-hooks-contrib/>`_ if both provide the same hook.

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -66,8 +66,3 @@ Pillow==9.4.0
 # numpy dropped support for python 3.7 as of 1.22
 numpy==1.24.2; python_version >= '3.8'
 numpy==1.21.5; python_version == '3.7'  # pyup: ignore
-
-
-# Install PyInstaller Hook Sample, to ensure that tests declared in
-# entry-points are discovered.
-https://github.com/pyinstaller/hooksample/archive/v4.0rc1.zip  # pyup: ignore


### PR DESCRIPTION
When both pyinstaller-hooks-contrib and a library contain a hook for that library, the hook from the library should take priority. That way a package which has a hook in pyinstaller-hooks-contrib can switch to taking ownership of their hook without our (likely out of date) version clobbering their efforts.

Currently, they have the same priority meaning that which hook is actually used is non deterministic.
