### PR TITLE
Fix readthedocs building on unsupported Python version

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,8 +5,12 @@ sphinx:
 
 formats: all
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: '3'
+
 python:
-  version: 3
   install:
     # Needed for autodoc to be able to read PyInstaller docstrings.
     - method: pip


### PR DESCRIPTION
All our readthedocs builds are failing due to their trying to build on Python 3.7 which we no longer support.