### PR TITLE
hookutils: gi: fix error handling in compile_glib_schema_files

### DIFF
--- a/PyInstaller/utils/hooks/gi.py
+++ b/PyInstaller/utils/hooks/gi.py
@@ -395,11 +395,17 @@ def compile_glib_schema_files(datas_toc, workdir, collect_source_files=False):
             stderr=subprocess.STDOUT,
             check=True,
             text=True,
+            errors='ignore',
         )
-        logger.debug("Extra output from glib-compile-schemas:\n%s", p.stdout)
+        logger.debug("Output from glib-compile-schemas:\n%s", p.stdout)
+    except subprocess.CalledProcessError as e:
+        # The called glib-compile-schema returned error. Display stdout/stderr, and return original datas TOC to
+        # minimize damage.
+        logger.warning("Failed to recompile GLib schemas! Returning collected files as-is!", exc_info=True)
+        logger.warning("Output from glib-compile-schemas:\n%s", e.stdout)
+        return datas_toc
     except Exception:
         # Compilation failed for whatever reason. Return original datas TOC to minimize damage.
-        logger.warning("Extra output from glib-compile-schemas:\n%s", p.stdout)
         logger.warning("Failed to recompile GLib schemas! Returning collected files as-is!", exc_info=True)
         return datas_toc
 

--- a/news/7833.bugfix.rst
+++ b/news/7833.bugfix.rst
@@ -1,0 +1,4 @@
+Fix error handling in GLib schema compilation helper function. Ignore
+character encoding errors when reading stdout/stderr from ``glib-schema-compile``
+process; this fixes errors in msys2/mingw64 environment, caused by
+``U+201C`` and ``U+201D`` quotation marks in the output.


### PR DESCRIPTION
Fix error handling in compile_glib_schema_files; do not attempt to access attributes of `p`, which is unavailable in the exception handling block. To display stdout/stderr of the failed process, use attributes of the `subprocess.CalledProcessError` instead.

Ignore the character encoding errors when decoding stdout/stderr from the `glib-compile-schema` process. The warnings it emits seem to use `U+201C` and `U+201D` quotation marks, which might cause issues with active locale (for example, in msys2/mingw64 environment).

Fixes #7833.