### PR TITLE
tests: Replace flake8 with ruff

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,14 +26,14 @@ jobs:
         python-version: 3.8
 
     - name: Install dependencies
-      run: pip install --upgrade flake8 wheel setuptools yapf==0.32.0 toml
+      run: pip install --upgrade ruff setuptools toml wheel yapf==0.32.0
 
     - name: Test that yapf has been applied
       # If this check fails for your PR, run `yapf -rip .`
       run: yapf --recursive --parallel --diff .
 
     - name: Run Lint
-      run: flake8 .
+      run: ruff --format=github .
 
     - name: Test Packaging
       run: |

--- a/PyInstaller/depend/analysis.py
+++ b/PyInstaller/depend/analysis.py
@@ -599,7 +599,7 @@ class PyiModuleGraph(ModuleGraph):
         mg_type = type(node).__name__
         assert mg_type is not None
 
-        if typecode and not (mg_type in typecode):
+        if typecode and mg_type not in typecode:
             # Type is not a to be selected one, skip this one
             return None
         # Extract the identifier and a path if any.

--- a/PyInstaller/hooks/hook-matplotlib.backends.py
+++ b/PyInstaller/hooks/hook-matplotlib.backends.py
@@ -69,7 +69,7 @@ def _recursive_scan_code_objects_for_mpl_use(co):
             # matplotlib.use(backend) or matplotlib.use(backend, force)
             # We support only literal arguments. Similarly, kwargs are
             # not supported.
-            if not len(args) in {1, 2} or not isinstance(args[0], str):
+            if len(args) not in {1, 2} or not isinstance(args[0], str):
                 continue
             if name in mpl_use_names:
                 backends.append(args[0])

