### PR TITLE
bootloader: check if gcc supports -Wno-error=unused-but-set-variable

### DIFF
--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -560,10 +560,13 @@ def configure(ctx):
                 '-Wall',
                 '-Werror',
                 '-Wno-error=unused-variable',
-                '-Wno-error=unused-but-set-variable',
                 '-Wno-error=unused-function',
             ]
         )
+
+        # -Wno-error=unused-but-set-variable is not available on old gcc versions (e.g., 4.4.3)
+        if ctx.check_cc(cflags='-Wno-error=unused-but-set-variable', execute=False, mandatory=False):
+            ctx.env.append_value('CFLAGS', ['-Wno-error=unused-but-set-variable'])
 
     # ** Defines, includes **
 

--- a/news/7592.bootloader.rst
+++ b/news/7592.bootloader.rst
@@ -1,0 +1,3 @@
+Fix bootloader building with old versions of ``gcc`` that do not
+support the ``-Wno-error=unused-but-set-variable`` compiler flag
+(e.g., ``gcc`` v4.4.3).


### PR DESCRIPTION
Check if gcc supports `-Wno-error=unused-but-set-variable` before trying to use it. Fixes bootloader building with old versions of gcc, such as 4.4.3.

Fixes #7592.