### PR TITLE
building: attempt to preserve parent directories for pywin32 extensions

### DIFF
--- a/PyInstaller/depend/bindepend.py
+++ b/PyInstaller/depend/bindepend.py
@@ -232,18 +232,6 @@ def _get_paths_for_parent_directory_preservation():
 
 
 def _select_destination_directory(src_filename, parent_dir_preservation_paths):
-    # Special handling for pywin32 on Windows, because its .pyd extensions end up linking each other, but, due to
-    # sys.path modifications the packages perform, they all end up as top-modules and should be collected into
-    # top-level directory... i.e., we must NOT preserve the directory layout in this case.
-    if compat.is_win:
-        # match <...>/site-packages/pythonwin
-        # The caller might not have resolved the src_filename, so we need to explicitly lower-case the parent_dir.name
-        # before comparing it to account for case variations.
-        parent_dir = src_filename.parent
-        if parent_dir.name.lower() == "pythonwin" and parent_dir.parent in parent_dir_preservation_paths:
-            # Collect into top-level directory.
-            return src_filename.name
-
     # Check parent directory preservation paths
     for parent_dir_preservation_path in parent_dir_preservation_paths:
         if parent_dir_preservation_path in src_filename.parents:

--- a/PyInstaller/loader/pyimod04_pywin32.py
+++ b/PyInstaller/loader/pyimod04_pywin32.py
@@ -16,10 +16,20 @@ import sys
 
 
 def install():
+    # Sub-directories containing extensions. In original python environment, these are added to `sys.path` by the
+    # `pywin32.pth` so the extensions end up treated as top-level modules. We attempt to preserve the directory
+    # layout, so we need to add these directories to `sys.path` ourselves.
+    pywin32_ext_paths = ('win32', 'pythonwin')
+    pywin32_ext_paths = [os.path.join(sys._MEIPASS, pywin32_ext_path) for pywin32_ext_path in pywin32_ext_paths]
+    pywin32_ext_paths = [path for path in pywin32_ext_paths if os.path.isdir(path)]
+    sys.path.extend(pywin32_ext_paths)
+
+    # Additional handling of `pywin32_system32` DLL directory
     pywin32_system32_path = os.path.join(sys._MEIPASS, 'pywin32_system32')
+
     if not os.path.isdir(pywin32_system32_path):
-        # Either pywin32 is not collected, or we are dealing with Anaconda-packaged version that does not use the
-        # pywin32_system32 sub-directory. In the latter case, the pywin32 DLLs should be in `sys._MEIPASS`, and nothing
+        # Either pywin32 is not collected, or we are dealing with version that does not use the pywin32_system32
+        # sub-directory. In the latter case, the pywin32 DLLs should be in `sys._MEIPASS`, and nothing
         # else needs to be done here.
         return
 

--- a/news/7627.bugfix.rst
+++ b/news/7627.bugfix.rst
@@ -1,0 +1,3 @@
+Attempt to mitigate issues with Anaconda ``pywin32`` package that
+result from the package installing three copies of ``pywintypes3X.dll``
+and ``pythoncom3X.dll`` in different locations.

--- a/news/7627.feature.rst
+++ b/news/7627.feature.rst
@@ -1,0 +1,3 @@
+Attempt to preserve the parent directory layout for ``pywin32``
+extensions that originate from ``win32`` and ``pythonwin`` directories,
+instead of collecting those extensions to top-level application directory.


### PR DESCRIPTION
Attempt to preserve the parent directories for `pywin32` extensions that originate from `win32` and `pythonwin` directories, rather than collecting them to the top-level application directory (which happens by default because those directories are added to `sys.path` by `pywin32.pth`). This is achieved by post-processing the `binaries` TOC at the end of the analysis process. 

This brings us closer to the original package layout, and allows us to remove a `pywin32`-specific hack from binary dependency analysis, where we earlier had to force collection of dependent binaries from the `pythonwin` directory to the top-level directory (so that an extension from that directory, discovered via modulegraph, and dependent extension from that directory, discovered via binary dependency scanner, ended up in the same place).

With a similar post-processing step, we also attempt to mitigate the issues caused by Anaconda `pywin32` package that installs three copies of  `pywintypes3X.dll` and `pythoncom3X.dll` in different locations, all of which are visible to us. So we have no control over which one we collect, which is problematic because we expect the copy to end up in `pywin32_system32` directory. But with post-processing, we can bend the reality to our will, and divert those two files into desired destination directory. See https://github.com/pyinstaller/pyinstaller/issues/7624#issuecomment-1545552955.

Our `pywin32` extension import tests now all seem to pass also under Anaconda environments with Anaconda `pywin32` package installed.