### PR TITLE
rthook: harden run-time hooks against global namespace changes

### DIFF
--- a/PyInstaller/hooks/rthooks/pyi_rth__tkinter.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth__tkinter.py
@@ -9,22 +9,28 @@
 # SPDX-License-Identifier: Apache-2.0
 #-----------------------------------------------------------------------------
 
-import os
-import sys
 
-tcldir = os.path.join(sys._MEIPASS, 'tcl')
-tkdir = os.path.join(sys._MEIPASS, 'tk')
+def _pyi_rthook():
+    import os
+    import sys
 
-# Notify "tkinter" of data directories. On macOS, we do not collect data directories if system Tcl/Tk framework is used.
-# On other OSes, we always collect them, so their absence is considered an error.
-is_darwin = sys.platform == 'darwin'
+    tcldir = os.path.join(sys._MEIPASS, 'tcl')
+    tkdir = os.path.join(sys._MEIPASS, 'tk')
 
-if os.path.isdir(tcldir):
-    os.environ["TCL_LIBRARY"] = tcldir
-elif not is_darwin:
-    raise FileNotFoundError('Tcl data directory "%s" not found.' % tcldir)
+    # Notify "tkinter" of data directories. On macOS, we do not collect data directories if system Tcl/Tk framework is
+    # used. On other OSes, we always collect them, so their absence is considered an error.
+    is_darwin = sys.platform == 'darwin'
 
-if os.path.isdir(tkdir):
-    os.environ["TK_LIBRARY"] = tkdir
-elif not is_darwin:
-    raise FileNotFoundError('Tk data directory "%s" not found.' % tkdir)
+    if os.path.isdir(tcldir):
+        os.environ["TCL_LIBRARY"] = tcldir
+    elif not is_darwin:
+        raise FileNotFoundError('Tcl data directory "%s" not found.' % tcldir)
+
+    if os.path.isdir(tkdir):
+        os.environ["TK_LIBRARY"] = tkdir
+    elif not is_darwin:
+        raise FileNotFoundError('Tk data directory "%s" not found.' % tkdir)
+
+
+_pyi_rthook()
+del _pyi_rthook

--- a/PyInstaller/hooks/rthooks/pyi_rth_django.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_django.py
@@ -11,20 +11,24 @@
 
 # This Django rthook was tested with Django 1.8.3.
 
-import django.utils.autoreload
 
-_old_restart_with_reloader = django.utils.autoreload.restart_with_reloader
+def _pyi_rthook():
+    import django.utils.autoreload
+
+    _old_restart_with_reloader = django.utils.autoreload.restart_with_reloader
+
+    def _restart_with_reloader(*args):
+        import sys
+        a0 = sys.argv.pop(0)
+        try:
+            return _old_restart_with_reloader(*args)
+        finally:
+            sys.argv.insert(0, a0)
+
+    # Override restart_with_reloader() function, otherwise the app might complain that some commands do not exist;
+    # e.g., runserver.
+    django.utils.autoreload.restart_with_reloader = _restart_with_reloader
 
 
-def _restart_with_reloader(*args):
-    import sys
-    a0 = sys.argv.pop(0)
-    try:
-        return _old_restart_with_reloader(*args)
-    finally:
-        sys.argv.insert(0, a0)
-
-
-# Override restart_with_reloader() function, otherwise the app might complain that some commands do not exist;
-# e.g., runserver.
-django.utils.autoreload.restart_with_reloader = _restart_with_reloader
+_pyi_rthook()
+del _pyi_rthook

--- a/PyInstaller/hooks/rthooks/pyi_rth_gdkpixbuf.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_gdkpixbuf.py
@@ -9,27 +9,33 @@
 # SPDX-License-Identifier: Apache-2.0
 #-----------------------------------------------------------------------------
 
-import atexit
-import os
-import sys
-import tempfile
 
-pixbuf_file = os.path.join(sys._MEIPASS, 'lib', 'gdk-pixbuf', 'loaders.cache')
+def _pyi_rthook():
+    import atexit
+    import os
+    import sys
+    import tempfile
 
-# If we are not on Windows, we need to rewrite the cache -> we rewrite on Mac OS to support --onefile mode
-if os.path.exists(pixbuf_file) and sys.platform != 'win32':
-    with open(pixbuf_file, 'rb') as fp:
-        contents = fp.read()
+    pixbuf_file = os.path.join(sys._MEIPASS, 'lib', 'gdk-pixbuf', 'loaders.cache')
 
-    # Create a temporary file with the cache and cleverly replace the prefix we injected with the actual path.
-    fd, pixbuf_file = tempfile.mkstemp()
-    with os.fdopen(fd, 'wb') as fp:
-        libpath = os.path.join(sys._MEIPASS, 'lib').encode('utf-8')
-        fp.write(contents.replace(b'@executable_path/lib', libpath))
+    # If we are not on Windows, we need to rewrite the cache -> we rewrite on Mac OS to support --onefile mode
+    if os.path.exists(pixbuf_file) and sys.platform != 'win32':
+        with open(pixbuf_file, 'rb') as fp:
+            contents = fp.read()
 
-    try:
-        atexit.register(os.unlink, pixbuf_file)
-    except OSError:
-        pass
+        # Create a temporary file with the cache and cleverly replace the prefix we injected with the actual path.
+        fd, pixbuf_file = tempfile.mkstemp()
+        with os.fdopen(fd, 'wb') as fp:
+            libpath = os.path.join(sys._MEIPASS, 'lib').encode('utf-8')
+            fp.write(contents.replace(b'@executable_path/lib', libpath))
 
-os.environ['GDK_PIXBUF_MODULE_FILE'] = pixbuf_file
+        try:
+            atexit.register(os.unlink, pixbuf_file)
+        except OSError:
+            pass
+
+    os.environ['GDK_PIXBUF_MODULE_FILE'] = pixbuf_file
+
+
+_pyi_rthook()
+del _pyi_rthook

--- a/PyInstaller/hooks/rthooks/pyi_rth_gi.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_gi.py
@@ -9,7 +9,13 @@
 # SPDX-License-Identifier: Apache-2.0
 #-----------------------------------------------------------------------------
 
-import os
-import sys
 
-os.environ['GI_TYPELIB_PATH'] = os.path.join(sys._MEIPASS, 'gi_typelibs')
+def _pyi_rthook():
+    import os
+    import sys
+
+    os.environ['GI_TYPELIB_PATH'] = os.path.join(sys._MEIPASS, 'gi_typelibs')
+
+
+_pyi_rthook()
+del _pyi_rthook

--- a/PyInstaller/hooks/rthooks/pyi_rth_gio.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_gio.py
@@ -9,7 +9,13 @@
 # SPDX-License-Identifier: Apache-2.0
 #-----------------------------------------------------------------------------
 
-import os
-import sys
 
-os.environ['GIO_MODULE_DIR'] = os.path.join(sys._MEIPASS, 'gio_modules')
+def _pyi_rthook():
+    import os
+    import sys
+
+    os.environ['GIO_MODULE_DIR'] = os.path.join(sys._MEIPASS, 'gio_modules')
+
+
+_pyi_rthook()
+del _pyi_rthook

