### PR TITLE
loader: attempt to fix compatibility with importlib's LazyLoader

### DIFF
--- a/PyInstaller/hooks/rthooks/pyi_rth_pkgres.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_pkgres.py
@@ -14,13 +14,13 @@ import pathlib
 import sys
 
 import pkg_resources
-from pyimod02_importers import FrozenImporter
+from pyimod02_importers import PyiFrozenImporter
 
 SYS_PREFIX = pathlib.PurePath(sys._MEIPASS)
 
-# To make pkg_resources work with frozen modules we need to set the 'Provider' class for FrozenImporter. This class
+# To make pkg_resources work with frozen modules we need to set the 'Provider' class for PyiFrozenImporter. This class
 # decides where to look for resources and other stuff. 'pkg_resources.NullProvider' is dedicated to PEP302 import hooks
-# like FrozenImporter is. It uses method __loader__.get_data() in methods pkg_resources.resource_string() and
+# like PyiFrozenImporter is. It uses method __loader__.get_data() in methods pkg_resources.resource_string() and
 # pkg_resources.resource_stream()
 #
 # We provide PyiFrozenProvider, which subclasses the NullProvider and implements _has(), _isdir(), and _listdir()
@@ -32,7 +32,7 @@ SYS_PREFIX = pathlib.PurePath(sys._MEIPASS)
 # results are typically combined for both types of resources (e.g., when listing a directory or checking whether a
 # resource exists). When the order of precedence matters, the PYZ-embedded resources take precedence over the
 # on-filesystem ones, to keep the behavior consistent with the actual file content retrieval via _get() method (which in
-# turn uses FrozenImporter's get_data() method). For example, when checking whether a resource is a directory via
+# turn uses PyiFrozenImporter's get_data() method). For example, when checking whether a resource is a directory via
 # _isdir(), a PYZ-embedded file will take precedence over a potential on-filesystem directory. Also, in contrast to
 # unfrozen packages, the frozen ones do not contain source .py files, which are therefore absent from content listings.
 
@@ -95,7 +95,7 @@ _toc_tree_cache = {}
 
 class PyiFrozenProvider(pkg_resources.NullProvider):
     """
-    Custom pkg_resources provider for FrozenImporter.
+    Custom pkg_resources provider for PyiFrozenImporter.
     """
     def __init__(self, module):
         super().__init__(module)
@@ -197,4 +197,4 @@ class PyiFrozenProvider(pkg_resources.NullProvider):
         return content
 
 
-pkg_resources.register_loader_type(FrozenImporter, PyiFrozenProvider)
+pkg_resources.register_loader_type(PyiFrozenImporter, PyiFrozenProvider)

--- a/PyInstaller/hooks/rthooks/pyi_rth_pkgutil.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_pkgutil.py
@@ -9,24 +9,24 @@
 # SPDX-License-Identifier: Apache-2.0
 #-----------------------------------------------------------------------------
 #
-# This rthook overrides pkgutil.iter_modules with custom implementation that uses PyInstaller's FrozenImporter to list
-# sub-modules embedded in the PYZ archive. The non-embedded modules (binary extensions, or .pyc modules in noarchive
-# build) are handled by original pkgutil iter_modules implementation (and consequently, python's FileFinder).
+# This rthook overrides pkgutil.iter_modules with custom implementation that uses PyInstaller's PyiFrozenImporter to
+# list sub-modules embedded in the PYZ archive. The non-embedded modules (binary extensions, or .pyc modules in
+# noarchive build) are handled by original pkgutil iter_modules implementation (and consequently, python's FileFinder).
 #
 # The preferred way of adding support for iter_modules would be adding non-standard iter_modules() method to
-# FrozenImporter itself. However, that seems to work only for path entry finders (for use with sys.path_hooks), while
-# PyInstaller's FrozenImporter is registered as meta path finders (for use with sys.meta_path). Turning FrozenImporter
-# into path entry finder, would seemingly require the latter to support on-filesystem resources (e.g., extension
-# modules) in addition to PYZ-embedded ones.
+# PyiFrozenImporter itself. However, that seems to work only for path entry finders (for use with sys.path_hooks), while
+# PyInstaller's PyiFrozenImporter is registered as meta path finders (for use with sys.meta_path). Turning
+# PyiFrozenImporter into path entry finder, would seemingly require the latter to support on-filesystem resources
+# (e.g., extension modules) in addition to PYZ-embedded ones.
 #
 # Therefore, we instead opt for overriding pkgutil.iter_modules with custom implementation that augments the output of
