### PR TITLE
building: macOS: use @rpath to rewrite binaries' dependency paths

### DIFF
--- a/PyInstaller/utils/osx.py
+++ b/PyInstaller/utils/osx.py
@@ -14,11 +14,23 @@ Utils for Mac OS platform.
 
 import math
 import os
+import pathlib
 import subprocess
 import shutil
+import tempfile
 
-from macholib.mach_o import LC_BUILD_VERSION, LC_CODE_SIGNATURE, LC_SEGMENT_64, LC_SYMTAB, LC_VERSION_MIN_MACOSX
+from macholib.mach_o import (
+    LC_BUILD_VERSION,
+    LC_CODE_SIGNATURE,
+    LC_ID_DYLIB,
+    LC_LOAD_DYLIB,
+    LC_RPATH,
+    LC_SEGMENT_64,
+    LC_SYMTAB,
+    LC_VERSION_MIN_MACOSX,
+)
 from macholib.MachO import MachO
+import macholib.util
 
 import PyInstaller.log as logging
 from PyInstaller.compat import base_prefix
@@ -288,11 +300,22 @@ def get_binary_architectures(filename):
     return bool(executable.fat), [_get_arch_string(hdr.header) for hdr in executable.headers]
 
 
-def convert_binary_to_thin_arch(filename, thin_arch):
+def convert_binary_to_thin_arch(filename, thin_arch, output_filename=None):
     """
     Convert the given fat binary into thin one with the specified target architecture.
     """
-    cmd_args = ['lipo', '-thin', thin_arch, filename, '-output', filename]
+    output_filename = output_filename or filename
+    cmd_args = ['lipo', '-thin', thin_arch, filename, '-output', output_filename]
+    p = subprocess.run(cmd_args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, universal_newlines=True)
+    if p.returncode:
+        raise SystemError(f"lipo command ({cmd_args}) failed with error code {p.returncode}!\noutput: {p.stdout}")
+
+
+def merge_into_fat_binary(output_filename, *slice_filenames):
+    """
+    Merge the given single-arch thin binary files into a fat binary.
+    """
+    cmd_args = ['lipo', '-create', '-output', output_filename, *slice_filenames]
     p = subprocess.run(cmd_args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, universal_newlines=True)
     if p.returncode:
         raise SystemError(f"lipo command ({cmd_args}) failed with error code {p.returncode}!\noutput: {p.stdout}")
@@ -357,3 +380,150 @@ def sign_binary(filename, identity=None, entitlements_file=None, deep=False):
     p = subprocess.run(cmd_args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, universal_newlines=True)
     if p.returncode:
         raise SystemError(f"codesign command ({cmd_args}) failed with error code {p.returncode}!\noutput: {p.stdout}")
