### PR TITLE
tests: fix importlib.resources test for compatibility with python 3.13

### DIFF
--- a/tests/functional/scripts/pyi_importlib_resources.py
+++ b/tests/functional/scripts/pyi_importlib_resources.py
@@ -50,243 +50,262 @@
 # PyInstaller's custom resource reader, if/when implemented). Without custom resource reader, the frozen version of the
 # test seems to work with the importlib.resources (python 3.9 and later) but not with the importlib_resources (python
 # 3.8 and earlier), due to implementation differences.
+#
+# NOTE: functions `contents`, `is_resource`, `path`, `read_binary`, and `read_text` have been deprecated in python 3.11
+# stdlib (importlib_resources 5.7) and removed in python 3.13 stdlib (importlib_resources 6.0). We test these based on
+# their availability.
 
 import sys
 import pathlib
 
+# Ensure importlib.resources from python 3.9 stdlib or equivalent importlib_resources >= 1.3.
 try:
-    from importlib.resources import (
-        as_file as importlib_resources_as_file,
-        contents as importlib_resources_contents,
-        is_resource as importlib_resources_is_resource,
-        files as importlib_resources_files,
-        path as importlib_resources_path,
-        read_binary as importlib_resources_read_binary,
-        read_text as importlib_resources_read_text,
-    )
+    import importlib.resources as importlib_resources
+    if not hasattr(importlib_resources, "files"):
+        raise ImportError("Built-in importlib.resources is too old!")
     is_builtin = True
+    package_name = 'importlib.resources'
     print("Using built-in importlib.resources...")
 except ImportError:
-    from importlib_resources import (
-        as_file as importlib_resources_as_file,
-        contents as importlib_resources_contents,
-        is_resource as importlib_resources_is_resource,
-        files as importlib_resources_files,
-        path as importlib_resources_path,
-        read_binary as importlib_resources_read_binary,
-        read_text as importlib_resources_read_text,
-    )
+    import importlib_resources
     is_builtin = False
+    package_name = 'importlib_resources'
     print("Using backported importlib_resources...")
 
 is_frozen = getattr(sys, 'frozen', False)
 
-
 ########################################################################
 #          Validate behavior of importlib.resources.contents()         #
 ########################################################################
-def _contents_test(pkgname, expected):
-    # For frozen application, remove .py files from expected results.
+if hasattr(importlib_resources, "contents"):
+    print(f"Testing {package_name}.contents()...")
+
+    def _contents_test(pkgname, expected):
+        # For frozen application, remove .py files from expected results.
+        if is_frozen:
+            expected = [x for x in expected if not x.endswith('.py')]
+        # List the content
+        content = list(importlib_resources.contents(pkgname))
+        # Ignore pycache
+        if '__pycache__' in content:
+            content.remove('__pycache__')
+        assert sorted(content) == sorted(expected), f"Content mismatch: {sorted(content)} vs. {sorted(expected)}"
+
+    # NOTE: contents() seems to be broken in importlib.resources (python 3.9) for zipped eggs, as it also recursively
+    # lists all subdirectories (but not their files) instead of just directories within the package directory.
+
+    # Top-level package
+    expected = ['__init__.py', 'a.py', 'b.py', 'subpkg1', 'subpkg2', 'subpkg3']
     if is_frozen:
-        expected = [x for x in expected if not x.endswith('.py')]
-    # List the content
-    content = list(importlib_resources_contents(pkgname))
-    # Ignore pycache
-    if '__pycache__' in content:
-        content.remove('__pycache__')
-    assert sorted(content) == sorted(expected), f"Content mismatch: {sorted(content)} vs. {sorted(expected)}"
+        expected.remove('subpkg2')  # FIXME: frozen reader does not list directories that are not on filesystem.
+    _contents_test('pyi_pkgres_testpkg', expected)
 
+    # Subpackage #1
+    expected = ['__init__.py', 'c.py', 'd.py', 'data']
+    _contents_test('pyi_pkgres_testpkg.subpkg1', expected)
 
