### PR TITLE
Deprecate TOC class and remove its usage from codebase

### DIFF
--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -106,7 +106,11 @@ class PYZ(Target):
         self.toc = []
         self.code_dict = {}
         for toc in tocs:
-            self.code_dict.update(getattr(toc, '_code_cache', {}))
+            # Check if code cache association exists for the given TOC list
+            code_cache = CONF['code_cache'].get(id(toc))
+            if code_cache is not None:
+                self.code_dict.update(code_cache)
+
             for entry in toc:
                 name, _, typecode = entry
                 # PYZ expects PYMODULE entries (python code objects) and DATA entries (data collected from zipped eggs).

--- a/PyInstaller/building/build_main.py
+++ b/PyInstaller/building/build_main.py
@@ -619,7 +619,7 @@ class Analysis(Target):
         self.scripts = self.graph.nodes_to_toc(priority_scripts)
 
         # Extend the binaries list with all the Extensions modulegraph has found.
-        self.binaries = self.graph.make_binaries_toc(self.binaries)
+        self.binaries += self.graph.make_binaries_toc()
 
         # Post-process GLib schemas
         self.datas = compile_glib_schema_files(self.datas, os.path.join(CONF['workpath'], "_pyi_gschema_compilation"))

--- a/PyInstaller/building/datastruct.py
+++ b/PyInstaller/building/datastruct.py
@@ -293,3 +293,15 @@ class Tree(Target, list):
                 else:
                     result.append((resfilename, fullfilename, self.typecode))
         self[:] = result
+
+
+def normalize_toc(toc):
+    # TODO: for now, this is a stub using TOC class. Replace it with priority-based de-duplication.
+    normalized_toc = TOC(toc)
+    return list(normalized_toc)
+
+
+def normalize_pyz_toc(toc):
+    # TODO: for now, this is a stub using TOC class. Replace it with priority-based de-duplication.
+    normalized_toc = TOC(toc)
+    return list(normalized_toc)

--- a/PyInstaller/building/datastruct.py
+++ b/PyInstaller/building/datastruct.py
@@ -146,7 +146,7 @@ class Target:
         self.__class__.invcnum += 1
         self.tocfilename = os.path.join(CONF['workpath'], '%s-%02d.toc' % (self.__class__.__name__, self.invcnum))
         self.tocbasename = os.path.basename(self.tocfilename)
-        self.dependencies = TOC()
+        self.dependencies = []
 
     def __postinit__(self):
         """
@@ -198,9 +198,9 @@ class Target:
         misc.save_py_data_struct(self.tocfilename, data)
 
 
-class Tree(Target, TOC):
+class Tree(Target, list):
     """
-    This class is a way of creating a TOC (Table of Contents) that describes some or all of the files within a
+    This class is a way of creating a TOC (Table of Contents) list that describes some or all of the files within a
     directory.
     """
     def __init__(self, root=None, prefix=None, excludes=None, typecode='DATA'):
@@ -221,7 +221,7 @@ class Tree(Target, TOC):
                 the typcodes.
         """
         Target.__init__(self)
-        TOC.__init__(self)
+        list.__init__(self)
         self.root = root
         self.prefix = prefix
         self.excludes = excludes

--- a/PyInstaller/building/datastruct.py
+++ b/PyInstaller/building/datastruct.py
@@ -11,6 +11,7 @@
 
 import os
 import pathlib
+import warnings
 
 from PyInstaller import log as logging
 from PyInstaller.building.utils import _check_guts_eq
@@ -38,8 +39,9 @@ def unique_name(entry):
     return name
 
 
+# This class is deprecated and has been replaced by plain lists with explicit normalization (de-duplication) via
+# `normalize_toc` and `normalize_pyz_toc` helper functions.
 class TOC(list):
-    # TODO: simplify the representation and use directly Modulegraph objects.
     """
     TOC (Table of Contents) class is a list of tuples of the form (name, path, typecode).
 
@@ -59,6 +61,14 @@ class TOC(list):
     """
     def __init__(self, initlist=None):
         super().__init__()
