### PR TITLE
rthooks: PySide: fix the QT_PLUGIN_PATH/QML2_IMPORT_PATH paths

### DIFF
--- a/PyInstaller/hooks/rthooks/pyi_rth_pyside2.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_pyside2.py
@@ -17,7 +17,7 @@ import sys
 if sys.platform.startswith('win'):
     pyqt_path = os.path.join(sys._MEIPASS, 'PySide2')
 else:
-    pyqt_path = os.path.join(sys._MEIPASS, 'Qt', 'PySide2')
+    pyqt_path = os.path.join(sys._MEIPASS, 'PySide2', 'Qt')
 os.environ['QT_PLUGIN_PATH'] = os.path.join(pyqt_path, 'plugins')
 os.environ['QML2_IMPORT_PATH'] = os.path.join(pyqt_path, 'qml')
 # Modelled after similar PATH modification in PyQt5 rthook. With PySide2, this modification seems necessary for SSL DLLs

--- a/PyInstaller/hooks/rthooks/pyi_rth_pyside6.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_pyside6.py
@@ -17,7 +17,7 @@ import sys
 if sys.platform.startswith('win'):
     pyqt_path = os.path.join(sys._MEIPASS, 'PySide6')
 else:
-    pyqt_path = os.path.join(sys._MEIPASS, 'Qt', 'PySide6')
+    pyqt_path = os.path.join(sys._MEIPASS, 'PySide6', 'Qt')
 os.environ['QT_PLUGIN_PATH'] = os.path.join(pyqt_path, 'plugins')
 os.environ['QML2_IMPORT_PATH'] = os.path.join(pyqt_path, 'qml')
 # Modelled after similar PATH modification in PyQt5 rthook. With PySide6, this modification seems necessary for SSL DLLs

--- a/news/7649.bugfix.rst
+++ b/news/7649.bugfix.rst
@@ -1,0 +1,5 @@
+(Linux/macOS) Fix the Qt directory path override in ``PySide2`` and
+``PySide6`` run-time hooks. These paths, set via ``QT_PLUGIN_PATH`` and
+``QML2_IMPORT_PATH`` environment variables, are used with ``PySide2``
+and ``PySide6`` builds that that use system-wide Qt installation and
+are not portable by default (e.g., Homebrew).


### PR DESCRIPTION
Fix the path to the collected Qt directory that we pass via `QT_PLUGIN_PATH` and `QML2_IMPORT_PATH`. The base path on Linux and macOS should be
```
os.path.join(sys._MEIPASS, 'PySide6', 'Qt')
```
instead of
```
os.path.join(sys._MEIPASS, 'Qt', 'PySide6')
```

The typo affects only PySide installations that do not bundle the Qt libraries; for example it affects Homebrew and Anaconda PySide2/6, but not PyPI wheels.