### PR TITLE
Support CLI configurable spec files (#4482)

### DIFF
--- a/doc/spec-files.rst
+++ b/doc/spec-files.rst
@@ -762,3 +762,58 @@ Other globals contain information about the build environment:
  mode: rst
  ispell-local-dictionary: "american"
  End:
+
+
+.. _spec_parameters:
+
+Adding parameters to spec files
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Sometimes, you may wish to have different build modes (e.g. a *debug* build and
+a *production* build) from the same spec file. Any command line arguments to
+``pyinstaller`` given after a ``--`` separator will not be parsed by PyInstaller
+and will instead be forwarded to the spec file where you can implement your own
+argument parsing and handle the options accordingly. For example, the following
+spec file will create a onedir application with console enabled if invoked via
+``pyinstaller example.spec -- --debug`` or a onefile console-less application if
+invoked with just ``pyinstaller example.spec``. If you use an :mod:`argparse`
+based parser rather than rolling your own using :data:`sys.argv` then
+``pyinstaller example.spec -- --help`` will display your spec options.
+
+.. code-block:: python
+
+    # example.spec
+
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--debug", action="store_true")
+    options = parser.parse_args()
+
+    a = Analysis(
+        ['example.py'],
+    )
+    pyz = PYZ(a.pure)
+
+    if options.debug:
+        exe = EXE(
+            pyz,
+            a.scripts,
+            exclude_binaries=True,
+            name='example',
+        )
+        coll = COLLECT(
+            exe,
+            a.binaries,
+            a.datas,
+            name='example_debug',
+        )
+    else:
+        exe = EXE(
+            pyz,
+            a.scripts,
+            a.binaries,
+            a.datas,
+            name='example',
+            console=False,
+        )

--- a/news/4482.feature.rst
+++ b/news/4482.feature.rst
@@ -1,0 +1,2 @@
+Allow spec files to take command line parameters. See :ref:`adding parameters to
+spec files <spec_parameters>`.

--- a/tests/functional/scripts/pyi_spec_options.py
+++ b/tests/functional/scripts/pyi_spec_options.py
@@ -1,0 +1,17 @@
+available_optional_dependencies = []
+try:
+    import email  # noqa: F401
+    available_optional_dependencies.append("email")
+except ImportError:
+    pass
+try:
+    import gzip  # noqa: F401
+    available_optional_dependencies.append("gzip")
+except ImportError:
+    pass
+try:
+    import pstats  # noqa: F401
+    available_optional_dependencies.append("pstats")
+except ImportError:
+    pass
+print("Available dependencies:", *available_optional_dependencies)

--- a/tests/functional/specs/pyi_spec_options.spec
+++ b/tests/functional/specs/pyi_spec_options.spec
@@ -1,0 +1,51 @@
+# -*- mode: python ; coding: utf-8 -*-
+import argparse
+
+parser = argparse.ArgumentParser()
+optional_dependencies = ["email", "gzip", "pstats"]
+parser.add_argument("--optional-dependency", choices=optional_dependencies,
+                    action="append", default=[], help="help blah blah blah")
+options = parser.parse_args()
+
+source = os.path.join(os.path.dirname(SPECPATH), 'scripts', 'pyi_spec_options.py')
+
+a = Analysis(
+    [source],
+    pathex=[],
+    binaries=[],
+    datas=[],
+    hiddenimports=options.optional_dependency,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[i for i in optional_dependencies if i not in options.optional_dependency],
+    noarchive=False,
+)
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name='pyi_spec_options',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name="pyi_spec_options",
+)


### PR DESCRIPTION
Any CLI options passed after a `--` separator will become `sys.argv[1:]`, allowing for spec files to parse these options and create multiple build variants from one spec file.