+
+
+def set_dylib_dependency_paths(filename, target_rpath):
+    """
+    Modify the given dylib's identity (in LC_ID_DYLIB command) and the paths to dependent dylibs (in LC_LOAD_DYLIB)
+    commands into `@rpath/<basename>` format, remove any existing rpaths (LC_RPATH commands), and add a new rpath
+    (LC_RPATH command) with the specified path.
+
+    Uses `install-tool-name` utility to make the changes.
+
+    The system libraries (e.g., the ones found in /usr/lib) are exempted from path rewrite.
+
+    For multi-arch fat binaries, this function extracts each slice into temporary file, processes it separately,
+    and then merges all processed slices back into fat binary. This is necessary because `install-tool-name` cannot
+    modify rpaths in cases when an existing rpath is present only in one slice.
+    """
+
+    # Check if we are dealing with a fat binary; the `install-name-tool` seems to be unable to remove an rpath that is
+    # present only in one slice, so we need to extract each slice, process it separately, and then stich processed
+    # slices back into a fat binary.
+    is_fat, archs = get_binary_architectures(filename)
+
+    if is_fat:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            slice_filenames = []
+            for arch in archs:
+                slice_filename = os.path.join(tmpdir, arch)
+                convert_binary_to_thin_arch(filename, arch, output_filename=slice_filename)
+                _set_dylib_dependency_paths(slice_filename, target_rpath)
+                slice_filenames.append(slice_filename)
+            merge_into_fat_binary(filename, *slice_filenames)
+    else:
+        # Thin binary - we can process it directly
+        _set_dylib_dependency_paths(filename, target_rpath)
+
+
+def _set_dylib_dependency_paths(filename, target_rpath):
+    """
+    The actual implementation of set_dylib_dependency_paths functionality.
+
+    Implicitly assumes that a single-arch thin binary is given.
+    """
+
+    # Parse dylib's header to extract the following commands:
+    #  - LC_LOAD_DYLIB: dylib load commands (dependent libraries)
+    #  - LC_RPATH: rpath definitions
+    #  - LC_ID_DYLIB: dylib's identity
+    binary = MachO(filename)
+
+    dylib_id = None
+    rpaths = set()
+    linked_libs = set()
+
+    for header in binary.headers:
+        for cmd in header.commands:
+            lc_type = cmd[0].cmd
+            if lc_type not in {LC_LOAD_DYLIB, LC_RPATH, LC_ID_DYLIB}:
+                continue
+
+            # Decode path, strip trailing NULL characters
+            path = cmd[2].decode('utf-8').rstrip('\x00')
+
+            if lc_type == LC_LOAD_DYLIB:
+                linked_libs.add(path)
+            elif lc_type == LC_RPATH:
+                rpaths.add(path)
+            elif lc_type == LC_ID_DYLIB:
+                dylib_id = path
+
+    del binary
+
+    # If dylib has identifier set, compute the normalized version, in form of `@rpath/basename`.
+    normalized_dylib_id = None
+    if dylib_id:
+        normalized_dylib_id = str(pathlib.PurePath('@rpath') / pathlib.PurePath(dylib_id).name)
+
+    # Find dependent libraries that should have their prefix path changed to `@rpath`. If any dependent libraries
+    # end up using `@rpath` (originally or due to rewrite), set the `rpath_required` boolean to True, so we know
+    # that we need to add our rpath.
+    changed_lib_paths = []
+    rpath_required = False
+    for linked_lib in linked_libs:
+        # Leave system dynamic libraries unchanged.
+        if macholib.util.in_system_path(linked_lib):
+            continue
+
+        # The older python.org builds that use system Tcl/Tk framework have their _tkinter.cpython-*-darwin.so
+        # library linked against /Library/Frameworks/Tcl.framework/Versions/8.5/Tcl and
+        # /Library/Frameworks/Tk.framework/Versions/8.5/Tk, although the actual frameworks are located in
+        # /System/Library/Frameworks. Therefore, they slip through the above in_system_path() check, and we need to
+        # exempt them manually.
+        _exemptions = [
+            '/Library/Frameworks/Tcl.framework/',
+            '/Library/Frameworks/Tk.framework/',
+        ]
+        if any([x in linked_lib for x in _exemptions]):
+            continue
+
+        # This linked library will end up using `@rpath`, whether modified or not...
+        rpath_required = True
+
+        new_path = str(pathlib.PurePath('@rpath') / pathlib.PurePath(linked_lib).name)
+        if linked_lib == new_path:
+            continue
+
+        changed_lib_paths.append((linked_lib, new_path))
+
+    # Gather arguments for `install-name-tool`
+    install_name_tool_args = []
+
+    # Modify the dylib identifier if necessary
+    if normalized_dylib_id and normalized_dylib_id != dylib_id:
+        install_name_tool_args += ["-id", normalized_dylib_id]
+
+    # Changed libs
+    for original_path, new_path in changed_lib_paths:
+        install_name_tool_args += ["-change", original_path, new_path]
+
+    # Remove all existing rpaths except for the target rpath (if it already exists). `install_name_tool` disallows using
+    # `-delete_rpath` and `-add_rpath` with the same argument.
+    for rpath in rpaths:
+        if rpath == target_rpath:
+            continue
+        install_name_tool_args += [
+            "-delete_rpath",
+            rpath,
+        ]
+
+    # If any of linked libraries use @rpath now and our target rpath is not already added, add it.
+    # NOTE: @rpath in the dylib identifier does not actually require the rpath to be set on the binary...
+    if rpath_required and target_rpath not in rpaths:
+        install_name_tool_args += [
+            "-add_rpath",
+            target_rpath,
+        ]
+
+    # If we have no arguments, finish immediately.
+    if not install_name_tool_args:
+        return
+
+    # Run `install_name_tool`
+    cmd_args = ["install_name_tool", *install_name_tool_args, filename]
+    p = subprocess.run(cmd_args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, universal_newlines=True)
+    if p.returncode:
+        raise SystemError(
+            f"install_name_tool command ({cmd_args}) failed with error code {p.returncode}!\noutput: {p.stdout}"
+        )

