### PR TITLE
building: ensure binaries from spec file undergo dependency analysis

### DIFF
--- a/PyInstaller/building/build_main.py
+++ b/PyInstaller/building/build_main.py
@@ -411,10 +411,7 @@ class Analysis(Target):
         self.noarchive = noarchive
         self.module_collection_mode = module_collection_mode or {}
 
-        self.__postinit__()
-
-        # TODO: create a function to convert datas/binaries from 'hook format' to TOC.
-        # Initialise 'binaries' and 'datas' with lists specified in .spec file.
+        # Initialize 'binaries' and 'datas' with lists specified in .spec file.
         if binaries:
             logger.info("Appending 'binaries' from .spec")
             for name, pth in format_binaries_and_datas(binaries, workingdir=spec_dir):
@@ -423,6 +420,8 @@ class Analysis(Target):
             logger.info("Appending 'datas' from .spec")
             for name, pth in format_binaries_and_datas(datas, workingdir=spec_dir):
                 self.datas.append((name, pth, 'DATA'))
+
+        self.__postinit__()
 
     _GUTS = (  # input parameters
         ('inputs', _check_guts_eq),  # parameter `scripts`

--- a/news/7522.bugfix.rst
+++ b/news/7522.bugfix.rst
@@ -1,0 +1,4 @@
+Ensure that binaries that are manually specified in the .spec file (or
+via corresponding `--add-binary` or ˙--collect-binaries˙ command-line
+switches) undergo the binary dependency analysis, so their dependencies
+are automatically collected.


### PR DESCRIPTION
Merge the `binaries` and `datas` lists that are passed as arguments to `Analysis` into `Analysis.binaries` and `Analysis.datas` before the `__postinit__` call instead of after it.

This ensures that binaries that are manually specified via the spec file (or the corresponding `--add-binary` or `--collect-binaries` command-line switches) undergo binary dependency analysis.