--- a/PyInstaller/hooks/rthooks/pyi_rth_glib.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_glib.py
@@ -9,23 +9,29 @@
 # SPDX-License-Identifier: Apache-2.0
 #-----------------------------------------------------------------------------
 
-import os
-import sys
 
-# Prepend the frozen application's data dir to XDG_DATA_DIRS. We need to avoid overwriting the existing paths in order
-# to allow the frozen application to run system-installed applications (for example, launch a web browser via the
-# webbrowser module on Linux). Should the user desire complete isolation of the frozen application from the system,
-# they need to clean up XDG_DATA_DIRS at the start of their program (i.e., remove all entries but first).
-pyi_data_dir = os.path.join(sys._MEIPASS, 'share')
+def _pyi_rthook():
+    import os
+    import sys
 
-xdg_data_dirs = os.environ.get('XDG_DATA_DIRS', None)
-if xdg_data_dirs:
-    if pyi_data_dir not in xdg_data_dirs:
-        xdg_data_dirs = pyi_data_dir + os.pathsep + xdg_data_dirs
-else:
-    xdg_data_dirs = pyi_data_dir
-os.environ['XDG_DATA_DIRS'] = xdg_data_dirs
+    # Prepend the frozen application's data dir to XDG_DATA_DIRS. We need to avoid overwriting the existing paths in
+    # order to allow the frozen application to run system-installed applications (for example, launch a web browser via
+    # the webbrowser module on Linux). Should the user desire complete isolation of the frozen application from the
+    # system, they need to clean up XDG_DATA_DIRS at the start of their program (i.e., remove all entries but first).
+    pyi_data_dir = os.path.join(sys._MEIPASS, 'share')
 
-# Cleanup aux variables
-del xdg_data_dirs
-del pyi_data_dir
+    xdg_data_dirs = os.environ.get('XDG_DATA_DIRS', None)
+    if xdg_data_dirs:
+        if pyi_data_dir not in xdg_data_dirs:
+            xdg_data_dirs = pyi_data_dir + os.pathsep + xdg_data_dirs
+    else:
+        xdg_data_dirs = pyi_data_dir
+    os.environ['XDG_DATA_DIRS'] = xdg_data_dirs
+
+    # Cleanup aux variables
+    del xdg_data_dirs
+    del pyi_data_dir
+
+
+_pyi_rthook()
+del _pyi_rthook

--- a/PyInstaller/hooks/rthooks/pyi_rth_gstreamer.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_gstreamer.py
@@ -9,18 +9,24 @@
 # SPDX-License-Identifier: Apache-2.0
 #-----------------------------------------------------------------------------
 
-import os
-import sys
 
-# Without this environment variable set to 'no' importing 'gst' causes 100% CPU load. (Tested on Mac OS.)
-os.environ['GST_REGISTRY_FORK'] = 'no'
+def _pyi_rthook():
+    import os
+    import sys
 
-gst_plugin_paths = [sys._MEIPASS, os.path.join(sys._MEIPASS, 'gst-plugins')]
-os.environ['GST_PLUGIN_PATH'] = os.pathsep.join(gst_plugin_paths)
+    # Without this environment variable set to 'no' importing 'gst' causes 100% CPU load. (Tested on Mac OS.)
+    os.environ['GST_REGISTRY_FORK'] = 'no'
 
-# Prevent permission issues on Windows
-os.environ['GST_REGISTRY'] = os.path.join(sys._MEIPASS, 'registry.bin')
+    gst_plugin_paths = [sys._MEIPASS, os.path.join(sys._MEIPASS, 'gst-plugins')]
+    os.environ['GST_PLUGIN_PATH'] = os.pathsep.join(gst_plugin_paths)
 
-# Only use packaged plugins to prevent GStreamer from crashing when it finds plugins from another version which are
-# installed system wide.
-os.environ['GST_PLUGIN_SYSTEM_PATH'] = ''
+    # Prevent permission issues on Windows
+    os.environ['GST_REGISTRY'] = os.path.join(sys._MEIPASS, 'registry.bin')
+
+    # Only use packaged plugins to prevent GStreamer from crashing when it finds plugins from another version which are
+    # installed system wide.
+    os.environ['GST_PLUGIN_SYSTEM_PATH'] = ''
+
+
+_pyi_rthook()
+del _pyi_rthook

--- a/PyInstaller/hooks/rthooks/pyi_rth_gtk.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_gtk.py
@@ -9,13 +9,19 @@
 # SPDX-License-Identifier: Apache-2.0
 #-----------------------------------------------------------------------------
 
-import os
-import sys
 
-os.environ['GTK_DATA_PREFIX'] = sys._MEIPASS
-os.environ['GTK_EXE_PREFIX'] = sys._MEIPASS
-os.environ['GTK_PATH'] = sys._MEIPASS
+def _pyi_rthook():
+    import os
+    import sys
 
-# Include these here, as GTK will import pango automatically.
-os.environ['PANGO_LIBDIR'] = sys._MEIPASS
-os.environ['PANGO_SYSCONFDIR'] = os.path.join(sys._MEIPASS, 'etc')  # TODO?
+    os.environ['GTK_DATA_PREFIX'] = sys._MEIPASS
+    os.environ['GTK_EXE_PREFIX'] = sys._MEIPASS
+    os.environ['GTK_PATH'] = sys._MEIPASS
+
+    # Include these here, as GTK will import pango automatically.
+    os.environ['PANGO_LIBDIR'] = sys._MEIPASS
+    os.environ['PANGO_SYSCONFDIR'] = os.path.join(sys._MEIPASS, 'etc')  # TODO?
+
+
+_pyi_rthook()
+del _pyi_rthook

--- a/PyInstaller/hooks/rthooks/pyi_rth_inspect.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_inspect.py
@@ -9,36 +9,40 @@
 # SPDX-License-Identifier: Apache-2.0
 #-----------------------------------------------------------------------------
 
-import inspect
-import os
-import sys
 