-# original implementation with contents of PYZ archive from FrozenImporter's TOC.
+# original implementation with contents of PYZ archive from PyiFrozenImporter's TOC.
 
 import os
 import pkgutil
 import sys
 
-from pyimod02_importers import FrozenImporter
+from pyimod02_importers import PyiFrozenImporter
 
 _orig_pkgutil_iter_modules = pkgutil.iter_modules
 
@@ -36,9 +36,9 @@ def _pyi_pkgutil_iter_modules(path=None, prefix=''):
     # extensions and compiled pyc modules in noarchive debug builds).
     yield from _orig_pkgutil_iter_modules(path, prefix)
 
-    # Find the instance of PyInstaller's FrozenImporter.
+    # Find the instance of PyInstaller's PyiFrozenImporter.
     for importer in pkgutil.iter_importers():
-        if isinstance(importer, FrozenImporter):
+        if isinstance(importer, PyiFrozenImporter):
             break
     else:
         return

--- a/PyInstaller/loader/pyimod01_archive.py
+++ b/PyInstaller/loader/pyimod01_archive.py
@@ -144,7 +144,7 @@ class ZlibArchiveReader:
 
     def is_package(self, name):
         """
-        Check if the given name refers to a package entry. Used by FrozenImporter at runtime.
+        Check if the given name refers to a package entry. Used by PyiFrozenImporter at runtime.
         """
         entry = self.toc.get(name)
         if entry is None:
@@ -154,7 +154,7 @@ class ZlibArchiveReader:
 
     def is_pep420_namespace_package(self, name):
         """
-        Check if the given name refers to a namespace package entry. Used by FrozenImporter at runtime.
+        Check if the given name refers to a namespace package entry. Used by PyiFrozenImporter at runtime.
         """
         entry = self.toc.get(name)
         if entry is None:

--- a/bootloader/src/pyi_launch.c
+++ b/bootloader/src/pyi_launch.c
@@ -514,7 +514,7 @@ pyi_launch_run_scripts(ARCHIVE_STATUS *status)
             }
 
             /* Store the code object to __main__ module's _pyi_main_co
-             * attribute, so it can be retrieved by FrozenImporter,
+             * attribute, so it can be retrieved by PyiFrozenImporter,
              * if necessary. */
             PI_PyObject_SetAttrString(__main__, "_pyi_main_co", code);
 

--- a/news/7657.bugfix.rst
+++ b/news/7657.bugfix.rst
@@ -1,0 +1,2 @@
+Attempt to fix compatibility of PyInstaller's ``PyiFrozenImporter`` with
+``importlib.util.LazyLoader``.

--- a/tests/functional/scripts/pyi_hooks/wx_lib_pubsub.py
+++ b/tests/functional/scripts/pyi_hooks/wx_lib_pubsub.py
@@ -22,8 +22,8 @@ current wxPython version (e.g., `setupv1` for wxPython 2.8 or older) _before_ th
 
 
 NOTE: "wx.lib.pubsub.__init__" on 2.8 tries to use `imp.find_loader` to find out if the module is importable;
-because `imp.find_loader` does not honor our FrozenImporter path hook, it always returns None for *any* frozen module.
-This means that 2.8 never uses the v1 API when frozen, which is a deviation from its non-frozen behavior.
+because `imp.find_loader` does not honor our PyiFrozenImporter path hook, it always returns None for *any* frozen
+module. This means that 2.8 never uses the v1 API when frozen, which is a deviation from its non-frozen behavior.
 
 We work around this in the wx.lib.pubsub hook by including the `autosetuppubsubv1.py` as a data file instead of a
 python module, which stores it as a plain file in the exe folder (or temp folder) and thus makes it visible

