### PR TITLE
Specify waf arguments when installing from pip

### DIFF
--- a/doc/bootloader-building.rst
+++ b/doc/bootloader-building.rst
@@ -46,6 +46,11 @@ By setting the environment variable ``PYINSTALLER_COMPILE_BOOTLOADER``
 the pip_ setup will attempt to build the bootloader for your platform, even
 if it is already present.
 
+  By default, the pip_ setup process will prioritize searching for the msvc (Microsoft Visual C++) compiler. 
+  If you prefer to use a specific compiler, you have the option to set the environment 
+  variable ``PYINSTALLER_BOOTLOADER_COMPILER`` 
+  to either 'gcc' or 'clang'. Doing so will instruct the setup to use the chosen compiler.
+
 Supported platforms are
 
 * GNU/Linux (using gcc)

--- a/doc/bootloader-building.rst
+++ b/doc/bootloader-building.rst
@@ -46,10 +46,10 @@ By setting the environment variable ``PYINSTALLER_COMPILE_BOOTLOADER``
 the pip_ setup will attempt to build the bootloader for your platform, even
 if it is already present.
 
-  By default, the pip_ setup process will prioritize searching for the msvc (Microsoft Visual C++) compiler. 
-  If you prefer to use a specific compiler, you have the option to set the environment 
-  variable ``PYINSTALLER_BOOTLOADER_COMPILER`` 
-  to either 'gcc' or 'clang'. Doing so will instruct the setup to use the chosen compiler.
+Doing so would execute the command ``python ./waf configure all`` upon installation.
+
+  You can pass additional arguements to the build process by setting the 
+  ``PYINSTALLER_BOOTLOADER_WAF_ARGS`` environment variable.
 
 Supported platforms are
 

--- a/doc/bootloader-building.rst
+++ b/doc/bootloader-building.rst
@@ -44,11 +44,9 @@ then ask for technical help.
 
 By setting the environment variable ``PYINSTALLER_COMPILE_BOOTLOADER``
 the pip_ setup will attempt to build the bootloader for your platform, even
-if it is already present.
+if it is already present. Doing so would execute the command ``python ./waf configure all`` upon installation.
 
-Doing so would execute the command ``python ./waf configure all`` upon installation.
-
-  You can pass additional arguements to the build process by setting the 
+  You can pass additional arguments to the build process by setting the 
   ``PYINSTALLER_BOOTLOADER_WAF_ARGS`` environment variable.
 
 Supported platforms are

--- a/doc/bootloader-building.rst
+++ b/doc/bootloader-building.rst
@@ -44,10 +44,7 @@ then ask for technical help.
 
 By setting the environment variable ``PYINSTALLER_COMPILE_BOOTLOADER``
 the pip_ setup will attempt to build the bootloader for your platform, even
-if it is already present. Doing so would execute the command ``python ./waf configure all`` upon installation.
-
-  You can pass additional arguments to the build process by setting the 
-  ``PYINSTALLER_BOOTLOADER_WAF_ARGS`` environment variable.
+if it is already present. Doing so would execute the command ``python ./waf configure all`` upon installation. You can also pass additional arguments to the build process by setting the ``PYINSTALLER_BOOTLOADER_WAF_ARGS`` environment variable.
 
 Supported platforms are
 

--- a/news/7796.build.rst
+++ b/news/7796.build.rst
@@ -1,3 +1,4 @@
-To select a specific compiler for PyInstaller's bootloader, you have two options through environment variables. 
-If the variable ``PYINSTALLER_BOOTLOADER_COMPILER`` exists and has a value of 'gcc' or 'clang', PyInstaller will use the corresponding compiler. 
-Additionally, the presence of the environment variable ``PYINSTALLER_COMPILER_BOOTLOADER`` is necessary to activate this behavior.
+To enable the passing of extra arguments to the bootloader compiler during installation via pip, 
+you can utilize the environment variable ``PYINSTALLER_BOOTLOADER_WAF_ARGS``. However, 
+it is essential to ensure that the environment variable ``PYINSTALLER_BOOTLOADER_COMPILER`` 
+is present for this functionality to work correctly.

--- a/news/7796.build.rst
+++ b/news/7796.build.rst
@@ -1,0 +1,3 @@
+To select a specific compiler for PyInstaller's bootloader, you have two options through environment variables. 
+If the variable ``PYINSTALLER_BOOTLOADER_COMPILER`` exists and has a value of 'gcc' or 'clang', PyInstaller will use the corresponding compiler. 
+Additionally, the presence of the environment variable ``PYINSTALLER_COMPILER_BOOTLOADER`` is necessary to activate this behavior.

--- a/news/7796.build.rst
+++ b/news/7796.build.rst
@@ -1,4 +1,4 @@
 To enable the passing of extra arguments to the bootloader compiler during installation via pip, 
 you can utilize the environment variable ``PYINSTALLER_BOOTLOADER_WAF_ARGS``. However, 
-it is essential to ensure that the environment variable ``PYINSTALLER_BOOTLOADER_COMPILER`` 
+it is essential to ensure that the environment variable ``PYINSTALLER_COMPILE_BOOTLOADER``
 is present for this functionality to work correctly.

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,17 @@ class build_bootloader(Command):
         from PyInstaller import HOMEPATH
 
         src_dir = os.path.join(HOMEPATH, 'bootloader')
+        match os.getenv('PYINSTALLER_BOOTLOADER_COMPILER'):
+            case 'gcc':
+                compiler_optional = '--gcc'
+            case 'clang':
+                compiler_optional = '--clang'
+            case _:
+                compiler_optional = None
+
         cmd = [sys.executable, './waf', 'configure', 'all']
+        if compiler_optional:
+            cmd.append(compiler_optional)
         rc = subprocess.call(cmd, cwd=src_dir)
         if rc:
             raise SystemExit('ERROR: Failed compiling the bootloader. Please compile manually and rerun setup.py')

--- a/setup.py
+++ b/setup.py
@@ -58,17 +58,9 @@ class build_bootloader(Command):
         from PyInstaller import HOMEPATH
 
         src_dir = os.path.join(HOMEPATH, 'bootloader')
-        match os.getenv('PYINSTALLER_BOOTLOADER_COMPILER'):
-            case 'gcc':
-                compiler_optional = '--gcc'
-            case 'clang':
-                compiler_optional = '--clang'
-            case _:
-                compiler_optional = None
-
+        additional_args = os.getenv('PYINSTALLER_BOOTLOADER_WAF_ARGS', '').strip().split()
         cmd = [sys.executable, './waf', 'configure', 'all']
-        if compiler_optional:
-            cmd.append(compiler_optional)
+        cmd += additional_args
         rc = subprocess.call(cmd, cwd=src_dir)
         if rc:
             raise SystemExit('ERROR: Failed compiling the bootloader. Please compile manually and rerun setup.py')


### PR DESCRIPTION
When you install PyInstaller from pip, it automatically checks for the presence of the `PYINSTALLER_COMPILE_BOOTLOADER` environment variable. If this variable is found, PyInstaller will try to build the bootloader, regardless of whether it is already present.

By default, on Windows, PyInstaller follows a specific searching order for compilers: MSVC > GCC > CLANG. However, to override this default behavior and use a particular compiler of your choice, you can set the `PYINSTALLER_BOOTLOADER_COMPILER` environment variable with either 'gcc' or 'clang' as its value. If PyInstaller detects this variable with the specified values, it will attempt to compile the bootloader using the corresponding compiler accordingly.