### PR TITLE
Add Nvidia libraries to Unix exclusion list

### DIFF
--- a/PyInstaller/depend/dylib.py
+++ b/PyInstaller/depend/dylib.py
@@ -209,6 +209,13 @@ _unix_excludes = {
     # graphical interface libraries come with graphical stack (see libglvnd)
     r'libE?(Open)?GLX?(ESv1_CM|ESv2)?(dispatch)?\.so(\..*)?',
     r'libdrm\.so(\..*)?',
+    # a subset of libraries included as part of the Nvidia Linux Graphics Driver as of 520.56.06:
+    # https://download.nvidia.com/XFree86/Linux-x86_64/520.56.06/README/installedcomponents.html
+    r'nvidia_drv\.so',
+    r'libglxserver_nvidia\.so(\..*)?'
+    r'libnvidia-egl-(gbm|wayland)\.so(\..*)?',
+    r'libnvidia-(cfg|compiler|e?glcore|glsi|glvkspirv|rtcore|allocator|tls|ml)\.so(\..*)?',  # |cfg|compiler
+    r'lib(EGL|GLX)_nvidia\.so(\..*)?',
     # libxcb-dri changes ABI frequently (e.g.: between Ubuntu LTS releases) and is usually installed as dependency of
     # the graphics stack anyway. No need to bundle it.
     r'libxcb\.so(\..*)?',

--- a/PyInstaller/depend/dylib.py
+++ b/PyInstaller/depend/dylib.py
@@ -212,9 +212,9 @@ _unix_excludes = {
     # a subset of libraries included as part of the Nvidia Linux Graphics Driver as of 520.56.06:
     # https://download.nvidia.com/XFree86/Linux-x86_64/520.56.06/README/installedcomponents.html
     r'nvidia_drv\.so',
-    r'libglxserver_nvidia\.so(\..*)?'
+    r'libglxserver_nvidia\.so(\..*)?',
     r'libnvidia-egl-(gbm|wayland)\.so(\..*)?',
-    r'libnvidia-(cfg|compiler|e?glcore|glsi|glvkspirv|rtcore|allocator|tls|ml)\.so(\..*)?',  # |cfg|compiler
+    r'libnvidia-(cfg|compiler|e?glcore|glsi|glvkspirv|rtcore|allocator|tls|ml)\.so(\..*)?',
     r'lib(EGL|GLX)_nvidia\.so(\..*)?',
     # libxcb-dri changes ABI frequently (e.g.: between Ubuntu LTS releases) and is usually installed as dependency of
     # the graphics stack anyway. No need to bundle it.

--- a/news/7746.bugfix.rst
+++ b/news/7746.bugfix.rst
@@ -1,0 +1,1 @@
+Exclude Nvidia graphics driver libraries from vendoring.


### PR DESCRIPTION
This changeset adds several Nvidia libraries to PyInstaller's list of excluded libraries, which fixes the issue reported in #7745 in the manner suggested by @rokm.

The libraries added by this PR are a subset of what is listed in the [Nvidia driver documentation](https://download.nvidia.com/XFree86/Linux-x86_64/520.56.06/README/installedcomponents.html) for one of the recently release driver versions as of the time of this PR. I did check some historical versions and though there are a few libraries present in older drivers that are not covered by this change, the libraries listed here seem to be stable features of the stack.

Note that I have explicitly left out any libraries related to CUDA or OpenCL which are reasonably likely candidates for inclusion in a PyInstaller application, and which have decent forward compatibility as far as I know.

---

The specific case that led me to file this PR and which I used to test its efficacy is a PyInstaller application that has a dependency `pynvml`, which induces a dependency (via `ctypes`) on `libnvidia-ml` that can cause mismatches if the application is run on a system with a different driver version than the system that built the PyInstaller distribution.