### PR TITLE
splash: perform binary dependency analysis on Tcl/Tk shared libraries

### DIFF
--- a/bootloader/src/pyi_splash.h
+++ b/bootloader/src/pyi_splash.h
@@ -120,12 +120,13 @@ typedef struct _splash_status {
     char *requirements;
     int   requirements_len;
     /*
-     * Flag if tcl and tk libraries were loaded. This indicate if it is safe
-     * to call functions from Tcl/Tk. If the binaries are missing the splash
-     * screen cannot be shown.
+     * Flag indicating that Tcl/Tk shared libraries were successfully loaded
+     * and required symbols from them have been succesfully loaded and bound.
+     * This is primarily used in finalization function to detect properly
+     * handle tear-down of splash screen that failed to load the libraries or
+     * symbols.
      */
-    bool is_tcl_loaded;
-    bool is_tk_loaded;
+    bool dlls_fully_loaded;
     /*
      * Keep the handles to the shared library, in order to close
      * them at finalization.

--- a/news/7679.bugfix.1.rst
+++ b/news/7679.bugfix.1.rst
@@ -1,0 +1,6 @@
+Implement proper binary dependency scanning in the ``SPLASH`` target,
+so that binary dependencies of the Tcl and Tk shared libraries are
+always collected and added to the list of splash requirements
+(for pre-extraction in onefile builds). This fixes the splash screen
+when building with Windows build of python.org Python 3.12b1, which
+ships Tcl shared library with new dependency on ``zlib1.dll``.

--- a/news/7679.bugfix.rst
+++ b/news/7679.bugfix.rst
@@ -1,0 +1,4 @@
+Fix splash-enabled program crashing due to NULL-pointer dereference
+in the bootloader when the Tcl/Tk shared libraries cannot be loaded.
+The program should now run the user's python code, where it will
+raise an exception if the ``pyi_splash`` module is used.

--- a/tests/functional/specs/spec_with_splash.spec
+++ b/tests/functional/specs/spec_with_splash.spec
@@ -12,46 +12,64 @@ import os
 
 app_name = "spec_with_splash"
 
-# If set and not None, a onefile project is built
-onefile = os.environ.get('_TEST_SPLASH_ONEFILE', None)
+# If set and 'onefile', a onefile project is built instead of onedir one.
+build_mode = os.environ.get('_TEST_SPLASH_BUILD_MODE', 'onedir')
 
-# To prevent that on some systems tkinter is included automatically
-# we exclude it specifically
-a = Analysis(['../scripts/pyi_interact_pyi_splash.py'],
-             excludes=['tkinter', '_tkinter'])
+# If set and different from '0', collect tkinter via hidden import.
+with_tkinter = os.environ.get('_TEST_SPLASH_WITH_TKINTER', '0')
 
-splash = Splash('../data/splash/image.png',
-                binaries=a.binaries,
-                datas=a.datas,
-                text_pos=(10, 50),
-                text_color='red')
+if with_tkinter != '0':
+    # Force tkinter collection via hiddenimports; this simulates a program importing tkinter.
+    a = Analysis(
+        ['../scripts/pyi_interact_pyi_splash.py'],
+        hiddenimports=['tkinter'],
+    )
+else:
+    # On some systems tkinter is included automatically; explicitly exclude it.
+    a = Analysis(
+        ['../scripts/pyi_interact_pyi_splash.py'],
+        excludes=['tkinter', '_tkinter'],
+    )
+
+splash = Splash(
+    '../data/splash/image.png',
+    binaries=a.binaries,
+    datas=a.datas,
+    text_pos=(10, 50),
+    text_color='red',
+)
 
 pyz = PYZ(a.pure, a.zipped_data)
 
-if onefile:
-     exe = EXE(pyz,
-               a.scripts,
-               a.binaries,
-               a.zipfiles,
-               a.datas,
-               splash,
-               splash.binaries,
-               exclude_binaries=False,
-               name=app_name,
-               debug=True,
-               console=True)
-
+if build_mode == 'onefile':
+    exe = EXE(
+        pyz,
+        a.scripts,
+        a.binaries,
+        a.zipfiles,
+        a.datas,
+        splash,
+        splash.binaries,
+        exclude_binaries=False,
+        name=app_name,
+        debug=True,
+        console=True,
+    )
 else:
-     exe = EXE(pyz,
-               a.scripts,
-               splash,
-               exclude_binaries=True,
-               name=app_name,
-               debug=True,
-               console=True)
-     coll = COLLECT(exe,
-                    a.binaries,
-                    a.zipfiles,
-                    a.datas,
-                    splash.binaries,
-                    name=app_name)
+    exe = EXE(
+        pyz,
+        a.scripts,
+        splash,
+        exclude_binaries=True,
+        name=app_name,
+        debug=True,
+        console=True,
+    )
+    coll = COLLECT(
+        exe,
+        a.binaries,
+        a.zipfiles,
+        a.datas,
+        splash.binaries,
+        name=app_name,
+    )

--- a/tests/functional/test_interactive.py
+++ b/tests/functional/test_interactive.py
@@ -33,14 +33,17 @@ def test_ipython(pyi_builder):
 
 # Splash screen is not supported on macOS due to incompatible design.
 @pytest.mark.skipif(is_darwin, reason="Splash screen is not supported on macOS.")
-@pytest.mark.parametrize("mode", ['onedir', 'onefile'])
+@pytest.mark.parametrize("build_mode", ['onedir', 'onefile'])
+@pytest.mark.parametrize("with_tkinter", [False, True], ids=['notkinter', 'tkinter'])
 @pytest.mark.xfail(is_musl, reason="musl + tkinter is known to cause mysterious segfaults.")
-def test_pyi_splash(pyi_builder_spec, capfd, monkeypatch, mode):
-    if mode == 'onefile':
-        monkeypatch.setenv('_TEST_SPLASH_ONEFILE', 'onefile')
+def test_pyi_splash(pyi_builder_spec, capfd, monkeypatch, build_mode, with_tkinter):
+    if build_mode == 'onefile':
+        monkeypatch.setenv('_TEST_SPLASH_BUILD_MODE', 'onefile')
+    if with_tkinter:
+        monkeypatch.setenv('_TEST_SPLASH_WITH_TKINTER', '1')
 
     pyi_builder_spec.test_spec('spec_with_splash.spec', runtime=_RUNTIME)
 
     out, err = capfd.readouterr()
     assert 'SPLASH: Splash screen started' in err, \
-        "Cannot find log entry indicating start of splash screen in:\n{}".format(err)
+        f"Cannot find log entry indicating start of splash screen in:\n{err}"


### PR DESCRIPTION
Have `SPLASH` perform proper dependency analysis on Tcl/Tk shared libraries, in order to ensure that dependencies are always collected (otherwise they might be missing unless the user's program uses `tkinter`), and that they are added to splash requirements list (so that onefile builds pre-extract them before running the splash screen). Up until now, the only dependency we had to worry about was `vcruntime140.dll` on Windows (and even that only in context of pre-extraction). But the python.org Python 3.12b1 Windows build comes with `tcl86t.dll` that has additionally dependency on `zlib1.dll`, which we fail to pick up in our tests.

The failed tests revealed that failing to load Tcl/Tk shared libs crashes the bootloader with NULL-pointer dereference, so fix that as well. The program now reaches the user's python code, and if the latter attempts to use `pyi_splash` module, it will raise an exception. 

Lastly, the splash tests are now ran in four variants: `notkinter-onedir` and `notkinter-onefile` (which we've had up until now), as well as `tkinter-onedir` and `tkinter-onefile` (where we use hidden import to simulate user's program depending on `tkinter`).