-# NOTE: contents() seems to be broken in importlib.resources (python 3.9) for zipped eggs, as it also recursively lists
-# all subdirectories (but not their files) instead of just directories within the package directory.
+    # Subpackage #2
+    if not is_frozen:
+        # Cannot list non-existing directory.
+        expected = ['__init__.py', 'mod.py', 'subsubpkg21']
+        _contents_test('pyi_pkgres_testpkg.subpkg2', expected)
 
-# Top-level package
-expected = ['__init__.py', 'a.py', 'b.py', 'subpkg1', 'subpkg2', 'subpkg3']
-if is_frozen:
-    expected.remove('subpkg2')  # FIXME: frozen reader does not list directories that are not on filesystem.
-_contents_test('pyi_pkgres_testpkg', expected)
+    # Sub-subpackage in subpackage #2
+    if not is_frozen:
+        # Cannot list non-existing directory.
+        expected = ['__init__.py', 'mod.py']
+        _contents_test('pyi_pkgres_testpkg.subpkg2.subsubpkg21', expected)
 
-# Subpackage #1
-expected = ['__init__.py', 'c.py', 'd.py', 'data']
-_contents_test('pyi_pkgres_testpkg.subpkg1', expected)
-
-# Subpackage #2
-if not is_frozen:
-    # Cannot list non-existing directory.
-    expected = ['__init__.py', 'mod.py', 'subsubpkg21']
-    _contents_test('pyi_pkgres_testpkg.subpkg2', expected)
-
-# Sub-subpackage in subpackage #2
-if not is_frozen:
-    # Cannot list non-existing directory.
-    expected = ['__init__.py', 'mod.py']
-    _contents_test('pyi_pkgres_testpkg.subpkg2.subsubpkg21', expected)
-
-# Subpackage #3
-expected = ['__init__.py', '_datafile.json']
-_contents_test('pyi_pkgres_testpkg.subpkg3', expected)
+    # Subpackage #3
+    expected = ['__init__.py', '_datafile.json']
+    _contents_test('pyi_pkgres_testpkg.subpkg3', expected)
+else:
+    print(f"Skipping {package_name}.contents() test...")
 
 ########################################################################
 #              Validate importlib.resources.is_resource()              #
 ########################################################################
-# In general, files (source or data) count as resources, directories do not.
+# `is_resource()` has been removed in python 3.13 stdlib and equivalent importlib_resources 6.0.0.
+if hasattr(importlib_resources, "is_resource"):
+    print(f"Testing {package_name}.is_resource()...")
 
-# Querying non-existent resource: return False instead of raising FileNotFoundError
-assert not importlib_resources_is_resource('pyi_pkgres_testpkg', 'subpkg_nonexistant')
-assert not importlib_resources_is_resource('pyi_pkgres_testpkg.subpkg1', 'nonexistant.txt')
+    # In general, files (source or data) count as resources, directories do not.
 
-# NOTE: frozen reader does not list .py files (nor equivalent .pyc ones)
-assert importlib_resources_is_resource('pyi_pkgres_testpkg', '__init__.py') is not is_frozen
-assert importlib_resources_is_resource('pyi_pkgres_testpkg', '__init__.py') is not is_frozen
-assert importlib_resources_is_resource('pyi_pkgres_testpkg', 'a.py') is not is_frozen
-assert importlib_resources_is_resource('pyi_pkgres_testpkg', 'b.py') is not is_frozen
+    # Querying non-existent resource: return False instead of raising FileNotFoundError
+    assert not importlib_resources.is_resource('pyi_pkgres_testpkg', 'subpkg_nonexistant')
+    assert not importlib_resources.is_resource('pyi_pkgres_testpkg.subpkg1', 'nonexistant.txt')
 
