### PR TITLE
win32utils: values of StringStruct in VSVersionInfo can contain quotes

### DIFF
--- a/PyInstaller/utils/win32/versioninfo.py
+++ b/PyInstaller/utils/win32/versioninfo.py
@@ -451,7 +451,7 @@ class StringStruct:
         return self.toRaw() == other
 
     def __str__(self, indent=''):
-        return "StringStruct('%s', '%s')" % (self.name, self.val)
+        return "StringStruct(%r, %r)" % (self.name, self.val)
 
     def __repr__(self):
         return 'versioninfo.StringStruct(%r, %r)' % (self.name, self.val)

--- a/news/7630.bugfix.rst
+++ b/news/7630.bugfix.rst
@@ -1,0 +1,2 @@
+(Windows) Fix string serialization of ``VSVersionInfo`` to account for
+the possibility of ``StringStruct`` values containing quote characters.


### PR DESCRIPTION
Fix string serialization of `StringStruct` in `VSVersionInfo` to account for the possibility of the string value containing a single quote. I.e., format the string using `%r` instead of `'%s'` and let python properly escape the string for representation.

Fixes #7630.