### PR TITLE
Lazy import `pathlib` for `pyimod02_importers`

### DIFF
--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -615,6 +615,7 @@ PY3_BASE_MODULES = {
     'enum',
     'functools',
     'genericpath',  # dependency of os.path
+    'io',
     'heapq',
     'keyword',
     'linecache',

--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -613,10 +613,8 @@ PY3_BASE_MODULES = {
     'copyreg',
     'encodings',
     'enum',
-    'fnmatch',  # dependency of pathlib
     'functools',
     'genericpath',  # dependency of os.path
-    'io',  # used by loader/pymod02_importers.py
     'heapq',
     'keyword',
     'linecache',
@@ -624,7 +622,6 @@ PY3_BASE_MODULES = {
     'ntpath',  # dependency of os.path
     'operator',
     'os',
-    'pathlib',  # used by loader/pymod02_importers.py
     'posixpath',  # dependency of os.path
     're',
     'reprlib',
@@ -632,11 +629,8 @@ PY3_BASE_MODULES = {
     'sre_constants',
     'sre_parse',
     'stat',  # dependency of os.path
-    'token',  # depdendency of tokenize
-    'tokenize',  # used by loader/pymod02_importers.py
     'traceback',  # for startup errors
     'types',
-    'urllib',  # dependency of pathlib
     'weakref',
     'warnings',
 }

--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -639,10 +639,6 @@ PY3_BASE_MODULES = {
 if not is_py310:
     PY3_BASE_MODULES.add('_bootlocale')
 
-if sys.version_info >= (3, 11, 4):
-    # required by loader/pymod02_importers.py -> pathlib -> urllib
-    PY3_BASE_MODULES.add('ipaddress')
-
 # Object types of Pure Python modules in modulegraph dependency graph.
 # Pure Python modules have code object (attribute co_code).
 PURE_PYTHON_MODULE_TYPES = {

--- a/PyInstaller/loader/pyimod02_importers.py
+++ b/PyInstaller/loader/pyimod02_importers.py
@@ -19,6 +19,7 @@ PEP-302 and PEP-451 importers for frozen applications.
 
 import sys
 import os
+import io
 import tokenize
 
 import _frozen_importlib
@@ -49,10 +50,9 @@ def _decode_source(source_bytes):
     Based on CPython's implementation of the same functionality:
     https://github.com/python/cpython/blob/3.9/Lib/importlib/_bootstrap_external.py#L679-L688
     """
-    from io import BytesIO, IncrementalNewlineDecoder
-    source_bytes_readline = BytesIO(source_bytes).readline
+    source_bytes_readline = io.BytesIO(source_bytes).readline
     encoding = tokenize.detect_encoding(source_bytes_readline)
-    newline_decoder = IncrementalNewlineDecoder(decoder=None, translate=True)
+    newline_decoder = io.IncrementalNewlineDecoder(decoder=None, translate=True)
     return newline_decoder.decode(source_bytes.decode(encoding[0]))
 
 

--- a/PyInstaller/loader/pyimod02_importers.py
+++ b/PyInstaller/loader/pyimod02_importers.py
@@ -49,6 +49,7 @@ def _decode_source(source_bytes):
     Based on CPython's implementation of the same functionality:
     https://github.com/python/cpython/blob/3.9/Lib/importlib/_bootstrap_external.py#L679-L688
     """
+    # Local import to avoid including `tokenize` and its dependencies in `base_library.zip`
     from tokenize import detect_encoding
     source_bytes_readline = io.BytesIO(source_bytes).readline
     encoding = detect_encoding(source_bytes_readline)
@@ -423,6 +424,7 @@ class PyiFrozenResourceReader:
       https://github.com/python/cpython/blob/839d7893943782ee803536a47f1d4de160314f85/Lib/importlib/abc.py#L312
     """
     def __init__(self, importer, name):
+        # Local import to avoid including `pathlib` and its dependencies in `base_library.zip`
         from pathlib import Path
         self.importer = importer
         self.path = Path(sys._MEIPASS).joinpath(*name.split('.'))

--- a/PyInstaller/loader/pyimod02_importers.py
+++ b/PyInstaller/loader/pyimod02_importers.py
@@ -19,6 +19,7 @@ PEP-302 and PEP-451 importers for frozen applications.
 
 import sys
 import os
+import tokenize
 
 import _frozen_importlib
 
@@ -48,10 +49,9 @@ def _decode_source(source_bytes):
     Based on CPython's implementation of the same functionality:
     https://github.com/python/cpython/blob/3.9/Lib/importlib/_bootstrap_external.py#L679-L688
     """
-    from tokenize import detect_encoding
     from io import BytesIO, IncrementalNewlineDecoder
     source_bytes_readline = BytesIO(source_bytes).readline
-    encoding = detect_encoding(source_bytes_readline)
+    encoding = tokenize.detect_encoding(source_bytes_readline)
     newline_decoder = IncrementalNewlineDecoder(decoder=None, translate=True)
     return newline_decoder.decode(source_bytes.decode(encoding[0]))
 

--- a/PyInstaller/loader/pyimod02_importers.py
+++ b/PyInstaller/loader/pyimod02_importers.py
@@ -19,9 +19,6 @@ PEP-302 and PEP-451 importers for frozen applications.
 
 import sys
 import os
-import pathlib
-import io
-import tokenize
 
 import _frozen_importlib
 
@@ -51,9 +48,11 @@ def _decode_source(source_bytes):
     Based on CPython's implementation of the same functionality:
     https://github.com/python/cpython/blob/3.9/Lib/importlib/_bootstrap_external.py#L679-L688
     """
-    source_bytes_readline = io.BytesIO(source_bytes).readline
-    encoding = tokenize.detect_encoding(source_bytes_readline)
-    newline_decoder = io.IncrementalNewlineDecoder(decoder=None, translate=True)
+    from tokenize import detect_encoding
+    from io import BytesIO, IncrementalNewlineDecoder
+    source_bytes_readline = BytesIO(source_bytes).readline
+    encoding = detect_encoding(source_bytes_readline)
+    newline_decoder = IncrementalNewlineDecoder(decoder=None, translate=True)
     return newline_decoder.decode(source_bytes.decode(encoding[0]))
 
 
@@ -424,8 +423,9 @@ class PyiFrozenResourceReader:
       https://github.com/python/cpython/blob/839d7893943782ee803536a47f1d4de160314f85/Lib/importlib/abc.py#L312
     """
     def __init__(self, importer, name):
+        from pathlib import Path
         self.importer = importer
-        self.path = pathlib.Path(sys._MEIPASS).joinpath(*name.split('.'))
+        self.path = Path(sys._MEIPASS).joinpath(*name.split('.'))
 
     def open_resource(self, resource):
         return self.files().joinpath(resource).open('rb')

--- a/PyInstaller/loader/pyimod02_importers.py
+++ b/PyInstaller/loader/pyimod02_importers.py
@@ -20,7 +20,6 @@ PEP-302 and PEP-451 importers for frozen applications.
 import sys
 import os
 import io
-import tokenize
 
 import _frozen_importlib
 
@@ -50,8 +49,9 @@ def _decode_source(source_bytes):
     Based on CPython's implementation of the same functionality:
     https://github.com/python/cpython/blob/3.9/Lib/importlib/_bootstrap_external.py#L679-L688
     """
+    from tokenize import detect_encoding
     source_bytes_readline = io.BytesIO(source_bytes).readline
-    encoding = tokenize.detect_encoding(source_bytes_readline)
+    encoding = detect_encoding(source_bytes_readline)
     newline_decoder = io.IncrementalNewlineDecoder(decoder=None, translate=True)
     return newline_decoder.decode(source_bytes.decode(encoding[0]))
 

--- a/news/7836.core.rst
+++ b/news/7836.core.rst
@@ -1,0 +1,2 @@
+Drop ``pathlib``, ``tokenize`` and their depenedencies (submodules included) in ``base_library.zip``.
+In our test, helloworld-script reduced more than 30% of final size.


### PR DESCRIPTION
Resolves https://github.com/pyinstaller/pyinstaller/pull/7835

### TODO
- add hook to hidden-import `pathlib`, to be guaranteed available after bootstrap.