-_orig_inspect_getsourcefile = inspect.getsourcefile
+def _pyi_rthook():
+    import inspect
+    import os
+    import sys
+
+    _orig_inspect_getsourcefile = inspect.getsourcefile
+
+    # Provide custom implementation of inspect.getsourcefile() for frozen applications that properly resolves relative
+    # filenames obtained from object (e.g., inspect stack-frames). See #5963.
+    def _pyi_getsourcefile(object):
+        filename = inspect.getfile(object)
+        if not os.path.isabs(filename):
+            # Check if given filename matches the basename of __main__'s __file__.
+            main_file = getattr(sys.modules['__main__'], '__file__', None)
+            if main_file and filename == os.path.basename(main_file):
+                return main_file
+
+            # If filename ends with .py suffix and does not correspond to frozen entry-point script, convert it to
+            # corresponding .pyc in sys._MEIPASS.
+            if filename.endswith('.py'):
+                filename = os.path.normpath(os.path.join(sys._MEIPASS, filename + 'c'))
+                # Ensure the relative path did not try to jump out of sys._MEIPASS, just in case...
+                if filename.startswith(sys._MEIPASS):
+                    return filename
+        elif filename.startswith(sys._MEIPASS) and filename.endswith('.pyc'):
+            # If filename is already PyInstaller-compatible, prevent any further processing (i.e., with original
+            # implementation).
+            return filename
+        # Use original implementation as a fallback.
+        return _orig_inspect_getsourcefile(object)
+
+    inspect.getsourcefile = _pyi_getsourcefile
 
 
-# Provide custom implementation of inspect.getsourcefile() for frozen applications that properly resolves relative
-# filenames obtained from object (e.g., inspect stack-frames). See #5963.
-def _pyi_getsourcefile(object):
-    filename = inspect.getfile(object)
-    if not os.path.isabs(filename):
-        # Check if given filename matches the basename of __main__'s __file__.
-        main_file = getattr(sys.modules['__main__'], '__file__', None)
-        if main_file and filename == os.path.basename(main_file):
-            return main_file
-
-        # If filename ends with .py suffix and does not correspond to frozen entry-point script, convert it to
-        # corresponding .pyc in sys._MEIPASS.
-        if filename.endswith('.py'):
-            filename = os.path.normpath(os.path.join(sys._MEIPASS, filename + 'c'))
-            # Ensure the relative path did not try to jump out of sys._MEIPASS, just in case...
-            if filename.startswith(sys._MEIPASS):
-                return filename
-    elif filename.startswith(sys._MEIPASS) and filename.endswith('.pyc'):
-        # If filename is already PyInstaller-compatible, prevent any further processing (i.e., with original
-        # implementation).
-        return filename
-    # Use original implementation as a fallback.
-    return _orig_inspect_getsourcefile(object)
-
-
-inspect.getsourcefile = _pyi_getsourcefile
+_pyi_rthook()
+del _pyi_rthook

--- a/PyInstaller/hooks/rthooks/pyi_rth_kivy.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_kivy.py
@@ -9,10 +9,16 @@
 # SPDX-License-Identifier: Apache-2.0
 #-----------------------------------------------------------------------------
 
-import os
-import sys
 
-root = os.path.join(sys._MEIPASS, 'kivy_install')
+def _pyi_rthook():
+    import os
+    import sys
 
-os.environ['KIVY_DATA_DIR'] = os.path.join(root, 'data')
-os.environ['KIVY_MODULES_DIR'] = os.path.join(root, 'modules')
+    root = os.path.join(sys._MEIPASS, 'kivy_install')
+
+    os.environ['KIVY_DATA_DIR'] = os.path.join(root, 'data')
+    os.environ['KIVY_MODULES_DIR'] = os.path.join(root, 'modules')
+
+
+_pyi_rthook()
+del _pyi_rthook

--- a/PyInstaller/hooks/rthooks/pyi_rth_mplconfig.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_mplconfig.py
@@ -22,17 +22,23 @@
 #
 # We need to force matplotlib to recreate config directory every time you run your app.
 
-import atexit
-import os
-import shutil
-import tempfile
 
-# Put matplot config dir to temp directory.
-configdir = tempfile.mkdtemp()
-os.environ['MPLCONFIGDIR'] = configdir
+def _pyi_rthook():
+    import atexit
+    import os
+    import shutil
+    import tempfile
 
-try:
-    # Remove temp directory at application exit and ignore any errors.
-    atexit.register(shutil.rmtree, configdir, ignore_errors=True)
-except OSError:
-    pass
+    # Put matplot config dir to temp directory.
+    configdir = tempfile.mkdtemp()
+    os.environ['MPLCONFIGDIR'] = configdir
+
+    try:
+        # Remove temp directory at application exit and ignore any errors.
+        atexit.register(shutil.rmtree, configdir, ignore_errors=True)
+    except OSError:
+        pass
+
+
+_pyi_rthook()
+del _pyi_rthook

--- a/PyInstaller/hooks/rthooks/pyi_rth_multiprocessing.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_multiprocessing.py
@@ -10,7 +10,7 @@
 #-----------------------------------------------------------------------------
 
 
-def _pyi_rth_multiprocessing():
+def _pyi_rthook():
     import os
     import sys
 
@@ -106,6 +106,5 @@ def _pyi_rth_multiprocessing():
         popen_forkserver.Popen = _ForkserverPopen
 
 
-# Run the hook function, then delete it. This prevents unnecessary pollution of the global namespace.
-_pyi_rth_multiprocessing()
-del _pyi_rth_multiprocessing
+_pyi_rthook()
+del _pyi_rthook

--- a/PyInstaller/hooks/rthooks/pyi_rth_pkgres.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_pkgres.py
@@ -9,15 +9,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #-----------------------------------------------------------------------------
 
-import os
-import pathlib
-import sys
-
-import pkg_resources
-from pyimod02_importers import PyiFrozenImporter
-
-SYS_PREFIX = pathlib.PurePath(sys._MEIPASS)
-
 # To make pkg_resources work with frozen modules we need to set the 'Provider' class for PyiFrozenImporter. This class
 # decides where to look for resources and other stuff. 'pkg_resources.NullProvider' is dedicated to PEP302 import hooks
 # like PyiFrozenImporter is. It uses method __loader__.get_data() in methods pkg_resources.resource_string() and
@@ -37,164 +28,174 @@ SYS_PREFIX = pathlib.PurePath(sys._MEIPASS)
 # unfrozen packages, the frozen ones do not contain source .py files, which are therefore absent from content listings.
 
 
-class _TocFilesystem:
-    """
-    A prefix tree implementation for embedded filesystem reconstruction.
-    """
-    def __init__(self, toc_files, toc_dirs=None):
-        toc_dirs = toc_dirs or []
-        # Reconstruct the filesystem hierarchy by building a prefix tree from the given file and directory paths.
-        self._tree = dict()
+def _pyi_rthook():
+    import os
+    import pathlib
+    import sys
 
-        # Data files
-        for path in toc_files:
-            path = pathlib.PurePath(path)
-            current = self._tree
-            for component in path.parts[:-1]:
-                current = current.setdefault(component, {})
-            current[path.parts[-1]] = ''
+    import pkg_resources
+    from pyimod02_importers import PyiFrozenImporter
 
-        # Extra directories
-        for path in toc_dirs:
+    SYS_PREFIX = pathlib.PurePath(sys._MEIPASS)
+
+    class _TocFilesystem:
+        """
+        A prefix tree implementation for embedded filesystem reconstruction.
+        """
+        def __init__(self, toc_files, toc_dirs=None):
+            toc_dirs = toc_dirs or []
+            # Reconstruct the filesystem hierarchy by building a prefix tree from the given file and directory paths.
+            self._tree = dict()
+
+            # Data files
+            for path in toc_files:
+                path = pathlib.PurePath(path)
+                current = self._tree
+                for component in path.parts[:-1]:
+                    current = current.setdefault(component, {})
+                current[path.parts[-1]] = ''
+
+            # Extra directories
+            for path in toc_dirs:
+                path = pathlib.PurePath(path)
+                current = self._tree
+                for component in path.parts:
+                    current = current.setdefault(component, {})
+
+        def _get_tree_node(self, path):
             path = pathlib.PurePath(path)
             current = self._tree
             for component in path.parts:
