### PR TITLE
cleanup: remove the --ascii command-line option

### DIFF
--- a/PyInstaller/utils/misc.py
+++ b/PyInstaller/utils/misc.py
@@ -57,21 +57,6 @@ def files_in_dir(directory, file_patterns=None):
     return files
 
 
-def get_unicode_modules():
-    """
-    Try importing modules required for unicode support in the frozen application.
-    """
-    modules = []
-    try:
-        # `codecs` depends on `encodings`, so the latter are included automatically.
-        import codecs  # noqa: F401
-        modules.append('codecs')
-    except ImportError:
-        logger.error("Cannot detect modules 'codecs'.")
-
-    return modules
-
-
 def get_path_to_toplevel_modules(filename):
     """
     Return the path to top-level directory that contains Python modules.

--- a/doc/spec-files.rst
+++ b/doc/spec-files.rst
@@ -58,7 +58,6 @@ Only the following command-line options have an effect when building from a spec
 * :option:`--distpath`
 * :option:`--workpath`
 * :option:`--noconfirm`
-* :option:`--ascii`
 * :option:`--clean`
 * :option:`--log-level`
 

--- a/news/7801.breaking.rst
+++ b/news/7801.breaking.rst
@@ -1,0 +1,3 @@
+Remove the ``--ascii`` command-line option, which is an effective no-op
+under python 3; the ``codecs`` module is always collected due to being
+listed among the base modules.


### PR DESCRIPTION
Remove the `--ascii` command-line option, which is an effective no-op under python 3; the `codecs` module is always collected due to being listed among the base modules.