+
+        # Deprecation warning
+        warnings.warn(
+            "TOC class is deprecated. Use a plain list of 3-element tuples instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         self.filenames = set()
         if initlist:
             for entry in initlist:

--- a/PyInstaller/building/osx.py
+++ b/PyInstaller/building/osx.py
@@ -14,7 +14,7 @@ import plistlib
 import shutil
 
 from PyInstaller.building.api import COLLECT, EXE
-from PyInstaller.building.datastruct import TOC, Target, logger
+from PyInstaller.building.datastruct import Target, logger, normalize_toc
 from PyInstaller.building.utils import _check_path_overlap, _rmtree, checkCache
 from PyInstaller.compat import is_darwin
 from PyInstaller.building.icon import normalize_icon_type
@@ -53,7 +53,7 @@ class BUNDLE(Target):
 
         self.appname = os.path.splitext(base_name)[0]
         self.version = kwargs.get("version", "0.0.0")
-        self.toc = TOC()
+        self.toc = []
         self.strip = False
         self.upx = False
         self.console = True
@@ -108,6 +108,9 @@ class BUNDLE(Target):
                 break
         else:
             raise ValueError("No EXECUTABLE entry found in the TOC!")
+
+        # Normalize TOC
+        self.toc = normalize_toc(self.toc)
 
         self.__postinit__()
 

--- a/PyInstaller/building/splash.py
+++ b/PyInstaller/building/splash.py
@@ -16,7 +16,7 @@ import struct
 from PyInstaller import log as logging
 from PyInstaller.archive.writers import SplashWriter
 from PyInstaller.building import splash_templates
-from PyInstaller.building.datastruct import TOC, Target
+from PyInstaller.building.datastruct import Target
 from PyInstaller.building.utils import _check_guts_eq, _check_guts_toc, misc
 from PyInstaller.compat import is_darwin, is_win, is_cygwin
 from PyInstaller.utils.hooks import tcl_tk as tcltk_utils
@@ -66,11 +66,11 @@ class Splash(Target):
 
             .. note:: If PIL (Pillow) is installed and the image is bigger than max_img_size, the image will be resized
                 to fit into the specified area.
-        :param TOC binaries:
-            The TOC of binaries the Analysis build target found. This TOC includes all extensionmodules and their
-            dependencies. This is required to figure out, if the users program uses tkinter.
-        :param TOC datas:
-            The TOC of data the Analysis build target found. This TOC includes all data-file dependencies of the
+        :param list binaries:
+            The TOC list of binaries the Analysis build target found. This TOC includes all extension modules and their
+            binary dependencies. This is required to determine whether the user's program uses `tkinter`.
+        :param list datas:
+            The TOC list of data the Analysis build target found. This TOC includes all data-file dependencies of the
             modules. This is required to check if all splash screen requirements can be bundled.
 
         :keyword text_pos:
@@ -207,7 +207,7 @@ class Splash(Target):
             # The user wants a full copy of tk, so make all tk files a requirement.
             self.splash_requirements.update(toc[0] for toc in tcltk_tree)
 
-        self.binaries = TOC()
+        self.binaries = []
         if not self.uses_tkinter:
             # The user's script does not use tkinter, so we need to provide a TOC of all necessary files add the shared
             # libraries to the binaries.

--- a/PyInstaller/building/toc_conversion.py
+++ b/PyInstaller/building/toc_conversion.py
@@ -15,7 +15,7 @@ import zipfile
 import pkg_resources
 
 from PyInstaller import log as logging
-from PyInstaller.building.datastruct import TOC, Tree
+from PyInstaller.building.datastruct import Tree, normalize_toc
 from PyInstaller.compat import ALL_SUFFIXES
 from PyInstaller.depend.utils import get_path_to_egg
 
@@ -97,11 +97,11 @@ class DependencyProcessor:
     # Public methods.
 
     def make_binaries_toc(self):
-        # TODO create a real TOC when handling of more files is added.
-        return [(x, y, 'BINARY') for x, y in self._binaries]
+        toc = [(x, y, 'BINARY') for x, y in self._binaries]
+        return normalize_toc(toc)
 
     def make_datas_toc(self):
-        toc = TOC((x, y, 'DATA') for x, y in self._datas)
+        toc = [(x, y, 'DATA') for x, y in self._datas]
         for dist in self._distributions:
             if (
                 dist._pyinstaller_info['egg'] and not dist._pyinstaller_info['zipped']
@@ -110,7 +110,7 @@ class DependencyProcessor:
                 # this is a un-zipped, not-zip-safe egg
                 tree = Tree(dist.location, excludes=PY_IGNORE_EXTENSIONS)
                 toc.extend(tree)
-        return toc
+        return normalize_toc(toc)
 
     def make_zipfiles_toc(self):
         # TODO create a real TOC when handling of more files is added.
@@ -119,7 +119,7 @@ class DependencyProcessor:
             if dist._pyinstaller_info['zipped'] and not dist._pyinstaller_info['egg']:
                 # Hmm, this should never happen as normal zip-files are not associated with a distribution, are they?
                 toc.append(("eggs/" + os.path.basename(dist.location), dist.location, 'ZIPFILE'))
-        return toc
+        return normalize_toc(toc)
 
     @staticmethod
     def __collect_data_files_from_zip(zipfilename):
@@ -138,7 +138,7 @@ class DependencyProcessor:
         return Tree(workpath, excludes=PY_IGNORE_EXTENSIONS)
 
     def make_zipped_data_toc(self):
-        toc = TOC()
+        toc = []
         logger.debug('Looking for egg data files...')
         for dist in self._distributions:
             if dist._pyinstaller_info['egg']:
@@ -153,4 +153,4 @@ class DependencyProcessor:
                 else:
                     # this is an un-zipped, not-zip-safe egg, handled in make_datas_toc()
                     pass
-        return toc
+        return normalize_toc(toc)

--- a/PyInstaller/config.py
+++ b/PyInstaller/config.py
@@ -44,6 +44,8 @@ upx_dir
 workpath
 
 tests_modgraph  - cached PyiModuleGraph object to speed up tests
+
+code_cache - dictionary associating `Analysis.pure` list instances with code cache dictionaries. Used by PYZ writer.
 """
 
 # NOTE: Do not import other PyInstaller modules here. Just define constants here.

--- a/PyInstaller/depend/analysis.py
+++ b/PyInstaller/depend/analysis.py
@@ -921,7 +921,7 @@ def get_bootstrap_modules():
     # Import 'struct' modules to get real paths to module file names.
     mod_struct = __import__('struct')
     # Basic modules necessary for the bootstrap process.
-    loader_mods = TOC()
+    loader_mods = list()
     loaderpath = os.path.join(HOMEPATH, 'PyInstaller', 'loader')
     # On some platforms (Windows, Debian/Ubuntu) '_struct' and zlib modules are built-in modules (linked statically)
     # and thus does not have attribute __file__. 'struct' module is required for reading Python bytecode from

--- a/PyInstaller/depend/imphookapi.py
+++ b/PyInstaller/depend/imphookapi.py
@@ -17,7 +17,6 @@ these modifications into appropriate operations on the current `PyiModuleGraph` 
 modules will be frozen into the executable.
 """
 
-from PyInstaller.building.datastruct import TOC
 from PyInstaller.building.utils import format_binaries_and_datas
 from PyInstaller.lib.modulegraph.modulegraph import (RuntimeModule, RuntimePackage)
 
@@ -430,29 +429,37 @@ class PostGraphAPI:
         """
         self._deleted_imports.extend(module_names)
 
-    def add_binaries(self, list_of_tuples):
+    def add_binaries(self, binaries):
         """
-        Add all external dynamic libraries in the passed list of `(name, path)` 2-tuples as dependencies of the
+        Add all external dynamic libraries in the passed list of `(src_name, dest_name)` 2-tuples as dependencies of the
         current module. This is equivalent to adding to the global `binaries` hook attribute.
 
-        For convenience, the `list_of_tuples` may also be a single TOC or TREE instance.
+        For convenience, the `binaries` may also be a list of TOC-style 3-tuples `(dest_name, src_name, typecode)`.
         """
-        if isinstance(list_of_tuples, TOC):
-            self._added_binaries.extend(i[:2] for i in list_of_tuples)
-        else:
-            self._added_binaries.extend(format_binaries_and_datas(list_of_tuples))
 
-    def add_datas(self, list_of_tuples):
-        """
-        Add all external data files in the passed list of `(name, path)` 2-tuples as dependencies of the current
-        module. This is equivalent to adding to the global `datas` hook attribute.
-
-        For convenience, the `list_of_tuples` may also be a single TOC or TREE instance.
-        """
-        if isinstance(list_of_tuples, TOC):
-            self._added_datas.extend(i[:2] for i in list_of_tuples)
+        # Detect TOC 3-tuple list by checking the length of the first entry
+        if binaries and len(binaries[0]) == 3:
+            self._added_binaries.extend(entry[:2] for entry in binaries)
         else:
-            self._added_datas.extend(format_binaries_and_datas(list_of_tuples))
+            # NOTE: `format_binaries_and_datas` changes tuples from input format `(src_name, dest_name)` to output
+            # format `(dest_name, src_name)`.
+            self._added_binaries.extend(format_binaries_and_datas(binaries))
+
+    def add_datas(self, datas):
+        """
+        Add all external data files in the passed list of `(src_name, dest_name)` 2-tuples as dependencies of the
+        current module. This is equivalent to adding to the global `datas` hook attribute.
+
+        For convenience, the `datas` may also be a list of TOC-style 3-tuples `(dest_name, src_name, typecode)`.
+        """
+
+        # Detect TOC 3-tuple list by checking the length of the first entry
+        if datas and len(datas[0]) == 3:
+            self._added_datas.extend(entry[:2] for entry in datas)
+        else:
+            # NOTE: `format_binaries_and_datas` changes tuples from input format `(src_name, dest_name)` to output
+            # format `(dest_name, src_name)`.
+            self._added_datas.extend(format_binaries_and_datas(datas))
 
     def set_module_collection_mode(self, name, mode):
         """"

--- a/news/7615.core.rst
+++ b/news/7615.core.rst
@@ -1,0 +1,9 @@
+Remove the use of the ``TOC`` class in the analysis / build process,
+and use plain ``list`` instances instead. The implicit normalization
+(de-duplication) of TOC entries performed by the ``TOC`` class has been
+replaced with explicit normalization. The TOC lists produced by ``Analysis``
+are explicitly normalized at the end of Analysis instantiation, before
+they are stored in the Analysis properties (e.g., ``Analysis.pure``,
+``Analysis.binaries``, ``Analysis.datas``). Similarly, the TOC lists
+passed to the build targets (e.g., ``PYZ``, ``EXE``, ``COLLECT``) are
+explicitly normalized as part of the targets' instantiation process.

--- a/news/7615.deprecation.rst
+++ b/news/7615.deprecation.rst
@@ -1,0 +1,5 @@
+The ``TOC`` class is now deprecated; use a plain ``list`` with the same
+three-element tuples instead. PyInstaller now performs explicit
+normalization (i.e., entry de-duplication) of the TOC lists passed
+to the build targets (e.g., ``PYZ``, ``EXE``, ``COLLECT``) during their
+instantiation.

--- a/news/7615.doc.rst
+++ b/news/7615.doc.rst
@@ -1,0 +1,2 @@
+Update the documentation on TOC lists and ``Tree`` class to reflect the
+deprecation of the ``TOC`` class.

--- a/tests/functional/test_regression.py
+++ b/tests/functional/test_regression.py
@@ -33,7 +33,8 @@ def test_issue_2492(monkeypatch, tmpdir):
             'dot-file': str(tmpdir.join('imports.dot')),
             'xref-file': str(tmpdir.join('imports.xref')),
             'hiddenimports': [],
-            'specnm': 'issue_2492_script'
+            'specnm': 'issue_2492_script',
+            'code_cache': dict(),
         }
     )
     # Speedup: avoid analyzing base_library.zip
