### PR TITLE
hookutils: qt: collect qt_{lang} translation files

### DIFF
--- a/news/7682.bugfix.rst
+++ b/news/7682.bugfix.rst
@@ -1,0 +1,4 @@
+Ensure that ``qt_{lang}`` translation files are collected with the
+``QtCore`` module, in addition to already-collected ``qtbase_{lang}``
+files. Applies to all four Qt-bindings: ``PySide2``, ``PySide6``,
+``PyQt5``, and ``PyQt6``.


### PR DESCRIPTION
Extend our Qt module definition and handling code to allow multiple translation files' base names to be associated with a single module.

Associate and collect `qt_{lang}` translation files with the `QtCore` module, in addition to already-associated `qtbase_{lang}` files.

Fixes #7682.