--- a/news/7664.bugfix.rst
+++ b/news/7664.bugfix.rst
@@ -1,0 +1,9 @@
+(macOS) When rewriting the dylib identifier and paths to linked
+libraries in a collected binary, instead of directly using
+``@loader_path``-based path, use ``@rpath``-based path and replace
+rpaths in the binary with a single rpath that points to the top-level
+application directory, relative to ``@loader_path``. This ensures that
+the library identifiers of collected shared libraries and their
+references in referring binaries always match, which allows packages
+to pre-load a library from an arbitrary location via for example
+``ctypes``.

--- a/news/7664.core.rst
+++ b/news/7664.core.rst
@@ -1,0 +1,8 @@
+(macOS) Use macOS-provided ``install_name_tool`` utility to modify headers
+on collected binaries: change the dylib identifier to ``@rpath/<name>.dylib``,
+rewrite paths to linked non-system shared libraries to ``@rpath/<dependency>``,
+remove any additional rpaths and add an rpath pointing to the application's
+top-level directory, relative to the ``@loader_path``. Previously, the
+header modification was performed using ``macholib`` and was limited
+only to modification of dylib identifier and paths to linked non-system
+shared libraries.

--- a/news/7664.feature.rst
+++ b/news/7664.feature.rst
@@ -1,0 +1,3 @@
+(macOS) PyInstaller now removes all rpaths from collected binaries
+and replaces them with a single rpath pointing to the top-level
+application directory, relative to ``@loader_path``.


### PR DESCRIPTION
When rewriting the dylib identifier and paths to linked non-system shared libraries in collected binaries, use `@rpath` instead of directly using `@loader_path`.

E.g., for a binary collected as `mypackage/lib/libsomething.dylib`, instead of rewriting the identifier and paths to linked dylibs as `@loader_lib/../../<something>`, rewrite as `@rpath/<something>` and set rpath to `@loader_path/../..`.

This ensures that the dylib identifier of a shared library (now `@rpath/libsomething.dylib`) always matches the name/path used by another collected binary to refer to this shared library (the dependency path now also being `@rpath/libsomething.dylib`), even if the shared library and referring binary are located at different directory depth w.r.t. the top-level application directory. Under the old approach that directly uses `@loader_path`, the dylib identifier of shared library might end up being `@loader_path/../../libsomething.dylib`, but the library path in the binary located one directory higher would end up being `@loader_path/../libsomething.dylib`.

Mismatches in dylib identifiers are typically not a problem, because the linked dylib is actually found at the specified location. However, some packages do not place shared libraries in "correct" location, and work around this by "preloading" the shared libraries from another location, for example via `ctypes`. In this case, for a binary to recognize an  already-loaded library, the referring name and the target dylib's identifier must match. And in PyInstaller's case, the only way to achieve that is to have identifiers (and referring paths) normalized to `@rpath/<name>`, and store the actual relative path to the top-level application directory in the rpath.

Using `@rpath`, however, means that we now need to ensure that our rpath is the only one set in the binary; i.e., we need to remove all other rpaths, and add our target rpath if necessary.  To do so, we need to use the external macOS-provided `install_name_tool` utility, which we now use for all header modifications: modification of dylib identifier, modification of dependend dylib paths, and removal/addition of rpaths.