### PR TITLE
analysis: fix import exclusion for relative imports and complex cases

### DIFF
--- a/news/7495.bugfix.1.rst
+++ b/news/7495.bugfix.1.rst
@@ -1,0 +1,7 @@
+Extend the ``excludedimports`` mechanism rework from :issue:`7066`
+to properly handle the case of multiple submodules being imported in a
+single ``from ... import ...`` statement (using absolute or relative import).
+For example, when package ``c`` does ``from d import e, f``, we need to
+consider potential ``excludedimports`` rules matching package ``d`` and,
+if ``d`` itself is not excluded, potential rules individually matching
+``d.e`` and ``d.f``.

--- a/news/7495.bugfix.rst
+++ b/news/7495.bugfix.rst
@@ -1,0 +1,5 @@
+Extend the ``excludedimports`` mechanism rework from :issue:`7066`
+to properly handle relative imports within the package. For example,
+ensure that ``excludedimports = ['a.b']`` within the hook for package
+``a`` takes effect when package ``a`` does ``from . import b`` (in
+addition to ``from a import b``).


### PR DESCRIPTION
Extend the import exclusion mechanism to properly account for relative imports (`from . import b` made within package `a`) and multiple imports (`from a import b, c`).