### PR TITLE
building: limit package import in binary dependency analysis to Windows

### DIFF
--- a/news/7698.bugfix.rst
+++ b/news/7698.bugfix.rst
@@ -1,0 +1,4 @@
+Limit the import of collected packages prior to performing binary
+dependency analysis to only Windows, where it is actually useful.
+On non-Windows platforms, there is no benefit to it, and it might
+cause issues with particular orders of package imports.


### PR DESCRIPTION
Limit the collected package import in the binary dependency analysis subprocess (performed prior to the actual analysis) to Windows.

Windows is the only platform where the packages' initialization code can modify shared library search paths (either by modifying `PATH` environment variables, or by calling `os.add_dll_search_path`), so importing the collected packages to initialize the environment makes sense only there.

Furthermore, non-deterministic package import order may cause issues with particular package combinations and import orders, so it is better to avoid it where we do not need it (i.e., on non-Windows platforms).

Closes #7695.