### PR TITLE
Clean up UPX handling

### DIFF
--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -433,10 +433,8 @@ class EXE(Target):
         # Code signing entitlements
         self.entitlements_file = kwargs.get('entitlements_file', None)
 
-        if CONF['hasUPX']:
-            self.upx = kwargs.get('upx', False)
-        else:
-            self.upx = False
+        # UPX needs to be both available and enabled for the target.
+        self.upx = CONF['upx_available'] and kwargs.get('upx', False)
 
         # Catch and clear options that are unsupported on specific platforms.
         if self.versrsrc and not is_win:
@@ -887,10 +885,8 @@ class COLLECT(Target):
         self.codesign_identity = None
         self.entitlements_file = None
 
-        if CONF['hasUPX']:
-            self.upx_binaries = kwargs.get('upx', False)
-        else:
-            self.upx_binaries = False
+        # UPX needs to be both available and enabled for the taget.
+        self.upx_binaries = CONF['upx_available'] and kwargs.get('upx', False)
 
         # The `name` should be the output directory name, without the parent path (the directory is created in the
         # DISTPATH). Old .spec formats included parent path, so strip it away.

--- a/PyInstaller/building/build_main.py
+++ b/PyInstaller/building/build_main.py
@@ -80,19 +80,6 @@ IMPORTANT: Do NOT post this list to the issue-tracker. Use it as a basis for
 """
 
 
-# TODO find better place for function.
-def setupUPXFlags():
-    f = compat.getenv("UPX", "")
-    if is_win:
-        # Binaries built with Visual Studio 7.1 require --strip-loadconf or they will not compress. Configure.py makes
-        # sure that UPX is new enough to support --strip-loadconf.
-        f = "--strip-loadconf " + f
-    # Do not compress any icon, so that additional icons in the executable can still be externally bound.
-    f = "--compress-icons=0 " + f
-    f = "--best " + f
-    compat.setenv("UPX", f)
-
-
 @isolated.decorate
 def discover_hook_directories():
     """
@@ -1022,12 +1009,9 @@ def main(
     # If configuration dict is supplied - skip configuration step.
     if pyi_config is None:
         import PyInstaller.configure as configure
-        CONF.update(configure.get_config(upx_dir))
+        CONF.update(configure.get_config(upx_dir=upx_dir))
     else:
         CONF.update(pyi_config)
-
-    if CONF['hasUPX']:
-        setupUPXFlags()
 
     CONF['ui_admin'] = kw.get('ui_admin', False)
     CONF['ui_access'] = kw.get('ui_uiaccess', False)

--- a/PyInstaller/building/utils.py
+++ b/PyInstaller/building/utils.py
@@ -272,7 +272,7 @@ def checkCache(
             bestopt = "--best"
             # FIXME: Linux builds of UPX do not seem to contain LZMA (they assert out).
             # A better configure-time check is due.
-            if CONF["hasUPX"] >= (3,) and os.name == "nt":
+            if CONF["hasUPX"] and os.name == "nt":
                 bestopt = "--lzma"
 
             upx_executable = "upx"

--- a/PyInstaller/building/utils.py
+++ b/PyInstaller/building/utils.py
@@ -348,7 +348,7 @@ def checkCache(
                                     raise
 
     if cmd:
-        logger.info("Executing - " + "".join(cmd))
+        logger.info("Executing: %s", " ".join(cmd))
         subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
     # update cache index

--- a/PyInstaller/config.py
+++ b/PyInstaller/config.py
@@ -34,12 +34,12 @@ And to use this variable in the build phase:
 This is the list of known variables. (Please update it if necessary.)
 
 cachedir
-hasUPX
 hiddenimports
 noconfirm
 pathex
 ui_admin
 ui_access
+upx_available
 upx_dir
 workpath
 

--- a/PyInstaller/configure.py
+++ b/PyInstaller/configure.py
@@ -95,6 +95,10 @@ def get_config(upx_dir=None):
     if upx_available:
         if compat.is_win or compat.is_cygwin:
             logger.info("UPX is available and will be used if enabled on build targets.")
+        elif os.environ.get("PYINSTALLER_FORCE_UPX", "0") != "0":
+            logger.warning(
+                "UPX is available and force-enabled on platform with known compatibility problems - use at own risk!"
+            )
         else:
             upx_available = False
             logger.info("UPX is available but is disabled on non-Windows due to known compatibility problems.")

--- a/PyInstaller/utils/conftest.py
+++ b/PyInstaller/utils/conftest.py
@@ -425,7 +425,7 @@ class AppBuilder:
 
         pyi_args = [self.script] + default_args + args
         # TODO: fix return code in running PyInstaller programmatically.
-        PYI_CONFIG = configure.get_config(upx_dir=None)
+        PYI_CONFIG = configure.get_config()
         # Override CACHEDIR for PyInstaller and put it into self.tmpdir
         PYI_CONFIG['cachedir'] = str(self._tmpdir)
 

--- a/tests/unit/test_recursion_limit.py
+++ b/tests/unit/test_recursion_limit.py
@@ -72,7 +72,7 @@ def test_RecursionError_prints_message(tmpdir, large_import_chain, monkeypatch):
     ]  # yapf: disable
 
     pyi_args = [script] + default_args
-    PYI_CONFIG = configure.get_config(upx_dir=None)
+    PYI_CONFIG = configure.get_config()
     PYI_CONFIG['cachedir'] = str(tmpdir)
 
     with pytest.raises(SystemExit) as execinfo:


### PR DESCRIPTION
In the UPX availability check, do not attempt to parse the UPX version; just display the first line of the UPX output for debugging purposes. Closes #7702.

When disabling UPX on platforms with known compatibility issues (non-Windows), do so in the initial setup phase instead of during the build, right before calling the `upx`. Also display an INFO message informing the user that while UPX is available, it will not be used. 

Do not set default UPX parameters via the `UPX` environment variable; put those parameters on the command-line. This prevents us from having two different places in which parameters are configured, when we are only calling UPX in one place.

Lastly, for development purposes, allow UPX to be enabled on platforms with known compatibility issues, via an environment variable. 