--- a/PyInstaller/isolated/__init__.py
+++ b/PyInstaller/isolated/__init__.py
@@ -27,5 +27,5 @@ This submodule provides:
 
 """
 
-# flake8: noqa
+# ruff: noqa
 from ._parent import Python, call, decorate

--- a/doc/_common_definitions.txt
+++ b/doc/_common_definitions.txt
@@ -17,7 +17,6 @@
 .. _Docker: https://www.docker.com/
 .. _`GPL License`: https://raw.github.com/pyinstaller/pyinstaller/develop/COPYING.txt
 .. _FAQ: https://github.com/pyinstaller/pyinstaller/wiki/FAQ
-.. _flake8: https://flake8.pycqa.org/
 .. _Git: http://git-scm.com/downloads
 .. _GraphViz: https://graphviz.org/
 .. _Homebrew: http://brew.sh/
@@ -49,6 +48,7 @@
 .. _PySide: http://qt-project.org/wiki/About-PySide
 .. _PyWin32: http://sourceforge.net/projects/pywin32/files/
 .. _Qt: http://www.qt-project.org
+.. _ruff: https://ruff.rs/docs/
 .. _setup_tools: https://pypi.python.org/pypi/setuptools
 .. _`shared COLLECT statement`: https://www.zacoding.com/en/post/pyinstaller-create-multiple-executables/
 .. _`Package resources`: https://pythonhosted.org/setuptools/pkg_resources.html#requirements-parsing

--- a/doc/development/coding-conventions.rst
+++ b/doc/development/coding-conventions.rst
@@ -6,7 +6,7 @@ Coding conventions
 The PyInstaller project follows the :pep:`8` Style Guide for Python Code for
 new code.
 It uses yapf_ to do the bulk of the formatting (mostly putting spaces in the
-correct places) automatically and flake8_ to validate :pep:`8` rules which yapf_
+correct places) automatically and ruff_ to validate :pep:`8` rules which yapf_
 doesn't cover.
 
 Before submitting changes to PyInstaller, please check your code with both
@@ -14,15 +14,15 @@ tools.
 
 To install them run::
 
-    pip install flake8 yapf==0.32.0 toml
+    pip install ruff toml yapf==0.32.0
 
 Reformat your code automatically with yapf_::
 
     yapf -rip .
 
-Then manually adjust your code based on any suggestions given by flake8_::
+Then manually adjust your code based on any suggestions given by ruff_::
 
-    git diff -U0 last-commit-id-which-you-did-not-write -- | flake8 --diff -
+    ruff --fix .
 
 
 Please abstain from reformatting existing code, even it it doesn't follow

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,43 @@
+[tool.ruff]
+exclude = [
+   ".git",
+   "bootloader",
+   "build",
+   "dist",
+   "doc/_build",
+   "doc/conf.py",
+   "PyInstaller/lib",
+   "tests/functional/data/name_clash_with_entry_point",
+   "tests/functional/data/sphinx/conf.py",
+   "tests/unit/test_modulegraph",
+]
+ignore = ["PLC1901"]
+line-length=120
+select = [
+  "C90",     # McCabe cyclomatic complexity
+  "DTZ",     # flake8-datetimez
+  "E",       # pycodestyle
+  "F",       # Pyflakes
+  "INT",     # flake8-gettext
+  "PLC",     # Pylint conventions
+  "PLE",     # Pylint errors
+  "PLR091",  # Pylint refactor just for max-args, max-branches, etc.
+  "PYI",     # flake8-pyi
+  "T10",     # flake8-debugger
+  "W",       # pycodestyle
+  "YTT",     # flake8-2020
+]
+# show-source = true
+
+[tool.ruff.mccabe]
+max-complexity = 52
+
+[tool.ruff.pylint]
+max-args = 42
+max-branches = 65
+max-returns = 13
+max-statements = 148
+
 [tool.towncrier]
 	filename = "doc/CHANGES.rst"
 	directory = "news"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,32 +11,13 @@ exclude = [
    "tests/functional/data/sphinx/conf.py",
    "tests/unit/test_modulegraph",
 ]
-ignore = ["PLC1901"]
 line-length=120
 select = [
-  "C90",     # McCabe cyclomatic complexity
-  "DTZ",     # flake8-datetimez
-  "E",       # pycodestyle
-  "F",       # Pyflakes
-  "INT",     # flake8-gettext
-  "PLC",     # Pylint conventions
-  "PLE",     # Pylint errors
-  "PLR091",  # Pylint refactor just for max-args, max-branches, etc.
-  "PYI",     # flake8-pyi
-  "T10",     # flake8-debugger
-  "W",       # pycodestyle
-  "YTT",     # flake8-2020
+  "E",       # pycodestyle errors
+  "F",       # pyflakes
+  "W",       # pycodestyle warnings
 ]
-# show-source = true
-
-[tool.ruff.mccabe]
-max-complexity = 52
-
-[tool.ruff.pylint]
-max-args = 42
-max-branches = 65
-max-returns = 13
-max-statements = 148
+show-source = true
 
 [tool.towncrier]
 	filename = "doc/CHANGES.rst"

--- a/setup.cfg
+++ b/setup.cfg
@@ -170,21 +170,3 @@ markers =
     darwin: only run on macOS
     linux: only runs on GNU/Linux
     win32: only runs on Windows
-
-
-[flake8]
-exclude =
-   .git,
-   doc/_build,
-   doc/conf.py,
-   build,
-   dist,
-   bootloader,
-   PyInstaller/lib,
-   tests/functional/data/sphinx/conf.py,
-   tests/functional/data/name_clash_with_entry_point
-   tests/unit/test_modulegraph,
-show-source = True
-# E265 - block comment should start with '# '
-extend-ignore = E265
-max-line-length=120

--- a/tests/requirements-tools.txt
+++ b/tests/requirements-tools.txt
@@ -30,7 +30,7 @@ flaky
 # Better subprocess alternative with implemented timeout.
 psutil
 
-# Check new ruff violations on pull requests
+# Check new linter violations on pull requests
 ruff
 
 # These are required by some of basic tests

--- a/tests/requirements-tools.txt
+++ b/tests/requirements-tools.txt
@@ -30,8 +30,8 @@ flaky
 # Better subprocess alternative with implemented timeout.
 psutil
 
-# Check new flake8 violations on pull requests
-flake8
+# Check new ruff violations on pull requests
+ruff
 
 # These are required by some of basic tests
 pywin32; sys_platform == 'win32'


### PR DESCRIPTION
[Ruff](https://beta.ruff.rs/) supports [over 500 lint rules](https://beta.ruff.rs/docs/rules) and can be used to replace [Flake8](https://pypi.org/project/flake8/) (plus dozens of plugins), [isort](https://pypi.org/project/isort/), [pydocstyle](https://pypi.org/project/pydocstyle/), [yesqa](https://github.com/asottile/yesqa), [eradicate](https://pypi.org/project/eradicate/), [pyupgrade](https://pypi.org/project/pyupgrade/), and [autoflake](https://pypi.org/project/autoflake/), all while executing (in Rust) tens or hundreds of times faster than any individual tool.

`ruff --format=github .` in GitHub Actions runs in <1 sec to rapidly provide intuitive GitHub Annotations to contributors.

![image](https://user-images.githubusercontent.com/3709715/223758136-afc386d2-70aa-4eff-953a-2c2d82ceea23.png)