### PR TITLE
building: changed input binaries/datas should invalidate Analysis

### DIFF
--- a/news/7653.bugfix.rst
+++ b/news/7653.bugfix.rst
@@ -1,0 +1,10 @@
+Changes made to ``datas`` and ``binaries`` lists that are passed to
+``Analysis`` constructor will now invalidate the cached ``Analysis``
+and trigger a re-build. This applies both to changes made by editing
+the .spec file manually and to automatic changes due to addition or
+removal of corresponding command-line options (:option:`--add-data`,
+:option:`--add-binaries`, :option:`--collect-data`,
+:option:`--collect-binaries`, :option:`--copy-metadata`).
+Previously, changes might not have taken effect as the old cached build
+was returned if available and unless user explicitly requested a clean
+build using the :option:`--clean` command-line option.


### PR DESCRIPTION
Changes in the input `binaries` or `datas` lists that are passed to `Analysis` constructor should invalidate the cached `Analysis` and trigger a re-analysis, and hence a rebuild. Otherwise, user might end up with a cached build that does not reflect the changes when they either edit the .spec file, or change the command line (e.g., add `--add-binary`, `--add-data`, `--collect-data`, `--collect-binaries`, etc.).

In order to detect the change, the TOC lists made from input `binaries` and `datas` need to be stored to separate variables, `Analysis._input_binaries` and `Analysis._input_datas`, that are under full TOC comparison using the `_check_guts_toc` function. During the `assemble` method, the entries from these lists are copied as initial values for `Analysis.binaries` and `Analysis.datas`.