-assert not importlib_resources_is_resource('pyi_pkgres_testpkg', 'subpkg1')
-assert not importlib_resources_is_resource('pyi_pkgres_testpkg', 'subpkg2')  # Non-existent in frozen variant.
-assert not importlib_resources_is_resource('pyi_pkgres_testpkg', 'subpkg3')
+    # NOTE: frozen reader does not list .py files (nor equivalent .pyc ones)
+    assert importlib_resources.is_resource('pyi_pkgres_testpkg', '__init__.py') is not is_frozen
+    assert importlib_resources.is_resource('pyi_pkgres_testpkg', '__init__.py') is not is_frozen
+    assert importlib_resources.is_resource('pyi_pkgres_testpkg', 'a.py') is not is_frozen
+    assert importlib_resources.is_resource('pyi_pkgres_testpkg', 'b.py') is not is_frozen
 
-assert importlib_resources_is_resource('pyi_pkgres_testpkg.subpkg1', '__init__.py') is not is_frozen
-assert not importlib_resources_is_resource('pyi_pkgres_testpkg.subpkg1', 'data')
+    assert not importlib_resources.is_resource('pyi_pkgres_testpkg', 'subpkg1')
+    assert not importlib_resources.is_resource('pyi_pkgres_testpkg', 'subpkg2')  # Non-existent in frozen variant.
+    assert not importlib_resources.is_resource('pyi_pkgres_testpkg', 'subpkg3')
 
-# Try to specify a sub-path; should raise ValueError.
-try:
-    ret = importlib_resources_is_resource('pyi_pkgres_testpkg.subpkg1', 'data/entry1.txt')
-except ValueError:
-    pass
-except Exception:
-    raise
+    assert importlib_resources.is_resource('pyi_pkgres_testpkg.subpkg1', '__init__.py') is not is_frozen
+    assert not importlib_resources.is_resource('pyi_pkgres_testpkg.subpkg1', 'data')
+
+    # Try to specify a sub-path; should raise ValueError.
+    try:
+        ret = importlib_resources.is_resource('pyi_pkgres_testpkg.subpkg1', 'data/entry1.txt')
+    except ValueError:
+        pass
+    except Exception:
+        raise
+    else:
+        assert False, "Expected a ValueError!"
+
+    if not is_frozen:
+        assert importlib_resources.is_resource('pyi_pkgres_testpkg.subpkg2', 'mod.py')
+
+    assert importlib_resources.is_resource('pyi_pkgres_testpkg.subpkg3', '_datafile.json')
 else:
-    assert False, "Expected a ValueError!"
-
-if not is_frozen:
-    assert importlib_resources_is_resource('pyi_pkgres_testpkg.subpkg2', 'mod.py')
-
-assert importlib_resources_is_resource('pyi_pkgres_testpkg.subpkg3', '_datafile.json')
-
+    print(f"Skipping {package_name}.is_resource() test...")
 
 ########################################################################
 #                  Validate importlib.resources.path()                 #
 ########################################################################
-# The path() function returns on-disk path. If the resource was originally on disk, direct path to it is returned.
-# Otherwise, path to a temporary file is returned. This function is probably superseded by files() and as_file(), which
-# are more flexible; for example, path() does not allow access to files in sub-directories (only files that are directly
-# within a package directory).
-def _path_test(pkgname, resource, expected_data):
-    with importlib_resources_path(pkgname, resource) as pth:
-        assert isinstance(pth, pathlib.Path)
-        with open(pth, 'rb') as fp:
-            data = fp.read()
-        if expected_data is not None:
-            assert data.splitlines() == expected_data.splitlines()  # Split to avoid OS-specific newline discrepancies.
+# `path()` has been removed in python 3.13 stdlib and equivalent importlib_resources 6.0.0.
+if hasattr(importlib_resources, "path"):
+    print(f"Testing {package_name}.path()...")
 
