### PR TITLE
hooks: rework the multiprocessing run-time hook

### DIFF
--- a/PyInstaller/hooks/rthooks/pyi_rth_multiprocessing.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_multiprocessing.py
@@ -9,91 +9,103 @@
 # SPDX-License-Identifier: Apache-2.0
 #-----------------------------------------------------------------------------
 
-import threading
-import multiprocessing
-import multiprocessing.spawn as spawn
-# 'spawn' multiprocessing needs some adjustments on osx
-import os
-import sys
-from subprocess import _args_from_interpreter_flags
 
-# prevent spawn from trying to read __main__ in from the main script
-multiprocessing.process.ORIGINAL_DIR = None
+def _pyi_rth_multiprocessing():
+    import os
+    import sys
 
+    import threading
+    import multiprocessing
+    import multiprocessing.spawn
 
-def _freeze_support():
-    # We want to catch the two processes that are spawned by the multiprocessing code:
-    # - the semaphore tracker, which cleans up named semaphores in the spawn multiprocessing mode
-    # - the fork server, which keeps track of worker processes in forkserver mode.
-    # both of these processes are started by spawning a new copy of the running executable, passing it the flags from
-    # _args_from_interpreter_flags and then "-c" and an import statement.
-    # Look for those flags and the import statement, then exec() the code ourselves.
+    from subprocess import _args_from_interpreter_flags
 
-    if (
-        len(sys.argv) >= 2 and sys.argv[-2] == '-c' and sys.argv[-1].startswith((
-            'from multiprocessing.semaphore_tracker import main',  # Py<3.8
-            'from multiprocessing.resource_tracker import main',  # Py>=3.8
-            'from multiprocessing.forkserver import main'
-        )) and set(sys.argv[1:-2]) == set(_args_from_interpreter_flags())
-    ):
-        exec(sys.argv[-1])
-        sys.exit()
+    # Prevent `spawn` from trying to read `__main__` in from the main script
+    multiprocessing.process.ORIGINAL_DIR = None
 
-    if spawn.is_forking(sys.argv):
-        kwds = {}
-        for arg in sys.argv[2:]:
-            name, value = arg.split('=')
-            if value == 'None':
-                kwds[name] = None
-            else:
-                kwds[name] = int(value)
-        spawn.spawn_main(**kwds)
-        sys.exit()
+    def _freeze_support():
+        # We want to catch the two processes that are spawned by the multiprocessing code:
+        # - the semaphore tracker, which cleans up named semaphores in the `spawn` multiprocessing mode
+        # - the fork server, which keeps track of worker processes in the `forkserver` mode.
+        # Both of these processes are started by spawning a new copy of the running executable, passing it the flags
+        # from `_args_from_interpreter_flags` and then "-c" and an import statement.
+        # Look for those flags and the import statement, then `exec()` the code ourselves.
 
+        if (
+            len(sys.argv) >= 2 and sys.argv[-2] == '-c' and sys.argv[-1].startswith((
+                'from multiprocessing.semaphore_tracker import main',  # Py<3.8
+                'from multiprocessing.resource_tracker import main',  # Py>=3.8
+                'from multiprocessing.forkserver import main'
+            )) and set(sys.argv[1:-2]) == set(_args_from_interpreter_flags())
+        ):
+            exec(sys.argv[-1])
+            sys.exit()
 
-multiprocessing.freeze_support = spawn.freeze_support = _freeze_support
-
-# Bootloader unsets _MEIPASS2 for child processes to allow running PyInstaller binaries inside pyinstaller binaries.
-# This is ok for mac or unix with fork() system call. But on Windows we need to overcome missing fork() function.
-
-if sys.platform.startswith('win'):
-    import multiprocessing.popen_spawn_win32 as forking
-else:
-    import multiprocessing.popen_fork as forking
-    import multiprocessing.popen_spawn_posix as spawning
-
-
-# Mix-in to re-set _MEIPASS2 from sys._MEIPASS.
-class FrozenSupportMixIn:
-    _lock = threading.Lock()
-
-    def __init__(self, *args, **kw):
-        # The whole code block needs be executed under a lock to prevent race conditions between `os.putenv` and
-        # `os.unsetenv` calls when processes are spawned concurrently from multiple threads. See #7410.
-        with self._lock:
-            # We have to set original _MEIPASS2 value from sys._MEIPASS to get --onefile mode working.
-            os.putenv('_MEIPASS2', sys._MEIPASS)  # @UndefinedVariable
-            try:
-                super().__init__(*args, **kw)
-            finally:
-                # On some platforms (e.g. AIX) 'os.unsetenv()' is not available. In those cases we cannot delete the
-                # variable but only set it to the empty string. The bootloader can handle this case.
-                if hasattr(os, 'unsetenv'):
-                    os.unsetenv('_MEIPASS2')
+        if multiprocessing.spawn.is_forking(sys.argv):
+            kwds = {}
+            for arg in sys.argv[2:]:
+                name, value = arg.split('=')
+                if value == 'None':
+                    kwds[name] = None
                 else:
