### PR TITLE
bootloader: always call Py_GetPath before Py_SetPath

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ env:
   PYINSTALLER_STRICT_BUNDLE_CODESIGN_ERROR: 1
   # Enable strict verification of macOS bundles w.r.t. the code-signing requirements.
   PYINSTALLER_VERIFY_BUNDLE_SIGNATURE: 1
+  # Force python memory debugging
+  PYTHONMALLOC: debug
 
 permissions:
   contents: read # to fetch code (actions/checkout)

--- a/bootloader/src/pyi_pythonlib.c
+++ b/bootloader/src/pyi_pythonlib.c
@@ -513,15 +513,15 @@ pyi_pylib_start_python(ARCHIVE_STATUS *status)
         return -1;
     }
     VS("LOADER: Pre-init sys.path is %s\n", pypath);
-#ifdef _WIN32
-    // Call GetPath first, so the static dllpath will be set as a side
-    // effect. Workaround for http://bugs.python.org/issue29778, see #2496.
-    // Due to another bug calling this on non-win32 with Python 3.6 causes
-    // memory corruption, see #2812 and
-    // https://bugs.python.org/issue31532. But the workaround is only
-    // needed for win32.
+
+    /*
+     * Call Py_GetPath() first. This used be necessary on Windows to
+     * work around https://bugs.python.org/issue29778, but it also seems
+     * necessary on other platforms with python 3.8 and 3.9 when python's
+     * memory debugging and validation is enabled (PYTHONMALLOC=debug or
+     * PYTHONDEVMODE=1).
+     */
     PI_Py_GetPath();
-#endif
     PI_Py_SetPath(pypath_w);
 
     /* Start python. */

--- a/news/7790.bootloader.rst
+++ b/news/7790.bootloader.rst
@@ -1,0 +1,4 @@
+Have bootloader call ``Py_GetPath`` before ``Py_SetPath`` on all platforms
+(instead of just on Windows) to work around memory-initialization issues
+in python 3.8 and 3.9, which come to light with ``PYTHONMALLOC=debug``
+or ``PYTHONDEVMODE=1`` being set in the environment.


### PR DESCRIPTION
Have bootloader call `Py_GetPath` before `Py_SetPath` on all platforms (instead of just on Windows) to work around memory-initialization issues in python 3.8 and 3.9, which come to light with `PYTHONMALLOC=debug` or `PYTHONDEVMODE=1` being set in the environment. Fixes #7790.

I'm leaving `PYTHONMALLOC=debug` enabled on the CI, as it might prove useful when we switch to the new interpreter initialization API. We can turn it off later if it turns out to slow the CI too much, or pick up issues in 3rd party libraries.