### PR TITLE
archive: splash: normalize path component separator in splash requirements

### DIFF
--- a/PyInstaller/archive/writers.py
+++ b/PyInstaller/archive/writers.py
@@ -347,6 +347,18 @@ class SplashWriter:
         :param str script: The tcl/tk script to execute to create the screen.
         """
 
+        # Ensure forward slashes in dependency names are on Windows converted to back slashes '\\', as on Windows the
+        # bootloader works only with back slashes.
+        def _normalize_filename(filename):
+            filename = os.path.normpath(filename)
+            if is_win and os.path.sep == '/':
+                # When building under MSYS, the above path normalization uses Unix-style separators, so replace them
+                # manually.
+                filename = filename.replace(os.path.sep, '\\')
+            return filename
+
+        name_list = [_normalize_filename(name) for name in name_list]
+
         with open(filename, "wb") as fp:
             # Reserve space for the header.
             fp.write(b'\0' * self._HEADER_LENGTH)

--- a/news/7828.bugfix.rst
+++ b/news/7828.bugfix.rst
@@ -1,0 +1,2 @@
+(Windows) Fix splash screen not being able to locate collected Tk resources
+in onefile applications created in MSYS2 python environment.


### PR DESCRIPTION
Explicitly normalize the names of splash requirements, and ensure that on Windows, back-slash is always used as the path component separator.

Fixes splash screen not being able to locate collected Tk resources in onefile applications created in MSYS2 python environments; splash requirements were using forward slash, and thus fail to match the actual PKG entries, which use the back-slash.

Fixes #7828.