### PR TITLE
`urllib.parse` instead of `urllib`

### DIFF
--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -636,7 +636,7 @@ PY3_BASE_MODULES = {
     'tokenize',  # used by loader/pymod02_importers.py
     'traceback',  # for startup errors
     'types',
-    'urllib',  # dependency of pathlib
+    'urllib.parse',  # dependency of pathlib
     'weakref',
     'warnings',
 }

--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -636,6 +636,7 @@ PY3_BASE_MODULES = {
     'tokenize',  # used by loader/pymod02_importers.py
     'traceback',  # for startup errors
     'types',
+    'urllib.',  # dependency of pathlib
     'urllib.parse',  # dependency of pathlib
     'weakref',
     'warnings',

--- a/PyInstaller/depend/analysis.py
+++ b/PyInstaller/depend/analysis.py
@@ -249,8 +249,8 @@ class PyiModuleGraph(ModuleGraph):
         required_mods = []
         # Collect submodules from required modules in base_library.zip.
         for m in PY3_BASE_MODULES:
-            if m.endswith('.'):
-                required_mods.append(m[:-1])
+            if m.endswith('.') and is_package(m[:-1]):
+                required_mods.append(collect_submodules(m[:-1])[0])
             elif is_package(m):
                 required_mods += collect_submodules(m)
             else:

--- a/PyInstaller/depend/analysis.py
+++ b/PyInstaller/depend/analysis.py
@@ -557,7 +557,7 @@ class PyiModuleGraph(ModuleGraph):
         #
         # This expression matches the base module name, optionally followed by a period and then any number of
         # characters. This matches the module name and the fully qualified names of any of its submodules.
-        regex_str = '(' + '|'.join(PY3_BASE_MODULES) + r')(\.|$)'
+        regex_str = '(' + '|'.join(x[:-1] if x.endswith(".") else x for x in PY3_BASE_MODULES) + r')(\.|$)'
         module_filter = re.compile(regex_str)
 
         toc = list()

--- a/PyInstaller/depend/analysis.py
+++ b/PyInstaller/depend/analysis.py
@@ -249,7 +249,9 @@ class PyiModuleGraph(ModuleGraph):
         required_mods = []
         # Collect submodules from required modules in base_library.zip.
         for m in PY3_BASE_MODULES:
-            if is_package(m):
+            if m.endswith('.'):
+                required_mods.append(m[:-1])
+            elif is_package(m):
                 required_mods += collect_submodules(m)
             else:
                 required_mods.append(m)

--- a/PyInstaller/depend/utils.py
+++ b/PyInstaller/depend/utils.py
@@ -45,8 +45,8 @@ def create_py3_base_library(libzip_filename, graph):
 
     # Construct regular expression for matching modules that should be bundled into base_library.zip. Excluded are plain
     # 'modules' or 'submodules.ANY_NAME'. The match has to be exact - start and end of string not substring.
-    regex_modules = '|'.join([rf'(^{x}$)' for x in compat.PY3_BASE_MODULES])
-    regex_submod = '|'.join([rf'(^{x}\..*$)' for x in compat.PY3_BASE_MODULES])
+    regex_modules = '|'.join([rf'(^{x[:-1] if x.endswith(".") else x}$)' for x in compat.PY3_BASE_MODULES])
+    regex_submod = '|'.join([rf'(^{x[:-1] if x.endswith(".") else x}\..*$)' for x in compat.PY3_BASE_MODULES])
     regex_str = regex_modules + '|' + regex_submod
     module_filter = re.compile(regex_str)
 


### PR DESCRIPTION
Tested in windows python 3.7.9.
Difference is huge: [before_and_after.zip](https://github.com/byehack/pyinstaller/files/12301499/before_and_after.zip)

The problem is base library doesn't contain `__init.__.py`

![image](https://github.com/byehack/pyinstaller/assets/26390254/1f172728-5832-45d9-a6ea-d2de6986d65e)

I think this is a bug and need to be fixed before merging this PR.
I can confirm that `urllib.py` is exists in pyz file (`build\app\PYZ-00.pyz`).