### PR TITLE
depend: suppress missing DLL warnings for all api-ms-win-* DLLs

### DIFF
--- a/PyInstaller/depend/dylib.py
+++ b/PyInstaller/depend/dylib.py
@@ -354,8 +354,7 @@ if compat.is_linux:
 
 # Suppress false warnings on win 10 and UCRT (see issue #1566).
 if compat.is_win_10:
-    _warning_suppressions.append(r'api-ms-win-crt.*')
-    _warning_suppressions.append(r'api-ms-win-core.*')
+    _warning_suppressions.append(r'api-ms-win-.*\.dll')
 
 
 class MissingLibWarningSuppressionList:


### PR DESCRIPTION
Extend the missing-DLL warning warning suppression pattern from `api-ms-win-crt-*` and `api-ms-win-core-*` to `api-ms-win-*`.

Suppresses the warning about `api-ms-win-shcore-scaling-l1-1-1.dll` when collecting PySide6 Qt plugins.