+    # The path() function returns on-disk path. If the resource was originally on disk, direct path to it is returned.
+    # Otherwise, path to a temporary file is returned. This function is probably superseded by files() and as_file(),
+    # which are more flexible; for example, path() does not allow access to files in sub-directories (only files that
+    # are directly within a package directory).
+    def _path_test(pkgname, resource, expected_data):
+        with importlib_resources.path(pkgname, resource) as pth:
+            assert isinstance(pth, pathlib.Path)
+            with open(pth, 'rb') as fp:
+                data = fp.read()
+            if expected_data is not None:
+                # Split to avoid OS-specific newline discrepancies.
+                assert data.splitlines() == expected_data.splitlines()
 
-if not is_frozen:
-    expected_data = b"""from . import a, b  # noqa: F401\nfrom . import subpkg1, subpkg2, subpkg3  # noqa: F401\n"""
-    _path_test('pyi_pkgres_testpkg', '__init__.py', expected_data)
+    if not is_frozen:
+        expected_data = b"""from . import a, b  # noqa: F401\nfrom . import subpkg1, subpkg2, subpkg3  # noqa: F401\n"""
+        _path_test('pyi_pkgres_testpkg', '__init__.py', expected_data)
 
-if not is_frozen:
-    expected_data = b"""#\n"""
-    _path_test('pyi_pkgres_testpkg.subpkg2', 'mod.py', expected_data)
+    if not is_frozen:
+        expected_data = b"""#\n"""
+        _path_test('pyi_pkgres_testpkg.subpkg2', 'mod.py', expected_data)
 
-expected_data = b"""{\n  "_comment": "Data file in supbkg3."\n}\n"""
-_path_test('pyi_pkgres_testpkg.subpkg3', '_datafile.json', expected_data)
+    expected_data = b"""{\n  "_comment": "Data file in supbkg3."\n}\n"""
+    _path_test('pyi_pkgres_testpkg.subpkg3', '_datafile.json', expected_data)
 
-# Try with a non-existent file; should raise FileNotFoundError.
-# NOTE: importlib.resources in python 3.9 seems to do so, but importlib_resources 5.2.2 does not...
-try:
-    _path_test('pyi_pkgres_testpkg.subpkg1', 'nonexistant.txt', None)
-except FileNotFoundError:
-    pass
-except Exception:
-    raise
+    # Try with a non-existent file; should raise FileNotFoundError.
+    # NOTE: importlib.resources in python 3.9 seems to do so, but importlib_resources 5.2.2 does not...
+    try:
+        _path_test('pyi_pkgres_testpkg.subpkg1', 'nonexistant.txt', None)
+    except FileNotFoundError:
+        pass
+    except Exception:
+        raise
+    else:
+        assert not is_builtin, "Expected a FileNotFoundError!"
+
+    # Try to specify a sub-path; should raise ValueError.
+    try:
+        _path_test('pyi_pkgres_testpkg.subpkg1', 'data/entry1.txt', None)
+    except ValueError:
+        pass
+    except Exception:
+        raise
+    else:
+        assert False, "Expected a ValueError!"
 else:
-    assert not is_builtin, "Expected a FileNotFoundError!"
-
-# Try to specify a sub-path; should raise ValueError.
-try:
-    _path_test('pyi_pkgres_testpkg.subpkg1', 'data/entry1.txt', None)
-except ValueError:
-    pass
-except Exception:
-    raise
-else:
-    assert False, "Expected a ValueError!"
+    print(f"Skipping {package_name}.path() test...")
 
 ########################################################################
 #               Validate importlib.resources.read_binary()             #
 ########################################################################
-# Data file in pyi_pkgres_testpkg.subpkg3
-expected_data = b"""{\n  "_comment": "Data file in supbkg3."\n}\n"""
-data = importlib_resources_read_binary('pyi_pkgres_testpkg.subpkg3', '_datafile.json')
-assert data.splitlines() == expected_data.splitlines()
+if hasattr(importlib_resources, "read_binary"):
+    print(f"Testing {package_name}.read_binary()...")
 
