### PR TITLE
tests: avoid installing QScintilla/PyQt6-QScintilla on linux

### DIFF
--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -38,7 +38,7 @@ PyQtChart==5.15.6
 PyQtDataVisualization==5.15.5
 PyQtNetworkAuth==5.15.5
 PyQtPurchasing==5.15.5
-QScintilla==2.14.0
+QScintilla==2.14.0; sys_platform != 'linux'  # binary wheels incompatible with ubuntu-20.04
 PyQtWebEngine==5.15.6
 # PyQt6 and add-on packages
 PyQt6==6.5.0
@@ -46,7 +46,7 @@ PyQt6-3D==6.5.0
 PyQt6-Charts==6.5.0
 PyQt6-DataVisualization==6.5.0
 PyQt6-NetworkAuth==6.5.0
-PyQt6-QScintilla==2.14.0
+PyQt6-QScintilla==2.14.0; sys_platform != 'linux'  # binary wheels incompatible with ubuntu-20.04
 PyQt6-WebEngine==6.5.0
 python-dateutil==2.8.2
 pytz==2023.3


### PR DESCRIPTION
Looks like `QScintilla-2.14.0-cp37-abi3-manylinux_2_17_x86_64.whl` and `PyQt6_QScintilla-2.14.0-cp37-abi3-manylinux_2_28_x86_64.whl` wheel on PyPI have been replaced by ˙QScintilla-2.14.0-cp37-abi3-manylinux_2_32_x86_64.whl˙ and `PyQt6_QScintilla-2.14.0-cp37-abi3-manylinux_2_32_x86_64.whl` on May 14th. 

And due to glibc >= 2.32 requirement, the wheels cannot be installed on our `ubuntu-20.04` runners anymore (glibc 2.31).

We could pin to 2.13.4 on linux, but in reality we are testing these just for the sake of completeness, so I think we get sufficient test coverage from Windows and macOS runners.