### PR TITLE
Configure and initialize python via PEP 587 API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,6 @@ env:
   PYINSTALLER_STRICT_BUNDLE_CODESIGN_ERROR: 1
   # Enable strict verification of macOS bundles w.r.t. the code-signing requirements.
   PYINSTALLER_VERIFY_BUNDLE_SIGNATURE: 1
-  # Force python memory debugging
-  PYTHONMALLOC: debug
 
 permissions:
   contents: read # to fetch code (actions/checkout)

--- a/PyInstaller/building/datastruct.py
+++ b/PyInstaller/building/datastruct.py
@@ -338,8 +338,14 @@ def normalize_pyz_toc(toc):
 
 
 def _normalize_toc(toc, toc_type_priorities, type_case_normalization_fcn=lambda typecode: False):
+    options_toc = []
     tmp_toc = dict()
     for dest_name, src_name, typecode in toc:
+        # Exempt OPTION entries from de-duplication processing. Some options might allow being specified multiple times.
+        if typecode == 'OPTION':
+            options_toc.append(((dest_name, src_name, typecode)))
+            continue
+
         # Always sanitize the dest_name with `os.path.normpath` to remove any local loops with parent directory path
         # components. `pathlib` does not seem to offer equivalent functionality.
         dest_name = os.path.normpath(dest_name)
