### PR TITLE
Fix relocate osx libraries

### DIFF
--- a/PyInstaller/building/osx.py
+++ b/PyInstaller/building/osx.py
@@ -205,7 +205,7 @@ class BUNDLE(Target):
             # Exempt python source files from this relocation, because their real path might need to resolve
             # to the directory that also contains the extension module.
             relocate_file = typecode == 'DATA' and base_path not in _QT_BASE_PATH
-            if relocate_file and os.path.splitext(dest_name)[1].lower() in {'.py', '.pyc'}:
+            if relocate_file and os.path.splitext(dest_name)[1].lower() in {'.py', '.pyc', '.dylib', '.so'}:
                 relocate_file = False
             if relocate_file:
                 links.append((dest_name, src_name))

--- a/PyInstaller/building/osx.py
+++ b/PyInstaller/building/osx.py
@@ -205,6 +205,8 @@ class BUNDLE(Target):
             # Exempt python source files from this relocation, because their real path might need to resolve
             # to the directory that also contains the extension module.
             relocate_file = typecode == 'DATA' and base_path not in _QT_BASE_PATH
+            if "plasma-store-server" in dest_name:
+                relocate_file = False
             if relocate_file and os.path.splitext(dest_name)[1].lower() in {'.py', '.pyc', '.dylib', '.so'}:
                 relocate_file = False
             if relocate_file:


### PR DESCRIPTION
Using codesign on osx fails if .so and .dynlib are not in the right locations. Right now they end on in Resources, but they should go into MacOS. 
The same happens for executable, for instance the "plasma-store-server" ends up in Resources, but should also go to MacOS. I am not sure however how to recognize binaries (will they have +x?).