-                current = current.setdefault(component, {})
+                if component not in current:
+                    return None
+                current = current[component]
+            return current
 
-    def _get_tree_node(self, path):
-        path = pathlib.PurePath(path)
-        current = self._tree
-        for component in path.parts:
-            if component not in current:
-                return None
-            current = current[component]
-        return current
+        def path_exists(self, path):
+            node = self._get_tree_node(path)
+            return node is not None  # File or directory
 
-    def path_exists(self, path):
-        node = self._get_tree_node(path)
-        return node is not None  # File or directory
-
-    def path_isdir(self, path):
-        node = self._get_tree_node(path)
-        if node is None:
-            return False  # Non-existent
-        if isinstance(node, str):
-            return False  # File
-        return True
-
-    def path_listdir(self, path):
-        node = self._get_tree_node(path)
-        if not isinstance(node, dict):
-            return []  # Non-existent or file
-        return list(node.keys())
-
-
-# Cache for reconstructed embedded trees
-_toc_tree_cache = {}
-
-
-class PyiFrozenProvider(pkg_resources.NullProvider):
-    """
-    Custom pkg_resources provider for PyiFrozenImporter.
-    """
-    def __init__(self, module):
-        super().__init__(module)
-
-        # Get top-level path; if "module" corresponds to a package, we need the path to the package itself. If "module"
-        # is a submodule in a package, we need the path to the parent package.
-        self._pkg_path = pathlib.PurePath(module.__file__).parent
-
-        # Defer initialization of PYZ-embedded resources tree to the first access.
-        self._embedded_tree = None
-
-    def _init_embedded_tree(self, rel_pkg_path, pkg_name):
-        # Collect relevant entries from TOC. We are interested in either files that are located in the package/module's
-        # directory (data files) or in packages that are prefixed with package/module's name (to reconstruct subpackage
-        # directories).
-        data_files = []
-        package_dirs = []
-        for entry in self.loader.toc:
-            entry_path = pathlib.PurePath(entry)
-            if rel_pkg_path in entry_path.parents:
-                # Data file path
-                data_files.append(entry_path)
-            elif entry.startswith(pkg_name) and self.loader.is_package(entry):
-                # Package or subpackage; convert the name to directory path
-                package_dir = pathlib.PurePath(*entry.split('.'))
-                package_dirs.append(package_dir)
-
-        # Reconstruct the filesystem
-        return _TocFilesystem(data_files, package_dirs)
-
-    @property
-    def embedded_tree(self):
-        if self._embedded_tree is None:
-            # Construct a path relative to _MEIPASS directory for searching the TOC.
-            rel_pkg_path = self._pkg_path.relative_to(SYS_PREFIX)
-
-            # Reconstruct package name prefix (use package path to obtain correct prefix in case of a module).
-            pkg_name = '.'.join(rel_pkg_path.parts)
-
-            # Initialize and cache the tree, if necessary.
-            if pkg_name not in _toc_tree_cache:
-                _toc_tree_cache[pkg_name] = \
-                    self._init_embedded_tree(rel_pkg_path, pkg_name)
-            self._embedded_tree = _toc_tree_cache[pkg_name]
-        return self._embedded_tree
-
-    def _normalize_path(self, path):
-        # Avoid using Path.resolve(), because it resolves symlinks. This is undesirable, because the pure path in
-        # self._pkg_path does not have symlinks resolved, so comparison between the two would be faulty. So use
-        # os.path.abspath() instead to normalize the path.
-        return pathlib.Path(os.path.abspath(path))
-
-    def _is_relative_to_package(self, path):
-        return path == self._pkg_path or self._pkg_path in path.parents
-
-    def _has(self, path):
-        # Prevent access outside the package.
-        path = self._normalize_path(path)
-        if not self._is_relative_to_package(path):
-            return False
-
-        # Check the filesystem first to avoid unnecessarily computing the relative path...
-        if path.exists():
+        def path_isdir(self, path):
+            node = self._get_tree_node(path)
+            if node is None:
+                return False  # Non-existent
+            if isinstance(node, str):
+                return False  # File
             return True
-        rel_path = path.relative_to(SYS_PREFIX)
-        return self.embedded_tree.path_exists(rel_path)
 
-    def _isdir(self, path):
-        # Prevent access outside the package.
-        path = self._normalize_path(path)
-        if not self._is_relative_to_package(path):
-            return False
+        def path_listdir(self, path):
+            node = self._get_tree_node(path)
+            if not isinstance(node, dict):
+                return []  # Non-existent or file
+            return list(node.keys())
 
-        # Embedded resources have precedence over filesystem...
-        rel_path = path.relative_to(SYS_PREFIX)
-        node = self.embedded_tree._get_tree_node(rel_path)
-        if node is None:
-            return path.is_dir()  # No match found; try the filesystem.
-        else:
-            # str = file, dict = directory
-            return not isinstance(node, str)
+    # Cache for reconstructed embedded trees
+    _toc_tree_cache = {}
 
-    def _listdir(self, path):
-        # Prevent access outside the package.
-        path = self._normalize_path(path)
-        if not self._is_relative_to_package(path):
-            return []
+    class PyiFrozenProvider(pkg_resources.NullProvider):
+        """
+        Custom pkg_resources provider for PyiFrozenImporter.
+        """
+        def __init__(self, module):
+            super().__init__(module)
 
