### PR TITLE
bootloader: linux: ignore /proc/self/exe when launched via ld.so

### DIFF
--- a/bootloader/src/pyi_path.h
+++ b/bootloader/src/pyi_path.h
@@ -33,6 +33,8 @@ bool pyi_path_executable(char *execfile, const char *appname);
 bool pyi_path_homepath(char *homepath, const char *executable);
 bool pyi_path_archivefile(char *archivefile, const char *executable);
 
+bool pyi_path_is_symlink(const char *path);
+
 #ifdef _WIN32
 FILE *pyi_path_fopen(const char *filename, const char *mode);
 #else

--- a/news/7551.bugfix.rst
+++ b/news/7551.bugfix.rst
@@ -1,0 +1,5 @@
+(Linux) Ignore the executable name resolution based on ``/proc/self/exe``
+when the PyInstaller-frozen executable is launched via the ``ld.so``
+dynamic loader executable. In such cases, the resolved name points to
+the ``ld.so`` executable, causing the PyInstaller-frozen executable to
+fail with *Cannot open PyInstaller archive from executable...* error.


### PR DESCRIPTION
When PyInstaller-frozen executable is launched via ld.so dynamic loader (e.g., `/lib64/ld-linux-x86-64.so.2 ./frozen_program`), the result of `/proc/self/exe` name resolution needs to be ignored, as it points to the `ld.so` program instead of the actual PyInstaller executable.

Therefore, we now try to detect if `/proc/self/exe` name matches the `ld.so` pattern (`ld-*.so.*`), and if it does, fall back to regular name analysis. In this fall-back mode, if the executable is a symbolic link, we need to explicitly resolve it ourselves.

See #7551.