### PR TITLE
Fix unhandled TclError in _get_tcl_tk_info

### DIFF
--- a/PyInstaller/utils/hooks/tcl_tk.py
+++ b/PyInstaller/utils/hooks/tcl_tk.py
@@ -39,8 +39,10 @@ def _get_tcl_tk_info():
     except ImportError:
         # tkinter unavailable
         return None, None, None, False
-
-    tcl = tkinter.Tcl()
+    try:
+        tcl = tkinter.Tcl()
+    except tkinter.TclError:  # e.g. "Can't find a usable init.tcl in the following directories: ..."
+        return None, None, None, False
 
     # Query the location of Tcl library/data directory.
     tcl_dir = tcl.eval("info library")


### PR DESCRIPTION
PyInstaller is currently failing to build projects in environments where the `tkinter.Tcl()` call raises `TclError`, which happens when TCL_LIBRARY and TK_LIBRARY env vars are not set, and is common in virtualenvs (ref: mitsuhiko/rye#226).

Rather than propagating this exception which crashes the build, catch this exception instead and allow PyInstaller to continue the the same as it does when `tkinter` fails to import.