-        # Relative path for searching embedded resources.
-        rel_path = path.relative_to(SYS_PREFIX)
-        # List content from embedded filesystem...
-        content = self.embedded_tree.path_listdir(rel_path)
-        # ... as well as the actual one.
-        if path.is_dir():
-            # Use os.listdir() to avoid having to convert Path objects to strings... Also make sure to de-duplicate the
-            # results.
-            path = str(path)  # not is_py36
-            content = list(set(content + os.listdir(path)))
-        return content
+            # Get top-level path; if "module" corresponds to a package, we need the path to the package itself.
+            # If "module" is a submodule in a package, we need the path to the parent package.
+            self._pkg_path = pathlib.PurePath(module.__file__).parent
+
+            # Defer initialization of PYZ-embedded resources tree to the first access.
+            self._embedded_tree = None
+
+        def _init_embedded_tree(self, rel_pkg_path, pkg_name):
+            # Collect relevant entries from TOC. We are interested in either files that are located in the
+            # package/module's directory (data files) or in packages that are prefixed with package/module's name
+            # (to reconstruct subpackage directories).
+            data_files = []
+            package_dirs = []
+            for entry in self.loader.toc:
+                entry_path = pathlib.PurePath(entry)
+                if rel_pkg_path in entry_path.parents:
+                    # Data file path
+                    data_files.append(entry_path)
+                elif entry.startswith(pkg_name) and self.loader.is_package(entry):
+                    # Package or subpackage; convert the name to directory path
+                    package_dir = pathlib.PurePath(*entry.split('.'))
+                    package_dirs.append(package_dir)
+
+            # Reconstruct the filesystem
+            return _TocFilesystem(data_files, package_dirs)
+
+        @property
+        def embedded_tree(self):
+            if self._embedded_tree is None:
+                # Construct a path relative to _MEIPASS directory for searching the TOC.
+                rel_pkg_path = self._pkg_path.relative_to(SYS_PREFIX)
+
+                # Reconstruct package name prefix (use package path to obtain correct prefix in case of a module).
+                pkg_name = '.'.join(rel_pkg_path.parts)
+
+                # Initialize and cache the tree, if necessary.
+                if pkg_name not in _toc_tree_cache:
+                    _toc_tree_cache[pkg_name] = self._init_embedded_tree(rel_pkg_path, pkg_name)
+                self._embedded_tree = _toc_tree_cache[pkg_name]
+            return self._embedded_tree
+
+        def _normalize_path(self, path):
+            # Avoid using Path.resolve(), because it resolves symlinks. This is undesirable, because the pure path in
+            # self._pkg_path does not have symlinks resolved, so comparison between the two would be faulty. So use
+            # os.path.abspath() instead to normalize the path.
+            return pathlib.Path(os.path.abspath(path))
+
+        def _is_relative_to_package(self, path):
+            return path == self._pkg_path or self._pkg_path in path.parents
+
+        def _has(self, path):
+            # Prevent access outside the package.
+            path = self._normalize_path(path)
+            if not self._is_relative_to_package(path):
+                return False
+
+            # Check the filesystem first to avoid unnecessarily computing the relative path...
+            if path.exists():
+                return True
+            rel_path = path.relative_to(SYS_PREFIX)
+            return self.embedded_tree.path_exists(rel_path)
+
+        def _isdir(self, path):
+            # Prevent access outside the package.
+            path = self._normalize_path(path)
+            if not self._is_relative_to_package(path):
+                return False
+
+            # Embedded resources have precedence over filesystem...
+            rel_path = path.relative_to(SYS_PREFIX)
+            node = self.embedded_tree._get_tree_node(rel_path)
+            if node is None:
+                return path.is_dir()  # No match found; try the filesystem.
+            else:
+                # str = file, dict = directory
+                return not isinstance(node, str)
+
+        def _listdir(self, path):
+            # Prevent access outside the package.
+            path = self._normalize_path(path)
+            if not self._is_relative_to_package(path):
+                return []
+
+            # Relative path for searching embedded resources.
+            rel_path = path.relative_to(SYS_PREFIX)
+            # List content from embedded filesystem...
+            content = self.embedded_tree.path_listdir(rel_path)
+            # ... as well as the actual one.
+            if path.is_dir():
+                # Use os.listdir() to avoid having to convert Path objects to strings... Also make sure to de-duplicate
+                # the results.
+                path = str(path)  # not is_py36
+                content = list(set(content + os.listdir(path)))
+            return content
+
+    pkg_resources.register_loader_type(PyiFrozenImporter, PyiFrozenProvider)
 
 
-pkg_resources.register_loader_type(PyiFrozenImporter, PyiFrozenProvider)
+_pyi_rthook()
+del _pyi_rthook

--- a/PyInstaller/hooks/rthooks/pyi_rth_pkgutil.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_pkgutil.py
@@ -22,65 +22,70 @@
 # Therefore, we instead opt for overriding pkgutil.iter_modules with custom implementation that augments the output of
 # original implementation with contents of PYZ archive from PyiFrozenImporter's TOC.
 
-import os
-import pkgutil
-import sys
 
-from pyimod02_importers import PyiFrozenImporter
+def _pyi_rthook():
+    import os
+    import pkgutil
+    import sys
 
-_orig_pkgutil_iter_modules = pkgutil.iter_modules
+    from pyimod02_importers import PyiFrozenImporter
 
+    _orig_pkgutil_iter_modules = pkgutil.iter_modules
 
-def _pyi_pkgutil_iter_modules(path=None, prefix=''):
-    # Use original implementation to discover on-filesystem modules (binary extensions in regular builds, or both binary
-    # extensions and compiled pyc modules in noarchive debug builds).
-    yield from _orig_pkgutil_iter_modules(path, prefix)
+    def _pyi_pkgutil_iter_modules(path=None, prefix=''):
+        # Use original implementation to discover on-filesystem modules (binary extensions in regular builds, or both
+        # binary extensions and compiled pyc modules in noarchive debug builds).
+        yield from _orig_pkgutil_iter_modules(path, prefix)
 
-    # Find the instance of PyInstaller's PyiFrozenImporter.
-    for importer in pkgutil.iter_importers():
-        if isinstance(importer, PyiFrozenImporter):
-            break
-    else:
-        return
+        # Find the instance of PyInstaller's PyiFrozenImporter.
+        for importer in pkgutil.iter_importers():
+            if isinstance(importer, PyiFrozenImporter):
+                break
+        else:
+            return
 
-    if path is None:
-        # Search for all top-level packages/modules. These will have no dots in their entry names.
-        for entry in importer.toc:
-            if entry.count('.') != 0:
-                continue
-            is_pkg = importer.is_package(entry)
-            yield pkgutil.ModuleInfo(importer, prefix + entry, is_pkg)
-    else:
-        # Declare SYS_PREFIX locally, to avoid clash with eponymous global symbol from pyi_rth_pkgutil hook.
-        #
-        # Use os.path.realpath() to fully resolve any symbolic links in sys._MEIPASS, in order to avoid path mis-matches
-        # when the given search paths also contain symbolic links and are already fully resolved. See #6537 for an
-        # example of such a problem with onefile build on macOS, where the temporary directory is placed under /var,
-        # which is actually a symbolic link to /private/var.
-        SYS_PREFIX = os.path.realpath(sys._MEIPASS) + os.path.sep
-        SYS_PREFIXLEN = len(SYS_PREFIX)
-
-        for pkg_path in path:
-            pkg_path = os.path.realpath(pkg_path)  # Fully resolve the given path, in case it contains symbolic links.
-            if not pkg_path.startswith(SYS_PREFIX):
-                # if the path does not start with sys._MEIPASS then it cannot be a bundled package.
-                continue
-            # Construct package prefix from path...
-            pkg_prefix = pkg_path[SYS_PREFIXLEN:]
-            pkg_prefix = pkg_prefix.replace(os.path.sep, '.')
-            # ... and ensure it ends with a dot (so we can directly filter out the package itself).
-            if not pkg_prefix.endswith('.'):
-                pkg_prefix += '.'
-            pkg_prefix_len = len(pkg_prefix)
-
+        if path is None:
+            # Search for all top-level packages/modules. These will have no dots in their entry names.
             for entry in importer.toc:
-                if not entry.startswith(pkg_prefix):
-                    continue
-                name = entry[pkg_prefix_len:]
-                if name.count('.') != 0:
+                if entry.count('.') != 0:
                     continue
                 is_pkg = importer.is_package(entry)
