### PR TITLE
Look for commercial PyQt wheel to determine layout

### DIFF
--- a/news/7770.hooks.rst
+++ b/news/7770.hooks.rst
@@ -1,0 +1,1 @@
+Add support for commercial PyQt5 and PyQt6 wheels.


### PR DESCRIPTION
Commercial PyQt wheels install with the "_commercial" suffix as their package name but still make the regular PyQt5/PyQt6 namespace packages available.

This leads the layout detection logic to assume the old layout because `is_module_satisfies()` enters a fallback code path where it looks for the `__version__` attribute inside the namespace package, which doesn't exist.

A possible solution is to look for package names with the "_commercial" suffix when the standard lookup fails. The `_use_new_layout` utility method was introduced to perform such checks and is then used in both PyQt5 and PyQt6 code paths.