### PR TITLE
archive: fix TOC entry alignment in PKG/CArchive

### DIFF
--- a/PyInstaller/archive/writers.py
+++ b/PyInstaller/archive/writers.py
@@ -277,14 +277,16 @@ class CArchiveWriter:
             name = name.encode('utf-8')
             name_length = len(name) + 1  # add 1 for a '\0'
 
-            # Align to 16-byte boundary so xplatform C can read
+            # Ensure TOC entries are aligned on 16-byte boundary, so they can be read by bootloader (C code) on
+            # platforms with strict data alignment requirements (for example linux on `armhf`/`armv7`, such as 32-bit
+            # Debian Buster on Raspberry Pi).
             entry_length = cls._TOC_ENTRY_LENGTH + name_length
             if entry_length % 16 == 0:
                 name_padding = b'\0'
             else:
                 padding_length = 16 - (entry_length % 16)
                 name_padding = b'\0' * padding_length
-            name_length += padding_length
+                name_length += padding_length
 
             # Serialize
             serialized_entry = struct.pack(

--- a/news/7566.bugfix.rst
+++ b/news/7566.bugfix.rst
@@ -1,0 +1,5 @@
+Fix regression on platforms with strict data alignment requirements
+(such as linux on `armhf`/`armv7`), caused by bug in PKG/CArchive
+generation that was introduced during the archive writer code cleanup.
+The regression caused executable to terminate with ``Bus error`` on
+the affected platforms, such as 32-bit Debian Buster on Raspberry Pi 4.


### PR DESCRIPTION
The archive writers clean-up in #7518 introduced a subtle bug that causes incorrect padding of TOC entries that require no padding; such entries receive padding of the previously-processed entry.

This in turn breaks 16-byte alignment of the TOC entries, causing bus error when running onefile executable on platforms with stricter alignment requirements, for example armhf (32-bit Raspian OS).

Fixes #7566.