-                yield pkgutil.ModuleInfo(importer, prefix + name, is_pkg)
+                yield pkgutil.ModuleInfo(importer, prefix + entry, is_pkg)
+        else:
+            # Declare SYS_PREFIX locally, to avoid clash with eponymous global symbol from pyi_rth_pkgutil hook.
+            #
+            # Use os.path.realpath() to fully resolve any symbolic links in sys._MEIPASS, in order to avoid path
+            # mis-matches when the given search paths also contain symbolic links and are already fully resolved.
+            # See #6537 for an example of such a problem with onefile build on macOS, where the temporary directory
+            # is placed under /var, which is actually a symbolic link to /private/var.
+            SYS_PREFIX = os.path.realpath(sys._MEIPASS) + os.path.sep
+            SYS_PREFIXLEN = len(SYS_PREFIX)
+
+            for pkg_path in path:
+                # Fully resolve the given path, in case it contains symbolic links.
+                pkg_path = os.path.realpath(pkg_path)
+                if not pkg_path.startswith(SYS_PREFIX):
+                    # If the path does not start with sys._MEIPASS, it cannot be a bundled package.
+                    continue
+                # Construct package prefix from path...
+                pkg_prefix = pkg_path[SYS_PREFIXLEN:]
+                pkg_prefix = pkg_prefix.replace(os.path.sep, '.')
+                # ... and ensure it ends with a dot (so we can directly filter out the package itself).
+                if not pkg_prefix.endswith('.'):
+                    pkg_prefix += '.'
+                pkg_prefix_len = len(pkg_prefix)
+
+                for entry in importer.toc:
+                    if not entry.startswith(pkg_prefix):
+                        continue
+                    name = entry[pkg_prefix_len:]
+                    if name.count('.') != 0:
+                        continue
+                    is_pkg = importer.is_package(entry)
+                    yield pkgutil.ModuleInfo(importer, prefix + name, is_pkg)
+
+    pkgutil.iter_modules = _pyi_pkgutil_iter_modules
 
 
-pkgutil.iter_modules = _pyi_pkgutil_iter_modules
+_pyi_rthook()
+del _pyi_rthook

--- a/PyInstaller/hooks/rthooks/pyi_rth_pyqt5.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_pyqt5.py
@@ -9,20 +9,25 @@
 # SPDX-License-Identifier: Apache-2.0
 #-----------------------------------------------------------------------------
 
-import os
-import sys
-
 # The path to Qt's components may not default to the wheel layout for self-compiled PyQt5 installations. Mandate the
-# wheel layout. See:
-# ``utils/hooks/qt.py`` for more details.
-#
-# Try PyQt5 5.15.4-style path first...
-pyqt_path = os.path.join(sys._MEIPASS, 'PyQt5', 'Qt5')
-if not os.path.isdir(pyqt_path):
-    # ... and fall back to the older version
-    pyqt_path = os.path.join(sys._MEIPASS, 'PyQt5', 'Qt')
-os.environ['QT_PLUGIN_PATH'] = os.path.join(pyqt_path, 'plugins')
-os.environ['QML2_IMPORT_PATH'] = os.path.join(pyqt_path, 'qml')
-# This is required starting in PyQt5 5.12.3. See discussion in #4293.
-if sys.platform.startswith('win') and 'PATH' in os.environ:
-    os.environ['PATH'] = sys._MEIPASS + os.pathsep + os.environ['PATH']
+# wheel layout. See ``utils/hooks/qt.py`` for more details.
+
+
+def _pyi_rthook():
+    import os
+    import sys
+
+    # Try PyQt5 5.15.4-style path first...
+    pyqt_path = os.path.join(sys._MEIPASS, 'PyQt5', 'Qt5')
+    if not os.path.isdir(pyqt_path):
+        # ... and fall back to the older version
+        pyqt_path = os.path.join(sys._MEIPASS, 'PyQt5', 'Qt')
+    os.environ['QT_PLUGIN_PATH'] = os.path.join(pyqt_path, 'plugins')
+    os.environ['QML2_IMPORT_PATH'] = os.path.join(pyqt_path, 'qml')
+    # This is required starting in PyQt5 5.12.3. See discussion in #4293.
+    if sys.platform.startswith('win') and 'PATH' in os.environ:
+        os.environ['PATH'] = sys._MEIPASS + os.pathsep + os.environ['PATH']
+
+
+_pyi_rthook()
+del _pyi_rthook

--- a/PyInstaller/hooks/rthooks/pyi_rth_pyqt5webengine.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_pyqt5webengine.py
@@ -9,11 +9,16 @@
 # SPDX-License-Identifier: Apache-2.0
 #-----------------------------------------------------------------------------
 
-import os
-import sys
 
-# See ``pyi_rth_qt5.py`: use a "standard" PyQt5 layout.
-if sys.platform == 'darwin':
+def _pyi_rthook():
+    import os
+    import sys
+
+    # Special handling is needed only on macOS.
+    if sys.platform != 'darwin':
+        return
+
+    # See ``pyi_rth_qt5.py`: use a "standard" PyQt5 layout.
     # Try PyQt5 5.15.4-style path first...
     pyqt_path = os.path.join(sys._MEIPASS, 'PyQt5', 'Qt5')
     if not os.path.isdir(pyqt_path):
@@ -30,3 +35,7 @@ if sys.platform == 'darwin':
     )
     if os.path.exists(process_path):
         os.environ['QTWEBENGINEPROCESS_PATH'] = process_path
+
+
+_pyi_rthook()
+del _pyi_rthook

--- a/PyInstaller/hooks/rthooks/pyi_rth_pyqt6.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_pyqt6.py
@@ -9,20 +9,26 @@
 # SPDX-License-Identifier: Apache-2.0
 #-----------------------------------------------------------------------------
 
-import os
-import sys
-
 # The path to Qt's components may not default to the wheel layout for self-compiled PyQt6 installations. Mandate the
 # wheel layout. See ``utils/hooks/qt.py`` for more details.
-#
-# Try PyQt6 6.0.3-style path first...
-pyqt_path = os.path.join(sys._MEIPASS, 'PyQt6', 'Qt6')
-if not os.path.isdir(pyqt_path):
-    # ... and fall back to the older version.
-    pyqt_path = os.path.join(sys._MEIPASS, 'PyQt6', 'Qt')
-os.environ['QT_PLUGIN_PATH'] = os.path.join(pyqt_path, 'plugins')
-os.environ['QML2_IMPORT_PATH'] = os.path.join(pyqt_path, 'qml')
-# Modelled after similar PATH modification in PyQt5 rthook. With PyQt6, this modification seems necessary for SSL DLLs
-# to be found in onefile builds.
-if sys.platform.startswith('win') and 'PATH' in os.environ:
-    os.environ['PATH'] = sys._MEIPASS + os.pathsep + os.environ['PATH']
+
+
+def _pyi_rthook():
+    import os
+    import sys
+
+    # Try PyQt6 6.0.3-style path first...
+    pyqt_path = os.path.join(sys._MEIPASS, 'PyQt6', 'Qt6')
+    if not os.path.isdir(pyqt_path):
+        # ... and fall back to the older version.
+        pyqt_path = os.path.join(sys._MEIPASS, 'PyQt6', 'Qt')
+    os.environ['QT_PLUGIN_PATH'] = os.path.join(pyqt_path, 'plugins')
+    os.environ['QML2_IMPORT_PATH'] = os.path.join(pyqt_path, 'qml')
+    # Modelled after similar PATH modification in PyQt5 rthook. With PyQt6, this modification seems necessary for SSL
+    # DLLs to be found in onefile builds.
+    if sys.platform.startswith('win') and 'PATH' in os.environ:
+        os.environ['PATH'] = sys._MEIPASS + os.pathsep + os.environ['PATH']
+
+
+_pyi_rthook()
+del _pyi_rthook

