### PR TITLE
Propagate sys.path to PyInstaller.isolated subprocesses.

### DIFF
--- a/PyInstaller/isolated/_child.py
+++ b/PyInstaller/isolated/_child.py
@@ -90,6 +90,8 @@ if __name__ == '__main__':
 
     with _open(read_from_parent, "rb") as read_fh:
         with _open(write_to_parent, "wb") as write_fh:
+            sys.path = loads(b64decode(read_fh.readline()))
+
             # Keep receiving and running instructions until the parent sends the signal to stop.
             while run_next_command(read_fh, write_fh):
                 pass

--- a/news/7456.bugfix.rst
+++ b/news/7456.bugfix.rst
@@ -1,0 +1,2 @@
+Fix changes to :data:`sys.path` made in the spec file being ignored by hook
+utility functions (e.g. :func:`~PyInstaller.utils.hooks.collect_submodules`).

--- a/tests/unit/test_hookutils.py
+++ b/tests/unit/test_hookutils.py
@@ -108,9 +108,6 @@ TEST_MOD_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'hookut
 
 @pytest.fixture
 def mod_list(monkeypatch):
-    # Add 'hookutils_files' to sys.path (so ``is_package`` can find it) and to
-    # ``pathex`` (so code run in a subprocess can find it).
-    monkeypatch.setattr('PyInstaller.config.CONF', {'pathex': [TEST_MOD_PATH]})
     monkeypatch.syspath_prepend(TEST_MOD_PATH)
     # Use the hookutils_test_files package for testing.
     return collect_submodules(TEST_MOD)


### PR DESCRIPTION
Fixes #7456.
