### PR TITLE
On macOS, LC_REEXPORT_DYLIB is not processed

### DIFF
--- a/PyInstaller/utils/osx.py
+++ b/PyInstaller/utils/osx.py
@@ -28,6 +28,7 @@ from macholib.mach_o import (
     LC_SEGMENT_64,
     LC_SYMTAB,
     LC_VERSION_MIN_MACOSX,
+    LC_REEXPORT_DYLIB,
 )
 from macholib.MachO import MachO
 import macholib.util
@@ -436,13 +437,13 @@ def _set_dylib_dependency_paths(filename, target_rpath):
     for header in binary.headers:
         for cmd in header.commands:
             lc_type = cmd[0].cmd
-            if lc_type not in {LC_LOAD_DYLIB, LC_RPATH, LC_ID_DYLIB}:
+            if lc_type not in {LC_LOAD_DYLIB, LC_RPATH, LC_ID_DYLIB, LC_REEXPORT_DYLIB}:
                 continue
 
             # Decode path, strip trailing NULL characters
             path = cmd[2].decode('utf-8').rstrip('\x00')
 
-            if lc_type == LC_LOAD_DYLIB:
+            if lc_type == LC_LOAD_DYLIB or lc_type == LC_REEXPORT_DYLIB:
                 linked_libs.add(path)
             elif lc_type == LC_RPATH:
                 rpaths.add(path)

--- a/PyInstaller/utils/osx.py
+++ b/PyInstaller/utils/osx.py
@@ -24,11 +24,14 @@ from macholib.mach_o import (
     LC_CODE_SIGNATURE,
     LC_ID_DYLIB,
     LC_LOAD_DYLIB,
+    LC_LOAD_UPWARD_DYLIB,
+    LC_LOAD_WEAK_DYLIB,
+    LC_PREBOUND_DYLIB,
+    LC_REEXPORT_DYLIB,
     LC_RPATH,
     LC_SEGMENT_64,
     LC_SYMTAB,
     LC_VERSION_MIN_MACOSX,
-    LC_REEXPORT_DYLIB,
 )
 from macholib.MachO import MachO
 import macholib.util