-                    os.putenv('_MEIPASS2', '')
+                    kwds[name] = int(value)
+            multiprocessing.spawn.spawn_main(**kwds)
+            sys.exit()
+
+    multiprocessing.freeze_support = multiprocessing.spawn.freeze_support = _freeze_support
+
+    # Bootloader clears the `_MEIPASS2` environment variable, which allows a PyInstaller-frozen executable to run a
+    # different PyInstaller-frozen executable. However, in the case of `multiprocessing`, we are actually trying
+    # to run the same executable, so we need to restore `_MEIPASS2` to prevent onefile executable from unpacking
+    # again in a different directory.
+    #
+    # This is needed for `spawn` start method (default on Windows and macOS) and also with `forkserver` start method
+    # (available on Linux and macOS). It is not needed for `fork` start method (default on Linux and other Unix OSes),
+    # because fork copies the parent process instead of starting it from scratch.
+
+    # Mix-in to re-set _MEIPASS2 from sys._MEIPASS.
+    class FrozenSupportMixIn:
+        _lock = threading.Lock()
+
+        def __init__(self, *args, **kw):
+            # The whole code block needs be executed under a lock to prevent race conditions between `os.putenv` and
+            # `os.unsetenv` calls when processes are spawned concurrently from multiple threads. See #7410.
+            with self._lock:
+                # We have to set original _MEIPASS2 value from sys._MEIPASS to get --onefile mode working.
+                os.putenv('_MEIPASS2', sys._MEIPASS)  # @UndefinedVariable
+                try:
+                    super().__init__(*args, **kw)
+                finally:
+                    # On some platforms (e.g. AIX) 'os.unsetenv()' is not available. In those cases we cannot delete the
+                    # variable but only set it to the empty string. The bootloader can handle this case.
+                    if hasattr(os, 'unsetenv'):
+                        os.unsetenv('_MEIPASS2')
+                    else:
+                        os.putenv('_MEIPASS2', '')
+
+    if sys.platform.startswith('win'):
+        # Windows; patch `Popen` for `spawn` start method
+        from multiprocessing import popen_spawn_win32
+
+        class _SpawnPopen(FrozenSupportMixIn, popen_spawn_win32.Popen):
+            pass
+
+        popen_spawn_win32.Popen = _SpawnPopen
+    else:
+        # UNIX OSes; patch `Popen` for `spawn` and `forkserver` start methods
+        from multiprocessing import popen_spawn_posix
+        from multiprocessing import popen_forkserver
+
+        class _SpawnPopen(FrozenSupportMixIn, popen_spawn_posix.Popen):
+            pass
+
+        class _ForkserverPopen(FrozenSupportMixIn, popen_forkserver.Popen):
+            pass
+
+        popen_spawn_posix.Popen = _SpawnPopen
+        popen_forkserver.Popen = _ForkserverPopen
 
 
-# Patch forking.Popen to re-set _MEIPASS2 from sys._MEIPASS.
-class _Popen(FrozenSupportMixIn, forking.Popen):
-    pass
-
-
-forking.Popen = _Popen
-
-if not sys.platform.startswith('win'):
-    # Patch spawning.Popen to re-set _MEIPASS2 from sys._MEIPASS.
-    class _Spawning_Popen(FrozenSupportMixIn, spawning.Popen):
-        pass
-
-    spawning.Popen = _Spawning_Popen
+# Run the hook function, then delete it. This prevents unnecessary pollution of the global namespace.
+_pyi_rth_multiprocessing()
+del _pyi_rth_multiprocessing

--- a/news/7494.bugfix.rst
+++ b/news/7494.bugfix.rst
@@ -1,0 +1,7 @@
+Reorganize the ``multiprocessing`` run-time hook to override ``Popen``
+implementations only for ``spawn`` and ``forkserver`` start methods,
+but not for the ``fork`` start method. This avoids a dead-lock when
+attempting to perform nested multiprocessing using the ``fork`` start
+method, which occurred due to override-provided lock (introduced in
+:issue:`7411`) being copied in its locked state into the forked
+sub-process.


### PR DESCRIPTION
Provide custom override of the `Popen` only for `spawn` and `forkserver` start methods. These run the `sys.executable` from scratch, and therefore need the `_MEIPASS2` environment variable restored.

In contrast, we do not need to override `Popen` for `fork`, which forks the current process, without re-running the executable. Even more, forking the process means that the child process inherits a copy of the lock in the `FrozenSupportMixIn` class; for nested multiprocess calls using the `fork` method, the lock is copied in the locked state, leading to deadlock.

Fixes #7494.

At the same time, reorganize the hook by wrapping all its functionality into a function that is executed and deleted afterwards. This minimizes the pollution of the global namespace with elements from the run-time hook.