--- a/PyInstaller/hooks/rthooks/pyi_rth_pyqt6webengine.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_pyqt6webengine.py
@@ -9,11 +9,17 @@
 # SPDX-License-Identifier: Apache-2.0
 #-----------------------------------------------------------------------------
 
-import os
-import sys
 
-# See ``pyi_rth_qt6.py`: use a "standard" PyQt6 layout.
-if sys.platform == 'darwin':
+def _pyi_rthook():
+    import os
+    import sys
+
+    # Special handling is needed only on macOS.
+    if sys.platform != 'darwin':
+        return
+
+    # See ``pyi_rth_qt6.py`: use a "standard" PyQt6 layout.
+
     # NOTE: QtWebEngine support was added in Qt6 6.2.x series, so we do not need to worry about pre-6.0.3 path layout.
     pyqt_path = os.path.join(sys._MEIPASS, 'PyQt6', 'Qt6')
 
@@ -33,3 +39,7 @@ if sys.platform == 'darwin':
         # This runtime hook should avoid importing PyQt6, so we have no way of querying the version, and always disable
         # sandboxing.
         os.environ['QTWEBENGINE_DISABLE_SANDBOX'] = '1'
+
+
+_pyi_rthook()
+del _pyi_rthook

--- a/PyInstaller/hooks/rthooks/pyi_rth_pyside2.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_pyside2.py
@@ -9,18 +9,25 @@
 # SPDX-License-Identifier: Apache-2.0
 #-----------------------------------------------------------------------------
 
-import os
-import sys
-
 # The path to Qt's components may not default to the wheel layout for self-compiled PySide2 installations. Mandate the
 # wheel layout. See ``utils/hooks/qt.py`` for more details.
-if sys.platform.startswith('win'):
-    pyqt_path = os.path.join(sys._MEIPASS, 'PySide2')
-else:
-    pyqt_path = os.path.join(sys._MEIPASS, 'PySide2', 'Qt')
-os.environ['QT_PLUGIN_PATH'] = os.path.join(pyqt_path, 'plugins')
-os.environ['QML2_IMPORT_PATH'] = os.path.join(pyqt_path, 'qml')
-# Modelled after similar PATH modification in PyQt5 rthook. With PySide2, this modification seems necessary for SSL DLLs
-# to be found in onefile builds (provided they were available during collection).
-if sys.platform.startswith('win') and 'PATH' in os.environ:
-    os.environ['PATH'] = sys._MEIPASS + os.pathsep + os.environ['PATH']
+
+
+def _pyi_rthook():
+    import os
+    import sys
+
+    if sys.platform.startswith('win'):
+        pyqt_path = os.path.join(sys._MEIPASS, 'PySide2')
+    else:
+        pyqt_path = os.path.join(sys._MEIPASS, 'PySide2', 'Qt')
+    os.environ['QT_PLUGIN_PATH'] = os.path.join(pyqt_path, 'plugins')
+    os.environ['QML2_IMPORT_PATH'] = os.path.join(pyqt_path, 'qml')
+    # Modelled after similar PATH modification in PyQt5 rthook. With PySide2, this modification seems necessary for SSL
+    # DLLs to be found in onefile builds (provided they were available during collection).
+    if sys.platform.startswith('win') and 'PATH' in os.environ:
+        os.environ['PATH'] = sys._MEIPASS + os.pathsep + os.environ['PATH']
+
+
+_pyi_rthook()
+del _pyi_rthook

--- a/PyInstaller/hooks/rthooks/pyi_rth_pyside2webengine.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_pyside2webengine.py
@@ -9,10 +9,15 @@
 # SPDX-License-Identifier: Apache-2.0
 #-----------------------------------------------------------------------------
 
-import os
-import sys
 
-if sys.platform == 'darwin':
+def _pyi_rthook():
+    import os
+    import sys
+
+    # Special handling is needed only on macOS.
+    if sys.platform != 'darwin':
+        return
+
     # If QtWebEngineProcess was collected from a framework-based Qt build, we need to set QTWEBENGINEPROCESS_PATH.
     # If not (a dylib-based build; Anaconda on macOS), it should be found automatically, same as on other OSes.
     process_path = os.path.normpath(
@@ -23,3 +28,7 @@ if sys.platform == 'darwin':
     )
     if os.path.exists(process_path):
         os.environ['QTWEBENGINEPROCESS_PATH'] = process_path
+
+
+_pyi_rthook()
+del _pyi_rthook

--- a/PyInstaller/hooks/rthooks/pyi_rth_pyside6.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_pyside6.py
@@ -9,18 +9,25 @@
 # SPDX-License-Identifier: Apache-2.0
 #-----------------------------------------------------------------------------
 
-import os
-import sys
-
 # The path to Qt's components may not default to the wheel layout for self-compiled PySide6 installations. Mandate the
 # wheel layout. See ``utils/hooks/qt.py`` for more details.
-if sys.platform.startswith('win'):
-    pyqt_path = os.path.join(sys._MEIPASS, 'PySide6')
-else:
-    pyqt_path = os.path.join(sys._MEIPASS, 'PySide6', 'Qt')
-os.environ['QT_PLUGIN_PATH'] = os.path.join(pyqt_path, 'plugins')
-os.environ['QML2_IMPORT_PATH'] = os.path.join(pyqt_path, 'qml')
-# Modelled after similar PATH modification in PyQt5 rthook. With PySide6, this modification seems necessary for SSL DLLs
-# to be found in onefile builds (provided they were available during collection).
-if sys.platform.startswith('win') and 'PATH' in os.environ:
-    os.environ['PATH'] = sys._MEIPASS + os.pathsep + os.environ['PATH']
+
+
+def _pyi_rthook():
+    import os
+    import sys
+
+    if sys.platform.startswith('win'):
+        pyqt_path = os.path.join(sys._MEIPASS, 'PySide6')
+    else:
+        pyqt_path = os.path.join(sys._MEIPASS, 'PySide6', 'Qt')
+    os.environ['QT_PLUGIN_PATH'] = os.path.join(pyqt_path, 'plugins')
+    os.environ['QML2_IMPORT_PATH'] = os.path.join(pyqt_path, 'qml')
+    # Modelled after similar PATH modification in PyQt5 rthook. With PySide6, this modification seems necessary for SSL
+    # DLLs to be found in onefile builds (provided they were available during collection).
+    if sys.platform.startswith('win') and 'PATH' in os.environ:
+        os.environ['PATH'] = sys._MEIPASS + os.pathsep + os.environ['PATH']
+
+
+_pyi_rthook()
+del _pyi_rthook