@@ -362,7 +368,8 @@ def _normalize_toc(toc, toc_type_priorities, type_case_normalization_fcn=lambda 
                 tmp_toc[entry_key] = (dest_name, src_name, typecode)
 
     # Return the items as list. The order matches the original order due to python dict maintaining the insertion order.
-    return list(tmp_toc.values())
+    # The exception are OPTION entries, which are now placed at the beginning of the TOC.
+    return options_toc + list(tmp_toc.values())
 
 
 def toc_process_symbolic_links(toc):

--- a/PyInstaller/loader/pyimod02_importers.py
+++ b/PyInstaller/loader/pyimod02_importers.py
@@ -490,3 +490,54 @@ def install():
         sys.modules['__main__'].__loader__ = importer
     except Exception:
         pass
+
+    # Apply hack for python >= 3.11 and its frozen stdlib modules.
+    if sys.version_info >= (3, 11):
+        _fixup_frozen_stdlib()
+
+
+# A hack for python >= 3.11 and its frozen stdlib modules. Unless `sys._stdlib_dir` is set, these modules end up
+# missing __file__ attribute, which causes problems with 3rd party code. At the time of writing, python interpreter
+# configuration API does not allow us to influence `sys._stdlib_dir` - it always resets it to `None`. Therefore,
+# we manually set the path, and fix __file__ attribute on modules.
+def _fixup_frozen_stdlib():
+    import _imp  # built-in
+
+    # If sys._stdlib_dir is None or empty, override it with sys._MEIPASS
+    if not sys._stdlib_dir:
+        try:
+            sys._stdlib_dir = sys._MEIPASS
+        except AttributeError:
+            pass
+
+    # The sys._stdlib_dir set above should affect newly-imported python-frozen modules. However, most of them have
+    # been already imported during python initialization and our bootstrap, so we need to retroactively fix their
+    # __file__ attribute.
+    for module_name, module in sys.modules.items():
+        if not _imp.is_frozen(module_name):
+            continue
+
+        is_pkg = _imp.is_frozen_package(module_name)
+
+        # Determine "real" name from __spec__.loader_state.
+        loader_state = module.__spec__.loader_state
+
+        orig_name = loader_state.origname
+        if is_pkg:
+            orig_name += '.__init__'
+
+        # We set suffix to .pyc to be consistent with out PyiFrozenImporter.
+        filename = os.path.join(sys._MEIPASS, *orig_name.split('.')) + '.pyc'
+
+        # Fixup the __file__ attribute
+        if not hasattr(module, '__file__'):
+            try:
+                module.__file__ = filename
+            except AttributeError:
+                pass
+
+        # Fixup the loader_state.filename
+        # Except for _frozen_importlib (importlib._bootstrap), whose loader_state.filename appears to be left at
+        # None in python.
+        if loader_state.filename is None and orig_name != 'importlib._bootstrap':
+            loader_state.filename = filename

--- a/PyInstaller/utils/cliutils/archive_viewer.py
+++ b/PyInstaller/utils/cliutils/archive_viewer.py
@@ -182,6 +182,10 @@ class ArchiveViewer:
 
     def _show_archive_contents(self, archive_name, archive):
         if isinstance(archive, CArchiveReader):
+            if archive.options:
+                print(f"Options in {archive_name!r} (PKG/CArchive):")
+                for option in archive.options:
+                    print(f" {option}")
             print(f"Contents of {archive_name!r} (PKG/CArchive):")
             if self.brief_mode:
                 for name in archive.toc.keys():

--- a/PyInstaller/utils/hooks/__init__.py
+++ b/PyInstaller/utils/hooks/__init__.py
@@ -724,7 +724,7 @@ PY_DYLIB_PATTERNS = [
 ]
 
 
-def collect_dynamic_libs(package: str, destdir: str | None = None, search_patterns: [str] = PY_DYLIB_PATTERNS):
+def collect_dynamic_libs(package: str, destdir: str | None = None, search_patterns: list = PY_DYLIB_PATTERNS):
     """
     This function produces a list of (source, dest) of dynamic library files that reside in package. Its output can be
     directly assigned to ``binaries`` in a hook script. The package parameter must be a string which names the package.

--- a/bootloader/src/main.c
+++ b/bootloader/src/main.c
@@ -30,7 +30,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <locale.h>
 
 #include "pyi_main.h"
 #include "pyi_global.h"

--- a/bootloader/src/pyi_archive.c
+++ b/bootloader/src/pyi_archive.c
@@ -32,18 +32,12 @@
 int pyvers = 0;
 
 /*
- * Return pointer to next toc entry.
+ * Return pointer to the next TOC entry.
  */
-TOC *
+const TOC *
 pyi_arch_increment_toc_ptr(const ARCHIVE_STATUS *status, const TOC *ptoc)
 {
-    TOC *result = (TOC*)((char *)ptoc + ptoc->structlen);
-
-    if (result < status->tocbuff) {
-        FATALERROR("Cannot read Table of Contents.\n");
-        return status->tocend;
-    }
-    return result;
+    return (const TOC *)((const char *)ptoc + ptoc->structlen);
 }
 
 /*
@@ -413,8 +407,8 @@ _pyi_arch_fix_toc_endianess(ARCHIVE_STATUS *status)
         ptoc->len = pyi_be32toh(ptoc->len);
         ptoc->ulen = pyi_be32toh(ptoc->ulen);
         /* Jump to next entry; with the current entry fixed up, we can
-         * use pyi_arch_increment_toc_ptr() */
-        ptoc = pyi_arch_increment_toc_ptr(status, ptoc);
+         * use non-const equivalent of pyi_arch_increment_toc_ptr() */
+        ptoc = (TOC *)((const char *)ptoc + ptoc->structlen);
     }
 }
 
@@ -627,7 +621,6 @@ pyi_arch_get_option(const ARCHIVE_STATUS *status, const char *optname)
                     /* No option value, just return the empty string. */
                     return ptoc->name + optlen;
                 }
-
             }
         }
     }

--- a/bootloader/src/pyi_archive.c
+++ b/bootloader/src/pyi_archive.c
@@ -35,7 +35,7 @@ int pyvers = 0;
  * Return pointer to next toc entry.
  */
 TOC *
-pyi_arch_increment_toc_ptr(const ARCHIVE_STATUS *status, const TOC* ptoc)
+pyi_arch_increment_toc_ptr(const ARCHIVE_STATUS *status, const TOC *ptoc)
 {
     TOC *result = (TOC*)((char *)ptoc + ptoc->structlen);
 
@@ -82,7 +82,7 @@ pyi_arch_close_fp(ARCHIVE_STATUS *status)
  * to be valid.
  */
 static int
-_pyi_arch_extract_compressed(ARCHIVE_STATUS *status, TOC *ptoc, FILE *out_fp, unsigned char *out_ptr)
+_pyi_arch_extract_compressed(const ARCHIVE_STATUS *status, const TOC *ptoc, FILE *out_fp, unsigned char *out_ptr)
 {
     const size_t CHUNK_SIZE = 8192;
     unsigned char *buffer_in = NULL;
@@ -180,7 +180,7 @@ cleanup:
  * the archive into the provided file handle.
  */
 static int
-_pyi_arch_extract2fs_uncompressed(ARCHIVE_STATUS *status, TOC *ptoc, FILE *out)
+_pyi_arch_extract2fs_uncompressed(const ARCHIVE_STATUS *status, const TOC *ptoc, FILE *out)
 {
     const size_t CHUNK_SIZE = 8192;
     unsigned char *buffer;
@@ -219,7 +219,7 @@ _pyi_arch_extract2fs_uncompressed(ARCHIVE_STATUS *status, TOC *ptoc, FILE *out)
  * the archive into the provided (pre-allocated) buffer.
  */
 static int
-_pyi_arch_extract_uncompressed(ARCHIVE_STATUS *status, TOC *ptoc, unsigned char *out)
+_pyi_arch_extract_uncompressed(const ARCHIVE_STATUS *status, const TOC *ptoc, unsigned char *out)
 {
     const size_t CHUNK_SIZE = 8192;
     unsigned char *buffer;
@@ -245,7 +245,7 @@ _pyi_arch_extract_uncompressed(ARCHIVE_STATUS *status, TOC *ptoc, unsigned char 
  * Returns pointer to the data (must be freed).
  */
 unsigned char *
-pyi_arch_extract(ARCHIVE_STATUS *status, TOC *ptoc)
+pyi_arch_extract(ARCHIVE_STATUS *status, const TOC *ptoc)
 {
     unsigned char *data = NULL;
     int rc = 0;
@@ -288,7 +288,7 @@ cleanup:
 /*
  * Create/extract symbolic link from the archive.
  */
-int pyi_arch_create_symlink(ARCHIVE_STATUS *status, TOC *ptoc)
+int pyi_arch_create_symlink(ARCHIVE_STATUS *status, const TOC *ptoc)
 {
     char *link_target = NULL;
     char link_name[PATH_MAX];
@@ -322,7 +322,7 @@ cleanup:
  * The path is relative to the directory the archive is in.
  */
 int
-pyi_arch_extract2fs(ARCHIVE_STATUS *status, TOC *ptoc)
+pyi_arch_extract2fs(ARCHIVE_STATUS *status, const TOC *ptoc)
 {
     FILE *out = NULL;
     int rc = 0;
@@ -538,7 +538,7 @@ pyi_arch_setup(ARCHIVE_STATUS *status, char const * archive_path, char const * e
         pyi_path_dirname(contents_dir, executable_dir);
         pyi_path_join(status->homepath, contents_dir, "Frameworks");
     } else {
-        char * contents_directory = pyi_arch_get_option(status, "pyi-contents-directory");
+        const char *contents_directory = pyi_arch_get_option(status, "pyi-contents-directory");
         if (!contents_directory) {
             FATALERROR("pyi-contents-directory option not found in onedir bundle archive!");
             return false;
@@ -559,29 +559,10 @@ pyi_arch_setup(ARCHIVE_STATUS *status, char const * archive_path, char const * e
 }
 
 /*
- * external API for iterating TOCs
- */
-TOC *
-getFirstTocEntry(ARCHIVE_STATUS *status)
-{
-    return status->tocbuff;
-}
-TOC *
-getNextTocEntry(ARCHIVE_STATUS *status, TOC *entry)
-{
-    TOC *rslt = (TOC*)((char *)entry + entry->structlen);
-
-    if (rslt >= status->tocend) {
-        return NULL;
-    }
-    return rslt;
-}
-
-/*
  * Helpers for embedders.
  */
 int
-pyi_arch_get_pyversion(ARCHIVE_STATUS *status)
+pyi_arch_get_pyversion(const ARCHIVE_STATUS *status)
 {
     return status->cookie.pyvers;
 }
@@ -626,12 +607,12 @@ pyi_arch_status_free(ARCHIVE_STATUS *archive_status)
  * The string returned is owned by the ARCHIVE_STATUS; the caller is NOT responsible
  * for freeing it.
  */
-char *
-pyi_arch_get_option(const ARCHIVE_STATUS * status, char * optname)
+const char *
+pyi_arch_get_option(const ARCHIVE_STATUS *status, const char *optname)
 {
     /* TODO: option-cache? */
     size_t optlen;
-    TOC *ptoc = status->tocbuff;
+    const TOC *ptoc = status->tocbuff;
 
     optlen = strlen(optname);
 
@@ -656,10 +637,10 @@ pyi_arch_get_option(const ARCHIVE_STATUS * status, char * optname)
 /*
  * Find a TOC entry by its name and return it.
  */
-TOC *
-pyi_arch_find_by_name(ARCHIVE_STATUS *status, const char *name)
+const TOC *
+pyi_arch_find_by_name(const ARCHIVE_STATUS *status, const char *name)
 {
-    TOC *ptoc = status->tocbuff;
+    const TOC *ptoc = status->tocbuff;
 
     while (ptoc < status->tocend) {
         if (strcmp(ptoc->name, name) == 0) {

--- a/bootloader/src/pyi_archive.h
+++ b/bootloader/src/pyi_archive.h
@@ -108,7 +108,7 @@ typedef struct _archive_status {
                        */
 } ARCHIVE_STATUS;
 
-TOC *pyi_arch_increment_toc_ptr(const ARCHIVE_STATUS *status, const TOC *ptoc);
+const TOC *pyi_arch_increment_toc_ptr(const ARCHIVE_STATUS *status, const TOC *ptoc);
 
 unsigned char *pyi_arch_extract(ARCHIVE_STATUS *status, const TOC *ptoc);
 int pyi_arch_extract2fs(ARCHIVE_STATUS *status, const TOC *ptoc);

--- a/bootloader/src/pyi_archive.h
+++ b/bootloader/src/pyi_archive.h
@@ -109,7 +109,7 @@ typedef struct _archive_status {
 const TOC *pyi_arch_increment_toc_ptr(const ARCHIVE_STATUS *status, const TOC *ptoc);
 
 unsigned char *pyi_arch_extract(const ARCHIVE_STATUS *status, const TOC *ptoc);
-int pyi_arch_extract2fs(ARCHIVE_STATUS *status, const TOC *ptoc);
+int pyi_arch_extract2fs(const ARCHIVE_STATUS *status, const TOC *ptoc);
 
 /**
  * Helpers for embedders
@@ -137,6 +137,9 @@ void pyi_arch_status_free(ARCHIVE_STATUS *status);
  * @return true on success, false otherwise.
  */
 bool pyi_arch_setup(ARCHIVE_STATUS *status, char const *archive_path, char const *executable_path);
+
+/* Temporary directory creation for builds that need to unpack themselvs */
+int pyi_arch_create_tempdir(ARCHIVE_STATUS *status);
 
 const char *pyi_arch_get_option(const ARCHIVE_STATUS *status, const char *optname);
 const TOC *pyi_arch_find_by_name(const ARCHIVE_STATUS *status, const char *name);

--- a/bootloader/src/pyi_archive.h
+++ b/bootloader/src/pyi_archive.h
@@ -59,10 +59,9 @@ typedef struct _cookie {
 } COOKIE;
 
 typedef struct _archive_status {
-    FILE * fp;
     uint64_t pkgstart;
-    TOC *  tocbuff;
-    TOC *  tocend;
+    TOC *tocbuff;
+    const TOC *tocend;
     COOKIE cookie;
     /*
      * On Windows:
@@ -100,17 +99,16 @@ typedef struct _archive_status {
     bool is_pylib_loaded;
     /*
      * Cached command-line arguments.
+     * On Windows, argv contains UTF-8 encoded version of __wargv. On
+     * Linux and macOS, it contains argv as received by main(),
      */
-    int    argc;      /* Count of command-line arguments. */
-    char **argv;      /*
-                       * On Windows, UTF-8 encoded form of __wargv.
-                       * On OS X/Linux, as received in main()
-                       */
+    int argc;
+    char **argv;
 } ARCHIVE_STATUS;
 
 const TOC *pyi_arch_increment_toc_ptr(const ARCHIVE_STATUS *status, const TOC *ptoc);
 
-unsigned char *pyi_arch_extract(ARCHIVE_STATUS *status, const TOC *ptoc);
+unsigned char *pyi_arch_extract(const ARCHIVE_STATUS *status, const TOC *ptoc);
 int pyi_arch_extract2fs(ARCHIVE_STATUS *status, const TOC *ptoc);
 
 /**

--- a/bootloader/src/pyi_archive.h
+++ b/bootloader/src/pyi_archive.h
@@ -108,15 +108,15 @@ typedef struct _archive_status {
                        */
 } ARCHIVE_STATUS;
 
-TOC *pyi_arch_increment_toc_ptr(const ARCHIVE_STATUS *status, const TOC* ptoc);
+TOC *pyi_arch_increment_toc_ptr(const ARCHIVE_STATUS *status, const TOC *ptoc);
 
-unsigned char *pyi_arch_extract(ARCHIVE_STATUS *status, TOC *ptoc);
-int pyi_arch_extract2fs(ARCHIVE_STATUS *status, TOC *ptoc);
+unsigned char *pyi_arch_extract(ARCHIVE_STATUS *status, const TOC *ptoc);
+int pyi_arch_extract2fs(ARCHIVE_STATUS *status, const TOC *ptoc);
 
 /**
  * Helpers for embedders
  */
-int pyi_arch_get_pyversion(ARCHIVE_STATUS *status);
+int pyi_arch_get_pyversion(const ARCHIVE_STATUS *status);
 extern int pyvers;
 
 /**
@@ -138,12 +138,9 @@ void pyi_arch_status_free(ARCHIVE_STATUS *status);
  *
  * @return true on success, false otherwise.
  */
-bool pyi_arch_setup(ARCHIVE_STATUS *status, char const * archive_path, char const * executable_path);
+bool pyi_arch_setup(ARCHIVE_STATUS *status, char const *archive_path, char const *executable_path);
 
-TOC *getFirstTocEntry(ARCHIVE_STATUS *status);
-TOC *getNextTocEntry(ARCHIVE_STATUS *status, TOC *entry);
-
-char * pyi_arch_get_option(const ARCHIVE_STATUS * status, char * optname);
-TOC *pyi_arch_find_by_name(ARCHIVE_STATUS *status, const char *name);
+const char *pyi_arch_get_option(const ARCHIVE_STATUS *status, const char *optname);
+const TOC *pyi_arch_find_by_name(const ARCHIVE_STATUS *status, const char *name);
 
 #endif  /* PYI_ARCHIVE_H */

--- a/bootloader/src/pyi_global.c
+++ b/bootloader/src/pyi_global.c
@@ -49,10 +49,6 @@
 /* Text length of MessageBox(). */
 #define MBTXTLEN 1024
 
-/* Locale is saved at the start of main(), and restored immediately before running
- * scripts in pyi_launch_run_scripts
- */
-char *saved_locale;
 
 /*
  * On Windows and with windowed mode (no console) show error messages

--- a/bootloader/src/pyi_global.h
+++ b/bootloader/src/pyi_global.h
@@ -286,7 +286,4 @@ void mbvs(const char *fmt, ...);
     #define pyi_be32toh(x) ntohl(x)
 #endif /* ifdef _WIN32 */
 
-/* Saved LC_CTYPE locale */
-extern char *saved_locale;
-
 #endif  /* PYI_GLOBAL_H */

--- a/bootloader/src/pyi_launch.c
+++ b/bootloader/src/pyi_launch.c
@@ -169,7 +169,7 @@ _get_archive(ARCHIVE_STATUS *archive_pool[], const char *path)
 static int
 _extract_dependency_from_archive(ARCHIVE_STATUS *status, const char *filename)
 {
-    TOC *ptoc = status->tocbuff;
+    const TOC *ptoc = status->tocbuff;
 
     VS("LOADER: Extracting dependency %s from archive\n", filename);
 
@@ -272,7 +272,7 @@ _extract_dependency(ARCHIVE_STATUS *archive_pool[], const char *item)
 int
 pyi_launch_need_to_extract_binaries(ARCHIVE_STATUS *archive_status)
 {
-    TOC * ptoc = archive_status->tocbuff;
+    const TOC *ptoc = archive_status->tocbuff;
 
     while (ptoc < archive_status->tocend) {
         if (ptoc->typcd == ARCHIVE_ITEM_BINARY || ptoc->typcd == ARCHIVE_ITEM_DATA ||
@@ -312,7 +312,7 @@ pyi_launch_extract_binaries(ARCHIVE_STATUS *archive_status, SPLASH_STATUS *splas
      * archive_pool[0] is reserved for the main process, the others for dependencies.
      */
     ARCHIVE_STATUS *archive_pool[_MAX_ARCHIVE_POOL_LEN];
-    TOC * ptoc = archive_status->tocbuff;
+    const TOC *ptoc = archive_status->tocbuff;
 
     /* Clean memory for archive_pool list. */
     memset(archive_pool, 0, _MAX_ARCHIVE_POOL_LEN * sizeof(ARCHIVE_STATUS *));
@@ -475,7 +475,7 @@ pyi_launch_run_scripts(ARCHIVE_STATUS *status)
 {
     unsigned char *data;
     char buf[PATH_MAX];
-    TOC * ptoc = status->tocbuff;
+    const TOC *ptoc = status->tocbuff;
     PyObject *__main__;
     PyObject *__file__;
     PyObject *main_dict;

--- a/bootloader/src/pyi_launch.c
+++ b/bootloader/src/pyi_launch.c
@@ -96,13 +96,9 @@ _split_dependency_name(char *path, char *filename, const char *item)
 
 /* Copy the dependencies file from a directory to the tempdir */
 static int
-_copy_dependency_from_dir(ARCHIVE_STATUS *status, const char *srcpath, const char *filename)
+_copy_dependency_from_dir(const ARCHIVE_STATUS *status, const char *srcpath, const char *filename)
 {
-    if (pyi_create_temp_path(status) == -1) {
-        return -1;
-    }
-
-    VS("LOADER: Coping file %s to %s\n", srcpath, status->temppath);
+    VS("LOADER: Copying file %s to %s\n", srcpath, status->temppath);
     return pyi_copy_file(srcpath, status->temppath, filename);
 }
 
@@ -123,10 +119,6 @@ _get_archive(ARCHIVE_STATUS *archive_pool[], const char *path)
     int SELF = 0;
 
     VS("LOADER: Getting file from archive.\n");
-
-    if (pyi_create_temp_path(archive_pool[SELF]) == -1) {
-        return NULL;
-    }
 
     for (index = 1; archive_pool[index] != NULL; index++) {
         if (strcmp(archive_pool[index]->archivename, path) == 0) {
@@ -270,7 +262,7 @@ _extract_dependency(ARCHIVE_STATUS *archive_pool[], const char *item)
  * and a child process will not be required on windows.
  */
 int
-pyi_launch_need_to_extract_binaries(ARCHIVE_STATUS *archive_status)
+pyi_launch_need_to_extract_binaries(const ARCHIVE_STATUS *archive_status)
 {
     const TOC *ptoc = archive_status->tocbuff;
 
@@ -471,7 +463,7 @@ _pyi_extract_exception_traceback(PyObject *ptype, PyObject *pvalue,
  * Return non zero on failure
  */
 int
-pyi_launch_run_scripts(ARCHIVE_STATUS *status)
+pyi_launch_run_scripts(const ARCHIVE_STATUS *status)
 {
     unsigned char *data;
     char buf[PATH_MAX];

--- a/bootloader/src/pyi_launch.h
+++ b/bootloader/src/pyi_launch.h
@@ -44,7 +44,7 @@ int pyi_launch_extract_binaries(ARCHIVE_STATUS *archive_status,
  * Check if binaries need to be extracted. If not, this is probably a onedir
  * solution, and a child process will not be required on windows.
  */
-int pyi_launch_need_to_extract_binaries(ARCHIVE_STATUS *archive_status);
+int pyi_launch_need_to_extract_binaries(const ARCHIVE_STATUS *archive_status);
 
 /*
  * Wrapped platform specific initialization before loading Python and executing

--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -106,7 +106,7 @@ pyi_main(int argc, char * argv[])
     setbuf(stderr, (char *)NULL);
 #endif  /* _MSC_VER */
 
-    VS("PyInstaller Bootloader 5.x\n");
+    VS("PyInstaller Bootloader 6.x\n");
 
     archive_status = pyi_arch_status_new();
     if (archive_status == NULL) {

--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -287,7 +287,7 @@ pyi_main(int argc, char * argv[])
      */
     splash_status = pyi_splash_status_new();
 
-    if (!in_child && pyi_splash_setup(splash_status, archive_status, NULL) == 0) {
+    if (!in_child && pyi_splash_setup(splash_status, archive_status) == 0) {
         /*
          * Splash resources found, start splash screen
          * If in onefile mode extract the required binaries

--- a/bootloader/src/pyi_path.h
+++ b/bootloader/src/pyi_path.h
@@ -38,9 +38,8 @@ bool pyi_path_is_symlink(const char *path);
 #ifdef _WIN32
 FILE *pyi_path_fopen(const char *filename, const char *mode);
 #else
-    #define pyi_path_fopen(x, y)    fopen(x, y)
+#define pyi_path_fopen(x, y) fopen(x, y)
 #endif
-#define pyi_path_fclose(x)    fclose(x)
 
 int pyi_path_mkdir(const char *path);
 int pyi_path_mksymlink(const char *link_target, const char *link_name);

--- a/bootloader/src/pyi_pyconfig.c
+++ b/bootloader/src/pyi_pyconfig.c
@@ -91,21 +91,21 @@ pyi_runtime_options_read(const ARCHIVE_STATUS *archive_status)
             continue;
         }
 
-        /* Verbose flag: v */
-        if (strcmp(ptoc->name, "v") == 0) {
-            options->verbose = 1;
+        /* Verbose flag: v, verbose */
+        if (strcmp(ptoc->name, "v") == 0 || strcmp(ptoc->name, "verbose") == 0) {
+            options->verbose++;
             continue;
         }
 
-        /* Unbuffered flag: u */
-        if (strcmp(ptoc->name, "u") == 0) {
+        /* Unbuffered flag: u, unbuffered */
+        if (strcmp(ptoc->name, "u") == 0 || strcmp(ptoc->name, "unbuffered") == 0) {
             options->unbuffered = 1;
             continue;
         }
 
-        /* Optimize flag: O */
-        if (strcmp(ptoc->name, "O") == 0) {
-            options->optimize = 1;
+        /* Optimize flag: O, optimize */
+        if (strcmp(ptoc->name, "O") == 0 || strcmp(ptoc->name, "optimize") == 0) {
+            options->optimize++;
             continue;
         }
 

--- a/bootloader/src/pyi_pyconfig.c
+++ b/bootloader/src/pyi_pyconfig.c
@@ -1,0 +1,537 @@
+/*
+ * ****************************************************************************
+ * Copyright (c) 2023, PyInstaller Development Team.
+ *
+ * Distributed under the terms of the GNU General Public License (version 2
+ * or later) with exception for distributing the bootloader.
+ *
+ * The full license is in the file COPYING.txt, distributed with this software.
+ *
+ * SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+ * ****************************************************************************
+ */
+
+/*
+ * Functions to deal with PEP 587 python initialization configuration.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "pyi_pyconfig.h"
+#include "pyi_global.h"
+#include "pyi_utils.h"
+#include "pyi_win32_utils.h"
+
+
+/*
+ * Clean up and free the PyiRuntimeOptions structure created by
+ * pyi_config_parse_runtime_options(). No-op if passed a NULL pointer.
+ */
+void
+pyi_runtime_options_free(PyiRuntimeOptions *options)
+{
+    if (options == NULL) {
+        return;
+    }
+
+    /* Free the wflags array */
+    if (options->num_wflags) {
+        int i;
+        for (i = 0; i < options->num_wflags; i++) {
+            free(options->wflags[i]);
+        }
+    }
+    free(options->wflags);
+
+    /* Free options structure itself */
+    free(options);
+}
+
+/*
+ * Allocate the PyiRuntimeOptions structure and populate it based on
+ * options found in the PKG archive.
+ */
+PyiRuntimeOptions *
+pyi_runtime_options_read(const ARCHIVE_STATUS *archive_status)
+{
+    PyiRuntimeOptions *options;
+    TOC *ptoc;
+    int num_wflags = 0;
+    int failed = 0;
+    char *env_utf8 = NULL;
+
+    /* Allocate the structure */
+    options = calloc(1, sizeof(PyiRuntimeOptions));
+    if (options == NULL) {
+        return options;
+    }
+
+    /* Honor the setting via PYTHONUTF8 environment variable (valid
+     * values are 0 and 1, same as with python interpreter) */
+    /* TODO: replace this with -Xutf8=0 / -Xutf8=1 bootloader option
+     * and ignore the environment */
+    options->utf8_mode = -1; /* Auto-select by default */
+    env_utf8 = pyi_getenv("PYTHONUTF8");
+    if (env_utf8) {
+        if (strcmp(env_utf8, "0") == 0) {
+            options->utf8_mode = 0;
+        } else if (strcmp(env_utf8, "1") == 0) {
+            options->utf8_mode = 1;
+        } else {
+            OTHERERROR("Invalid value for PYTHONUTF8=%s; disabling utf-8 mode!\n", env_utf8);
+            options->utf8_mode = 0;
+        }
+    }
+
+    /* Parse run-time options from PKG archive */
+    for (ptoc = archive_status->tocbuff; ptoc < archive_status->tocend; ptoc = pyi_arch_increment_toc_ptr(archive_status, ptoc)) {
+        /* Skip bootloader options; these start with "pyi-" */
+        if (strncmp(ptoc->name, "pyi-", 4) == 0) {
+            continue;
+        }
+
+        /* Verbose flag: v */
+        if (strcmp(ptoc->name, "v") == 0) {
+            options->verbose = 1;
+            continue;
+        }
+
+        /* Unbuffered flag: u */
+        if (strcmp(ptoc->name, "u") == 0) {
+            options->unbuffered = 1;
+            continue;
+        }
+
+        /* Optimize flag: O */
+        if (strcmp(ptoc->name, "O") == 0) {
+            options->optimize = 1;
+            continue;
+        }
+
+        /* W flag */
+        if (ptoc->name[0] == 'W') {
+            num_wflags++;
+            continue;
+        }
+    }
+
+    if (num_wflags) {
+        /* Allocate Wflags array */
+        options->wflags = calloc(num_wflags, sizeof(wchar_t *));
+        if (options->wflags == NULL) {
+            failed = 1;
+            goto end;
+        }
+
+        /* Collect Wflags */
+        for (ptoc = archive_status->tocbuff; ptoc < archive_status->tocend; ptoc = pyi_arch_increment_toc_ptr(archive_status, ptoc)) {
+            if (ptoc->name[0] != 'W') {
+                continue;
+            }
+
+            /* Convert multi-byte string to wide-char. The multibyte
+             * encoding should be UTF-8, although W-options should
+             * consist only of ASCII characters. */
+            wchar_t wflag_tmp[PATH_MAX];
+            if (mbstowcs(wflag_tmp, &ptoc->name[2], PATH_MAX) == -1) {
+                failed = 1;
+                goto end;
+            }
+
+            /* Copy */
+            options->wflags[options->num_wflags] = wcsdup(wflag_tmp);
+            if (options->wflags[options->num_wflags] == NULL) {
+                failed = 1;
+                goto end;
+            }
+            options->num_wflags++;
+        }
+    }
+
+end:
+    /* Clean-up on error */
+    if (failed) {
+        pyi_runtime_options_free(options);
+        options = NULL;
+    }
+
+    return options;
+}
+
+
+/*
+ * Helper that sets a string field in the PyConfig structure.
+ * On Windows, the string is converted from UTF-8 to wide-character, and
+ * set using PyConfig_SetString. On other systems, PyConfig_SetBytesString
+ * is used, which internally calls Py_DecodeLocale.
+ */
+static int
+_pyi_pyconfig_set_string(PyConfig *config, wchar_t **dest_field, const char *str)
+{
+    PyStatus status;
+
+#ifdef _WIN32
+    wchar_t *str_w;
+    str_w = pyi_win32_utils_from_utf8(NULL, str, 0);
+    if (!str_w) {
+        return -1;
+    }
+    status = PI_PyConfig_SetString(config, dest_field, str_w);
+    free(str_w);
+#else
+    status = PI_PyConfig_SetBytesString(config, dest_field, str);
+#endif
+
+    return PI_PyStatus_Exception(status) ? -1 : 0;
+}
+
+
+/*
+ * Allocate the PyConfig structure, based on the python version.
+ */
+PyConfig *
+pyi_pyconfig_create()
+{
+    /* Macro to avoid manual code repetition. */
+    #define _IMPL_CASE(PY_VERSION, PYCONFIG_IMPL) \
+    case PY_VERSION: { \
+        return (PyConfig *)calloc(1, sizeof(PYCONFIG_IMPL)); \
+    }
+    /* Macro end */
+
+    switch (pyvers) {
+        _IMPL_CASE(308, PyConfig_v38)
+        _IMPL_CASE(309, PyConfig_v39)
+        _IMPL_CASE(310, PyConfig_v310)
+        _IMPL_CASE(311, PyConfig_v311)
+        _IMPL_CASE(312, PyConfig_v312)
+        default: {
+            break;
+        }
+    }
+
+    #undef _IMPL_CASE
+
+    return NULL; /* Unsupported python version */
+}
+
+/*
+ * Clean up and free the PyConfig structure.
+ */
+void
+pyi_pyconfig_free(PyConfig *config)
+{
+    /* Clear the fields that PyConfig API allocated */
+    PI_PyConfig_Clear(config);
+
+    /* Free the allocated structure itself; was allocated using calloc
+     * in pyi_pyconfig_create(). */
+    free(config);
+}
+
+/*
+ * Set program name. Used to set sys.executable, and in early error messages.
+ */
+int
+pyi_pyconfig_set_program_name(PyConfig *config, const ARCHIVE_STATUS *archive_status)
+{
+    /* Macro to avoid manual code repetition. */
+    #define _IMPL_CASE(PY_VERSION, PYCONFIG_IMPL) \
+    case PY_VERSION: { \
+        PYCONFIG_IMPL *config_impl = (PYCONFIG_IMPL *)config; \
+        if (_pyi_pyconfig_set_string(config, &config_impl->program_name, archive_status->executablename) < 0) { \
+            return -1; \
+        } \
+        return 0; \
+    }
+    /* Macro end */
+
+    switch (pyvers) {
+        _IMPL_CASE(308, PyConfig_v38)
+        _IMPL_CASE(309, PyConfig_v39)
+        _IMPL_CASE(310, PyConfig_v310)
+        _IMPL_CASE(311, PyConfig_v311)
+        _IMPL_CASE(312, PyConfig_v312)
+        default: {
+            break;
+        }
+    }
+
+    #undef _IMPL_CASE
+
+    return -1; /* Unsupported python version */
+}
+
+/*
+ * Set python home directory. Used to set sys.prefix.
+ */
+int
+pyi_pyconfig_set_python_home(PyConfig *config, const ARCHIVE_STATUS *archive_status)
+{
+    /* Macro to avoid manual code repetition. */
+    #define _IMPL_CASE(PY_VERSION, PYCONFIG_IMPL) \
+    case PY_VERSION: { \
+        PYCONFIG_IMPL *config_impl = (PYCONFIG_IMPL *)config; \
+        return _pyi_pyconfig_set_string(config, &config_impl->home, archive_status->mainpath); \
+    }
+    /* Macro end */
+
+    switch (pyvers) {
+        _IMPL_CASE(308, PyConfig_v38)
+        _IMPL_CASE(309, PyConfig_v39)
+        _IMPL_CASE(310, PyConfig_v310)
+        _IMPL_CASE(311, PyConfig_v311)
+        _IMPL_CASE(312, PyConfig_v312)
+        default: {
+            break;
+        }
+    }
+
+    #undef _IMPL_CASE
+
+    return -1; /* Unsupported python version */
+}
+
+/*
+ * Set module search paths (sys.path).
+ *
+ * Setting `pythonpath_env` seems to not have the desired effect (python
+ * overrides sys.path with pre-defined paths anchored in home directory).
+ * Therefore, we directly manipulate the `module_search_paths` and
+ * `module_search_paths_set`, which puts the desired set of paths into
+ * sys.path.
+ */
+static int
+_pyi_pyconfig_set_module_search_paths(PyConfig *config, int num_paths, wchar_t **paths)
+{
+    /* Macro to avoid manual code repetition. */
+    #define _IMPL_CASE(PY_VERSION, PYCONFIG_IMPL) \
+    case PY_VERSION: { \
+        PyStatus status; \
+        PYCONFIG_IMPL *config_impl = (PYCONFIG_IMPL *)config; \
+        status = PI_PyConfig_SetWideStringList(config, &config_impl->module_search_paths, num_paths, paths); \
+        config_impl->module_search_paths_set = 1; \
+        return PI_PyStatus_Exception(status) ? -1 : 0; \
+    }
+    /* Macro end */
+
+    switch (pyvers) {
+        _IMPL_CASE(308, PyConfig_v38)
+        _IMPL_CASE(309, PyConfig_v39)
+        _IMPL_CASE(310, PyConfig_v310)
+        _IMPL_CASE(311, PyConfig_v311)
+        _IMPL_CASE(312, PyConfig_v312)
+        default: {
+            break;
+        }
+    }
+
+    #undef _IMPL_CASE
+
+    return -1; /* Unsupported python version */
+}
+
+int
+pyi_pyconfig_set_module_search_paths(PyConfig *config, const ARCHIVE_STATUS *archive_status)
+{
+    /* TODO: instead of stitching together char strings and converting
+     * them, we could probably stitch together wide-char strings directly,
+     * as `home` field in config structure has already been converted. */
+    char base_library_path[PATH_MAX + 1];
+    char lib_dynload_path[PATH_MAX + 1];
+
+    const char *module_search_paths[3];
+    wchar_t *module_search_paths_w[3];
+
+    int ret = 0;
+    int i;
+
+    /* home/base_library.zip */
+    if (snprintf(base_library_path, PATH_MAX, "%s%c%s", archive_status->mainpath, PYI_SEP, "base_library.zip") >= PATH_MAX) {
+        return -1;
+    }
+
+    /* home/lib-dynload */
+    if (snprintf(lib_dynload_path, PATH_MAX, "%s%c%s", archive_status->mainpath, PYI_SEP, "lib-dynload") >= PATH_MAX) {
+        return -1;
+    }
+
+    module_search_paths[0] = base_library_path;
+    module_search_paths[1] = lib_dynload_path;
+    module_search_paths[2] = archive_status->mainpath;
+
+    /* Convert */
+    for (i = 0; i < 3; i++) {
+#ifdef _WIN32
+        module_search_paths_w[i] = pyi_win32_utils_from_utf8(NULL, module_search_paths[i], 0);
+#else
+        module_search_paths_w[i] = PI_Py_DecodeLocale(module_search_paths[i], NULL);
+#endif
+        if (module_search_paths_w[i] == NULL) {
+            /* Do not break; we need to initialize all elements */
+            ret = -1;
+        }
+    }
+    if (ret < -1) {
+        goto end; /* Conversion of at least one path failed */
+    }
+
+    /* Set */
+    ret = _pyi_pyconfig_set_module_search_paths(config, 3, module_search_paths_w);
+
+end:
+    /* Cleanup */
+    for (i = 0; i < 3; i++) {
+#ifdef _WIN32
+        free(module_search_paths_w[i]);
+#else
+        PI_PyMem_RawFree(module_search_paths_w[i]);
+#endif
+    }
+
+    return ret;
+}
+
+
+/*
+ * Set program arguments (sys.argv).
+ */
+static int
+_pyi_pyconfig_set_argv(PyConfig *config, int argc, wchar_t **argv_w)
+{
+    /* Macro to avoid manual code repetition. */
+    #define _IMPL_CASE(PY_VERSION, PYCONFIG_IMPL) \
+    case PY_VERSION: { \
+        PyStatus status; \
+        PYCONFIG_IMPL *config_impl = (PYCONFIG_IMPL *)config; \
+        status = PI_PyConfig_SetWideStringList(config, &config_impl->argv, argc, argv_w); \
+        return PI_PyStatus_Exception(status) ? -1 : 0; \
+    }
+    /* Macro end */
+
+    switch (pyvers) {
+        _IMPL_CASE(308, PyConfig_v38)
+        _IMPL_CASE(309, PyConfig_v39)
+        _IMPL_CASE(310, PyConfig_v310)
+        _IMPL_CASE(311, PyConfig_v311)
+        _IMPL_CASE(312, PyConfig_v312)
+        default: {
+            break;
+        }
+    }
+
+    #undef _IMPL_CASE
+
+    return -1; /* Unsupported python version */
+}
+
+
+int
+pyi_pyconfig_set_argv(PyConfig *config, const ARCHIVE_STATUS *archive_status)
+{
+    wchar_t **argv_w;
+    int ret = 0;
+    int i;
+
+    /* Allocate */
+    argv_w = calloc(archive_status->argc, sizeof(wchar_t *));
+    if (argv_w == NULL) {
+        return -1;
+    }
+
+    /* Convert */
+    for (i = 0; i < archive_status->argc; i++) {
+#ifdef _WIN32
+        argv_w[i] = pyi_win32_utils_from_utf8(NULL, archive_status->argv[i], 0);
+#else
+        argv_w[i] = PI_Py_DecodeLocale(archive_status->argv[i], NULL);
+#endif
+        if (argv_w[i] == NULL) {
+            /* Do not break; we need to initialize all elements */
+            ret = -1;
+        }
+    }
+    if (ret < -1) {
+        goto end; /* Conversion of at least one arg failed */
+    }
+
+    /* Set */
+    ret = _pyi_pyconfig_set_argv(config, archive_status->argc, argv_w);
+
+end:
+    /* Cleanup */
+    for (i = 0; i < archive_status->argc; i++) {
+#ifdef _WIN32
+        free(argv_w[i]);
+#else
+        PI_PyMem_RawFree(argv_w[i]);
+#endif
+    }
+    free(argv_w);
+
+    return ret;
+}
+
+
+/*
+ * Set run-time options.
+ */
+int
+pyi_pyconfig_set_runtime_options(PyConfig *config, const PyiRuntimeOptions *runtime_options)
+{
+    /* Macro to avoid manual code repetition. */
+    #define _IMPL_CASE(PY_VERSION, PYCONFIG_IMPL) \
+    case PY_VERSION: { \
+        PyStatus status; \
+        PYCONFIG_IMPL *config_impl = (PYCONFIG_IMPL *)config; \
+        /* Extend the isolated config, which leaves site_import and write_bytecode on */ \
+        config_impl->site_import = 0; \
+        config_impl->write_bytecode = 0; \
+        /* These flags map to our run-time options (O, u, v) */ \
+        config_impl->optimization_level = runtime_options->optimize; \
+        config_impl->buffered_stdio = !runtime_options->unbuffered; \
+        config_impl->verbose = runtime_options->verbose; \
+        /* Set W-flags, if available */ \
+        if (runtime_options->num_wflags) { \
+            status = PI_PyConfig_SetWideStringList(config, &config_impl->warnoptions, runtime_options->num_wflags, runtime_options->wflags); \
+            if (PI_PyStatus_Exception(status)) { \
+                return -1; \
+            } \
+        } \
+        return 0; \
+    }
+    /* Macro end */
+
+    switch (pyvers) {
+        _IMPL_CASE(308, PyConfig_v38)
+        _IMPL_CASE(309, PyConfig_v39)
+        _IMPL_CASE(310, PyConfig_v310)
+        _IMPL_CASE(311, PyConfig_v311)
+        _IMPL_CASE(312, PyConfig_v312)
+        default: {
+            break;
+        }
+    }
+
+    #undef _IMPL_CASE
+
+    return -1; /* Unsupported python version */
+}
+
+
+/*
+ * Pre-initialize python interpreter.
+ */
+int
+pyi_pyconfig_preinit_python(const PyiRuntimeOptions *runtime_options)
+{
+    PyPreConfig_Common config;
+
+    PI_PyPreConfig_InitIsolatedConfig((PyPreConfig *)&config);
+    config.utf8_mode = runtime_options->utf8_mode;
+
+    /* Pre-initialize */
+    PyStatus status = PI_Py_PreInitialize((const PyPreConfig *)&config);
+    return PI_PyStatus_Exception(status) ? -1 : 0;
+}

--- a/bootloader/src/pyi_pyconfig.c
+++ b/bootloader/src/pyi_pyconfig.c
@@ -110,7 +110,7 @@ pyi_runtime_options_read(const ARCHIVE_STATUS *archive_status)
         }
 
         /* W flag */
-        if (ptoc->name[0] == 'W') {
+        if (strncmp(ptoc->name, "W ", 2) == 0) {
             num_wflags++;
             continue;
         }
@@ -126,7 +126,7 @@ pyi_runtime_options_read(const ARCHIVE_STATUS *archive_status)
 
         /* Collect Wflags */
         for (ptoc = archive_status->tocbuff; ptoc < archive_status->tocend; ptoc = pyi_arch_increment_toc_ptr(archive_status, ptoc)) {
-            if (ptoc->name[0] != 'W') {
+            if (strncmp(ptoc->name, "W ", 2) != 0) {
                 continue;
             }
 

--- a/bootloader/src/pyi_pyconfig.c
+++ b/bootloader/src/pyi_pyconfig.c
@@ -140,7 +140,7 @@ PyiRuntimeOptions *
 pyi_runtime_options_read(const ARCHIVE_STATUS *archive_status)
 {
     PyiRuntimeOptions *options;
-    TOC *ptoc;
+    const TOC *ptoc;
     int num_wflags = 0;
     int num_xflags = 0;
     int failed = 0;

--- a/bootloader/src/pyi_pyconfig.c
+++ b/bootloader/src/pyi_pyconfig.c
@@ -488,6 +488,9 @@ pyi_pyconfig_set_runtime_options(PyConfig *config, const PyiRuntimeOptions *runt
         /* Extend the isolated config, which leaves site_import and write_bytecode on */ \
         config_impl->site_import = 0; \
         config_impl->write_bytecode = 0; \
+        /* Enable configure_c_stdio (disabled in isolated config by default) to let python configure stdout/stderr
+         * streams (set binary mode, disable buffer in unbuffered mode, etc.) */ \
+        config_impl->configure_c_stdio = 1; \
         /* These flags map to our run-time options (O, u, v) */ \
         config_impl->optimization_level = runtime_options->optimize; \
         config_impl->buffered_stdio = !runtime_options->unbuffered; \

--- a/bootloader/src/pyi_pyconfig.h
+++ b/bootloader/src/pyi_pyconfig.h
@@ -32,6 +32,9 @@ typedef struct
     int unbuffered;
     int optimize;
 
+    int use_hash_seed;
+    unsigned long hash_seed;
+
     int utf8_mode;
     int dev_mode;
 

--- a/bootloader/src/pyi_pyconfig.h
+++ b/bootloader/src/pyi_pyconfig.h
@@ -36,6 +36,9 @@ typedef struct
 
     int num_wflags;
     wchar_t **wflags;
+
+    int num_xflags;
+    wchar_t **xflags;
 }  PyiRuntimeOptions;
 
 PyiRuntimeOptions *pyi_runtime_options_read(const ARCHIVE_STATUS *archive_status);

--- a/bootloader/src/pyi_pyconfig.h
+++ b/bootloader/src/pyi_pyconfig.h
@@ -1,0 +1,56 @@
+/*
+ * ****************************************************************************
+ * Copyright (c) 2023, PyInstaller Development Team.
+ *
+ * Distributed under the terms of the GNU General Public License (version 2
+ * or later) with exception for distributing the bootloader.
+ *
+ * The full license is in the file COPYING.txt, distributed with this software.
+ *
+ * SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+ * ****************************************************************************
+ */
+
+/*
+ * Functions to deal with PEP 587 python initialization configuration.
+ *
+ * These helpers allow the rest of bootloader to pretend that PEP 587 has
+ * a sane API with opaque types.
+ */
+
+#ifndef PYI_PYCONFIG_H
+#define PYI_PYCONFIG_H
+
+#include "pyi_python.h"
+#include "pyi_archive.h"
+
+
+/* Collect run-time options from PKG */
+typedef struct
+{
+    int verbose;
+    int unbuffered;
+    int optimize;
+
+    int utf8_mode;
+
+    int num_wflags;
+    wchar_t **wflags;
+}  PyiRuntimeOptions;
+
+PyiRuntimeOptions *pyi_runtime_options_read(const ARCHIVE_STATUS *archive_status);
+void pyi_runtime_options_free(PyiRuntimeOptions *options);
+
+/* PEP 587 helpers */
+PyConfig *pyi_pyconfig_create();
+void pyi_pyconfig_free(PyConfig *config);
+
+int pyi_pyconfig_set_program_name(PyConfig *config, const ARCHIVE_STATUS *archive_status);
+int pyi_pyconfig_set_python_home(PyConfig *config, const ARCHIVE_STATUS *archive_status);
+int pyi_pyconfig_set_module_search_paths(PyConfig *config, const ARCHIVE_STATUS *archive_status);
+int pyi_pyconfig_set_argv(PyConfig *config, const ARCHIVE_STATUS *archive_status);
+int pyi_pyconfig_set_runtime_options(PyConfig *config, const PyiRuntimeOptions *runtime_options);
+
+int pyi_pyconfig_preinit_python(const PyiRuntimeOptions *runtime_options);
+
+#endif /* PYI_PYCONFIG_H */

--- a/bootloader/src/pyi_pyconfig.h
+++ b/bootloader/src/pyi_pyconfig.h
@@ -33,6 +33,7 @@ typedef struct
     int optimize;
 
     int utf8_mode;
+    int dev_mode;
 
     int num_wflags;
     wchar_t **wflags;

--- a/bootloader/src/pyi_pyconfig_v310.h
+++ b/bootloader/src/pyi_pyconfig_v310.h
@@ -1,0 +1,91 @@
+/*
+ * ****************************************************************************
+ * Copyright (c) 2023, PyInstaller Development Team.
+ *
+ * Distributed under the terms of the GNU General Public License (version 2
+ * or later) with exception for distributing the bootloader.
+ *
+ * The full license is in the file COPYING.txt, distributed with this software.
+ *
+ * SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+ * ****************************************************************************
+ */
+
+#ifndef PYI_PYCONFIG_V310_H
+#define PYI_PYCONFIG_V310_H
+
+#include "pyi_global.h"
+#include <wchar.h>
+
+/* PyConfig structure for Python 3.10
+ * https://github.com/python/cpython/blob/v3.10.0/Include/cpython/initconfig.h
+ */
+typedef struct {
+    int _config_init;
+
+    int isolated;
+    int use_environment;
+    int dev_mode;
+    int install_signal_handlers;
+    int use_hash_seed;
+    unsigned long hash_seed;
+    int faulthandler;
+    int tracemalloc;
+    int import_time;
+    int show_ref_count;
+    int dump_refs;
+    int malloc_stats;
+    wchar_t *filesystem_encoding;
+    wchar_t *filesystem_errors;
+    wchar_t *pycache_prefix;
+    int parse_argv;
+    PyWideStringList orig_argv;
+    PyWideStringList argv;
+    PyWideStringList xoptions;
+    PyWideStringList warnoptions;
+    int site_import;
+    int bytes_warning;
+    int warn_default_encoding;
+    int inspect;
+    int interactive;
+    int optimization_level;
+    int parser_debug;
+    int write_bytecode;
+    int verbose;
+    int quiet;
+    int user_site_directory;
+    int configure_c_stdio;
+    int buffered_stdio;
+    wchar_t *stdio_encoding;
+    wchar_t *stdio_errors;
+#ifdef MS_WINDOWS
+    int legacy_windows_stdio;
+#endif
+    wchar_t *check_hash_pycs_mode;
+
+    int pathconfig_warnings;
+    wchar_t *program_name;
+    wchar_t *pythonpath_env;
+    wchar_t *home;
+    wchar_t *platlibdir;
+
+    int module_search_paths_set;
+    PyWideStringList module_search_paths;
+    wchar_t *executable;
+    wchar_t *base_executable;
+    wchar_t *prefix;
+    wchar_t *base_prefix;
+    wchar_t *exec_prefix;
+    wchar_t *base_exec_prefix;
+
+    int skip_source_first_line;
+    wchar_t *run_command;
+    wchar_t *run_module;
+    wchar_t *run_filename;
+
+    int _install_importlib;
+    int _init_main;
+    int _isolated_interpreter;
+} PyConfig_v310;
+
+#endif /* PYI_PYCONFIG_V310_H */

--- a/bootloader/src/pyi_pyconfig_v311.h
+++ b/bootloader/src/pyi_pyconfig_v311.h
@@ -1,0 +1,98 @@
+/*
+ * ****************************************************************************
+ * Copyright (c) 2023, PyInstaller Development Team.
+ *
+ * Distributed under the terms of the GNU General Public License (version 2
+ * or later) with exception for distributing the bootloader.
+ *
+ * The full license is in the file COPYING.txt, distributed with this software.
+ *
+ * SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+ * ****************************************************************************
+ */
+
+#ifndef PYI_PYCONFIG_V311_H
+#define PYI_PYCONFIG_V311_H
+
+#include "pyi_global.h"
+#include <wchar.h>
+
+/* PyConfig structure for Python 3.11
+ * https://github.com/python/cpython/blob/v3.11.0/Include/cpython/initconfig.h
+ */
+typedef struct {
+    int _config_init;
+
+    int isolated;
+    int use_environment;
+    int dev_mode;
+    int install_signal_handlers;
+    int use_hash_seed;
+    unsigned long hash_seed;
+    int faulthandler;
+    int tracemalloc;
+    int import_time;
+    int code_debug_ranges;
+    int show_ref_count;
+    int dump_refs;
+    wchar_t *dump_refs_file;
+    int malloc_stats;
+    wchar_t *filesystem_encoding;
+    wchar_t *filesystem_errors;
+    wchar_t *pycache_prefix;
+    int parse_argv;
+    PyWideStringList orig_argv;
+    PyWideStringList argv;
+    PyWideStringList xoptions;
+    PyWideStringList warnoptions;
+    int site_import;
+    int bytes_warning;
+    int warn_default_encoding;
+    int inspect;
+    int interactive;
+    int optimization_level;
+    int parser_debug;
+    int write_bytecode;
+    int verbose;
+    int quiet;
+    int user_site_directory;
+    int configure_c_stdio;
+    int buffered_stdio;
+    wchar_t *stdio_encoding;
+    wchar_t *stdio_errors;
+#ifdef MS_WINDOWS
+    int legacy_windows_stdio;
+#endif
+    wchar_t *check_hash_pycs_mode;
+    int use_frozen_modules;
+    int safe_path;
+
+    int pathconfig_warnings;
+    wchar_t *program_name;
+    wchar_t *pythonpath_env;
+    wchar_t *home;
+    wchar_t *platlibdir;
+
+    int module_search_paths_set;
+    PyWideStringList module_search_paths;
+    wchar_t *stdlib_dir;
+    wchar_t *executable;
+    wchar_t *base_executable;
+    wchar_t *prefix;
+    wchar_t *base_prefix;
+    wchar_t *exec_prefix;
+    wchar_t *base_exec_prefix;
+
+    int skip_source_first_line;
+    wchar_t *run_command;
+    wchar_t *run_module;
+    wchar_t *run_filename;
+
+    int _install_importlib;
+    int _init_main;
+    int _isolated_interpreter;
+    int _is_python_build;
+} PyConfig_v311;
+
+#endif /* PYI_PYCONFIG_V311_H */
+

--- a/bootloader/src/pyi_pyconfig_v312.h
+++ b/bootloader/src/pyi_pyconfig_v312.h
@@ -1,0 +1,98 @@
+/*
+ * ****************************************************************************
+ * Copyright (c) 2023, PyInstaller Development Team.
+ *
+ * Distributed under the terms of the GNU General Public License (version 2
+ * or later) with exception for distributing the bootloader.
+ *
+ * The full license is in the file COPYING.txt, distributed with this software.
+ *
+ * SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+ * ****************************************************************************
+ */
+
+#ifndef PYI_PYCONFIG_V312_H
+#define PYI_PYCONFIG_V312_H
+
+#include "pyi_global.h"
+#include <wchar.h>
+
+/* PyConfig structure for Python 3.12
+ * https://github.com/python/cpython/blob/v3.12.0rc1/Include/cpython/initconfig.h
+ */
+typedef struct {
+    int _config_init;
+
+    int isolated;
+    int use_environment;
+    int dev_mode;
+    int install_signal_handlers;
+    int use_hash_seed;
+    unsigned long hash_seed;
+    int faulthandler;
+    int tracemalloc;
+    int perf_profiling;
+    int import_time;
+    int code_debug_ranges;
+    int show_ref_count;
+    int dump_refs;
+    wchar_t *dump_refs_file;
+    int malloc_stats;
+    wchar_t *filesystem_encoding;
+    wchar_t *filesystem_errors;
+    wchar_t *pycache_prefix;
+    int parse_argv;
+    PyWideStringList orig_argv;
+    PyWideStringList argv;
+    PyWideStringList xoptions;
+    PyWideStringList warnoptions;
+    int site_import;
+    int bytes_warning;
+    int warn_default_encoding;
+    int inspect;
+    int interactive;
+    int optimization_level;
+    int parser_debug;
+    int write_bytecode;
+    int verbose;
+    int quiet;
+    int user_site_directory;
+    int configure_c_stdio;
+    int buffered_stdio;
+    wchar_t *stdio_encoding;
+    wchar_t *stdio_errors;
+#ifdef MS_WINDOWS
+    int legacy_windows_stdio;
+#endif
+    wchar_t *check_hash_pycs_mode;
+    int use_frozen_modules;
+    int safe_path;
+    int int_max_str_digits;
+
+    int pathconfig_warnings;
+    wchar_t *program_name;
+    wchar_t *pythonpath_env;
+    wchar_t *home;
+    wchar_t *platlibdir;
+
+    int module_search_paths_set;
+    PyWideStringList module_search_paths;
+    wchar_t *stdlib_dir;
+    wchar_t *executable;
+    wchar_t *base_executable;
+    wchar_t *prefix;
+    wchar_t *base_prefix;
+    wchar_t *exec_prefix;
+    wchar_t *base_exec_prefix;
+
+    int skip_source_first_line;
+    wchar_t *run_command;
+    wchar_t *run_module;
+    wchar_t *run_filename;
+
+    int _install_importlib;
+    int _init_main;
+    int _is_python_build;
+} PyConfig_v312;
+
+#endif /* PYI_PYCONFIG_V312_H */

--- a/bootloader/src/pyi_pyconfig_v38.h
+++ b/bootloader/src/pyi_pyconfig_v38.h
@@ -1,0 +1,87 @@
+/*
+ * ****************************************************************************
+ * Copyright (c) 2023, PyInstaller Development Team.
+ *
+ * Distributed under the terms of the GNU General Public License (version 2
+ * or later) with exception for distributing the bootloader.
+ *
+ * The full license is in the file COPYING.txt, distributed with this software.
+ *
+ * SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+ * ****************************************************************************
+ */
+
+#ifndef PYI_PYCONFIG_V38_H
+#define PYI_PYCONFIG_V38_H
+
+#include "pyi_global.h"
+#include <wchar.h>
+
+/* PyConfig structure for Python 3.11
+ * https://github.com/python/cpython/blob/v3.11.0/Include/cpython/initconfig.h
+ */
+typedef struct {
+    int _config_init;
+
+    int isolated;
+    int use_environment;
+    int dev_mode;
+    int install_signal_handlers;
+    int use_hash_seed;
+    unsigned long hash_seed;
+    int faulthandler;
+    int tracemalloc;
+    int import_time;
+    int show_ref_count;
+    int show_alloc_count;
+    int dump_refs;
+    int malloc_stats;
+    wchar_t *filesystem_encoding;
+    wchar_t *filesystem_errors;
+    wchar_t *pycache_prefix;
+    int parse_argv;
+    PyWideStringList argv;
+    wchar_t *program_name;
+    PyWideStringList xoptions;
+    PyWideStringList warnoptions;
+    int site_import;
+    int bytes_warning;
+    int inspect;
+    int interactive;
+    int optimization_level;
+    int parser_debug;
+    int write_bytecode;
+    int verbose;
+    int quiet;
+    int user_site_directory;
+    int configure_c_stdio;
+    int buffered_stdio;
+    wchar_t *stdio_encoding;
+    wchar_t *stdio_errors;
+#ifdef MS_WINDOWS
+    int legacy_windows_stdio;
+#endif
+    wchar_t *check_hash_pycs_mode;
+    int pathconfig_warnings;
+    wchar_t *pythonpath_env;
+    wchar_t *home;
+
+    int module_search_paths_set;
+    PyWideStringList module_search_paths;
+    wchar_t *executable;
+    wchar_t *base_executable;
+    wchar_t *prefix;
+    wchar_t *base_prefix;
+    wchar_t *exec_prefix;
+    wchar_t *base_exec_prefix;
+
+    int skip_source_first_line;
+    wchar_t *run_command;
+    wchar_t *run_module;
+    wchar_t *run_filename;
+
+    int _install_importlib;
+    int _init_main;
+} PyConfig_v38;
+
+#endif /* PYI_PYCONFIG_V38_H */

--- a/bootloader/src/pyi_pyconfig_v39.h
+++ b/bootloader/src/pyi_pyconfig_v39.h
@@ -1,0 +1,90 @@
+/*
+ * ****************************************************************************
+ * Copyright (c) 2023, PyInstaller Development Team.
+ *
+ * Distributed under the terms of the GNU General Public License (version 2
+ * or later) with exception for distributing the bootloader.
+ *
+ * The full license is in the file COPYING.txt, distributed with this software.
+ *
+ * SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+ * ****************************************************************************
+ */
+
+#ifndef PYI_PYCONFIG_V39_H
+#define PYI_PYCONFIG_V39_H
+
+#include "pyi_global.h"
+#include <wchar.h>
+
+/* PyConfig structure for Python 3.9
+ * https://github.com/python/cpython/blob/v3.9.0/Include/cpython/initconfig.h
+ */
+typedef struct {
+    int _config_init;
+
+    int isolated;
+    int use_environment;
+    int dev_mode;
+    int install_signal_handlers;
+    int use_hash_seed;
+    unsigned long hash_seed;
+    int faulthandler;
+    int _use_peg_parser;
+    int tracemalloc;
+    int import_time;
+    int show_ref_count;
+    int dump_refs;
+    int malloc_stats;
+    wchar_t *filesystem_encoding;
+    wchar_t *filesystem_errors;
+    wchar_t *pycache_prefix;
+    int parse_argv;
+    PyWideStringList argv;
+    wchar_t *program_name;
+    PyWideStringList xoptions;
+    PyWideStringList warnoptions;
+    int site_import;
+    int bytes_warning;
+    int inspect;
+    int interactive;
+    int optimization_level;
+    int parser_debug;
+    int write_bytecode;
+    int verbose;
+    int quiet;
+    int user_site_directory;
+    int configure_c_stdio;
+    int buffered_stdio;
+    wchar_t *stdio_encoding;
+    wchar_t *stdio_errors;
+#ifdef MS_WINDOWS
+    int legacy_windows_stdio;
+#endif
+    wchar_t *check_hash_pycs_mode;
+    int pathconfig_warnings;
+    wchar_t *pythonpath_env;
+    wchar_t *home;
+
+    int module_search_paths_set;
+    PyWideStringList module_search_paths;
+    wchar_t *executable;
+    wchar_t *base_executable;
+    wchar_t *prefix;
+    wchar_t *base_prefix;
+    wchar_t *exec_prefix;
+    wchar_t *base_exec_prefix;
+    wchar_t *platlibdir;
+
+    int skip_source_first_line;
+    wchar_t *run_command;
+    wchar_t *run_module;
+    wchar_t *run_filename;
+
+    int _install_importlib;
+    int _init_main;
+    int _isolated_interpreter;
+    PyWideStringList _orig_argv;
+} PyConfig_v39;
+
+#endif /* PYI_PYCONFIG_V39_H */

--- a/bootloader/src/pyi_python.c
+++ b/bootloader/src/pyi_python.c
@@ -11,161 +11,139 @@
  * ****************************************************************************
  */
 
-/*
- * Python.h replacements.
- */
-
 #ifdef _WIN32
-    #include <windows.h>  /* HMODULE */
+#include <windows.h>  /* HMODULE */
 #else
-    #include <dlfcn.h>  /* dlsym */
+#include <dlfcn.h>  /* dlsym */
 #endif
 #include <stddef.h>  /* ptrdiff_t */
 #include <stdlib.h>
 
-/* PyInstaller headers. */
 #include "pyi_global.h"
 #include "pyi_python.h"
 
-/*
- * Python Entry point declarations (see macros in pyi_python.h).
- */
-/* external variables */
-DECLVAR(Py_DontWriteBytecodeFlag);
-DECLVAR(Py_FileSystemDefaultEncoding);
-DECLVAR(Py_FrozenFlag);
-DECLVAR(Py_IgnoreEnvironmentFlag);
-DECLVAR(Py_NoSiteFlag);
-DECLVAR(Py_NoUserSiteDirectory);
-DECLVAR(Py_OptimizeFlag);
-DECLVAR(Py_VerboseFlag);
-DECLVAR(Py_UnbufferedStdioFlag);
-DECLVAR(Py_UTF8Mode);
 
-/* functions with prefix `Py_` */
-DECLPROC(Py_BuildValue);
+/* Python functions to bind */
 DECLPROC(Py_DecRef);
+DECLPROC(Py_DecodeLocale);
 DECLPROC(Py_Finalize);
-DECLPROC(Py_IncRef);
-DECLPROC(Py_Initialize);
-DECLPROC(Py_SetPath);
-DECLPROC(Py_GetPath);
-DECLPROC(Py_SetProgramName);
-DECLPROC(Py_SetPythonHome);
+DECLPROC(Py_InitializeFromConfig);
+DECLPROC(Py_IsInitialized);
+DECLPROC(Py_PreInitialize);
 
-/* other functions */
-DECLPROC(PyDict_GetItemString);
+DECLPROC(PyConfig_Clear);
+DECLPROC(PyConfig_InitIsolatedConfig);
+DECLPROC(PyConfig_Read);
+DECLPROC(PyConfig_SetBytesString);
+DECLPROC(PyConfig_SetString);
+DECLPROC(PyConfig_SetWideStringList);
+
 DECLPROC(PyErr_Clear);
+DECLPROC(PyErr_Fetch);
+DECLPROC(PyErr_NormalizeException);
 DECLPROC(PyErr_Occurred);
 DECLPROC(PyErr_Print);
-DECLPROC(PyErr_Fetch);
 DECLPROC(PyErr_Restore);
-DECLPROC(PyErr_NormalizeException);
+
+DECLPROC(PyEval_EvalCode);
 
 DECLPROC(PyImport_AddModule);
 DECLPROC(PyImport_ExecCodeModule);
 DECLPROC(PyImport_ImportModule);
+
 DECLPROC(PyList_Append);
-DECLPROC(PyList_New);
-DECLPROC(PyLong_AsLong);
+
+DECLPROC(PyMarshal_ReadObjectFromString);
+
+DECLPROC(PyMem_RawFree);
+
 DECLPROC(PyModule_GetDict);
+
 DECLPROC(PyObject_CallFunction);
 DECLPROC(PyObject_CallFunctionObjArgs);
-DECLPROC(PyObject_SetAttrString);
 DECLPROC(PyObject_GetAttrString);
+DECLPROC(PyObject_SetAttrString);
 DECLPROC(PyObject_Str);
+
+DECLPROC(PyPreConfig_InitIsolatedConfig);
+
 DECLPROC(PyRun_SimpleStringFlags);
-DECLPROC(PySys_AddWarnOption);
-DECLPROC(PySys_SetArgvEx);
+
+DECLPROC(PyStatus_Exception);
+
 DECLPROC(PySys_GetObject);
 DECLPROC(PySys_SetObject);
-DECLPROC(PySys_SetPath);
-DECLPROC(PyUnicode_FromString);
 
-DECLPROC(Py_DecodeLocale);
-DECLPROC(PyMem_RawFree);
-DECLPROC(PyUnicode_FromFormat);
-DECLPROC(PyUnicode_DecodeFSDefault);
-DECLPROC(PyUnicode_Decode);
 DECLPROC(PyUnicode_AsUTF8);
+DECLPROC(PyUnicode_Decode);
+DECLPROC(PyUnicode_DecodeFSDefault);
+DECLPROC(PyUnicode_FromFormat);
+DECLPROC(PyUnicode_FromString);
 DECLPROC(PyUnicode_Join);
 DECLPROC(PyUnicode_Replace);
 
-DECLPROC(PyEval_EvalCode);
-DECLPROC(PyMarshal_ReadObjectFromString);
 
 /*
- * Get all of the entry points from libpython
- * that we are interested in.
+ * Bind all required functions from python shared library.
  */
 int
-pyi_python_map_names(HMODULE dll, int pyvers)
+pyi_python_bind_functions(HMODULE dll, int pyvers)
 {
-    GETVAR(dll, Py_DontWriteBytecodeFlag);
-    GETVAR(dll, Py_FileSystemDefaultEncoding);
-    GETVAR(dll, Py_FrozenFlag);
-    GETVAR(dll, Py_IgnoreEnvironmentFlag);
-    GETVAR(dll, Py_NoSiteFlag);
-    GETVAR(dll, Py_NoUserSiteDirectory);
-    GETVAR(dll, Py_OptimizeFlag);
-    GETVAR(dll, Py_VerboseFlag);
-    GETVAR(dll, Py_UnbufferedStdioFlag);
-    if (pyvers >= 307) {
-        GETVAR(dll, Py_UTF8Mode);
-    }
-
-    /* functions with prefix `Py_` */
-    GETPROC(dll, Py_BuildValue);
     GETPROC(dll, Py_DecRef);
+    GETPROC(dll, Py_DecodeLocale);
     GETPROC(dll, Py_Finalize);
-    GETPROC(dll, Py_IncRef);
-    GETPROC(dll, Py_Initialize);
+    GETPROC(dll, Py_InitializeFromConfig);
+    GETPROC(dll, Py_IsInitialized);
+    GETPROC(dll, Py_PreInitialize);
 
-    GETPROC(dll, Py_SetPath);
-    GETPROC(dll, Py_GetPath);
-    GETPROC(dll, Py_SetProgramName);
-    GETPROC(dll, Py_SetPythonHome);
+    GETPROC(dll, PyConfig_Clear);
+    GETPROC(dll, PyConfig_InitIsolatedConfig);
+    GETPROC(dll, PyConfig_Read);
+    GETPROC(dll, PyConfig_SetBytesString);
+    GETPROC(dll, PyConfig_SetString);
+    GETPROC(dll, PyConfig_SetWideStringList);
 
-    /* other functions */
-    GETPROC(dll, PyDict_GetItemString);
     GETPROC(dll, PyErr_Clear);
+    GETPROC(dll, PyErr_Fetch);
+    GETPROC(dll, PyErr_NormalizeException);
     GETPROC(dll, PyErr_Occurred);
     GETPROC(dll, PyErr_Print);
-    GETPROC(dll, PyErr_Fetch);
     GETPROC(dll, PyErr_Restore);
-    GETPROC(dll, PyErr_NormalizeException);
+
+    GETPROC(dll, PyEval_EvalCode);
+
     GETPROC(dll, PyImport_AddModule);
     GETPROC(dll, PyImport_ExecCodeModule);
     GETPROC(dll, PyImport_ImportModule);
+
     GETPROC(dll, PyList_Append);
-    GETPROC(dll, PyList_New);
-    GETPROC(dll, PyLong_AsLong);
+
+    GETPROC(dll, PyMarshal_ReadObjectFromString);
+
+    GETPROC(dll, PyMem_RawFree);
+
     GETPROC(dll, PyModule_GetDict);
+
     GETPROC(dll, PyObject_CallFunction);
     GETPROC(dll, PyObject_CallFunctionObjArgs);
-    GETPROC(dll, PyObject_SetAttrString);
     GETPROC(dll, PyObject_GetAttrString);
+    GETPROC(dll, PyObject_SetAttrString);
     GETPROC(dll, PyObject_Str);
+
+    GETPROC(dll, PyPreConfig_InitIsolatedConfig);
 
     GETPROC(dll, PyRun_SimpleStringFlags);
 
-    GETPROC(dll, PySys_AddWarnOption);
-    GETPROC(dll, PySys_SetArgvEx);
+    GETPROC(dll, PyStatus_Exception);
+
     GETPROC(dll, PySys_GetObject);
     GETPROC(dll, PySys_SetObject);
-    GETPROC(dll, PySys_SetPath);
-    GETPROC(dll, PyEval_EvalCode);
-    GETPROC(dll, PyMarshal_ReadObjectFromString);
 
-    GETPROC(dll, PyUnicode_FromString);
-
-    GETPROC(dll, Py_DecodeLocale);
-    GETPROC(dll, PyMem_RawFree);
-
-    GETPROC(dll, PyUnicode_FromFormat);
+    GETPROC(dll, PyUnicode_AsUTF8);
     GETPROC(dll, PyUnicode_Decode);
     GETPROC(dll, PyUnicode_DecodeFSDefault);
-    GETPROC(dll, PyUnicode_AsUTF8);
+    GETPROC(dll, PyUnicode_FromFormat);
+    GETPROC(dll, PyUnicode_FromString);
     GETPROC(dll, PyUnicode_Join);
     GETPROC(dll, PyUnicode_Replace);
 

--- a/bootloader/src/pyi_python.c
+++ b/bootloader/src/pyi_python.c
@@ -26,6 +26,7 @@
 /* Python functions to bind */
 DECLPROC(Py_DecRef);
 DECLPROC(Py_DecodeLocale);
+DECLPROC(Py_ExitStatusException);
 DECLPROC(Py_Finalize);
 DECLPROC(Py_InitializeFromConfig);
 DECLPROC(Py_IsInitialized);
@@ -91,6 +92,7 @@ pyi_python_bind_functions(HMODULE dll, int pyvers)
 {
     GETPROC(dll, Py_DecRef);
     GETPROC(dll, Py_DecodeLocale);
+    GETPROC(dll, Py_ExitStatusException);
     GETPROC(dll, Py_Finalize);
     GETPROC(dll, Py_InitializeFromConfig);
     GETPROC(dll, Py_IsInitialized);

--- a/bootloader/src/pyi_python.h
+++ b/bootloader/src/pyi_python.h
@@ -157,6 +157,7 @@ typedef struct _PyConfig PyConfig;
 /* Py_ */
 EXTDECLPROC(void, Py_DecRef, (PyObject *));
 EXTDECLPROC(wchar_t *, Py_DecodeLocale, (const char *, size_t *));
+EXTDECLPROC(void, Py_ExitStatusException, (PyStatus));
 EXTDECLPROC(int, Py_Finalize, (void));
 EXTDECLPROC(PyStatus, Py_InitializeFromConfig, (PyConfig *));
 EXTDECLPROC(int, Py_IsInitialized, (void));

--- a/bootloader/src/pyi_python.h
+++ b/bootloader/src/pyi_python.h
@@ -27,120 +27,205 @@
 #endif
 #include <wchar.h>
 
+
+/* Bind all required functions from python shared library */
+int pyi_python_bind_functions(HMODULE dll, int pyvers);
+
 /*
  * Python.h replacements.
  *
- * We do not want to include Python.h because we do no want to bind
- * to a specific version of Python. If we were to, eg., use the
- * Py_INCREF macro from Python.h, the compiled code would depend
- * on the specific layout in memory of PyObject, and thus change
- * when Python changes (or if your platform changes between 32bit
- * and 64bit). In other words, you wouldn't be able to build a single
- * bootloader working across all Python versions (which is specifically
- * important on Windows).
+ * We do not include Python.h because we want to avoid binding to a
+ * specific version of Python. For example, if we used the Py_INCREF
+ * macro from Python.h, the compiled code would depend on the specific
+ * in-memory layout of PyObject, and thus change between Python versions
+ * (and between 32-bit and 64-bit architectures). That would make it
+ * impossible to build a single bootloader executable that works across
+ * all Python version (which is especially important on Windows).
  *
- * Instead, the bootloader does not depend on the Python ABI at all.
- * It dynamically-load the Python library (after having unpacked it)
- * and bind the exported functions. All Python objects are used as
- * opaque data structures (through pointers only), so the code is
- * fully compatible if the Python data structure layouts change.
+ * Instead, the bootloader does its best to avoid depending on the Python
+ * API exported by Python.h header. Instead, it dynamically loads the
+ * collected Python shared library (after having unpacked it, if necessary)
+ * and binds the exported functions that it requires. Wherever possible,
+ * Python objects are used as opaque data structures (passed via pointers
+ * only) to ensure that the code is invariant to the layout changes of
+ * Python data structures.
+ *
+ * Well, at least that was the plan, and that is how things were in the
+ * days of yore. Then came along PEP 587 with new python initialization
+ * configuration API, and those days are but a distant memory now...
+ *
+ * The new configuration API requires us to allocate the config structure
+ * ourselves, so we need to know its size. And we also need to know its
+ * layout, because the fields in the structure need to be accessed (set)
+ * directly. So if we want to keep avoiding using Python.h and building
+ * bootloader for each python version, we need to provide the configuration
+ * structure layouts for all supported python versions.
  */
 
 /* Forward declarations of opaque Python types. */
-struct _PyObject;
 typedef struct _PyObject PyObject;
-struct _PyThreadState;
 typedef struct _PyThreadState PyThreadState;
-struct _PyCompilerFlags;
 typedef struct _PyCompilerFlags PyCompilerFlags;
 
-/* The actual declarations of var & function entry points used. */
 
-/* Flags. */
-EXTDECLVAR(int, Py_FrozenFlag);
-EXTDECLVAR(int, Py_NoSiteFlag);
-EXTDECLVAR(int, Py_OptimizeFlag);
-EXTDECLVAR(const char*, Py_FileSystemDefaultEncoding);
-EXTDECLVAR(int, Py_VerboseFlag);
-EXTDECLVAR(int, Py_IgnoreEnvironmentFlag);
-EXTDECLVAR(int, Py_DontWriteBytecodeFlag);
-EXTDECLVAR(int, Py_NoUserSiteDirectory);
-EXTDECLVAR(int, Py_UnbufferedStdioFlag);
-EXTDECLVAR(int, Py_UTF8Mode);
-
-/* This initializes the table of loaded modules (sys.modules), and creates the fundamental modules builtins, __main__ and sys. It also initializes the module search path (sys.path). It does not set sys.argv; */
-EXTDECLPROC(int, Py_Initialize, (void));
-/* Undo all initializations made by Py_Initialize() and subsequent use of Python/C API functions, and destroy all sub-interpreters. */
-EXTDECLPROC(int, Py_Finalize, (void));
-
-EXTDECLPROC(void, Py_IncRef, (PyObject *));
-EXTDECLPROC(void, Py_DecRef, (PyObject *));
-
-/*
- * These functions have to be called before Py_Initialize()
+/* Strictly speaking, Py_ssize_t should be mapped to ssize_t wherever
+ * possible, but for portability reasons, we use size_t. We are primarily
+ * concerned about the storage size, not the signedness.
  */
-EXTDECLPROC(void, Py_SetProgramName, (wchar_t *));
-EXTDECLPROC(void, Py_SetPythonHome, (wchar_t *));
-EXTDECLPROC(void, Py_SetPath, (wchar_t *));  /* new in Python 3 */
-EXTDECLPROC(wchar_t *, Py_GetPath, (void));  /* new in Python 3 */
+typedef size_t Py_ssize_t;
 
-EXTDECLPROC(void, PySys_SetPath, (wchar_t *));
-EXTDECLPROC(int, PySys_SetArgvEx, (int, wchar_t **, int));
-EXTDECLPROC(int, PyRun_SimpleStringFlags, (const char *, PyCompilerFlags *));  /* Py3: UTF-8 encoded string */
 
-/* In Python 3 for these the first argument has to be a UTF-8 encoded string: */
-EXTDECLPROC(PyObject *, PyImport_ExecCodeModule, (char *, PyObject *));
-EXTDECLPROC(PyObject *, PyImport_ImportModule, (char *));
-EXTDECLPROC(PyObject *, PyImport_AddModule, (char *));
+/* Definitions of configuration structure layouts. These are not opaque,
+ * because we need to allocate them, and manipulate with their fields.
+ *
+ * The original definitions can be found in the include/cpython/initconfig.h
+ *
+ * For the sake of brevity, our variants do not include the comments.
+ *
+ * In the original structures, some fields are guarded with MS_WINDOWS
+ * define. We map it to our _WIN32 define, because MS_WINDOWS appears
+ * to be defined in all Windows build; either directly via customized
+ * pyconfig.h header (python.org and Anaconda builds) or due to
+ * modifications in pyport.h header (msys2/mingw32 and msys2/mingw64).
+ */
 
-EXTDECLPROC(int, PyObject_SetAttrString, (PyObject *, char *, PyObject *));
-EXTDECLPROC(PyObject *, PyList_New, (int));
-EXTDECLPROC(int, PyList_Append, (PyObject *, PyObject *));
-/* Create a new value based on a format string similar to those accepted by the PyArg_Parse*() */
-EXTDECLPROC(PyObject *, Py_BuildValue, (char *, ...));
-/* Create a Unicode object from the char buffer. The bytes will be interpreted as being UTF-8 encoded. */
-EXTDECLPROC(PyObject *, PyUnicode_FromString, (const char *));
-EXTDECLPROC(PyObject *, PyObject_CallFunction, (PyObject *, char *, ...));
-EXTDECLPROC(PyObject *, PyObject_CallFunctionObjArgs, (PyObject *, ...));
-EXTDECLPROC(PyObject *, PyModule_GetDict, (PyObject *));
-EXTDECLPROC(PyObject *, PyDict_GetItemString, (PyObject *, char *));
+#ifdef _WIN32
+    #define MS_WINDOWS
+#endif
+
+/* This structure is returned from functions by value, so we need to know
+ * its layout. At the time of writing, it remains unchanged between the
+ * supported python versions.
+ */
+typedef struct {
+    enum {
+        _PyStatus_TYPE_OK=0,
+        _PyStatus_TYPE_ERROR=1,
+        _PyStatus_TYPE_EXIT=2
+    } _type;
+    const char *func;
+    const char *err_msg;
+    int exitcode;
+} PyStatus;
+
+
+/* This structure is embedded in the configuration structure, so we need
+ * to know its layout. At the time of writing, it remains unchanged between
+ * the supported python versions.
+ */
+typedef struct {
+    Py_ssize_t length;
+    wchar_t **items;
+} PyWideStringList;
+
+
+/* The PyPreConfig structure. At the time of writing, it remains unchanged
+ * between the supported python versions; but in anticipation of future
+ * changes, we name our commonly-used layout with _Common suffix.
+ */
+typedef struct {
+    int _config_init;
+    int parse_argv;
+    int isolated;
+    int use_environment;
+    int configure_locale;
+    int coerce_c_locale;
+    int coerce_c_locale_warn;
+#ifdef MS_WINDOWS
+    int legacy_windows_fs_encoding;
+#endif
+    int utf8_mode;
+    int dev_mode;
+    int allocator;
+} PyPreConfig_Common;
+
+/* The opaque type used with functions that accept pointer */
+typedef struct _PyPreConfig PyPreConfig;
+
+
+/* Keep configuration structures in separate header */
+#include "pyi_pyconfig_v38.h"
+#include "pyi_pyconfig_v39.h"
+#include "pyi_pyconfig_v310.h"
+#include "pyi_pyconfig_v311.h"
+#include "pyi_pyconfig_v312.h"
+
+/* The opaque type used with functions that accept pointer */
+typedef struct _PyConfig PyConfig;
+
+
+/* Py_ */
+EXTDECLPROC(void, Py_DecRef, (PyObject *));
+EXTDECLPROC(wchar_t *, Py_DecodeLocale, (const char *, size_t *));
+EXTDECLPROC(int, Py_Finalize, (void));
+EXTDECLPROC(PyStatus, Py_InitializeFromConfig, (PyConfig *));
+EXTDECLPROC(int, Py_IsInitialized, (void));
+EXTDECLPROC(PyStatus, Py_PreInitialize, (const PyPreConfig *));
+
+/* PyConfig_ */
+EXTDECLPROC(void, PyConfig_Clear, (PyConfig *));
+EXTDECLPROC(void, PyConfig_InitIsolatedConfig, (PyConfig *));
+EXTDECLPROC(PyStatus, PyConfig_Read, (PyConfig *));
+EXTDECLPROC(PyStatus, PyConfig_SetBytesString, (PyConfig *, wchar_t **, const char *));
+EXTDECLPROC(PyStatus, PyConfig_SetString, (PyConfig *, wchar_t **, const wchar_t *));
+EXTDECLPROC(PyStatus, PyConfig_SetWideStringList, (PyConfig *, PyWideStringList *, Py_ssize_t, wchar_t **));
+
+/* PyErr_ */
 EXTDECLPROC(void, PyErr_Clear, (void) );
+EXTDECLPROC(void, PyErr_Fetch, (PyObject **, PyObject **, PyObject **));
+EXTDECLPROC(void, PyErr_NormalizeException, (PyObject **, PyObject **, PyObject **));
 EXTDECLPROC(PyObject *, PyErr_Occurred, (void) );
 EXTDECLPROC(void, PyErr_Print, (void) );
-EXTDECLPROC(void, PySys_AddWarnOption, (wchar_t *));
-/* Return a C long representation of the contents of pylong. */
-EXTDECLPROC(long, PyLong_AsLong, (PyObject *) );
+EXTDECLPROC(void, PyErr_Restore, (PyObject *, PyObject *, PyObject *));
 
-EXTDECLPROC(int, PySys_SetObject, (char *, PyObject *));
+/* PyEval */
+EXTDECLPROC(PyObject *, PyEval_EvalCode, (PyObject *, PyObject *, PyObject *));
 
-/*
- * Used to convert argv to wchar_t on Linux/OS X
- * On Python 3.0-3.4, this function was called _Py_char2wchar
- */
-EXTDECLPROC(wchar_t *, Py_DecodeLocale, (char *, size_t *));
+/* PyImport_ */
+EXTDECLPROC(PyObject *, PyImport_AddModule, (char *));
+EXTDECLPROC(PyObject *, PyImport_ExecCodeModule, (char *, PyObject *));
+EXTDECLPROC(PyObject *, PyImport_ImportModule, (char *));
+
+/* PyList_ */
+EXTDECLPROC(int, PyList_Append, (PyObject *, PyObject *));
+
+/* PyMarshal_ */
+EXTDECLPROC(PyObject *, PyMarshal_ReadObjectFromString, (const char *, Py_ssize_t));
+
+/* PyMem_ */
 EXTDECLPROC(void, PyMem_RawFree, (void *));
 
-/* Used to add PYZ to sys.path */
-EXTDECLPROC(PyObject *, PySys_GetObject, (const char *));
-EXTDECLPROC(PyObject *, PyUnicode_FromFormat, (const char *, ...));
-EXTDECLPROC(PyObject *, PyUnicode_DecodeFSDefault, (const char *));
-EXTDECLPROC(PyObject *, PyUnicode_Decode,
-            (const char *, size_t, const char *, const char *));                               /* Py_ssize_t */
+/* PyModule_ */
+EXTDECLPROC(PyObject *, PyModule_GetDict, (PyObject *));
 
-/* Used to load and execute marshalled code objects */
-EXTDECLPROC(PyObject *, PyEval_EvalCode, (PyObject *, PyObject *, PyObject *));
-EXTDECLPROC(PyObject *, PyMarshal_ReadObjectFromString, (const char *, size_t));  /* Py_ssize_t */
-
-/* Used to get traceback information while launching run scripts */
-EXTDECLPROC(void, PyErr_Fetch, (PyObject **, PyObject **, PyObject **));
-EXTDECLPROC(void, PyErr_Restore, (PyObject *, PyObject *, PyObject *));
-EXTDECLPROC(void, PyErr_NormalizeException, (PyObject **, PyObject **, PyObject **));
-EXTDECLPROC(PyObject *, PyObject_Str, (PyObject *));
+/* PyObject_ */
+EXTDECLPROC(PyObject *, PyObject_CallFunction, (PyObject *, char *, ...));
+EXTDECLPROC(PyObject *, PyObject_CallFunctionObjArgs, (PyObject *, ...));
 EXTDECLPROC(PyObject *, PyObject_GetAttrString, (PyObject *, const char *));
-EXTDECLPROC(const char *, PyUnicode_AsUTF8, (PyObject *));
-EXTDECLPROC(PyObject *, PyUnicode_Join, (PyObject *, PyObject *));
-EXTDECLPROC(PyObject *, PyUnicode_Replace, (PyObject *, PyObject *, PyObject *, size_t));  /* Py_ssize_t */
+EXTDECLPROC(int, PyObject_SetAttrString, (PyObject *, char *, PyObject *));
+EXTDECLPROC(PyObject *, PyObject_Str, (PyObject *));
 
-int pyi_python_map_names(HMODULE dll, int pyvers);
+/* PyPreConfig_ */
+EXTDECLPROC(void, PyPreConfig_InitIsolatedConfig, (PyPreConfig *));
+
+/* PyRun_ */
+EXTDECLPROC(int, PyRun_SimpleStringFlags, (const char *, PyCompilerFlags *));
+
+/* PyStatus_ */
+EXTDECLPROC(int, PyStatus_Exception, (PyStatus));
+
+/* PySys_ */
+EXTDECLPROC(PyObject *, PySys_GetObject, (const char *));
+EXTDECLPROC(int, PySys_SetObject, (char *, PyObject *));
+
+/* PyUnicode_ */
+EXTDECLPROC(const char *, PyUnicode_AsUTF8, (PyObject *));
+EXTDECLPROC(PyObject *, PyUnicode_Decode, (const char *, Py_ssize_t, const char *, const char *));
+EXTDECLPROC(PyObject *, PyUnicode_DecodeFSDefault, (const char *));
+EXTDECLPROC(PyObject *, PyUnicode_FromFormat, (const char *, ...));
+EXTDECLPROC(PyObject *, PyUnicode_FromString, (const char *));
+EXTDECLPROC(PyObject *, PyUnicode_Join, (PyObject *, PyObject *));
+EXTDECLPROC(PyObject *, PyUnicode_Replace, (PyObject *, PyObject *, PyObject *, Py_ssize_t));
+
 
 #endif  /* PYI_PYTHON_H */

--- a/bootloader/src/pyi_python.h
+++ b/bootloader/src/pyi_python.h
@@ -182,9 +182,9 @@ EXTDECLPROC(void, PyErr_Restore, (PyObject *, PyObject *, PyObject *));
 EXTDECLPROC(PyObject *, PyEval_EvalCode, (PyObject *, PyObject *, PyObject *));
 
 /* PyImport_ */
-EXTDECLPROC(PyObject *, PyImport_AddModule, (char *));
-EXTDECLPROC(PyObject *, PyImport_ExecCodeModule, (char *, PyObject *));
-EXTDECLPROC(PyObject *, PyImport_ImportModule, (char *));
+EXTDECLPROC(PyObject *, PyImport_AddModule, (const char *));
+EXTDECLPROC(PyObject *, PyImport_ExecCodeModule, (const char *, PyObject *));
+EXTDECLPROC(PyObject *, PyImport_ImportModule, (const char *));
 
 /* PyList_ */
 EXTDECLPROC(int, PyList_Append, (PyObject *, PyObject *));

--- a/bootloader/src/pyi_pythonlib.c
+++ b/bootloader/src/pyi_pythonlib.c
@@ -241,6 +241,8 @@ pyi_pylib_start_python(const ARCHIVE_STATUS *archive_status)
 
     if (PI_PyStatus_Exception(status)) {
         FATALERROR("Failed to start embedded python interpreter!\n");
+        /* Dump exception information to stderr and exit the process with error code. */
+        PI_Py_ExitStatusException(status);
     } else {
         ret = 0; /* Succeeded */
     }

--- a/bootloader/src/pyi_pythonlib.c
+++ b/bootloader/src/pyi_pythonlib.c
@@ -28,7 +28,6 @@
 #include <stddef.h>  /* ptrdiff_t */
 #include <stdio.h>
 #include <string.h>
-#include <locale.h>  /* setlocale */
 
 /* PyInstaller headers. */
 #include "pyi_pythonlib.h"
@@ -38,12 +37,13 @@
 #include "pyi_utils.h"
 #include "pyi_python.h"
 #include "pyi_win32_utils.h"
+#include "pyi_pyconfig.h"
 
 /*
- * Load the Python DLL, and get all of the necessary entry points
+ * Load the Python shared library, and bind all required functions from it.
  */
 int
-pyi_pylib_load(ARCHIVE_STATUS *status)
+pyi_pylib_load(const ARCHIVE_STATUS *archive_status)
 {
     dylib_t dll;
     char dllpath[PATH_MAX];
@@ -62,7 +62,7 @@ pyi_pylib_load(ARCHIVE_STATUS *status)
      * libpython?.?.a(libpython?.?.so) format
      */
     char *p;
-    if ((p = strrchr(status->cookie.pylibname, '.')) != NULL && strcmp(p, ".a") == 0) {
+    if ((p = strrchr(archive_status->cookie.pylibname, '.')) != NULL && strcmp(p, ".a") == 0) {
       /*
        * On AIX 'ar' archives are used for both static and shared object.
        * To load a shared object from a library, it should be loaded like this:
@@ -79,15 +79,15 @@ pyi_pylib_load(ARCHIVE_STATUS *status)
               pyvers_major, pyvers_minor, pyvers_major, pyvers_minor);
     }
     else {
-      len = snprintf(dllname, DLLNAME_LEN, "%s", status->cookie.pylibname);
+      len = snprintf(dllname, DLLNAME_LEN, "%s", archive_status->cookie.pylibname);
     }
 #else
-    len = snprintf(dllname, DLLNAME_LEN, "%s", status->cookie.pylibname);
+    len = snprintf(dllname, DLLNAME_LEN, "%s", archive_status->cookie.pylibname);
 #endif
 
     if (len >= DLLNAME_LEN) {
         FATALERROR("Reported length (%d) of DLL name (%s) length exceeds buffer[%d] space\n",
-                   len, status->cookie.pylibname, DLLNAME_LEN);
+                   len, archive_status->cookie.pylibname, DLLNAME_LEN);
         return -1;
     }
 
@@ -97,13 +97,11 @@ pyi_pylib_load(ARCHIVE_STATUS *status)
      * library loading to avoid Python library loading failure (unresolved
      * symbol errors) on systems with Universal CRT update not installed.
      */
-    if (status->has_temp_directory) {
+    if (archive_status->has_temp_directory) {
         char ucrtpath[PATH_MAX];
-        if (pyi_path_join(ucrtpath,
-                          status->temppath, "ucrtbase.dll") == NULL) {
-            FATALERROR("Path of ucrtbase.dll (%s) length exceeds "
-                       "buffer[%d] space\n", status->temppath, PATH_MAX);
-        };
+        if (pyi_path_join(ucrtpath, archive_status->temppath, "ucrtbase.dll") == NULL) {
+            FATALERROR("Path of ucrtbase.dll (%s) length exceeds buffer[%d] space\n", archive_status->temppath, PATH_MAX);
+        }
         if (pyi_path_exists(ucrtpath)) {
             VS("LOADER: ucrtbase.dll found: %s\n", ucrtpath);
             pyi_utils_dlopen(ucrtpath);
@@ -115,9 +113,8 @@ pyi_pylib_load(ARCHIVE_STATUS *status)
      * Look for Python library in homepath or temppath.
      * It depends on the value of mainpath.
      */
-    if (pyi_path_join(dllpath, status->mainpath, dllname) == NULL) {
-        FATALERROR("Path of DLL (%s) length exceeds buffer[%d] space\n",
-                   status->mainpath, PATH_MAX);
+    if (pyi_path_join(dllpath, archive_status->mainpath, dllname) == NULL) {
+        FATALERROR("Path of DLL (%s) length exceeds buffer[%d] space\n", archive_status->mainpath, PATH_MAX);
     };
 
     VS("LOADER: Python library: %s\n", dllpath);
@@ -136,101 +133,85 @@ pyi_pylib_load(ARCHIVE_STATUS *status)
         return -1;
     }
 
-    return pyi_python_map_names(dll, pyvers);
+    return pyi_python_bind_functions(dll, pyvers);
 }
 
 /*
- * Use this from a dll instead of pyi_pylib_load().
- * It will attach to an existing pythonXX.dll or load one if needed.
+ * Initialize and start python interpreter.
  */
 int
-pyi_pylib_attach(ARCHIVE_STATUS *status, int *loadedNew)
+pyi_pylib_start_python(const ARCHIVE_STATUS *archive_status)
 {
-#ifdef _WIN32
-    HMODULE dll;
-    char nm[PATH_MAX + 1];
-    int ret = 0;
+    PyiRuntimeOptions *runtime_options = NULL;
+    PyConfig *config = NULL;
+    PyStatus status;
+    int ret = -1;
 
-    /* Get python's name */
-    sprintf(nm, "python%d%d.dll", pyvers / 100, pyvers % 100);
-
-    /* See if it's loaded */
-    dll = GetModuleHandleA(nm);
-
-    if (dll == 0) {
-        *loadedNew = 1;
-        return pyi_pylib_load(status);
-    }
-    ret = pyi_python_map_names(dll, pyvers);
-    *loadedNew = 0;
-    return ret;
-#endif /* ifdef _WIN32 */
-    return 0;
-}
-
-/*
- * A toc entry of type 'o' holds runtime options
- * toc->name is the arg
- * this is so you can freeze in command line args to Python
- */
-static int
-pyi_pylib_set_runtime_opts(ARCHIVE_STATUS *status)
-{
-    int unbuffered = 0;
-    TOC *ptoc = status->tocbuff;
-    wchar_t wchar_tmp[PATH_MAX + 1];
-
-    /*
-     * Startup flags - default values. 1 means enabled, 0 disabled.
-     */
-    /* Suppress 'import site'. */
-    *PI_Py_NoSiteFlag = 1;
-    /* Needed by getpath.c from Python. */
-    *PI_Py_FrozenFlag = 1;
-    /* Suppress writing bytecode files (*.py[co]) */
-    *PI_Py_DontWriteBytecodeFlag = 1;
-    /* Do not try to find any packages in user's site directory. */
-    *PI_Py_NoUserSiteDirectory = 1;
-    /* This flag ensures PYTHONPATH and PYTHONHOME are ignored by Python. */
-    *PI_Py_IgnoreEnvironmentFlag = 1;
-    /* Disable verbose imports by default. */
-    *PI_Py_VerboseFlag = 0;
-
-    /* Override some runtime options by custom values from PKG archive.
-     * User is allowed to changes these options. */
-    for (; ptoc < status->tocend; ptoc = pyi_arch_increment_toc_ptr(status, ptoc)) {
-        if (ptoc->typcd == ARCHIVE_ITEM_RUNTIME_OPTION) {
-            if (0 == strncmp(ptoc->name, "pyi-", 4)) {
-                VS("LOADER: Bootloader option: %s\n", ptoc->name);
-                continue;  /* Not handled here - use pyi_arch_get_option(status, ...) */
-            }
-            VS("LOADER: Runtime option: %s\n", ptoc->name);
-
-            switch (ptoc->name[0]) {
-            case 'v':
-                *PI_Py_VerboseFlag = 1;
-                break;
-            case 'u':
-                unbuffered = 1;
-                break;
-            case 'W':
-                /* TODO: what encoding is ptoc->name? May not be important */
-                /* as all known Wflags are ASCII. */
-                if ((size_t)-1 == mbstowcs(wchar_tmp, &ptoc->name[2], PATH_MAX)) {
-                    FATALERROR("Failed to convert Wflag %s using mbstowcs "
-                               "(invalid multibyte string)\n", &ptoc->name[2]);
-                    return -1;
-                }
-                PI_PySys_AddWarnOption(wchar_tmp);
-                break;
-            case 'O':
-                *PI_Py_OptimizeFlag = 1;
-                break;
-            }
-        }
+    /* Read run-time options */
+    runtime_options = pyi_runtime_options_read(archive_status);
+    if (runtime_options == NULL) {
+        FATALERROR("Failed to parse run-time options!\n");
+        goto end;
     }
 
-    if (unbuffered) {
+    /* Pre-initialize python. This ensures that PEP 540 UTF-8 mode is enabled
+     * if necessary. */
+    VS("LOADER: Pre-initializing embedded python interpreter...\n");
+    if (pyi_pyconfig_preinit_python(runtime_options) < 0) {
+        FATALERROR("Failed to pre-initialize embedded python interpreter!\n");
+        goto end;
+    }
+
+    /* Allocate the config structure. Since underlying layout is specific to
+     * python version, this also verifies that python version is supported. */
+    VS("LOADER: Creating PyConfig structure...\n");
+    config = pyi_pyconfig_create();
+    if (config == NULL) {
+        FATALERROR("Failed to allocate PyConfig structure! Unsupported python version?\n");
+        goto end;
+    }
+
+    /* Initialize isolated configuration */
+    VS("LOADER: Initializing interpreter configuration...\n");
+    PI_PyConfig_InitIsolatedConfig(config);
+
+    /* Set program name */
+    VS("LOADER: Setting program name...\n");
+    if (pyi_pyconfig_set_program_name(config, archive_status) < 0) {
+        FATALERROR("Failed to set program name!\n");
+        goto end;
+    }
+
+    /* Set python home */
+    VS("LOADER: Setting python home path...\n");
+    if (pyi_pyconfig_set_python_home(config, archive_status) < 0) {
+        FATALERROR("Failed to set python home path!\n");
+        goto end;
+    }
+
+    /* Set module search paths */
+    VS("LOADER: Setting module search paths...\n");
+    if (pyi_pyconfig_set_module_search_paths(config, archive_status) < 0) {
+        FATALERROR("Failed to set module search paths!\n");
+        goto end;
+    }
+
+    /* Set arguments (sys.argv) */
+    VS("LOADER: Setting sys.argv...\n");
+    if (pyi_pyconfig_set_argv(config, archive_status) < 0) {
+        FATALERROR("Failed to set sys.argv!\n");
+        goto end;
+    }
+
+    /* Apply run-time options */
+    VS("LOADER: Applying run-time options...\n");
+    if (pyi_pyconfig_set_runtime_options(config, runtime_options) < 0) {
+        FATALERROR("Failed to set run-time options!\n");
+        goto end;
+    }
+
+    /* In unbuffered mode, we need to adjust the streams */
+    if (runtime_options->unbuffered) {
 #ifdef _WIN32
         _setmode(fileno(stdin), _O_BINARY);
         _setmode(fileno(stdout), _O_BINARY);
@@ -241,292 +222,10 @@ pyi_pylib_set_runtime_opts(ARCHIVE_STATUS *status)
         setbuf(stdin, (char *)NULL);
         setbuf(stdout, (char *)NULL);
         setbuf(stderr, (char *)NULL);
-
-        /* Enable unbuffered mode via Py_UnbufferedStdioFlag */
-        *PI_Py_UnbufferedStdioFlag = 1;
-    }
-    return 0;
-}
-
-/* Enable UTF-8 mode as per PEP540.
- * It seems Py_UTF8Mode must be set before Py_SetPath is called, but
- * in practice, it is probably a good idea to call it before any
- * Py_* functions are used
- */
-static void
-pyi_pylib_set_pep540_utf8_mode()
-{
-    int enable_utf8_mode = -1;
-    char *env_utf8 = NULL;
-
-    /* Honor the setting via PYTHONUTF8 environment variable (valid
-     * values are 0 and 1, same as with python interpreter) */
-    env_utf8 = pyi_getenv("PYTHONUTF8");
-    if (env_utf8) {
-        if (strcmp(env_utf8, "0") == 0) {
-            enable_utf8_mode = 0;
-        } else if (strcmp(env_utf8, "1") == 0) {
-            enable_utf8_mode = 1;
-        } else {
-            OTHERERROR("Invalid value for PYTHONUTF8=%s; disabling utf-8 mode!\n", env_utf8);
-            enable_utf8_mode = 0;
-        }
     }
 
-#ifndef _WIN32
-    /* On non-Windows, the C locale and the POSIX locale enable the
-     * UTF-8 Mode (PEP 540) */
-    if (enable_utf8_mode < 0) {
-        const char *lc_ctype = NULL;
-        char *orig_lc_ctype = NULL;
-
-        /* Get original value of LC_CTYPE. */
-        lc_ctype = setlocale(LC_CTYPE, NULL);
-        if (lc_ctype) {
-            orig_lc_ctype = strdup(lc_ctype);
-        }
-
-        /* Set user-preferred locale, and retrieve corresponding LC_CTYPE. */
-        lc_ctype = setlocale(LC_CTYPE, "");
-        if (lc_ctype != NULL && (strcmp(lc_ctype, "C") == 0 || strcmp(lc_ctype, "POSIX") == 0)) {
-            enable_utf8_mode = 1;
-        }
-
-        /* Restore old value. */
-        if (orig_lc_ctype) {
-            setlocale(LC_CTYPE, orig_lc_ctype);
-            free(orig_lc_ctype);
-        }
-    }
-#endif
-
-    /* Enable/disable UTF-8 mode */
-    if (enable_utf8_mode > 0) {
-        VS("LOADER: Enabling UTF-8 mode\n");
-        *PI_Py_UTF8Mode = 1;
-    } else {
-        *PI_Py_UTF8Mode = 0;
-    }
-}
-
-
-void
-pyi_free_wargv(wchar_t ** wargv)
-{
-    wchar_t ** arg = wargv;
-
-    while (arg[0]) {
-#ifdef _WIN32
-        // allocated using `malloc` in pyi_win32_wargv_from_utf8
-        free(arg[0]);
-#else
-        // allocated using Py_DecodeLocale in pyi_wargv_from_argv
-        PI_PyMem_RawFree(arg[0]);
-#endif
-        arg++;
-    }
-    free(wargv);
-}
-
-/* Convert argv to wchar_t for Python 3. Based on code from Python's main().
- *
- * Uses 'Py_DecodeLocale' ('_Py_char2wchar' in 3.0-3.4) function from python lib,
- * so don't call until after python lib is loaded.
- *
- * Returns NULL on failure. Caller is responsible for freeing
- * both argv and argv[0..argc]
- */
-
-wchar_t **
-pyi_wargv_from_argv(int argc, char ** argv)
-{
-    wchar_t ** wargv;
-    char *oldloc;
-    int i;
-
-    oldloc = strdup(setlocale(LC_CTYPE, NULL));
-
-    if (!oldloc) {
-        FATALERROR("out of memory\n");
-        return NULL;
-    }
-
-    wargv = (wchar_t **)calloc(sizeof(wchar_t*) * (argc + 1), 1);
-
-    if (!wargv) {
-        FATALERROR("out of memory\n");
-        return NULL;
-    }
-
-    setlocale(LC_CTYPE, "");
-
-    for (i = 0; i < argc; i++) {
-
-        wargv[i] = PI_Py_DecodeLocale(argv[i], NULL);
-
-        if (!wargv[i]) {
-            pyi_free_wargv(wargv);
-            free(oldloc);
-            FATALERROR("Fatal error: "
-                       "unable to decode the command line argument #%i\n",
-                       i + 1);
-            return NULL;
-        }
-    }
-    wargv[argc] = NULL;
-
-    setlocale(LC_CTYPE, oldloc);
-    free(oldloc);
-    return wargv;
-}
-
-/*
- * Set Python list sys.argv from *argv/argc. (Command-line options).
- * sys.argv[0] should be full absolute path to the executable (Derived from
- * status->archivename).
- */
-static int
-pyi_pylib_set_sys_argv(ARCHIVE_STATUS *status)
-{
-    wchar_t ** wargv;
-
-    VS("LOADER: Setting sys.argv\n");
-
-#ifdef _WIN32
-    /* Convert UTF-8 argv back to wargv */
-    wargv = pyi_win32_wargv_from_utf8(status->argc, status->argv);
-#else
-    /* Convert argv to wargv using Python's Py_DecodeLocale */
-    wargv = pyi_wargv_from_argv(status->argc, status->argv);
-#endif
-
-    if (wargv) {
-        /* last parameter '0' to PySys_SetArgv means do not update sys.path. */
-        PI_PySys_SetArgvEx(status->argc, wargv, 0);
-        pyi_free_wargv(wargv);
-    }
-    else {
-        FATALERROR("Failed to convert argv to wchar_t\n");
-        return -1;
-    };
-    return 0;
-}
-
-/* Convenience function to convert current locale to wchar_t on Linux/OS X
- * and convert UTF-8 to wchar_t on Windows.
- *
- * To be called when converting internal PyI strings to wchar_t for
- * Python 3's consumption
- */
-wchar_t *
-pyi_locale_char2wchar(wchar_t * dst, char * src, size_t len)
-{
-#ifdef _WIN32
-    return pyi_win32_utils_from_utf8(dst, src, len);
-#else
-    wchar_t * buffer;
-    saved_locale = strdup(setlocale(LC_CTYPE, NULL));
-    setlocale(LC_CTYPE, "");
-
-    buffer = PI_Py_DecodeLocale(src, &len);
-
-    setlocale(LC_CTYPE, saved_locale);
-
-    if (!buffer) {
-        return NULL;
-    }
-    wcsncpy(dst, buffer, len);
-    PI_PyMem_RawFree(buffer);
-    return dst;
-#endif /* ifdef _WIN32 */
-}
-
-/*
- * Start python - return 0 on success
- */
-int
-pyi_pylib_start_python(ARCHIVE_STATUS *status)
-{
-    /* Set sys.path, sys.prefix, and sys.executable so dynamic libs will load.
-     *
-     * The Python APIs we use here (Py_SetProgramName, Py_SetPythonHome)
-     * specify their argument should be a "string in static storage".
-     * That is, the APIs use the string pointer as given and will neither copy
-     * its contents nor free its memory.
-     *
-     * NOTE: Static variables are zero-initialized. */
-    #define MAX_PYPATH_SIZE (3 * PATH_MAX + 32)
-    static char pypath[MAX_PYPATH_SIZE];
-
-    /* Wide string forms of the above, for Python 3. */
-    static wchar_t pypath_w[MAX_PYPATH_SIZE];
-    static wchar_t pyhome_w[PATH_MAX + 1];
-    static wchar_t progname_w[PATH_MAX + 1];
-
-    /* Enable PEP540 UTF-8 mode, if necessary. Must be done before Py_SetPath()
-     * is called for the setting to take effect (but we should probably also
-     * set it before pyi_locale_char2wchar() calls). */
-    pyi_pylib_set_pep540_utf8_mode();
-
-    /* Decode using current locale */
-    if (!pyi_locale_char2wchar(progname_w, status->executablename, PATH_MAX)) {
-        FATALERROR("Failed to convert progname to wchar_t\n");
-        return -1;
-    }
-    /* Py_SetProgramName() should be called before Py_SetPath(). */
-    PI_Py_SetProgramName(progname_w);
-
-    VS("LOADER: Manipulating environment (sys.path, sys.prefix)\n");
-
-    /* Set sys.prefix and sys.exec_prefix using Py_SetPythonHome */
-    /* Decode using current locale */
-    if (!pyi_locale_char2wchar(pyhome_w, status->mainpath, PATH_MAX)) {
-        FATALERROR("Failed to convert pyhome to wchar_t\n");
-        return -1;
-    }
-    VS("LOADER: sys.prefix is %s\n", status->mainpath);
-    PI_Py_SetPythonHome(pyhome_w);
-
-    /* Set sys.path */
-    /* sys.path = [mainpath/base_library.zip, mainpath/lib-dynload, mainpath] */
-    if (snprintf(pypath, MAX_PYPATH_SIZE, "%s%c%s" "%c" "%s%c%s" "%c" "%s",
-                 status->mainpath, PYI_SEP, "base_library.zip",
-                 PYI_PATHSEP,
-                 status->mainpath, PYI_SEP, "lib-dynload",
-                 PYI_PATHSEP,
-                 status->mainpath)
-        >= MAX_PYPATH_SIZE) {
-        // This should never happen, since mainpath is < PATH_MAX and pypath is
-        // huge enough
-        FATALERROR("sys.path (based on %s) exceeds buffer[%d] space\n",
-                   status->mainpath, MAX_PYPATH_SIZE);
-        return -1;
-    }
-
-    /*
-     * We must set sys.path to have base_library.zip before
-     * calling Py_Initialize as it needs `encodings` and other modules.
-     */
-    /* Decode using current locale */
-    if (!pyi_locale_char2wchar(pypath_w, pypath, MAX_PYPATH_SIZE)) {
-        FATALERROR("Failed to convert pypath to wchar_t\n");
-        return -1;
-    }
-    VS("LOADER: Pre-init sys.path is %s\n", pypath);
-
-    /*
-     * Call Py_GetPath() first. This used be necessary on Windows to
-     * work around https://bugs.python.org/issue29778, but it also seems
-     * necessary on other platforms with python 3.8 and 3.9 when python's
-     * memory debugging and validation is enabled (PYTHONMALLOC=debug or
-     * PYTHONDEVMODE=1).
-     */
-    PI_Py_GetPath();
-    PI_Py_SetPath(pypath_w);
-
-    /* Start python. */
-    VS("LOADER: Setting runtime options\n");
-    pyi_pylib_set_runtime_opts(status);
+    /* Start the interpreter */
+    VS("LOADER: Starting embedded python interpreter...\n");
 
     /*
      * Py_Initialize() may rudely call abort(), and on Windows this triggers the error
@@ -542,42 +241,29 @@ pyi_pylib_start_python(ARCHIVE_STATUS *status)
     SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX);
 #endif
 
-    VS("LOADER: Initializing python\n");
-    PI_Py_Initialize();
+    status = PI_Py_InitializeFromConfig(config);
 
 #if defined(_WIN32) && defined(LAUNCH_DEBUG)
     SetErrorMode(0);
 #endif
 
-    /*
-     * Set sys.path list.
-     * Python's default sys.path is no good - it includes the working directory
-     * and the folder containing the executable. Replace sys.path with only
-     * the paths we want.
-     */
-    VS("LOADER: Overriding Python's sys.path\n");
-    VS("LOADER: Post-init sys.path is %s\n", pypath);
-    PI_PySys_SetPath(pypath_w);
-
-    /* Setting sys.argv should be after Py_Initialize() call. */
-    if (pyi_pylib_set_sys_argv(status)) {
-        return -1;
+    if (PI_PyStatus_Exception(status)) {
+        FATALERROR("Failed to start embedded python interpreter!\n");
+    } else {
+        ret = 0; /* Succeeded */
     }
 
-    /* Check for a python error */
-    if (PI_PyErr_Occurred()) {
-        FATALERROR("Error detected starting Python VM.\n");
-        return -1;
-    }
-
-    return 0;
+end:
+    pyi_pyconfig_free(config);
+    pyi_runtime_options_free(runtime_options);
+    return ret;
 }
 
 /*
- * Import modules embedded in the archive - return 0 on success
+ * Import (bootstrap) modules embedded in the PKG archive.
  */
 int
-pyi_pylib_import_modules(ARCHIVE_STATUS *status)
+pyi_pylib_import_modules(ARCHIVE_STATUS *archive_status)
 {
     TOC *ptoc;
     PyObject *co;
@@ -588,12 +274,9 @@ pyi_pylib_import_modules(ARCHIVE_STATUS *status)
 
     /* TODO extract function pyi_char_to_pyobject */
 #ifdef _WIN32
-    meipass_obj = PI_PyUnicode_Decode(status->mainpath,
-                                      strlen(status->mainpath),
-                                      "utf-8",
-                                      "strict");
+    meipass_obj = PI_PyUnicode_Decode(archive_status->mainpath, strlen(archive_status->mainpath), "utf-8", "strict");
 #else
-    meipass_obj = PI_PyUnicode_DecodeFSDefault(status->mainpath);
+    meipass_obj = PI_PyUnicode_DecodeFSDefault(archive_status->mainpath);
 #endif
 
     if (!meipass_obj) {
@@ -606,19 +289,16 @@ pyi_pylib_import_modules(ARCHIVE_STATUS *status)
     VS("LOADER: importing modules from CArchive\n");
 
     /* Iterate through toc looking for module entries (type 'm')
-     * this is normally just bootstrap stuff (archive and iu)
-     */
-    ptoc = status->tocbuff;
-
-    while (ptoc < status->tocend) {
-        if (ptoc->typcd == ARCHIVE_ITEM_PYMODULE ||
-            ptoc->typcd == ARCHIVE_ITEM_PYPACKAGE) {
-            unsigned char *modbuf = pyi_arch_extract(status, ptoc);
+     * this is normally just bootstrap stuff (archive and iu) */
+    ptoc = archive_status->tocbuff;
+    while (ptoc < archive_status->tocend) {
+        if (ptoc->typcd == ARCHIVE_ITEM_PYMODULE || ptoc->typcd == ARCHIVE_ITEM_PYPACKAGE) {
+            unsigned char *modbuf = pyi_arch_extract(archive_status, ptoc);
 
             VS("LOADER: extracted %s\n", ptoc->name);
 
             /* Unmarshal the stored code object */
-            co = PI_PyMarshal_ReadObjectFromString((const char *) modbuf, ptoc->ulen);
+            co = PI_PyMarshal_ReadObjectFromString((const char *)modbuf, ptoc->ulen);
 
             if (co != NULL) {
                 VS("LOADER: running unmarshalled code object for %s...\n", ptoc->name);
@@ -640,127 +320,129 @@ pyi_pylib_import_modules(ARCHIVE_STATUS *status)
             }
 
             free(modbuf);
+
+            /* Exit on error */
+            if (mod == NULL) {
+                return -1;
+            }
         }
-        ptoc = pyi_arch_increment_toc_ptr(status, ptoc);
+        ptoc = pyi_arch_increment_toc_ptr(archive_status, ptoc);
     }
 
     return 0;
 }
 
 /*
- * Install a zlib from a toc entry.
+ * Install a PYZ from a TOC entry, by adding it to sys.path.
  *
  * Must be called after Py_Initialize (i.e. after pyi_pylib_start_python)
  *
  * The installation is done by adding an entry like
  *    absolute_path/dist/hello_world/hello_world?123456
  * to sys.path. The end number is the offset where the
- * Python bootstrap code should read the zip data.
+ * Python-side bootstrap code should read the PYZ data.
  * Return non zero on failure.
- * NB: This entry is removed from sys.path by the bootstrap scripts.
+ * NB: This entry is removed from sys.path by the Python-side bootstrap scripts.
  */
 int
-pyi_pylib_install_zlib(ARCHIVE_STATUS *status, TOC *ptoc)
+_pyi_pylib_install_pyz_entry(const ARCHIVE_STATUS *archive_status, const TOC *ptoc)
 {
     int rc = 0;
-    unsigned long long zlibpos = status->pkgstart + ptoc->pos;
+    unsigned long long zlibpos = archive_status->pkgstart + ptoc->pos;
     PyObject * sys_path, *zlib_entry, *archivename_obj;
 
     /* Note that sys.path contains PyUnicode on py3. Ensure
-     * that filenames are encoded or decoded correctly.
-     */
+     * that filenames are encoded or decoded correctly. */
 #ifdef _WIN32
     /* Decode UTF-8 to PyUnicode */
-    archivename_obj = PI_PyUnicode_Decode(status->archivename,
-                                          strlen(status->archivename),
-                                          "utf-8",
-                                          "strict");
+    archivename_obj = PI_PyUnicode_Decode(archive_status->archivename, strlen(archive_status->archivename), "utf-8", "strict");
 #else
     /* Decode locale-encoded filename to PyUnicode object using Python's
-     * preferred decoding method for filenames.
-     */
-    archivename_obj = PI_PyUnicode_DecodeFSDefault(status->archivename);
+     * preferred decoding method for filenames. */
+    archivename_obj = PI_PyUnicode_DecodeFSDefault(archive_status->archivename);
 #endif
     zlib_entry = PI_PyUnicode_FromFormat("%U?%llu", archivename_obj, zlibpos);
     PI_Py_DecRef(archivename_obj);
 
     sys_path = PI_PySys_GetObject("path");
 
-    if (NULL == sys_path) {
-        FATALERROR("Installing PYZ: Could not get sys.path\n");
+    if (sys_path == NULL) {
+        FATALERROR("Installing PYZ: Could not get sys.path!\n");
         PI_Py_DecRef(zlib_entry);
         return -1;
     }
 
     rc = PI_PyList_Append(sys_path, zlib_entry);
-
-    if (rc) {
-        FATALERROR("Failed to append to sys.path\n");
+    if (rc != 0) {
+        FATALERROR("Failed to append PYZ entry to sys.path!\n");
     }
 
     return rc;
 }
 
 /*
- * Install PYZ
- * Return non zero on failure
+ * Install PYZ archive(s) to sys.path.
+ * Return non zero on failure.
  */
 int
-pyi_pylib_install_zlibs(ARCHIVE_STATUS *status)
+pyi_pylib_install_pyz(const ARCHIVE_STATUS *archive_status)
 {
-    TOC * ptoc;
+    TOC *ptoc;
 
     VS("LOADER: Installing PYZ archive with Python modules.\n");
 
-    /* Iterate through toc looking for zlibs (PYZ, type 'z') */
-    ptoc = status->tocbuff;
-
-    while (ptoc < status->tocend) {
+    /* Iterate through TOC looking for PYZ (type 'z') */
+    ptoc = archive_status->tocbuff;
+    while (ptoc < archive_status->tocend) {
         if (ptoc->typcd == ARCHIVE_ITEM_PYZ) {
             VS("LOADER: PYZ archive: %s\n", ptoc->name);
-            pyi_pylib_install_zlib(status, ptoc);
+            if (_pyi_pylib_install_pyz_entry(archive_status, ptoc) < 0) {
+                return -1;
+            }
         }
 
-        ptoc = pyi_arch_increment_toc_ptr(status, ptoc);
+        ptoc = pyi_arch_increment_toc_ptr(archive_status, ptoc);
     }
     return 0;
 }
 
 void
-pyi_pylib_finalize(ARCHIVE_STATUS *status)
+pyi_pylib_finalize(const ARCHIVE_STATUS *archive_status)
 {
-    /*
-     * Call this function only if Python library was initialized.
-     *
-     * Otherwise it should be NULL pointer. If Python library is not properly
-     * loaded then calling this function might cause some segmentation faults.
-     */
-    if (status->is_pylib_loaded == true) {
-        #ifndef WINDOWED
-            /*
-             * We need to manually flush the buffers because otherwise there can be errors.
-             * The native python interpreter flushes buffers before calling Py_Finalize,
-             * so we need to manually do the same. See isse #4908.
-             */
-
-            VS("LOADER: Manually flushing stdout and stderr\n");
-
-            /* sys.stdout.flush() */
-            PI_PyRun_SimpleStringFlags(
-                "import sys; sys.stdout.flush(); \
-                (sys.__stdout__.flush if sys.__stdout__ \
-                is not sys.stdout else (lambda: None))()", NULL);
-
-            /* sys.stderr.flush() */
-            PI_PyRun_SimpleStringFlags(
-                "import sys; sys.stderr.flush(); \
-                (sys.__stderr__.flush if sys.__stderr__ \
-                is not sys.stderr else (lambda: None))()", NULL);
-
-        #endif
-
-        /* Finalize the interpreter. This function call calls all of the atexit functions. */
-        VS("LOADER: Cleaning up Python interpreter.\n");
-        PI_Py_Finalize();
+    /* Ensure python library was loaded; otherwise PI_* function pointers
+     * are invalid, and we have nothing to do here. */
+    if (archive_status->is_pylib_loaded != true) {
+        return;
     }
+
+    /* Nothing to do if python interpreter was not initialized. Attempting
+     * to flush streams using PyRun_SimpleStringFlags requires a valid
+     * interpreter instance. */
+    if (PI_Py_IsInitialized() == 0) {
+        return;
+    }
+
+#ifndef WINDOWED
+    /* We need to manually flush the buffers because otherwise there can be errors.
+     * The native python interpreter flushes buffers before calling Py_Finalize,
+     * so we need to manually do the same. See isse #4908. */
+    VS("LOADER: Manually flushing stdout and stderr\n");
+
+    /* sys.stdout.flush() */
+    PI_PyRun_SimpleStringFlags(
+        "import sys; sys.stdout.flush(); \
+        (sys.__stdout__.flush if sys.__stdout__ \
+        is not sys.stdout else (lambda: None))()", NULL);
+
+    /* sys.stderr.flush() */
+    PI_PyRun_SimpleStringFlags(
+        "import sys; sys.stderr.flush(); \
+        (sys.__stderr__.flush if sys.__stderr__ \
+        is not sys.stderr else (lambda: None))()", NULL);
+
+#endif
+
+    /* Finalize the interpreter. This calls all of the atexit functions. */
+    VS("LOADER: Cleaning up Python interpreter.\n");
+    PI_Py_Finalize();
 }

--- a/bootloader/src/pyi_pythonlib.c
+++ b/bootloader/src/pyi_pythonlib.c
@@ -257,7 +257,7 @@ end:
 int
 pyi_pylib_import_modules(ARCHIVE_STATUS *archive_status)
 {
-    TOC *ptoc;
+    const TOC *ptoc;
     PyObject *co;
     PyObject *mod;
     PyObject *meipass_obj;
@@ -379,7 +379,7 @@ _pyi_pylib_install_pyz_entry(const ARCHIVE_STATUS *archive_status, const TOC *pt
 int
 pyi_pylib_install_pyz(const ARCHIVE_STATUS *archive_status)
 {
-    TOC *ptoc;
+    const TOC *ptoc;
 
     VS("LOADER: Installing PYZ archive with Python modules.\n");
 

--- a/bootloader/src/pyi_pythonlib.h
+++ b/bootloader/src/pyi_pythonlib.h
@@ -20,13 +20,12 @@
 
 #include "pyi_archive.h"
 
-int pyi_pylib_attach(ARCHIVE_STATUS *status, int *loadedNew);
-int pyi_pylib_load(ARCHIVE_STATUS *status);  /* note - pyi_pylib_attach will call this if not already loaded */
-int pyi_pylib_start_python(ARCHIVE_STATUS *status);
-int pyi_pylib_import_modules(ARCHIVE_STATUS *status);
-int pyi_pylib_install_zlibs(ARCHIVE_STATUS *status);
-int pyi_pylib_run_scripts(ARCHIVE_STATUS *status);
+int pyi_pylib_load(const ARCHIVE_STATUS *archive_status);
+int pyi_pylib_start_python(const ARCHIVE_STATUS *archive_status);
+int pyi_pylib_import_modules(ARCHIVE_STATUS *archive_status);
+int pyi_pylib_install_pyz(const ARCHIVE_STATUS *archive_status);
+int pyi_pylib_run_scripts(const ARCHIVE_STATUS *archive_status);
 
-void pyi_pylib_finalize(ARCHIVE_STATUS *status);
+void pyi_pylib_finalize(const ARCHIVE_STATUS *archive_status);
 
 #endif  /* PYI_PYTHONLIB_H */

--- a/bootloader/src/pyi_splash.c
+++ b/bootloader/src/pyi_splash.c
@@ -288,7 +288,8 @@ pyi_splash_extract(ARCHIVE_STATUS *archive_status, SPLASH_STATUS *splash_status)
      *         system in PyInstaller and the bootloader
      */
     size_t pos;
-    TOC *tmp_toc, *ptoc;
+    const TOC *ptoc;
+    TOC *tmp_toc;
     int rc = 0;
     bool extracted = false;
     char *filename;
@@ -296,7 +297,7 @@ pyi_splash_extract(ARCHIVE_STATUS *archive_status, SPLASH_STATUS *splash_status)
     char run_dir[PATH_MAX];
 
     /* The last item in TOC is a path, so limit it is at PATH_MAX */
-    tmp_toc = (TOC*) calloc(1, sizeof(TOC) + PATH_MAX);
+    tmp_toc = (TOC*)calloc(1, sizeof(TOC) + PATH_MAX);
 
     /* Iterate over the requirements array */
     for (pos = 0; pos < splash_status->requirements_len; pos += strlen(filename) + 1) {

--- a/bootloader/src/pyi_splash.c
+++ b/bootloader/src/pyi_splash.c
@@ -292,7 +292,7 @@ pyi_splash_extract(ARCHIVE_STATUS *archive_status, SPLASH_STATUS *splash_status)
     tmp_toc = (TOC*)calloc(1, sizeof(TOC) + PATH_MAX);
 
     /* Iterate over the requirements array */
-    for (pos = 0; pos < splash_status->requirements_len; pos += strlen(filename) + 1) {
+    for (pos = 0; pos < (size_t)splash_status->requirements_len; pos += strlen(filename) + 1) {
         filename = splash_status->requirements + pos;
 
         if ((ptoc = pyi_arch_find_by_name(archive_status, filename)) != NULL) {

--- a/bootloader/src/pyi_splash.h
+++ b/bootloader/src/pyi_splash.h
@@ -136,13 +136,15 @@ typedef struct _splash_status {
 
 } SPLASH_STATUS;
 
-typedef int (pyi_splash_event_proc)(SPLASH_STATUS *, void *);
+typedef int (pyi_splash_event_proc)(SPLASH_STATUS *, const void *);
 
 /**
  * Public API functions for pyi_splash
  */
-int pyi_splash_setup(SPLASH_STATUS *splash_status, ARCHIVE_STATUS *archive_status,
-                     SPLASH_DATA_HEADER *data_header);
+int pyi_splash_setup(
+    SPLASH_STATUS *splash_status,
+    ARCHIVE_STATUS *archive_status
+);
 int pyi_splash_attach(SPLASH_STATUS *status);
 int pyi_splash_finalize(SPLASH_STATUS *status);
 int pyi_splash_start(SPLASH_STATUS *status, const char *executable);
@@ -151,9 +153,13 @@ int pyi_splash_start(SPLASH_STATUS *status, const char *executable);
 SPLASH_DATA_HEADER *pyi_splash_find(ARCHIVE_STATUS *status);
 int pyi_splash_extract(ARCHIVE_STATUS *archive_status, SPLASH_STATUS *splash_status);
 
-int pyi_splash_send(SPLASH_STATUS *status, bool async, void *user_data,
-                    pyi_splash_event_proc proc);
-int pyi_splash_update_prg(SPLASH_STATUS *status, TOC *ptoc);
+int pyi_splash_send(
+    SPLASH_STATUS *status,
+    bool async,
+    const void *user_data,
+    pyi_splash_event_proc proc
+);
+int pyi_splash_update_prg(SPLASH_STATUS *status, const TOC *ptoc);
 
 /* Memory allocation functions */
 SPLASH_STATUS *pyi_splash_status_new();

--- a/bootloader/src/pyi_utils.c
+++ b/bootloader/src/pyi_utils.c
@@ -97,20 +97,6 @@ strnlen(const char *str, size_t n)
 }
 #endif
 
-// some platforms do not provide strndup
-#ifndef HAVE_STRNDUP
-char *
-strndup(const char * str, size_t n)
-{
-    char *ret = NULL;
-    size_t len = strnlen(str, n);
-    ret = (char *)malloc(len + 1);
-    if (ret == NULL) return NULL;
-    ret[len] = '\0';
-    return (char *)memcpy(ret, str, len);
-}
-#endif
-
 
 char *
 pyi_strjoin(const char *first, const char *sep, const char *second){

--- a/bootloader/src/pyi_utils.c
+++ b/bootloader/src/pyi_utils.c
@@ -775,6 +775,11 @@ pyi_utils_set_environment(const ARCHIVE_STATUS *status)
 static BOOL WINAPI
 _pyi_win32_console_ctrl(DWORD dwCtrlType)
 {
+    /* Due to different handling of VS() macro in MSVC and mingw gcc, the former requires the name variable
+     * below to be available even in non-debug builds (where VS() is no-op), while the latter complains about
+     * the unused variable. So put everything under ifdef guard to appease both.
+     */
+#if defined(LAUNCH_DEBUG)
     /* https://docs.microsoft.com/en-us/windows/console/handlerroutine */
     static const char *name_map[] = {
         "CTRL_C_EVENT", // 0
@@ -793,6 +798,7 @@ _pyi_win32_console_ctrl(DWORD dwCtrlType)
      * See Remarks section at: https://docs.microsoft.com/en-us/windows/console/setconsolectrlhandler
      */
     VS("LOADER: received console control signal %d (%s)!\n", dwCtrlType, name ? name : "unknown");
+#endif
 
     /* Handle Ctrl+C and Ctrl+Break signals immediately. By returning TRUE, their default handlers
      * (which would call ExitProcess()) are not called, so we are effectively suppressing the signal

--- a/bootloader/src/pyi_utils.c
+++ b/bootloader/src/pyi_utils.c
@@ -241,8 +241,8 @@ pyi_unsetenv(const char *variable)
 #ifdef _WIN32
 
 /* Resolve the runtime tmpdir path and build nested directories */
-wchar_t
-*pyi_build_temp_folder(char *runtime_tmpdir)
+static wchar_t
+*pyi_build_temp_folder(const char *runtime_tmpdir)
 {
     wchar_t *wruntime_tmpdir;
     wchar_t wruntime_tmpdir_expanded[PATH_MAX];
@@ -295,8 +295,8 @@ wchar_t
 }
 
 /* TODO rename function and revisit */
-int
-pyi_get_temp_path(char *buffer, char *runtime_tmpdir)
+static int
+pyi_get_temp_path(char *buffer, const char *runtime_tmpdir)
 {
     int i;
     wchar_t *wchar_ret;
@@ -397,7 +397,7 @@ pyi_test_temp_path(char *buff)
 
 /* TODO merge this function with windows version. */
 static int
-pyi_get_temp_path(char *buff, char *runtime_tmpdir)
+pyi_get_temp_path(char *buff, const char *runtime_tmpdir)
 {
     if (runtime_tmpdir != NULL) {
       strcpy(buff, runtime_tmpdir);
@@ -446,11 +446,11 @@ pyi_get_temp_path(char *buff, char *runtime_tmpdir)
 int
 pyi_create_temp_path(ARCHIVE_STATUS *status)
 {
-    char *runtime_tmpdir = NULL;
+    const char *runtime_tmpdir = NULL;
 
     if (status->has_temp_directory != true) {
         runtime_tmpdir = pyi_arch_get_option(status, "pyi-runtime-tmpdir");
-        if(runtime_tmpdir != NULL) {
+        if (runtime_tmpdir != NULL) {
           VS("LOADER: Found runtime-tmpdir %s\n", runtime_tmpdir);
         }
 

--- a/bootloader/src/pyi_utils.h
+++ b/bootloader/src/pyi_utils.h
@@ -36,15 +36,15 @@ char *strndup(const char * str, size_t n);
 #endif
 
 /* Environment variables. */
-
 char *pyi_getenv(const char *variable);
 int pyi_setenv(const char *variable, const char *value);
 int pyi_unsetenv(const char *variable);
 
-/* Temporary files. */
+/* Temporary directory. */
+int pyi_create_tempdir(char *buff, const char *runtime_tmpdir);
 
-int pyi_create_temp_path(ARCHIVE_STATUS *status);
-void pyi_remove_temp_path(const char *dir);
+/* Recursive directory deletion. */
+void pyi_recursive_rmdir(const char *dir);
 
 /* File manipulation. */
 int pyi_create_parent_directory(const char *path, const char *name_);

--- a/bootloader/src/pyi_utils.h
+++ b/bootloader/src/pyi_utils.h
@@ -30,11 +30,6 @@
 size_t strnlen(const char *str, size_t n);
 #endif
 
-// some platforms do not provide strndup
-#ifndef HAVE_STRNDUP
-char *strndup(const char * str, size_t n);
-#endif
-
 /* Environment variables. */
 char *pyi_getenv(const char *variable);
 int pyi_setenv(const char *variable, const char *value);

--- a/bootloader/src/pyi_win32_utils.c
+++ b/bootloader/src/pyi_win32_utils.c
@@ -100,9 +100,8 @@ pyi_win32_wcs_to_mbs(const wchar_t *wstr)
     DWORD len, ret;
     char * str;
 
-    /* NOTE: setlocale hysterics are not needed on Windows - this function
-     *  has an explicit codepage parameter. CP_ACP means "current ANSI codepage"
-     *  which is set in the "Language for Non-Unicode Programs" control panel setting. */
+    /* NOTE: CP_ACP means "current ANSI codepage" which is set in the
+     * "Language for Non-Unicode Programs" control panel setting. */
 
     /* Get buffer size by passing NULL and 0 for output arguments */
     len = WideCharToMultiByte(CP_ACP,  /* CodePage */
@@ -183,39 +182,6 @@ err:
     return NULL;
 }
 
-/* Convert elements of wargv back from UTF-8. Used when calling
- *  PySys_SetArgv on Python 3.
- */
-
-wchar_t **
-pyi_win32_wargv_from_utf8(int argc, char **argv)
-{
-    int i, j;
-    wchar_t ** wargv;
-
-    wargv = (wchar_t **)calloc(argc + 1, sizeof(wchar_t *));
-    if (wargv == NULL) {
-        return NULL;
-    };
-
-    for (i = 0; i < argc; i++) {
-        wargv[i] = pyi_win32_utils_from_utf8(NULL, argv[i], 0);
-
-        if (NULL == wargv[i]) {
-            goto err;
-        }
-    }
-    wargv[argc] = NULL;
-
-    return wargv;
-err:
-
-    for (j = 0; j <= i; j++) {
-        free(wargv[j]);
-    }
-    free(wargv);
-    return NULL;
-}
 
 /*
  * Encode wchar_t (UTF16) into char (UTF8).

--- a/bootloader/src/pyi_win32_utils.h
+++ b/bootloader/src/pyi_win32_utils.h
@@ -20,7 +20,6 @@
 char * GetWinErrorString(DWORD error_code);
 
 char ** pyi_win32_argv_to_utf8(int argc, wchar_t **wargv);
-wchar_t ** pyi_win32_wargv_from_utf8(int argc, char **argv);
 
 char * pyi_win32_utils_to_utf8(char *buffer, const wchar_t *str, size_t n);
 wchar_t * pyi_win32_utils_from_utf8(wchar_t *buffer, const char *ostr, size_t n);

--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -640,7 +640,6 @@ def configure(ctx):
         ('stdlib.h', 'mkdtemp'),
         ('libgen.h', 'dirname'),
         ('libgen.h', 'basename'),
-        ('string.h', 'strndup'),
         ('string.h', 'strnlen'),
     ):
         ctx.check(

--- a/doc/CHANGES.rst
+++ b/doc/CHANGES.rst
@@ -993,7 +993,7 @@ Features
   caching when user renames the executable and attempts to run it before
   also renaming the manifest file). The old behavior of generating the
   external manifest file in ``onedir`` mode can be re-enabled using the
-  :option:`--no-embed-manifest` command-line switch, or via the
+  ``--no-embed-manifest`` command-line switch, or via the
   ``embed_manifest=False`` argument to ``EXE()`` in the .spec file.
   (:issue:`6223`)
 * (Wine) Prevent collection of Wine built-in DLLs (in either PE-converted or
@@ -1051,7 +1051,7 @@ Incompatible Changes
   or via :option:`--argv-emulation` command-line flag. (:issue:`6089`)
 * (Windows) By default, manifest is now embedded into the executable in
   ``onedir`` mode. The old behavior of generating the external manifest
-  file can be re-enabled using the :option:`--no-embed-manifest`
+  file can be re-enabled using the ``--no-embed-manifest``
   command-line switch, or via the ``embed_manifest=False`` argument to
   ``EXE()`` in the .spec file. (:issue:`6223`)
 * Issue an error report if a `.spec` file will not be generated, but
@@ -1358,7 +1358,7 @@ Features
   caching when user renames the executable and attempts to run it before
   also renaming the manifest file). The old behavior of generating the
   external manifest file in ``onedir`` mode can be re-enabled using the
-  :option:`--no-embed-manifest` command-line switch, or via the
+  ``--no-embed-manifest`` command-line switch, or via the
   ``embed_manifest=False`` argument to ``EXE()`` in the .spec file.
   (:issue:`6248`)
 * (Windows) Respect :pep:`239` encoding specifiers in Window's VSVersionInfo
@@ -1432,7 +1432,7 @@ Incompatible Changes
 
 * (Windows) By default, manifest is now embedded into the executable in
   ``onedir`` mode. The old behavior of generating the external manifest
-  file can be re-enabled using the :option:`--no-embed-manifest`
+  file can be re-enabled using the ``--no-embed-manifest``
   command-line switch, or via the ``embed_manifest=False`` argument to
   ``EXE()`` in the .spec file. (:issue:`6248`)
 

--- a/news/7713.feature.rst
+++ b/news/7713.feature.rst
@@ -1,5 +1,5 @@
 Restructure onedir mode builds so that everything except the executable (and
 ``.pkg`` if you're using external PYZ archive mode) are hidden inside a
 sub-directory. This sub-directory's name defaults to ``_internal`` but may be
-configured with the new :option:`--internals-prefix` option. Onefile
+configured with the new :option:`--contents-directory` option. Onefile
 applications and macOS ``.app`` bundles are unaffected.

--- a/news/7790.bootloader.rst
+++ b/news/7790.bootloader.rst
@@ -1,4 +1,0 @@
-Have bootloader call ``Py_GetPath`` before ``Py_SetPath`` on all platforms
-(instead of just on Windows) to work around memory-initialization issues
-in python 3.8 and 3.9, which come to light with ``PYTHONMALLOC=debug``
-or ``PYTHONDEVMODE=1`` being set in the environment.

--- a/news/7847.bootloader.rst
+++ b/news/7847.bootloader.rst
@@ -1,0 +1,3 @@
+Use `PEP 587 Python Initialization Configuration API
+<https://peps.python.org/pep-0587>`_ to configure the embedded Python
+interpreter.

--- a/news/7847.breaking.rst
+++ b/news/7847.breaking.rst
@@ -1,4 +1,4 @@
 PyInstaller-frozen applications are not affected by the ``PYTHONUTF8``
 environment variable anymore. To permanently enable or disable the
 UTF8 mode, use the ``X utf8_mode=1`` or ``X utf_mode=0`` :ref:`run-time
-option <giving run-time python options>` when building the application.
+option <specifying python interpreter options>` when building the application.

--- a/news/7847.breaking.rst
+++ b/news/7847.breaking.rst
@@ -1,0 +1,4 @@
+PyInstaller-frozen applications are not affected by the ``PYTHONUTF8``
+environment variable anymore. To permanently enable or disable the
+UTF8 mode, use the ``X utf8_mode=1`` or ``X utf_mode=0`` :ref:`run-time
+option <giving run-time python options>` when building the application.

--- a/news/7847.bugfix.rst
+++ b/news/7847.bugfix.rst
@@ -1,0 +1,3 @@
+Implement a work-around for un-initialized ``sys._stdlib_dir`` and ensure
+that python-frozen stdlib modules in Python >= 3.11 have ``__file__``
+attribute set.

--- a/news/7847.feature.1.rst
+++ b/news/7847.feature.1.rst
@@ -1,4 +1,4 @@
 Add support for specifying hash randomization seed via ``hash_seed=<value>``
-:ref:`run-time option <giving run-time python options>` when building the
+:ref:`run-time option <specifying python interpreter options>` when building the
 application. This allows the application to use a fixed seed value or disable
 hash randomization altogether by using seed value of 0.

--- a/news/7847.feature.1.rst
+++ b/news/7847.feature.1.rst
@@ -1,0 +1,4 @@
+Add support for specifying hash randomization seed via ``hash_seed=<value>``
+:ref:`run-time option <giving run-time python options>` when building the
+application. This allows the application to use a fixed seed value or disable
+hash randomization altogether by using seed value of 0.

--- a/news/7847.feature.rst
+++ b/news/7847.feature.rst
@@ -1,3 +1,3 @@
 Implement pass-through for `Python's X-options
 <https://docs.python.org/3/using/cmdline.html#cmdoption-X>`_ via
-PyInstaller's :ref:`run-time options mechanism <giving run-time python options>`.
+PyInstaller's :ref:`run-time options mechanism <specifying python interpreter options>`.

--- a/news/7847.feature.rst
+++ b/news/7847.feature.rst
@@ -1,0 +1,3 @@
+Implement pass-through for `Python's X-options
+<https://docs.python.org/3/using/cmdline.html#cmdoption-X>`_ via
+PyInstaller's :ref:`run-time options mechanism <giving run-time python options>`.

--- a/tests/functional/scripts/pyi_frozen_stdlib_modules.py
+++ b/tests/functional/scripts/pyi_frozen_stdlib_modules.py
@@ -1,0 +1,50 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2023, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+import sys
+import pprint
+import _imp  # A built-in
+
+if sys.version_info < (3, 11):
+    raise RuntimeError("Requires python >= 3.11!")
+
+# Check that sys._stdlib_dir is set
+if not sys._stdlib_dir:
+    raise RuntimeError("sys._stdlib_dir is not set!")
+
+# Frozen stdlib modules to test. Since these are frozen (by python itself), we do not need to specify them as hidden
+# imports when this test script is frozen using PyInstaller.
+frozen_stdlib_modules = sorted([name for name in _imp._frozen_module_names() if name in sys.stdlib_module_names])
+
+output_data = [sys._stdlib_dir]  # First entry is sys._stdlib_dir
+for module_name in frozen_stdlib_modules:
+    print(f"Checking {module_name}...", file=sys.stderr)
+    module = __import__(module_name)
+
+    if not hasattr(module, '__file__'):
+        raise RuntimeError(f"No __file__ attribute on {module_name}!")
+
+    # Collect: module_name, __file__, filename and origname from __spec__.loaded_state
+    loader_state = module.__spec__.loader_state
+    entry = (
+        module_name,
+        module.__file__,
+        loader_state.filename,
+        loader_state.origname,
+    )
+    output_data.append(entry)
+
+# Output: stdout or file
+if len(sys.argv) > 1:
+    with open(sys.argv[1], "w") as fp:
+        pprint.pprint(output_data, stream=fp)
+else:
+    pprint.pprint(output_data)

--- a/tests/functional/test_misc.py
+++ b/tests/functional/test_misc.py
@@ -62,15 +62,16 @@ def test_dis_main(pyi_builder):
     )
 
 
-# Test that setting PYTHONUTF8 controls the PEP540 UTF-8 mode on all OSes, regardless of current locale setting.
-@pytest.mark.parametrize('python_utf8', [True, False])
-def test_utf8_mode_envvar(python_utf8, pyi_builder, monkeypatch):
-    monkeypatch.setenv('PYTHONUTF8', str(int(python_utf8)))
+# Test that setting utf8 X-flag controls the PEP540 UTF-8 mode on all OSes, regardless of current locale setting.
+@pytest.mark.parametrize('xflag,enabled', [("X utf8", True), ("X utf8=1", True), ("X utf8=0", False)])
+def test_utf8_mode_xflag(xflag, enabled, pyi_builder):
     pyi_builder.test_source(
         """
         import sys
+        print("sys.flags:", sys.flags)
         assert sys.flags.utf8_mode == {}
-        """.format(python_utf8)
+        """.format(enabled),
+        pyi_args=["--python-option", xflag]
     )
 
 
