### PR TITLE
bootloader: waf: limit the strip task's after directive to C tasks

### DIFF
--- a/bootloader/tools/strip.py
+++ b/bootloader/tools/strip.py
@@ -50,7 +50,7 @@ def configure(conf):
 class strip(Task.Task):
     run_str = '${STRIP} ${STRIPFLAGS} ${SRC}'
     color = 'BLUE'
-    after = ['cprogram', 'cxxprogram', 'cshlib', 'cxxshlib', 'fcprogram', 'fcshlib']
+    after = ['cprogram', 'cshlib']
 
 
 @TaskGen.feature('strip')


### PR DESCRIPTION
Limit the `strip` task's `after` directive to only C-based tasks (`cprogram` and `cshlib`), to avoid messages about erroneous order constraints

```
Waf: Entering directory `[...]/pyinstaller/bootloader/build/release'
Erroneous order constraint 'after'='cxxprogram' on task class 'strip'
Erroneous order constraint 'after'='cxxshlib' on task class 'strip'
Erroneous order constraint 'after'='fcprogram' on task class 'strip'
Erroneous order constraint 'after'='fcshlib' on task class 'strip'
[16/17] Processing build/release/run
```

when running waf with --verbose option.