### PR TITLE
Add option to hide/minimize console in console-enabled Windows program

### DIFF
--- a/PyInstaller/building/makespec.py
+++ b/PyInstaller/building/makespec.py
@@ -493,6 +493,14 @@ def __add_options(parser):
         "file. This option is ignored on *NIX systems.",
     )
     g.add_argument(
+        "--hide-console",
+        type=str,
+        choices={'hide-early', 'hide-late', 'minimize-early', 'minimize-late'},
+        default=None,
+        help="Windows only: in console-enabled executable, have bootloader automatically hide or minimize the console "
+        "window if the program owns the console window (i.e., was not launched from an existing console window).",
+    )
+    g.add_argument(
         "-i",
         "--icon",
         action='append',
@@ -673,6 +681,7 @@ def main(
     codesign_identity=None,
     entitlements_file=None,
     argv_emulation=False,
+    hide_console=None,
     **_kwargs
 ):
     # Default values for onefile and console when not explicitly specified on command-line (indicated by None)
@@ -723,6 +732,8 @@ def main(
         icon_file = 'None'
     if contents_directory:
         exe_options += "\n    contents_directory='%s'," % (contents_directory or "_internal")
+    if hide_console:
+        exe_options += "\n    hide_console='%s'," % hide_console
 
     if bundle_identifier:
         # We need to encapsulate it into apostrofes.

--- a/bootloader/src/pyi_win32_utils.c
+++ b/bootloader/src/pyi_win32_utils.c
@@ -520,5 +520,41 @@ int pyi_win32_is_drive_root(const wchar_t *path)
     return 0;
 }
 
+#if !defined(WINDOWED)
+
+/* Helper that hides or minimizes the console window
+ * if it is owned by the process. The show_cmd argument
+ * is passed to the ShowWindow call, and should be
+ * either SW_HIDE or SW_SHOWMINNOACTIVE.
+ */
+static void pyi_win32_adjust_console(int show_cmd)
+{
+    HWND hConsole = GetConsoleWindow();
+    if (hConsole != NULL) {
+        DWORD dwProcessId = GetCurrentProcessId();
+        DWORD dwConsoleProcessId;
+
+        if (GetWindowThreadProcessId(hConsole, &dwConsoleProcessId) == 0) {
+            return;  /* Window handle is invalid */
+        }
+
+        if (dwProcessId == dwConsoleProcessId) {
+            ShowWindow(hConsole, show_cmd);
+        }
+    }
+}
+
+void pyi_win32_hide_console()
+{
+    pyi_win32_adjust_console(SW_HIDE);
+}
+
+void pyi_win32_minimize_console()
+{
+    pyi_win32_adjust_console(SW_SHOWMINNOACTIVE);
+}
+
+#endif
+
 
 #endif  /* _WIN32 */

--- a/bootloader/src/pyi_win32_utils.h
+++ b/bootloader/src/pyi_win32_utils.h
@@ -33,6 +33,13 @@ int pyi_win32_is_symlink(const wchar_t *path);
 
 int pyi_win32_is_drive_root(const wchar_t *path);
 
+#if !defined(WINDOWED)
+
+void pyi_win32_hide_console();
+void pyi_win32_minimize_console();
+
+#endif
+
 #endif /* ifdef _WIN32 */
 
 #endif  /* UTILS_H */

--- a/doc/feature-notes.rst
+++ b/doc/feature-notes.rst
@@ -1583,6 +1583,63 @@ terminated. The child process keeps running. Since the parent process
 was terminated before it could perform clean-up, the temporary directory
 is left behind.
 
+
+Automatic hiding and minimization of console window under Windows
+=================================================================
+
+For console-enabled Windows applications, PyInstaller offers an option
+to automatically hide or minimize the console window *when the console
+window is owned by the program's process* (i.e., the program was not
+launched from an existing console window).
+
+Automatic minimization of console window allows a GUI application to
+put the console out of the user's way, while allowing it to be brought
+back if required. Automatic hiding of console window might be used to
+create an illusion of a hybrid application that has no console when
+launched by double-clicking on the executable, but shows console
+output when launched from existing console window.
+
+Note that the programmatic hiding/minimization of console can be easily
+implemented by application itself using win32 API via ``ctypes``.
+The advantage of having it in PyInstaller's bootloader is that:
+
+* it can be performed very early in the program's life cycle (especially
+  in case of ``onefile`` builds).
+
+* in ``onefile`` builds, the bootloader can easily determine the
+  ownership of console, regardless of parent and child process being
+  used (as the check is executed in the parent process).
+
+Also note that console hiding is different from ``windowed``/``noconsole``
+builds, which have no console at all. This option works only with
+console-enabled builds, and involves PyInstaller's bootloader
+programmatically hiding or minimizing the console.
+
+To enable this functionality, use the :option:`--hide-console` command-line
+option, or corresponding ``hide_console`` argument to ``EXE`` in the .spec
+file. Currently, four modes are supported: ``hide-early``, ``minimize-early``,
+``hide-late``, and ``minimize-late``.
+
+Depending on the setting, the console is hidden/mininized either early
+in the bootloader execution or late in the bootloader execution. The
+early option takes place as soon as the PKG archive is found. In ``onefile``
+builds, the late option takes place after application has unpacked itself
+and before it launches the child process. In ``onedir`` builds, the late
+option takes place before starting the embedded python interpreter.
+
+.. note::
+
+   Even with hiding/minimizing console early in the bootloader's execution,
+   the user might see console being opened for an instant before it is
+   hidden or minimized.
+
+   In fact, hiding console before the application's UI is brought up
+   might give the user an impression that the application has crashed.
+   Therefore, it might be preferable to have the application code to
+   implement its own programmatic hiding/minimization of the console
+   window, and have it performed only after the UI becomes visible.
+
+
 .. include:: _common_definitions.txt
 
 .. Emacs config:

--- a/news/7729.feature.rst
+++ b/news/7729.feature.rst
@@ -1,0 +1,4 @@
+(Windows) Add an option to hide or minimize the console window in
+console-enabled applications, but only if the program's process owns
+the console window (i.e., the program was not launched from an existing
+console window).


### PR DESCRIPTION
Add new EXE argument (`hide_console`) and command-line option (`--hide-console`) with options `hide-early`, `hide-late`, `minimize-early`, and `minimize-late`; these are mapped to a bootloader option that instructs the bootloader to programmatically hide or minimize the console window, either as soon as possible or as late as possible. The operation is performed only if the process owns the console window (i.e., the program was not launched from an existing console window).

Applies only to console-enabled builds on Windows.

Closes #7729.