### PR TITLE
hooks: improve support for matplotlib >= 3.7.0

### DIFF
--- a/PyInstaller/hooks/hook-matplotlib.py
+++ b/PyInstaller/hooks/hook-matplotlib.py
@@ -10,6 +10,8 @@
 #-----------------------------------------------------------------------------
 
 from PyInstaller import isolated
+from PyInstaller import compat
+from PyInstaller.utils import hooks as hookutils
 
 
 @isolated.decorate
@@ -21,3 +23,16 @@ def mpl_data_dir():
 datas = [
     (mpl_data_dir(), "matplotlib/mpl-data"),
 ]
+
+binaries = []
+
+# Windows PyPI wheels for `matplotlib` >= 3.7.0 use `delvewheel`.
+# In addition to DLLs from `matplotlib.libs` directory, which should be picked up automatically by dependency analysis
+# in contemporary PyInstaller versions, we also need to collect the load-order file. This used to be required for
+# python <= 3.7 (that lacked `os.add_dll_directory`), but is also needed for Anaconda python 3.8 and 3.9, where
+# `delvewheel` falls back to load-order file codepath due to Anaconda breaking `os.add_dll_directory` implementation.
+if compat.is_win and hookutils.is_module_satisfies('matplotlib >= 3.7.0'):
+    delvewheel_datas, delvewheel_binaries = hookutils.collect_delvewheel_libs_directory('matplotlib')
+
+    datas += delvewheel_datas
+    binaries += delvewheel_binaries

--- a/news/7503.hooks.rst
+++ b/news/7503.hooks.rst
@@ -1,0 +1,4 @@
+(Windows) Improve support for ``matplotlib >= 3.7.0`` by collecting all
+``delvewheel``-generated files from the ``matplotlib.libs`` directory,
+including the load-order file. This is required when PyPI ``matplotlib``
+wheels are used in combination with Anaconda python 3.8 and 3.9.


### PR DESCRIPTION
Improve support for `matplotlib` >= 3.7.0, where Windows PyPI wheels use `delvewheel` now.

Ensure that in addition to the DLLs from `matplotlib.libs` directory, we also collect the load-order file, which is still necessary with Anaconda python 3.8 and 3.9.

Fixes #7503.