### PR TITLE
isolated: Handle unexpected subprocess deaths.

### DIFF
--- a/tests/unit/test_isolation.py
+++ b/tests/unit/test_isolation.py
@@ -299,3 +299,14 @@ def test_shutdown_timeout_dangling_threads(strict_mode, caplog):
 
         # The isolated function should finish and return its expected results, regardless of the shutdown timeout.
         assert actual == expected
+
+
+def test_subprocess_crash():
+    def crash(a):
+        import os
+        os.kill(os.getpid(), 9)
+
+    with pytest.raises(
+        isolated._parent.SubprocessDiedError, match=r"died calling crash\(\) with args=\(12,\) and kwargs=\{\}. .* -?9"
+    ):
+        isolated.call(crash, 12)


### PR DESCRIPTION
Whenever a subprocess dies due to a SIGSEV or similar unhandle-able error, it's unable to send its error information back up to the parent. The parent, trying to read from the pipe to the child, encounters a broken pipe error which leads to a particularly unhelpful stacktrace dumped on our issue tracker – it tells us what function failed but not its inputs or where it failed. This is most prominent in find_binary_dependencies() which imports large numbers of unknown packages and the stacktrace doesn't tell us which one caused the crash.

* Catch the broken pipe error and re-raise adding the function parameters to the error message.

* Restructure find_binary_dependencies() so that each import is processed in separate function calls (with a shared subprocess) so that an import which crashes the subprocess has its name in the error message.

For reference, the error for importing a package `instant_death` which signals SIGSEV to itself looks something like:

```python
4522 INFO: Looking for dynamic libraries
Traceback (most recent call last):
  File "C:\Python310\lib\runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  ...
  File "d:\notebooks\pyinstaller\PyInstaller\building\build_main.py", line 782, in assemble
    find_binary_dependencies(self.binaries, self.binding_redirects, collected_packages)
  File "d:\notebooks\pyinstaller\PyInstaller\building\build_main.py", line 181, in find_binary_dependencies
    child.call(import_library, package)
  File "d:\notebooks\pyinstaller\PyInstaller\isolated\_parent.py", line 307, in call
    raise SubprocessDiedError(f"Child process died calling {function.__name__}() with args={args} and "
PyInstaller.isolated._parent.SubprocessDiedError: Child process died calling import_library() with args=('instant_death',) and kwargs={}. Its exit code was 9.
```