### PR TITLE
building: add support for collecting .pyc files from .zip archives

### DIFF
--- a/PyInstaller/utils/misc.py
+++ b/PyInstaller/utils/misc.py
@@ -19,6 +19,7 @@ import codecs
 import re
 import tokenize
 import io
+import pathlib
 
 from PyInstaller import log as logging
 from PyInstaller.compat import is_win
@@ -232,3 +233,15 @@ def is_iterable(arg):
     except TypeError:
         return False
     return True
+
+
+def path_to_parent_archive(filename):
+    """
+    Check if the given file path points to a file inside an existing archive file. Returns first path from the set of
+    parent paths that points to an existing file, or `None` if no such path exists (i.e., file is an actual stand-alone
+    file).
+    """
+    for parent in pathlib.Path(filename).parents:
+        if parent.is_file():
+            return parent
+    return None

--- a/news/4989.feature.rst
+++ b/news/4989.feature.rst
@@ -1,0 +1,2 @@
+(Windows) Add support for collecting .pyc files from the ``python3X.zip`` archive
+where ``Windows embeddable package`` Python stores its stdlib modules.


### PR DESCRIPTION
Extend the `get_code_object` and `compile_pymodule` helpers from `PyInstaller.buildings.utils` to allow retrieval of code objects from .pyc files embedded in a zip archive.

This acommodates `Windows embeddable python`, where stdlib .pyc modules are stored in `python3x.zip˙ file.

Most of those modules are collected from modulegraph's code cache, so their source location does not really matter; this commit fixes the collection of the remaining few that are collected directly from the filesystem.

---

Tested manually with embeddable python 3.7.9 and 3.11.4 with basic hello-world program. Closes #4989.

 Typically, only `compile_pymodule` seems to be called (and even that only for `struct.py`, probably because we put it directly into PKG). By commenting out code cache support in PYZ, calls to `get_code_object` can be triggered for all modules collected from stdlib (including ones that are packages and have submodules, e.g., `ctypes/__init__.py`) - I'm not sure if we can ever get in situation when code cache is unavailable (maybe if cached Analysis is used, but PYZ needs to be regenerated because it was manually removed from the build directory?).

