### PR TITLE
bootloader: fix crash when encountering duplicated file in CArchive/PKG

### DIFF
--- a/bootloader/src/pyi_utils.c
+++ b/bootloader/src/pyi_utils.c
@@ -589,12 +589,16 @@ _check_strict_unpack_mode ()
     static int enabled = -1;
     if (enabled == -1) {
         char *env_strict = pyi_getenv("PYINSTALLER_STRICT_UNPACK_MODE"); /* strdup'd copy or NULL */
-        if (strcmp(env_strict, "0") == 0) {
-            enabled = 0;
+        if (env_strict) {
+            if (strcmp(env_strict, "0") == 0) {
+                enabled = 0;
+            } else {
+                enabled = 1;
+            }
+            free(env_strict);
         } else {
-            enabled = 1;
+            enabled = 0;
         }
-        free(env_strict);
     }
     return enabled;
 }

--- a/news/7613.bugfix.rst
+++ b/news/7613.bugfix.rst
@@ -1,0 +1,3 @@
+Fix a regression in bootloader that caused crash in onefile executables
+when encountering a duplicated entry in the PKG/CArchive and the
+``PYINSTALLER_STRICT_UNPACK_MODE`` environment variable not being set.


### PR DESCRIPTION
Fix crash in onefile executable when CArchive/PKG contains a duplicated file and `PYINSTALLER_STRICT_UNPACK_MODE` environment variable is not set. This is regression that was introduced by 4a9eea9 as part of #7273.