@@ -87,7 +88,8 @@ def test_issue_5131(monkeypatch, tmpdir):
             'dot-file': str(tmpdir.join('imports.dot')),
             'xref-file': str(tmpdir.join('imports.xref')),
             'hiddenimports': [],
-            'specnm': 'issue_5131_script'
+            'specnm': 'issue_5131_script',
+            'code_cache': dict(),
         }
     )
     # Speedup: avoid analyzing base_library.zip

--- a/tests/unit/test_TOC.py
+++ b/tests/unit/test_TOC.py
@@ -29,6 +29,9 @@ ELEMS2 = (
 
 ELEMS3 = (('PIL.Image.py', '/usr/lib/python2.7/encodings/__init__.py', 'PYMODULE'),)
 
+# Ignore deprecation warnings for the TOC class
+pytestmark = pytest.mark.filterwarnings("ignore:TOC class is deprecated.")
+
 
 def test_init_empty():
     toc = TOC()

--- a/tests/unit/test_toc_normalization.py
+++ b/tests/unit/test_toc_normalization.py
@@ -1,0 +1,186 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2023, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+# Tests for explicit TOC list normalization that replaced the implicit normalization with class:``TOC``.
+import copy
+
+from PyInstaller import compat
+from PyInstaller.building.datastruct import normalize_pyz_toc, normalize_toc
+
+# Tests for regular TOC normalization.
+
+_BASE_TOC = [
+    ('libpython3.10.so', '/usr/lib64/libpython3.10.so', 'BINARY'),
+    ('libsomething.so', '/usr/local/lib64/libsomething.so', 'BINARY'),
+    ('README', '/home/user/tmp/README', 'DATA'),
+    ('data/data.csv', '/home/user/tmp/data/data.csv', 'DATA'),
+    ('dependency.bin', 'other_multipackage:dependency.bin', 'DEPENDENCY'),
+    ('myextension.so', 'myextension.so', 'EXTENSION'),
+]
+
+
+def test_normalize_toc_no_duplicates():
+    # No duplicates. We expect the output list to match the input list.
+    toc = copy.copy(_BASE_TOC)
+    expected_toc = _BASE_TOC
+
+    normalized_toc = normalize_toc(toc)
+    assert normalized_toc == expected_toc
+
+
+def test_normalize_toc_duplicate_binary():
+    # A duplicated BINARY entry. We expect the (second) duplicate to be removed.
+    toc = copy.copy(_BASE_TOC)
+    toc.insert(2, ('libsomething.so', '/opt/something/lib/libsomething.so', 'BINARY'))
+    expected_toc = _BASE_TOC
+
+    normalized_toc = normalize_toc(toc)
+    assert normalized_toc == expected_toc
+
+
+def test_normalize_toc_duplicate_binary_case_sensitive():
+    # A BINARY entry that is a duplicate only on case-insensitive OSes.
+    toc = copy.copy(_BASE_TOC)
+    toc.insert(2, ('libSoMeThInG.so', '/opt/something/lib/libSoMeThInG.so', 'BINARY'))
+    expected_toc = _BASE_TOC
+
+    if compat.is_win:
+        expected_toc = _BASE_TOC
+    else:
+        expected_toc = toc
+
+    normalized_toc = normalize_toc(toc)
+    assert normalized_toc == expected_toc
+
+
+def test_normalize_toc_duplicate_data():
+    # A duplicated DATA entry. We expect the (second) duplicate to be removed.
+    toc = copy.copy(_BASE_TOC)
+    toc.insert(3, ('README', '/home/user/tmp/README', 'DATA'))
+    expected_toc = _BASE_TOC
+
+    normalized_toc = normalize_toc(toc)
+    assert normalized_toc == expected_toc
+
+
+def test_normalize_toc_duplicate_data_case_sensitive():
+    # A DATA entry that is a duplicate on case-insensitive OSes.
+    toc = copy.copy(_BASE_TOC)
+    toc.insert(-1, ('readme', '/home/user/tmp-other/readme', 'DATA'))
+    expected_toc = _BASE_TOC
+
+    if compat.is_win:
+        expected_toc = _BASE_TOC
+    else:
+        expected_toc = toc
+
+    normalized_toc = normalize_toc(toc)
+    assert normalized_toc == expected_toc
+
+
+def test_normalize_toc_conflicting_binary_and_data1():
+    # An entry that's duplicated as both BINARY and DATA.
+    # BINARY entry should be kept.
+    toc = copy.copy(_BASE_TOC)
+    toc.insert(2, ('libsomething.so', '/usr/local/lib64/libsomething.so', 'DATA'))  # Insert after BINARY entry
+    expected_toc = _BASE_TOC
+
+    normalized_toc = normalize_toc(toc)
+    assert normalized_toc == expected_toc
+
+
+def test_normalize_toc_conflicting_binary_and_data2():
+    # An entry that's duplicated as both BINARY and DATA, in reverse order.
+    # BINARY entry should be kept.
+    toc = copy.copy(_BASE_TOC)
+    toc.insert(1, ('libsomething.so', '/usr/local/lib64/libsomething.so', 'DATA'))  # Insert before BINARY entry
+    expected_toc = _BASE_TOC
+
+    normalized_toc = normalize_toc(toc)
+    assert normalized_toc == expected_toc
+
+
+def test_normalize_toc_multipackage_dependency():
+    # An entry that's duplicated as both BINARY, DATA, EXTENSION, and DEPENDENCY.
+    # DEPENDENCY should have the highest priority of the four.
+    # The priority-based replacement during normalization might not preserve the order, so we need to sort the
+    # resulting and expected TOC before comparing them. In this particular case, we insert duplicates at the
+    # start of the list, so de-duplication effectively moves the DEPENDENCY entry to the first place in the
+    # output list.
+    toc = copy.copy(_BASE_TOC)
+    toc.insert(0, ('dependency.bin', '/mnt/somewhere/dependency.bin', 'EXTENSION'))
+    toc.insert(0, ('dependency.bin', '/mnt/somewhere/dependency.bin', 'BINARY'))
+    toc.insert(0, ('dependency.bin', '/mnt/somewhere/dependency.bin', 'DATA'))
+    expected_toc = _BASE_TOC
+
+    normalized_toc = normalize_toc(toc)
+    assert sorted(normalized_toc) == sorted(expected_toc)
+
+
+# Tests for PYZ TOC normalization.
+_BASE_PYZ_TOC = [
+    ('copy', '/usr/lib64/python3.11/copy.py', 'PYMODULE'),
+    ('csv', '/usr/lib64/python3.11/csv.py', 'PYMODULE'),
+    ('dataclasses', '/usr/lib64/python3.11/dataclasses.py', 'PYMODULE'),
+    ('datetime', '/usr/lib64/python3.11/datetime.py', 'PYMODULE'),
+    ('decimal', '/usr/lib64/python3.11/decimal.py', 'PYMODULE'),
+    ('mymodule1', 'mymodule1.py', 'PYMODULE'),
+    ('mymodule2', 'mymodule2.py', 'PYMODULE'),
+]
+
+
+def test_normalize_pyz_toc_no_duplicates():
+    # No duplicates. We expect the output list to match the input list.
+    toc = copy.copy(_BASE_PYZ_TOC)
+    expected_toc = _BASE_PYZ_TOC
+
+    normalized_toc = normalize_pyz_toc(toc)
+    assert normalized_toc == expected_toc
+
+
+def test_normalize_pyz_toc_duplicates():
+    # Duplicated entry. We expect the (second) duplicate to be removed.
+    toc = copy.copy(_BASE_PYZ_TOC)
+    toc.insert(6, ('mymodule1', 'some-other-path/mymodule1.py', 'PYMODULE'))
+    expected_toc = _BASE_PYZ_TOC
+
+    normalized_toc = normalize_pyz_toc(toc)
+    assert normalized_toc == expected_toc
+
+
+def test_normalize_pyz_toc_case_sensitivity():
+    # Duplicated entry with different case. In PYZ, the entries are case-sensitive, so the list is not modified.
+    toc = copy.copy(_BASE_PYZ_TOC)
+    toc.insert(6, ('MyMoDuLe1', 'some-other-path/MyMoDuLe1.py', 'PYMODULE'))
+    expected_toc = toc
+
+    normalized_toc = normalize_pyz_toc(toc)
+    assert normalized_toc == expected_toc
+
+
+def test_normalize_pyz_toc_module_and_data1():
+    # In PYZ TOC, a DATA entry should not mask a PYMODULE one.
+    toc = copy.copy(_BASE_PYZ_TOC)
+    toc.insert(5, ('mymodule1', 'data-dir/mymodule1', 'DATA'))
+    expected_toc = _BASE_PYZ_TOC
+
+    normalized_toc = normalize_pyz_toc(toc)
+    assert normalized_toc == expected_toc
+
+
+def test_normalize_pyz_toc_module_and_data2():
+    # In PYZ TOC, a DATA entry should not mask a PYMODULE one. Variant with switched order.
+    toc = copy.copy(_BASE_PYZ_TOC)
+    toc.insert(6, ('mymodule1', 'data-dir/mymodule1', 'DATA'))
+    expected_toc = _BASE_PYZ_TOC
+
+    normalized_toc = normalize_pyz_toc(toc)
+    assert normalized_toc == expected_toc


### PR DESCRIPTION
The `TOC` class with its on-line entry de-duplication seems convenient at first, but trying to be both a list (officially) and a set (unofficially) brings up a slew of corner-case issues, especially when it comes to element update and removal operations. 

Therefore, within our codebase, we mostly treat `TOC` as a `list`. To avoid hitting the weird corner cases with modification behavior, we mostly treat it as immutable - if we need to modify the list, we create a plain list with filtered entries, and pass it to a `TOC` constructor, which performs list normalization (i.e., entry de-duplication).

One issue I have with the `TOC`'s normalization is that it is order-based - if there is a DATA entry already present in the TOC, it is difficult to have it replaced with a BINARY entry. Although in the grand scheme of things, BINARY entries should have precedence over the DATA ones, due to binary dependency scanning and additional processing steps we subject them to on some OSes. While it would be possible to implement a priority-based mechanism within the existing `TOC` class, doing so would even further complicate the already-muddy semantics of the element operations.

Therefore, this PR marks the `TOC` class as deprecated (both with warning emitted from constructor and in revised documentation) and removes all uses of the `TOC` class from our codebase. The implicit list normalization that the `TOC` provided is now replaced by helper functions which we explicitly use to perform priority-based list normalization at certain "checkpoints" during the build process. Specifically, the TOC lists are explicitly normalized at the end of `Analysis` instantiation, before they are stored in `Analysis` properties (e.g., `Analysis.pure`, `Analysis.datas`, `Analysis.binaries`). The build targets (`PYZ`, `EXE`, `COLLECT`, etc.) also explicitly normalize the combined TOC that they construct from the TOCs that they are passed as arguments of the constructor - this is to account for the possibility of the user performing additional modification of the lists in the spec file (which could result in entry duplication). 

We now have a separate normalization function for PYZ TOC (because at least nominally, PYZ implementation is case sensitive) and "regular" TOC (which follows the OS-specific case-normalization behavior). And the priority system for the latter ensures the following precedence order: DEPENDENCY > BINARY, EXTENSION > everything else.

The `TOC` class also made it easier to implement shortcuts in other areas of the code - for example passing the code cache dictionary to PYZ via dynamic attribute set on the `TOC` object. We cannot do that with plain `list` anymore, so code cache passing is now implemented via global `CONF` dictionary. 

Closes #6688.

See also: #6669, #6689.