### PR TITLE
bootloader: fix building on e2k with lcc compiler

### DIFF
--- a/bootloader/src/pyi_launch.c
+++ b/bootloader/src/pyi_launch.c
@@ -356,6 +356,10 @@ pyi_launch_extract_binaries(ARCHIVE_STATUS *archive_status, SPLASH_STATUS *splas
     return retcode;
 }
 
+
+/* These helper functions are used only in windowed bootloader variants. */
+#if defined(WINDOWED)
+
 /*
  * Extract python exception message (string representation) from pvalue
  * part of the error indicator data returned by PyErr_Fetch().
@@ -453,6 +457,8 @@ _pyi_extract_exception_traceback(PyObject *ptype, PyObject *pvalue,
 
     return retval;
 }
+
+#endif /* if defined(WINDOWED) */
 
 /*
  * Run scripts

--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -54,8 +54,6 @@ _pyi_allow_pkg_sideload(const char *executable)
     uint64_t magic_offset;
     unsigned char magic[8];
 
-    int rc = 0;
-
     /* First, find the PKG sideload signature in the executable */
     file = pyi_path_fopen(executable, "rb");
     if (!file) {

--- a/bootloader/src/pyi_utils.c
+++ b/bootloader/src/pyi_utils.c
@@ -1081,7 +1081,6 @@ pyi_utils_create_child(const char *thisfile, const ARCHIVE_STATUS* status,
 {
     pid_t pid = 0;
     int rc = 0;
-    int i;
 
     /* cause nonzero return unless this is overwritten
      * with a successful return code from wait() */

--- a/bootloader/waflib/Tools/c_config.py
+++ b/bootloader/waflib/Tools/c_config.py
@@ -57,6 +57,7 @@ MACRO_TO_DEST_CPU = {
     '__s390__': 's390',
     '__sh__': 'sh',
     '__xtensa__': 'xtensa',
+    '__e2k__': 'e2k',
     '__riscv': 'riscv',
 }
 

--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -157,13 +157,6 @@ def options(ctx):
         dest='target_arch',
     )
     ctx.add_option(
-        '--show-warnings',
-        action='store_true',
-        help='Make gcc print out the warnings we consider as being non-fatal. All other warnings are still treated as '
-        'errors. Remember to delete the `build` directory first to ensure all files are actually recompiled.',
-        dest='show_warnings',
-    )
-    ctx.add_option(
         '--static-zlib',
         action='store_true',
         help='Statically compile zlib into the bootloaders rather than dynamically linking to the system-wide copy. '
@@ -571,8 +564,6 @@ def configure(ctx):
                 '-Wno-error=unused-function',
             ]
         )
-        if not ctx.options.show_warnings:
-            ctx.env.append_value('CFLAGS', ['-Wno-unused-variable', '-Wno-unused-function'])
 
     # ** Defines, includes **
 

--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -562,7 +562,15 @@ def configure(ctx):
         # Turn on all warnings to improve code quality and avoid errors. Unused variables and unused functions are still
         # accepted to avoid even more conditional code. If you are ever tempted to change this, review the commit
         # history of this place first.
-        ctx.env.append_value('CFLAGS', ['-Wall', '-Werror', '-Wno-error=unused-variable', '-Wno-error=unused-function'])
+        ctx.env.append_value(
+            'CFLAGS', [
+                '-Wall',
+                '-Werror',
+                '-Wno-error=unused-variable',
+                '-Wno-error=unused-but-set-variable',
+                '-Wno-error=unused-function',
+            ]
+        )
         if not ctx.options.show_warnings:
             ctx.env.append_value('CFLAGS', ['-Wno-unused-variable', '-Wno-unused-function'])
 


### PR DESCRIPTION
The first two patches in this PR were sent to me via e-mail, and fix building bootloader on e2k platform with lcc compiler. The first one is a cherry-pick of https://gitlab.com/ita1024/waf/-/commit/260f6065b98ecbcfe376639e3af7b307cab02357 (we already have [a similar cherry pick for RISC-V](https://gitlab.com/ita1024/waf/-/commit/a82625297d082e0e7b0cfa9f0bf1291081f0fdfd)). The second one demotes a particular variant of unused-variable compiler warning to non-fatal, as the lcc 1.26.16 compiler seems a bit more picky (or rather, more specific in the warning variants).

The second patch made me realize that we are, in fact, suppressing some compiler warnings on gcc, which we should be addressing instead. So I've removed the `--show-warnings` option from our waf script - we now always display the warnings, even if they are considered non-fatal. And then fixed the warnings by cleaning up the unused variables and putting the unused functions behind an ifdef.