### PR TITLE
tests: improve ctypes.util.find_library compatibility check on macOS

### DIFF
--- a/tests/unit/test_depend_utils.py
+++ b/tests/unit/test_depend_utils.py
@@ -14,7 +14,7 @@ import pytest
 import textwrap
 
 from PyInstaller.depend import utils
-from PyInstaller.compat import is_win, is_musl, is_macos_11_compat
+from PyInstaller import compat
 
 CTYPES_CLASSNAMES = (
     'CDLL', 'ctypes.CDLL',
@@ -66,11 +66,14 @@ def test_ctypes_LibraryLoader_LoadLibrary(monkeypatch, classname, extended_args)
 
 
 @pytest.mark.parametrize('extended_args', [False, True])
-@pytest.mark.skipif(is_musl, reason="find_library() doesn't work on musl")
-@pytest.mark.skipif(is_macos_11_compat, reason="find_library() requires python built with Big Sur support.")
+@pytest.mark.skipif(compat.is_musl, reason="find_library() doesn't work on musl")
+@pytest.mark.skipif(
+    compat.is_macos_11 and not (compat.is_macos_11_native and compat.is_py39),
+    reason="find_library() requires python >= 3.9 built with Big Sur support.",
+)
 def test_ctypes_util_find_library(monkeypatch, extended_args):
     # for lind_library() we need a lib actually existing on the system
-    if is_win:
+    if compat.is_win:
         libname = "KERNEL32"
     else:
         libname = "c"
@@ -97,7 +100,7 @@ def test_ctypes_util_find_library_as_default_argument():
 def test_ldconfig_cache():
     utils.load_ldconfig_cache()
 
-    if is_musl:
+    if compat.is_musl:
         # load_ldconfig_cache() should be a no-op on musl because musl does not use ldconfig.
         assert not utils.LDCONFIG_CACHE
         return


### PR DESCRIPTION
On macOS, having python compiled with Big Sur support does not automatically guarantee that `ctypes.util.find_library` is able to find system-wide libraries; that behavior was properly implemented in python 3.9.

Therefore, gate the `test_ctypes_util_find_library` behind both `is_macos_11_native` and `is_py39` check to prevent the test from being run (and failing) on older python versions that happen to be built with Big Sur support.