--- a/tests/functional/scripts/pyi_lazy_import.py
+++ b/tests/functional/scripts/pyi_lazy_import.py
@@ -1,0 +1,32 @@
+# -----------------------------------------------------------------------------
+# Copyright (c) 2023, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+# -----------------------------------------------------------------------------
+
+# An importlib.util.LazyLoader test, based on example from
+# https://docs.python.org/3/library/importlib.html#implementing-lazy-imports
+
+import sys
+import importlib.util
+
+
+def lazy_import(name):
+    spec = importlib.util.find_spec(name)
+    loader = importlib.util.LazyLoader(spec.loader)
+    spec.loader = loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    loader.exec_module(module)
+    return module
+
+
+# Lazy-load the module...
+lazy_module = lazy_import(sys.argv[1])
+# ... and then trigger load by listing its contents
+print(dir(lazy_module))

--- a/tests/functional/test_import.py
+++ b/tests/functional/test_import.py
@@ -156,7 +156,8 @@ def test_module_with_coding_utf8(pyi_builder):
     pyi_builder.test_source("import module_with_coding_utf8")
 
 
-# Test that our FrozenImporter's get_source() method can load source files with utf-8 emoji characters. See issue #6143.
+# Test that our PyiFrozenImporter's get_source() method can load source files with utf-8 emoji characters.
+# See issue #6143.
 def test_source_utf8_emoji(pyi_builder):
     # Collect the module's source as data file
     datas = os.pathsep.join((os.path.join(_MODULES_DIR, 'module_with_utf8_emoji.py'), os.curdir))

--- a/tests/functional/test_import_lazy_loader.py
+++ b/tests/functional/test_import_lazy_loader.py
@@ -1,0 +1,41 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2023, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.tests import importorskip
+
+
+# A basic lazy loader test with a stdlib module
+def test_importlib_lazy_loader(pyi_builder):
+    pyi_builder.test_script(
+        'pyi_lazy_import.py',
+        app_args=['json'],
+        pyi_args=['--hiddenimport', 'json'],
+    )
+
+
+# Lazy loader test with aliased module - using original name
+@importorskip('pkg_resources._vendor.jaraco.text')
+def test_importlib_lazy_loader_alias1(pyi_builder):
+    pyi_builder.test_script(
+        'pyi_lazy_import.py',
+        app_args=['pkg_resources._vendor.jaraco.text'],
+        pyi_args=['--hiddenimport', 'pkg_resources'],
+    )
+
+
+# Lazy loader test with aliased module - using alias
+@importorskip('pkg_resources.extern.jaraco.text')
+def test_importlib_lazy_loader_alias2(pyi_builder):
+    pyi_builder.test_script(
+        'pyi_lazy_import.py',
+        app_args=['pkg_resources.extern.jaraco.text'],
+        pyi_args=['--hiddenimport', 'pkg_resources'],
+    )

--- a/tests/functional/test_importlib_resources.py
+++ b/tests/functional/test_importlib_resources.py
@@ -15,7 +15,7 @@
 #
 # Running the unfrozen test script allows us to verify the behavior of importlib.resources (or its importlib_resources
 # back-port for python 3.8 and earlier) and thereby also validate the test script itself. Running the frozen test
-# validates the behavior of the resource reader implemented by PyInstaller's FrozenImporter.
+# validates the behavior of the resource reader implemented by PyInstaller's PyiFrozenImporter.
 #
 # For details on the structure of the test and the contents of the test package, see the top comment in the test script
 # itself.


### PR DESCRIPTION
When a module is lazily imported using `importlib.util.LazyLoader`, the module's spec is modified and the `loader_state` member is overwritten with a dictionary constructed by the `LazyLoader`'s code. Unfortunately, this breaks our frozen importer, because our `find_spec` implementation uses that field to store the PYZ entry name, and `exec_module` reads it before trying to look-up the code object in the PYZ. (And this seems to be necessary to handle aliased modules, such as `pkg_resources._vendor.jaraco.text` being aliased as `pkg_resources.extern.jaraco.text`).

See for an example in the wild: https://github.com/pyinstaller/pyinstaller/issues/7655#issuecomment-1560829870