### PR TITLE
Convert an icon to RGBA before converting it

### DIFF
--- a/PyInstaller/building/icon.py
+++ b/PyInstaller/building/icon.py
@@ -63,7 +63,8 @@ def normalize_icon_type(icon_path: str, allowed_types: Tuple[str], convert_type:
         _generated_name = f"generated-{hashlib.sha256(icon_path.encode()).hexdigest()}.{convert_type}"
         generated_icon = os.path.join(workpath, _generated_name)
         with PILImage.open(icon_path) as im:
-            img = img.convert("RGBA")
+            if im.mode == "P" and im.info.get("transparency", None) is not None:
+                im = im.convert("RGBA")
             im.save(generated_icon)
         icon_path = generated_icon
     except PIL.UnidentifiedImageError:

--- a/PyInstaller/building/icon.py
+++ b/PyInstaller/building/icon.py
@@ -63,12 +63,10 @@ def normalize_icon_type(icon_path: str, allowed_types: Tuple[str], convert_type:
         _generated_name = f"generated-{hashlib.sha256(icon_path.encode()).hexdigest()}.{convert_type}"
         generated_icon = os.path.join(workpath, _generated_name)
         with PILImage.open(icon_path) as im:
-            # If an image uses a custom palette + transparency,
-            # convert it to RGBA for a better alpha mask depth.
+            # If an image uses a custom palette + transparency, convert it to RGBA for a better alpha mask depth.
             if im.mode == "P" and im.info.get("transparency", None) is not None:
-                # The bit depth of the alpha channel will be higher,
-                # and the images will look better when eventually scaled
-                # to multiple sizes (16,24,32,..) for the ICO format for example.
+                # The bit depth of the alpha channel will be higher, and the images will look better when eventually
+                # scaled to multiple sizes (16,24,32,..) for the ICO format for example.
                 im = im.convert("RGBA")
             im.save(generated_icon)
         icon_path = generated_icon

--- a/PyInstaller/building/icon.py
+++ b/PyInstaller/building/icon.py
@@ -63,7 +63,12 @@ def normalize_icon_type(icon_path: str, allowed_types: Tuple[str], convert_type:
         _generated_name = f"generated-{hashlib.sha256(icon_path.encode()).hexdigest()}.{convert_type}"
         generated_icon = os.path.join(workpath, _generated_name)
         with PILImage.open(icon_path) as im:
+            # If an image uses a custom palette + transparency,
+            # convert it to RGBA for a better alpha mask depth.
             if im.mode == "P" and im.info.get("transparency", None) is not None:
+                # The bit depth of the alpha channel will be higher,
+                # and the images will look better when eventually scaled
+                # to multiple sizes (16,24,32,..) for the ICO format for example.
                 im = im.convert("RGBA")
             im.save(generated_icon)
         icon_path = generated_icon

--- a/PyInstaller/building/icon.py
+++ b/PyInstaller/building/icon.py
@@ -63,6 +63,7 @@ def normalize_icon_type(icon_path: str, allowed_types: Tuple[str], convert_type:
         _generated_name = f"generated-{hashlib.sha256(icon_path.encode()).hexdigest()}.{convert_type}"
         generated_icon = os.path.join(workpath, _generated_name)
         with PILImage.open(icon_path) as im:
+            img = img.convert("RGBA")
             im.save(generated_icon)
         icon_path = generated_icon
     except PIL.UnidentifiedImageError:


### PR DESCRIPTION
The resulting quality will be much better, because Pillow will use the full alpha channel to do anti-aliasing.

EDIT 1: It helps only with a image with transparency.