-# Source file in pyi_pkgres_testpkg
-if not is_frozen:
-    expected_data = b"""from . import a, b  # noqa: F401\nfrom . import subpkg1, subpkg2, subpkg3  # noqa: F401\n"""
-    data = importlib_resources_read_binary('pyi_pkgres_testpkg', '__init__.py')
+    # Data file in pyi_pkgres_testpkg.subpkg3
+    expected_data = b"""{\n  "_comment": "Data file in supbkg3."\n}\n"""
+    data = importlib_resources.read_binary('pyi_pkgres_testpkg.subpkg3', '_datafile.json')
     assert data.splitlines() == expected_data.splitlines()
 
-# Try with non-existent file; should raise FileNotFoundError
-try:
-    importlib_resources_read_binary('pyi_pkgres_testpkg.subpkg1', 'nonexistant.txt')
-except FileNotFoundError:
-    pass
-except Exception:
-    raise
-else:
-    assert False, "Expected a FileNotFoundError!"
+    # Source file in pyi_pkgres_testpkg
+    if not is_frozen:
+        expected_data = b"""from . import a, b  # noqa: F401\nfrom . import subpkg1, subpkg2, subpkg3  # noqa: F401\n"""
+        data = importlib_resources.read_binary('pyi_pkgres_testpkg', '__init__.py')
+        assert data.splitlines() == expected_data.splitlines()
 
-# Try to specify sub-path; should raise ValueError
-try:
-    importlib_resources_read_binary('pyi_pkgres_testpkg.subpkg1', 'data/entry1.txt')
-except ValueError:
-    pass
-except Exception:
-    raise
+    # Try with non-existent file; should raise FileNotFoundError
+    try:
+        importlib_resources.read_binary('pyi_pkgres_testpkg.subpkg1', 'nonexistant.txt')
+    except FileNotFoundError:
+        pass
+    except Exception:
+        raise
+    else:
+        assert False, "Expected a FileNotFoundError!"
+
+    # Try to specify sub-path; should raise ValueError
+    try:
+        importlib_resources.read_binary('pyi_pkgres_testpkg.subpkg1', 'data/entry1.txt')
+    except ValueError:
+        pass
+    except Exception:
+        raise
+    else:
+        assert False, "Expected a ValueError!"
 else:
-    assert False, "Expected a ValueError!"
+    print(f"Skipping {package_name}.read_binary() test...")
 
 ########################################################################
 #                Validate importlib.resources.read_text()              #
 ########################################################################
-# Data file in pyi_pkgres_testpkg.subpkg3
-expected_data = """{\n  "_comment": "Data file in supbkg3."\n}\n"""
-data = importlib_resources_read_text('pyi_pkgres_testpkg.subpkg3', '_datafile.json', encoding='utf8')
-assert data.splitlines() == expected_data.splitlines()
+if hasattr(importlib_resources, "read_text"):
+    print(f"Testing {package_name}.read_text()...")
 
-# Source file in pyi_pkgres_testpkg
-if not is_frozen:
-    expected_data = """from . import a, b  # noqa: F401\nfrom . import subpkg1, subpkg2, subpkg3  # noqa: F401\n"""
-    data = importlib_resources_read_text('pyi_pkgres_testpkg', '__init__.py', encoding='utf8')
+    # Data file in pyi_pkgres_testpkg.subpkg3
+    expected_data = """{\n  "_comment": "Data file in supbkg3."\n}\n"""
+    data = importlib_resources.read_text('pyi_pkgres_testpkg.subpkg3', '_datafile.json', encoding='utf8')
     assert data.splitlines() == expected_data.splitlines()
 