--- a/PyInstaller/hooks/rthooks/pyi_rth_pyside6webengine.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_pyside6webengine.py
@@ -9,10 +9,14 @@
 # SPDX-License-Identifier: Apache-2.0
 #-----------------------------------------------------------------------------
 
-import os
-import sys
 
-if sys.platform == 'darwin':
+def _pyi_rthook():
+    import os
+    import sys
+
+    if sys.platform != 'darwin':
+        return
+
     # If QtWebEngineProcess was collected from a framework-based Qt build, we need to set QTWEBENGINEPROCESS_PATH.
     # If not (a dylib-based build; Anaconda on macOS), it should be found automatically, same as on other OSes.
     process_path = os.path.normpath(
@@ -29,3 +33,7 @@ if sys.platform == 'darwin':
         # This runtime hook should avoid importing PySide6, so we have no way of querying the version, and always
         # disable sandboxing.
         os.environ['QTWEBENGINE_DISABLE_SANDBOX'] = '1'
+
+
+_pyi_rthook()
+del _pyi_rthook

--- a/PyInstaller/hooks/rthooks/pyi_rth_setuptools.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_setuptools.py
@@ -9,27 +9,29 @@
 # SPDX-License-Identifier: Apache-2.0
 #-----------------------------------------------------------------------------
 
-
 # This runtime hook performs the equivalent of the distutils-precedence.pth from the setuptools package;
-# it registers a special meta finder that diverts import of distutils to setuptools._distutils, if
-# available.
-def _install_setuptools_distutils_hack():
-    import os
-    import setuptools
-
-    # We need to query setuptools version at runtime, because the default value for SETUPTOOLS_USE_DISTUTILS
-    # has changed at version 60.0 from "stdlib" to "local", and we want to mimic that behavior.
-    setuptools_major = int(setuptools.__version__.split('.')[0])
-    default_value = "stdlib" if setuptools_major < 60 else "local"
-
-    if os.environ.get("SETUPTOOLS_USE_DISTUTILS", default_value) == "local":
-        import _distutils_hack
-        _distutils_hack.add_shim()
+# it registers a special meta finder that diverts import of distutils to setuptools._distutils, if available.
 
 
-try:
-    _install_setuptools_distutils_hack()
-except Exception:
-    pass
+def _pyi_rthook():
+    def _install_setuptools_distutils_hack():
+        import os
+        import setuptools
 
-del _install_setuptools_distutils_hack
+        # We need to query setuptools version at runtime, because the default value for SETUPTOOLS_USE_DISTUTILS
+        # has changed at version 60.0 from "stdlib" to "local", and we want to mimic that behavior.
+        setuptools_major = int(setuptools.__version__.split('.')[0])
+        default_value = "stdlib" if setuptools_major < 60 else "local"
+
+        if os.environ.get("SETUPTOOLS_USE_DISTUTILS", default_value) == "local":
+            import _distutils_hack
+            _distutils_hack.add_shim()
+
+    try:
+        _install_setuptools_distutils_hack()
+    except Exception:
+        pass
+
+
+_pyi_rthook()
+del _pyi_rthook

--- a/PyInstaller/hooks/rthooks/pyi_rth_win32comgenpy.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_win32comgenpy.py
@@ -16,37 +16,44 @@
 #
 # http://www.py2exe.org/index.cgi/UsingEnsureDispatch
 
-import atexit
-import os
-import shutil
-import tempfile
 
-# Put gen_py cache in temp directory.
-supportdir = tempfile.mkdtemp()
-# gen_py has to be put into directory 'gen_py'.
-genpydir = os.path.join(supportdir, 'gen_py')
+def _pyi_rthook():
+    import atexit
+    import os
+    import shutil
+    import tempfile
 
-# Create 'gen_py' directory. This directory does not need to contain '__init__.py' file.
-try:
-    # win32com gencache cannot be put directly to 'supportdir' with any random name. It has to be put in a directory
-    # called 'gen_py'. This is the reason why to create this directory in supportdir'.
-    os.makedirs(genpydir)
-    # Remove temp directory at application exit and ignore any errors.
-    atexit.register(shutil.rmtree, supportdir, ignore_errors=True)
-except OSError:
-    pass
+    # Put gen_py cache in temp directory.
+    supportdir = tempfile.mkdtemp()
+    # gen_py has to be put into directory 'gen_py'.
+    genpydir = os.path.join(supportdir, 'gen_py')
 
-# Override the default path to gen_py cache.
-import win32com  # noqa: E402
+    # Create 'gen_py' directory. This directory does not need to contain '__init__.py' file.
+    try:
+        # win32com gencache cannot be put directly to 'supportdir' with any random name. It has to be put in a directory
+        # called 'gen_py'. This is the reason why to create this directory in supportdir'.
+        os.makedirs(genpydir)
+        # Remove temp directory at application exit and ignore any errors.
+        atexit.register(shutil.rmtree, supportdir, ignore_errors=True)
+    except OSError:
+        pass
 
-win32com.__gen_path__ = genpydir
+    # Override the default path to gen_py cache.
+    import win32com  # noqa: E402
 
-# The attribute __loader__ makes module 'pkg_resources' working but On Windows it breaks pywin32 (win32com) and test
-# 'basic/test_pyttsx' will fail. Just removing that attribute for win32com fixes that and gencache is created properly.
-if hasattr(win32com, '__loader__'):
-    del win32com.__loader__
+    win32com.__gen_path__ = genpydir
 
-# Ensure genpydir is in 'gen_py' module paths.
-import win32com.gen_py  # noqa: E402
+    # The attribute __loader__ makes module 'pkg_resources' working but On Windows it breaks pywin32 (win32com) and test
+    # 'basic/test_pyttsx' will fail. Just removing that attribute for win32com fixes that and gencache is created
+    # properly.
+    if hasattr(win32com, '__loader__'):
+        del win32com.__loader__
 
-win32com.gen_py.__path__.insert(0, genpydir)
+    # Ensure genpydir is in 'gen_py' module paths.
+    import win32com.gen_py  # noqa: E402
+
+    win32com.gen_py.__path__.insert(0, genpydir)
+
+
+_pyi_rthook()
+del _pyi_rthook


### PR DESCRIPTION
Our run-time hooks are executed as scripts and often place symbols in the global namespace (imported modules, functions, variables).

On one hand, this unnecessarily pollutes the global namespace (for example, with override functions provided by run-time hooks), but on the other hand, it also puts us at the mercy of user's code, which might happen to rebind the symbol used by the run-time hook. In cases when hook's code might be executed later during program's execution (e.g., overridden function or registered callback), such re-bound symbols might result in errors. See #7642 for the latest example.

So wrap all run-time hooks' code into `_pyi_rthook` functions that the hook executes and deletes afterwards. This way, all symbols are bound in the local namespace, alleviating global-namespace related issues.