### PR TITLE
Revert installing pywin32-ctypes from git on Python 3.12.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -64,8 +64,7 @@ install_requires =
     setuptools >= 42.0.0
     altgraph
     pefile >= 2022.5.30 ; sys_platform == 'win32'
-    pywin32-ctypes >= 0.2.0 ; sys_platform == 'win32' and python_version < '3.12'
-    pywin32-ctypes @ git+https://github.com/enthought/pywin32-ctypes.git ; sys_platform == 'win32' and python_version >= '3.12'
+    pywin32-ctypes >= 0.2.1 ; sys_platform == 'win32'
     macholib >= 1.8 ; sys_platform == 'darwin'
     pyinstaller-hooks-contrib >= 2021.4
     importlib-metadata >= 1.4 ; python_version < '3.8'


### PR DESCRIPTION
This reverts commit 91e37e3625dc9c3f9d98f3ed98f8472b18bd42b5. pywin32-ctypes has made a v0.2.1 release which includes the fix for Python 3.12 compatibility.

Turns out all we had to do was ask (https://github.com/enthought/pywin32-ctypes/pull/121#issuecomment-1596881483).