@@ -424,8 +427,17 @@ def _set_dylib_dependency_paths(filename, target_rpath):
     Implicitly assumes that a single-arch thin binary is given.
     """
 
+    # Relocatable commands that we should overwrite - same list as used by `macholib`.
+    _RELOCATABLE = {
+        LC_LOAD_DYLIB,
+        LC_LOAD_UPWARD_DYLIB,
+        LC_LOAD_WEAK_DYLIB,
+        LC_PREBOUND_DYLIB,
+        LC_REEXPORT_DYLIB,
+    }
+
     # Parse dylib's header to extract the following commands:
-    #  - LC_LOAD_DYLIB: dylib load commands (dependent libraries)
+    #  - LC_LOAD_DYLIB (or any member of _RELOCATABLE list): dylib load commands (dependent libraries)
     #  - LC_RPATH: rpath definitions
     #  - LC_ID_DYLIB: dylib's identity
     binary = MachO(filename)
@@ -437,13 +449,13 @@ def _set_dylib_dependency_paths(filename, target_rpath):
     for header in binary.headers:
         for cmd in header.commands:
             lc_type = cmd[0].cmd
-            if lc_type not in {LC_LOAD_DYLIB, LC_RPATH, LC_ID_DYLIB, LC_REEXPORT_DYLIB}:
+            if lc_type not in _RELOCATABLE and lc_type not in {LC_RPATH, LC_ID_DYLIB}:
                 continue
 
             # Decode path, strip trailing NULL characters
             path = cmd[2].decode('utf-8').rstrip('\x00')
 
-            if lc_type == LC_LOAD_DYLIB or lc_type == LC_REEXPORT_DYLIB:
+            if lc_type in _RELOCATABLE:
                 linked_libs.add(path)
             elif lc_type == LC_RPATH:
                 rpaths.add(path)


### PR DESCRIPTION
Hi all! 

First of all: Thanks for the great work, I really enjoy using PyInstaller!
In my latest endeavors, I noticed a strange bug in a PyInstaller and thought I give fixing it a try. 😆 

## Background 

I'm currently working on bundling a program for macOS using packages from a local [Nix](https://nixos.org) store. The building went ok, but on another machine I could not execute the program, where it threw 

```
Traceback (most recent call last):
  File "worker.py", line 21, in <module>
  File "PyInstaller/loader/pyimod02_importers.py", line 385, in exec_module
  File "gi/__init__.py", line 40, in <module>
ImportError: dlopen(/Users/user/Desktop/local_tomedo_voice/testNativeMacServerARM/tomedo.Voice-se-macOS-arm64-v1.0.1/gi/_gi.cpython-310-darwin.so, 0x0002): Library not loaded: /nix/store/667wm1rg7m6pnwlpwakgvvp2xyj04ay3-libiconv-50/lib/libiconv-nocharset.dylib
  Referenced from: <no uuid> /Users/user/Desktop/local_tomedo_voice/testNativeMacServerARM/tomedo.Voice-se-macOS-arm64-v1.0.1/libiconv.dylib
  Reason: tried: '/nix/store/667wm1rg7m6pnwlpwakgvvp2xyj04ay3-libiconv-50/lib/libiconv-nocharset.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/nix/store/667wm1rg7m6pnwlpwakgvvp2xyj04ay3-libiconv-50/lib/libiconv-nocharset.dylib' (no such file), '/nix/store/667wm1rg7m6pnwlpwakgvvp2xyj04ay3-libiconv-50/lib/libiconv-nocharset.dylib' (no such file), '/usr/lib/libiconv-nocharset.dylib' (no such file, not in dyld cache)
[12479] Failed to execute script 'worker' due to unhandled exception!
```

The `otool -Ll libiconv.dylib` command gave me 

```
[...]
Load command 9
          cmd LC_REEXPORT_DYLIB
      cmdsize 112
         name /nix/store/667wm1rg7m6pnwlpwakgvvp2xyj04ay3-libiconv-50/lib/libiconv-nocharset.dylib (offset 24)
   time stamp 2 Thu Jan  1 01:00:02 1970
      current version 7.0.0
compatibility version 7.0.0
Load command 10
          cmd LC_REEXPORT_DYLIB
      cmdsize 104
         name /nix/store/667wm1rg7m6pnwlpwakgvvp2xyj04ay3-libiconv-50/lib/libcharset.1.dylib (offset 24)
   time stamp 2 Thu Jan  1 01:00:02 1970
      current version 2.0.0
compatibility version 2.0.0
Load command 11
          cmd LC_LOAD_DYLIB
      cmdsize 56
         name /usr/lib/libSystem.B.dylib (offset 24)
   time stamp 2 Thu Jan  1 01:00:02 1970
      current version 1292.60.1
compatibility version 1.0.0
Load command 12
      cmd LC_FUNCTION_STARTS
  cmdsize 16
  dataoff 32792
 datasize 8
Load command 13
      cmd LC_DATA_IN_CODE
  cmdsize 16
  dataoff 32800
 datasize 0
Load command 14
      cmd LC_CODE_SIGNATURE
  cmdsize 16
  dataoff 32880
 datasize 18672
	@rpath/libiconv.dylib (compatibility version 7.0.0, current version 7.0.0)
	/nix/store/667wm1rg7m6pnwlpwakgvvp2xyj04ay3-libiconv-50/lib/libiconv-nocharset.dylib (compatibility version 7.0.0, current version 7.0.0, reexport)
	/nix/store/667wm1rg7m6pnwlpwakgvvp2xyj04ay3-libiconv-50/lib/libcharset.1.dylib (compatibility version 2.0.0, current version 2.0.0, reexport)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1292.60.1)
```

## Analysis / Solution

Apparently, the `LC_REEXPORT_DYLIB` command is not processed by PyInstaller. This PR adds the command for processing like `LC_LOAD_DYLIB`. 

I'm looking forward to your feedback.

Best,
Fabian