@@ -81,10 +82,26 @@ def test_utf8_mode_envvar(python_utf8, pyi_builder, monkeypatch):
 def test_utf8_mode_locale(locale, pyi_builder, monkeypatch):
     monkeypatch.setenv('LC_CTYPE', locale)
     monkeypatch.setenv('LC_ALL', locale)  # Required by macOS CI; setting just LC_CTYPE is not enough.
-    pyi_builder.test_source("""
+    pyi_builder.test_source(
+        """
         import sys
+        print("sys.flags:", sys.flags)
         assert sys.flags.utf8_mode == 1
-        """)
+        """
+    )
+
+
+# Test that setting dev X-flag controls dev mode.
+@pytest.mark.parametrize('xflag,enabled', [("X dev", True), ("X dev=1", True), ("X dev=0", False)])
+def test_dev_mode_xflag(xflag, enabled, pyi_builder):
+    pyi_builder.test_source(
+        """
+        import sys
+        print("sys.flags:", sys.flags)
+        assert sys.flags.dev_mode == {}
+        """.format(enabled),
+        pyi_args=["--python-option", xflag]
+    )
 
 
 # Test that onefile cleanup does not remove contents of a directory that user symlinks into sys._MEIPASS (see #6074).

--- a/tests/functional/test_misc.py
+++ b/tests/functional/test_misc.py
@@ -104,6 +104,18 @@ def test_dev_mode_xflag(xflag, enabled, pyi_builder):
     )
 
 
