### PR TITLE
building: PKG: ensure DATA files are excluded when in onedir mode

### DIFF
--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -300,6 +300,15 @@ class PKG(Target):
                         strict_arch_validation=(typecode == 'EXTENSION'),
                     )
                     archive_toc.append((dest_name, src_name, self.cdict.get(typecode, False), self.xformdict[typecode]))
+            elif typecode in ('DATA', 'ZIPFILE'):
+                # Same logic as above for BINARY and EXTENSION; if `exclude_binaries` is set, we are in onedir mode;
+                # we should exclude DATA (and ZIPFILE) entries and instead pass them on via PKG's `dependencies`. This
+                # prevents a onedir application from becoming a broken onefile one if user accidentally passes datas
+                # and binaries TOCs to EXE instead of COLLECT.
+                if self.exclude_binaries:
+                    self.dependencies.append((dest_name, src_name, typecode))
+                else:
+                    archive_toc.append((dest_name, src_name, self.cdict.get(typecode, False), self.xformdict[typecode]))
             elif typecode == 'OPTION':
                 archive_toc.append((dest_name, '', False, 'o'))
             elif typecode in ('PYSOURCE', 'PYMODULE'):
@@ -307,7 +316,6 @@ class PKG(Target):
                 bootstrap_toc.append((dest_name, src_name, self.cdict.get(typecode, False), self.xformdict[typecode]))
             else:
                 # PYZ, PKG, DEPENDENCY, SPLASH
-                # TODO: are DATA and ZIPFILE valid here?
                 archive_toc.append((dest_name, src_name, self.cdict.get(typecode, False), self.xformdict[typecode]))
 
         # Bootloader has to know the name of Python library. Pass python libname to CArchive.

--- a/news/7708.bugfix.rst
+++ b/news/7708.bugfix.rst
@@ -1,0 +1,7 @@
+When building PKG for ``onedir`` build, ensure that ``DATA`` entries
+are put into dependencies list instead of including them in the PKG.
+This complements existing behavior for ``BINARY`` and ``EXTENSION``
+entries, and prevents a ``onedir`` build from becoming a broken
+``onefile`` one if user accidentally passes binaries and data files
+TOCs to ``EXE`` instead of `COLLECT` when manually editing the
+spec file.


### PR DESCRIPTION
When building PKG for `onedir` build, ensure that `DATA` entries are put into dependencies list instead of including them in the PKG. This complements existing behavior for `BINARY` and `EXTENSION` entries, and prevents a `onedir` build from becoming a broken `onefile` one if user accidentally passes binaries and data files TOCs to `EXE` instead of `COLLECT` when manually editing the spec file (see #7699).