### PR TITLE
bindepend: macOS: resolve symlinks for loader_path and executable_path

### DIFF
--- a/PyInstaller/depend/bindepend.py
+++ b/PyInstaller/depend/bindepend.py
@@ -414,9 +414,10 @@ def _get_imports_macholib(filename, search_paths):
     referenced_libs = set()  # Libraries referenced in Mach-O headers.
 
     # Parent directory of the input binary and parent directory of python executable, used to substitute @loader_path
-    # and @executable_path.
-    bin_path = os.path.abspath(os.path.dirname(filename))
-    python_bin_path = os.path.abspath(os.path.dirname(sys.executable))
+    # and @executable_path. The MacOS dylib loader (dyld) fully resolves the symbolic links when using @loader_path
+    # and @executable_path references, so we need to do the same using `os.path.realpath`.
+    bin_path = os.path.dirname(os.path.realpath(filename))
+    python_bin_path = os.path.dirname(os.path.realpath(sys.executable))
 
     # Walk through Mach-O headers, and collect all referenced libraries.
     m = MachO(filename)


### PR DESCRIPTION
When resolving the dependency paths anchored to `@loader_path` or `@executable_path`, fully resolve the path to the binary under analysis (loader_path) or python executable (executable_path). The binary under analysis (or python executable) themselves might be symbolic links, and `dyld` on macOS fully resolves their location when looking for dependencies.

This fixes compatibility with Homebrew-installed `PySide6` and `PyQt6`, where for example `QtWidgets` extension from `PySide6` is visible to us as

```
/usr/local/lib/python3.11/site-packages/PySide6/QtWidgets.abi3.so
```

and references the Qt libraries as:

```
@loader_path/../../../../../../../opt/qt/lib/QtWidgets.framework/Versions/A/QtWidgets
@loader_path/../../../../../../../opt/qt/lib/QtGui.framework/Versions/A/QtGui
@loader_path/../../../../../../../opt/qt/lib/QtCore.framework/Versions/A/QtCore
```

Taking the location of the extension at face value results in invalid dependency paths; however, the extension is actually a symbolic link pointing to:

```
../../../../Cellar/pyside/6.5.2/lib/python3.11/site-packages/PySide6/QtWidgets.abi3.so
```

Resolving the extension location allows us to resolve the paths to dependencies as well:

```
/usr/local/opt/qt/lib/QtWidgets.framework/Versions/A/QtWidgets
/usr/local/opt/qt/lib/QtGui.framework/Versions/A/QtGui
/usr/local/opt/qt/lib/QtCore.framework/Versions/A/QtCore
```