+# Test that setting hash seed to zero via --python-option disables hash randomization.
+def test_disable_hash_randomization(pyi_builder):
+    pyi_builder.test_source(
+        """
+        import sys
+        print("sys.flags:", sys.flags)
+        assert sys.flags.hash_randomization == 0
+        """,
+        pyi_args=["--python-option", "hash_seed=0"]
+    )
+
+
 # Test that onefile cleanup does not remove contents of a directory that user symlinks into sys._MEIPASS (see #6074).
 def test_onefile_cleanup_symlinked_dir(pyi_builder, tmpdir):
     if pyi_builder._mode != 'onefile':


### PR DESCRIPTION
Replace python interpreter configuration via deprecated global variables and legacy functions to the new PEP 587 API.

The global variables and legacy functions have been deprecated in python 3.11 by https://github.com/python/cpython/issues/88279, and appear to be slated for removal in python 3.13.

The new config API requires us to allocate and directly manipulate the fields in the PyConfig structure. This is not ideal for us, because it means we need to know the size and the layout of the structure, which is specific to each python version (plus on Windows, there is additional field, but thankfully, that seems to be consistently the case for all Windows builds - python.org, Anaconda, and msys/mingw).

So either we would need to use python headers and compile a bootloader variant for each python (minor) version, or we need to provide the structure definitions for all supported python versions. For the time being, we are going to try the latter approach (it should be relatively easy to convert to the former one, should that be required).

Both approaches assume that the config structure layout does not change between micro/revision versions; based on
https://discuss.python.org/t/fr-allow-private-runtime-config-to-enable-extending-without-breaking-the-pyconfig-abi/18004
I think that is a fair assumption.

Hopefully https://github.com/python/cpython/issues/107954 will result in a saner API with opaque types for us to work with.