-# Try with non-existent file; should raise FileNotFoundError
-try:
-    importlib_resources_read_text('pyi_pkgres_testpkg.subpkg1', 'nonexistant.txt', encoding='utf8')
-except FileNotFoundError:
-    pass
-except Exception:
-    raise
-else:
-    assert False, "Expected a FileNotFoundError!"
+    # Source file in pyi_pkgres_testpkg
+    if not is_frozen:
+        expected_data = """from . import a, b  # noqa: F401\nfrom . import subpkg1, subpkg2, subpkg3  # noqa: F401\n"""
+        data = importlib_resources.read_text('pyi_pkgres_testpkg', '__init__.py', encoding='utf8')
+        assert data.splitlines() == expected_data.splitlines()
 
-# Try to specify sub-path; should raise ValueError
-try:
-    importlib_resources_read_text('pyi_pkgres_testpkg.subpkg1', 'data/entry1.txt', encoding='utf8')
-except ValueError:
-    pass
-except Exception:
-    raise
+    # Try with non-existent file; should raise FileNotFoundError
+    try:
+        importlib_resources.read_text('pyi_pkgres_testpkg.subpkg1', 'nonexistant.txt', encoding='utf8')
+    except FileNotFoundError:
+        pass
+    except Exception:
+        raise
+    else:
+        assert False, "Expected a FileNotFoundError!"
+
+    # Try to specify sub-path; should raise ValueError
+    try:
+        importlib_resources.read_text('pyi_pkgres_testpkg.subpkg1', 'data/entry1.txt', encoding='utf8')
+    except ValueError:
+        pass
+    except Exception:
+        raise
+    else:
+        assert False, "Expected a ValueError!"
 else:
-    assert False, "Expected a ValueError!"
+    print(f"Skipping {package_name}.read_text() test...")
 
 ########################################################################
 #          Validate importlib.resources.files() and as_file()          #
 ########################################################################
+print(f"Testing {package_name}.files() and {package_name}.as_file()...")
+
 # files() should return a Traversable (or just a plain pathlib.Path). For on-disk resources, as_file() should not be
 # opening a temporary-file copy.
-pkg_path = importlib_resources_files('pyi_pkgres_testpkg')
-subpkg1_path = importlib_resources_files('pyi_pkgres_testpkg.subpkg1')
+pkg_path = importlib_resources.files('pyi_pkgres_testpkg')
+subpkg1_path = importlib_resources.files('pyi_pkgres_testpkg.subpkg1')
 
 # assert subpkg1_path == pkg_path / 'subpkg1'  # True only for on-disk resources!
 
@@ -299,7 +318,7 @@ subpkg1_path = importlib_resources_files('pyi_pkgres_testpkg.subpkg1')
 data_path = subpkg1_path / 'data/entry1.txt'
 expected_data = b"""Data entry #1 in subpkg1/data.\n"""
 
-with importlib_resources_as_file(data_path) as file_path:
+with importlib_resources.as_file(data_path) as file_path:
     with open(file_path, 'rb') as fp:
         data = fp.read()
 assert data.splitlines() == expected_data.splitlines()
@@ -311,13 +330,13 @@ assert data.splitlines() == expected_data.splitlines()
 expected_data = b"""Data entry #2 in `subpkg1/data`.\n"""
 
 data_path = pkg_path / 'subpkg1' / 'data' / 'entry2.md'
-with importlib_resources_as_file(data_path) as file_path:
+with importlib_resources.as_file(data_path) as file_path:
     with open(file_path, 'rb') as fp:
         data = fp.read()
 assert data.splitlines() == expected_data.splitlines()
 
 data_path = subpkg1_path / 'data' / 'entry2.md'
-with importlib_resources_as_file(data_path) as file_path:
+with importlib_resources.as_file(data_path) as file_path:
     with open(file_path, 'rb') as fp:
         data = fp.read()
 assert data.splitlines() == expected_data.splitlines()


### PR DESCRIPTION
Fix importlib.resources / importlib_resources test for compatibility with importlib.resources from python 3.13 stdlib and its equivalent importlib_resources 6.0, which removed the following functions (deprecated in python 3.11 stdlib / importlib_resources 5.7): `contents`, `is_resource`, `path`, `read_binary`, and `read_text`.

Test these functions only if they are available.