### PR TITLE
depend: ensure PyiModuleGraph.get_collected_packages returns plain strings

### DIFF
--- a/PyInstaller/depend/analysis.py
+++ b/PyInstaller/depend/analysis.py
@@ -844,8 +844,10 @@ class PyiModuleGraph(ModuleGraph):
         """
         Return the list of collected python packages.
         """
+        # `node.identifier` might be an instance of `modulegraph.Alias`, hence explicit conversion to `str`.
         return [
-            node.identifier for node in self.iter_graph(start=self._top_script_node) if type(node).__name__ == 'Package'
+            str(node.identifier) for node in self.iter_graph(start=self._top_script_node)
+            if type(node).__name__ == 'Package'
         ]
 
 

--- a/news/7515.bugfix.rst
+++ b/news/7515.bugfix.rst
@@ -1,0 +1,3 @@
+Fix marshal error in binary dependency search stage, caused by the list
+of collected packages containing a `modulegraph.Alias` instance instead
+of only plain `str` instances.


### PR DESCRIPTION
Explicitly convert `node.identifier` to plain `str` to avoid later marshal errors when `node.identifier` happens to be an instance of `modulegraph.Alias`.

Fixes #7515.