### PR TITLE
Declutter onedir bundles

### DIFF
--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -960,7 +960,10 @@ class COLLECT(Target):
                     'Security-Alert: attempting to store file outside of the dist directory: %r. Aborting.' % dest_name
                 )
             # Create parent directory structure, if necessary
-            dest_path = os.path.join(self.name, dest_name)  # Absolute destination path
+            if typecode in ("EXECUTABLE", "PKG"):
+                dest_path = os.path.join(self.name, dest_name)
+            else:
+                dest_path = os.path.join(self.name, "_internal", dest_name)  # Absolute destination path
             dest_dir = os.path.dirname(dest_path)
             try:
                 os.makedirs(dest_dir, exist_ok=True)

--- a/PyInstaller/building/makespec.py
+++ b/PyInstaller/building/makespec.py
@@ -227,6 +227,11 @@ def __add_options(parser):
         "--name",
         help="Name to assign to the bundled app and spec file (default: first script's basename)",
     )
+    g.add_argument(
+        "--contents-directory",
+        help="For onedir builds only, specify the name of the directory in which all supporting files (i.e. everything "
+        "except the executable itself) will be placed in.",
+    )
 
     g = parser.add_argument_group('What to bundle, where to search')
     g.add_argument(
@@ -615,6 +620,7 @@ def main(
     noupx=False,
     upx_exclude=None,
     runtime_tmpdir=None,
+    contents_directory=None,
     pathex=[],
     version_file=None,
     specpath=None,
@@ -695,6 +701,8 @@ def main(
         # On Mac OS, the default icon has to be copied into the .app bundle.
         # The the text value 'None' means - use default icon.
         icon_file = 'None'
+    if contents_directory:
+        exe_options += "\n    contents_directory='%s'," % (contents_directory or "_internal")
 
     if bundle_identifier:
         # We need to encapsulate it into apostrofes.

--- a/PyInstaller/utils/conftest.py
+++ b/PyInstaller/utils/conftest.py
@@ -13,6 +13,7 @@ import copy
 import glob
 import logging
 import os
+import platform
 import re
 import shutil
 import subprocess
@@ -541,7 +542,7 @@ def compiled_dylib(tmpdir, request):
         elif is_darwin:
             tmp_data_dir = tmp_data_dir.join('ctypes_dylib.dylib')
             # On Mac OS X we need to detect architecture - 32 bit or 64 bit.
-            arch = 'i386' if architecture == '32bit' else 'x86_64'
+            arch = 'arm64' if platform.machine() == 'arm64' else 'i386' if architecture == '32bit' else 'x86_64'
             cmd = (
                 'gcc -arch ' + arch + ' -Wall -dynamiclib '
                 'ctypes_dylib.c -o ctypes_dylib.dylib -headerpad_max_install_names'

--- a/bootloader/src/pyi_launch.c
+++ b/bootloader/src/pyi_launch.c
@@ -66,6 +66,7 @@ _format_and_check_path(char *buf, const char *fmt, ...)
     };
     va_end(args);
 
+    VS("Checking for file %s\n", buf);
     return stat(buf, &tmp);
 }
 
@@ -206,6 +207,11 @@ _extract_dependency(ARCHIVE_STATUS *archive_pool[], const char *item)
 
     pyi_path_dirname(dirname, path);
     pyi_path_dirname(homepath_parent, archive_status->homepath);
+    char * contents_directory = pyi_arch_get_option(archive_pool[0], "pyi-contents-directory");
+    if (!contents_directory) {
+        FATALERROR("pyi-contents-directory option not found in onedir bundle archive!");
+        return -1;
+    }
 
     /* We need to identify and handle three situations:
      *  1) dependencies are in a onedir archive next to the current onefile archive,
@@ -214,7 +220,7 @@ _extract_dependency(ARCHIVE_STATUS *archive_pool[], const char *item)
      */
     VS("LOADER: homepath is %s\n", archive_status->homepath);
     /* TODO implement pyi_path_join to accept variable length of arguments for this case. */
-    if (_format_and_check_path(srcpath, "%s%c%s%c%s%c%s", homepath_parent, PYI_SEP, dirname, PYI_SEP, "_internal", PYI_SEP, filename) == 0) {
+    if (_format_and_check_path(srcpath, "%s%c%s%c%s%c%s", homepath_parent, PYI_SEP, dirname, PYI_SEP, contents_directory, PYI_SEP, filename) == 0) {
         VS("LOADER: File %s found, assuming onedir reference\n", srcpath);
 
         if (_copy_dependency_from_dir(archive_status, srcpath, filename) == -1) {
@@ -223,7 +229,7 @@ _extract_dependency(ARCHIVE_STATUS *archive_pool[], const char *item)
         }
         /* TODO implement pyi_path_join to accept variable length of arguments for this case. */
     }
-    else if (_format_and_check_path(srcpath, "%s%c%s%c%s%c%s", homepath_parent, PYI_SEP, dirname, PYI_SEP, "_internal", PYI_SEP, filename) == 0) {
+    else if (_format_and_check_path(srcpath, "%s%c%s%c%s%c%s", homepath_parent, PYI_SEP, dirname, PYI_SEP, contents_directory, PYI_SEP, filename) == 0) {
         VS("LOADER: File %s found, assuming onedir reference\n", srcpath);
 
         if (_copy_dependency_from_dir(archive_status, srcpath, filename) == -1) {
@@ -235,7 +241,7 @@ _extract_dependency(ARCHIVE_STATUS *archive_pool[], const char *item)
         VS("LOADER: File %s not found, assuming onefile reference.\n", srcpath);
 
         /* TODO implement pyi_path_join to accept variable length of arguments for this case. */
-        if ((_format_and_check_path(archive_path, "%s%c%s%c%s.pkg", homepath_parent, PYI_SEP, "_internal", PYI_SEP, path) != 0) &&
+        if ((_format_and_check_path(archive_path, "%s%c%s%c%s.pkg", homepath_parent, PYI_SEP, contents_directory, PYI_SEP, path) != 0) &&
             (_format_and_check_path(archive_path, "%s%c%s.exe", homepath_parent, PYI_SEP, path) != 0) &&
             (_format_and_check_path(archive_path, "%s%c%s", homepath_parent, PYI_SEP, path) != 0)) {
             FATALERROR("Archive not found: %s\n", archive_path);

--- a/bootloader/src/pyi_launch.c
+++ b/bootloader/src/pyi_launch.c
@@ -196,6 +196,7 @@ _extract_dependency(ARCHIVE_STATUS *archive_pool[], const char *item)
     char archive_path[PATH_MAX];
 
     char dirname[PATH_MAX];
+    char homepath_parent[PATH_MAX];
 
     VS("LOADER: Extracting dependency/reference %s\n", item);
 
@@ -204,16 +205,16 @@ _extract_dependency(ARCHIVE_STATUS *archive_pool[], const char *item)
     }
 
     pyi_path_dirname(dirname, path);
+    pyi_path_dirname(homepath_parent, archive_status->homepath);
 
     /* We need to identify and handle three situations:
      *  1) dependencies are in a onedir archive next to the current onefile archive,
      *  2) dependencies are in a onedir/onefile archive next to the current onedir archive,
      *  3) dependencies are in a onefile archive next to the current onefile archive.
      */
-    VS("LOADER: Checking if file exists\n");
-
+    VS("LOADER: homepath is %s\n", archive_status->homepath);
     /* TODO implement pyi_path_join to accept variable length of arguments for this case. */
-    if (_format_and_check_path(srcpath, "%s%c%s%c%s", archive_status->homepath, PYI_SEP, dirname, PYI_SEP, filename) == 0) {
+    if (_format_and_check_path(srcpath, "%s%c%s%c%s%c%s", homepath_parent, PYI_SEP, dirname, PYI_SEP, "_internal", PYI_SEP, filename) == 0) {
         VS("LOADER: File %s found, assuming onedir reference\n", srcpath);
 
         if (_copy_dependency_from_dir(archive_status, srcpath, filename) == -1) {
@@ -222,7 +223,7 @@ _extract_dependency(ARCHIVE_STATUS *archive_pool[], const char *item)
         }
         /* TODO implement pyi_path_join to accept variable length of arguments for this case. */
     }
-    else if (_format_and_check_path(srcpath, "%s%c%s%c%s%c%s", archive_status->homepath, PYI_SEP, "..", PYI_SEP, dirname, PYI_SEP, filename) == 0) {
+    else if (_format_and_check_path(srcpath, "%s%c%s%c%s%c%s", homepath_parent, PYI_SEP, dirname, PYI_SEP, "_internal", PYI_SEP, filename) == 0) {
         VS("LOADER: File %s found, assuming onedir reference\n", srcpath);
 
         if (_copy_dependency_from_dir(archive_status, srcpath, filename) == -1) {
@@ -234,9 +235,9 @@ _extract_dependency(ARCHIVE_STATUS *archive_pool[], const char *item)
         VS("LOADER: File %s not found, assuming onefile reference.\n", srcpath);
 
         /* TODO implement pyi_path_join to accept variable length of arguments for this case. */
-        if ((_format_and_check_path(archive_path, "%s%c%s.pkg", archive_status->homepath, PYI_SEP, path) != 0) &&
-            (_format_and_check_path(archive_path, "%s%c%s.exe", archive_status->homepath, PYI_SEP, path) != 0) &&
-            (_format_and_check_path(archive_path, "%s%c%s", archive_status->homepath, PYI_SEP, path) != 0)) {
+        if ((_format_and_check_path(archive_path, "%s%c%s%c%s.pkg", homepath_parent, PYI_SEP, "_internal", PYI_SEP, path) != 0) &&
+            (_format_and_check_path(archive_path, "%s%c%s.exe", homepath_parent, PYI_SEP, path) != 0) &&
+            (_format_and_check_path(archive_path, "%s%c%s", homepath_parent, PYI_SEP, path) != 0)) {
             FATALERROR("Archive not found: %s\n", archive_path);
             return -1;
         }

--- a/bootloader/src/pyi_path.c
+++ b/bootloader/src/pyi_path.c
@@ -412,18 +412,6 @@ pyi_path_executable(char *execfile, const char *appname)
 }
 
 /*
- * Return absolute path to homepath. It is the directory containing executable.
- */
-bool
-pyi_path_homepath(char *homepath, const char *thisfile)
-{
-    /* Fill in here (directory of thisfile). */
-    bool rc = pyi_path_dirname(homepath, thisfile);
-    VS("LOADER: homepath is %s\n", homepath);
-    return rc;
-}
-
-/*
  * Return full path to an external PYZ-archive.
  * The name is based on the excutable's name: path/myappname.pkg
  *

--- a/doc/operating-mode.rst
+++ b/doc/operating-mode.rst
@@ -133,12 +133,6 @@ than the entire folder.
 or different dependencies, or if the dependencies
 are upgraded, you must redistribute the whole bundle.)
 
-A small disadvantage of the one-folder format is that the one folder contains
-a large number of files.
-Your user must find the :file:`myscript` executable
-in a long list of names or among a big array of icons.
-Also your user can create
-a problem by accidentally dragging files out of the folder.
 
 .. _how the one-folder program works:
 

--- a/doc/runtime-information.rst
+++ b/doc/runtime-information.rst
@@ -16,7 +16,8 @@ check "are we bundled?"::
 
 When a bundled app starts up, the bootloader sets the ``sys.frozen``
 attribute and stores the absolute path to the bundle folder in
-``sys._MEIPASS``. For a one-folder bundle, this is the path to that folder. For
+``sys._MEIPASS``. For a one-folder bundle, this is the path to the
+``_internal`` folder within the bundle. For
 a one-file bundle, this is the path to the temporary folder created by the
 bootloader (see :ref:`How the One-File Program Works`).
 

--- a/news/7713.breaking.rst
+++ b/news/7713.breaking.rst
@@ -1,0 +1,13 @@
+All of onedir build's contents except for the executable are now moved into a
+sub-directory (called ``_internal`` by default). ``sys._MEIPASS`` is adjusted to
+point to this ``_internal`` directory. The breaking implications for this are:
+
+* Assumptions that ``os.path.dirname(sys.executable) == sys._MEIPASS`` will
+  break. Code locating application resources using
+  ``os.path.dirname(sys.executable)`` should be adjusted to use ``__file__``
+  or ``sys._MEIPASS`` and any code locating the original executable using
+  ``sys._MEIPASS`` should use :data:`sys.executable` directly.
+
+* Any custom post processing steps (either in the ``.spec`` file or
+  externally) which modify the bundle will likely need adjusting to
+  accommodate the new directory.

--- a/news/7713.feature.rst
+++ b/news/7713.feature.rst
@@ -1,0 +1,5 @@
+Restructure onedir mode builds so that everything except the executable (and
+``.pkg`` if you're using external PYZ archive mode) are hidden inside a
+sub-directory. This sub-directory's name defaults to ``_internal`` but may be
+configured with the new :option:`--internals-prefix` option. Onefile
+applications and macOS ``.app`` bundles are unaffected.


### PR DESCRIPTION
When building in onedir mode, move everything except the executable into a subdirectory so the executable is easily findable.

I'm deliberately not making this optional for now because the new if/else path arithmetic bootloader logic it would require will multiply with all the other if/else path arithmetic bootloader logic for macOS `.app` bundles and the too many variants of `MERGE()` leading to a testing/debugging hell hole which far exceeds my motivation to implement.

This is all rebased on top of #7619 to avoid the merge conflicts it would otherwise lead to.