### PR TITLE
fix(sec): upgrade certifi to 2022.12.07

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,7 +1,6 @@
 alabaster==0.7.12
 altgraph==0.17
 Babel==2.9.1
-certifi==2022.12.07
 chardet==4.0.0
 # docutils must be kept below 0.17 or bullet lists don't render properly
 docutils==0.16

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,7 +1,7 @@
 alabaster==0.7.12
 altgraph==0.17
 Babel==2.9.1
-certifi==2021.5.30
+certifi==2022.12.07
 chardet==4.0.0
 # docutils must be kept below 0.17 or bullet lists don't render properly
 docutils==0.16


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in certifi 2021.5.30
- [CVE-2022-23491](https://www.oscs1024.com/hd/CVE-2022-23491)


### What did I do？
Upgrade certifi from 2021.5.30 to 2022.12.07 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS