### PR TITLE
building: validate dest_dir path in (src, dest_dir) tuples

### DIFF
--- a/PyInstaller/exceptions.py
+++ b/PyInstaller/exceptions.py
@@ -67,3 +67,8 @@ _MISSING_PYTHON_LIB_MSG = \
 class PythonLibraryNotFoundError(IOError):
     def __init__(self):
         super().__init__(_MISSING_PYTHON_LIB_MSG.format(", ".join(compat.PYDYLIB_NAMES),))
+
+
+class InvalidSrcDestTupleError(SystemExit):
+    def __init__(self, src_dest, message):
+        super().__init__(f"Invalid (SRC, DEST_DIR) tuple: {src_dest!r}. {message}")


### PR DESCRIPTION
Have the `format_binaries_and_datas` helper function validate the destination directories in the given (src, dest_dir) tuples:
 - the destination directory must be a relative path
 - the destination directory must not end up pointing outside of the application's top level directory (e.g., '../simple-outside', 'complex/../../outside').

In onedir builds, both types of invalid path result in an error during file collection (due to explicit check against collection outside of the application's directory).

However, they went unnoticed in onefile builds, where they may cause unexpected run-time behavior; creating the originally-absolute path under the application's top-level directory in the former, and creating the file outside of the application's (temporary) top-level directory in the latter case.