### PR TITLE
building: extend the operation retry mechanism

### DIFF
--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -797,9 +797,7 @@ class EXE(Target):
 
             # Append the data
             logger.info("Appending %s to EXE", append_type)
-            with open(build_name, 'ab') as outf:
-                with open(append_file, 'rb') as inf:
-                    shutil.copyfileobj(inf, outf, length=64 * 1024)
+            self._append_data_to_exe(build_name, append_file)
 
             # Fix Mach-O headers
             logger.info("Fixing EXE headers for code signing")
@@ -807,9 +805,7 @@ class EXE(Target):
         else:
             # Fall back to just appending data at the end of the file
             logger.info("Appending %s to EXE", append_type)
-            with open(build_name, 'ab') as outf:
-                with open(append_file, 'rb') as inf:
-                    shutil.copyfileobj(inf, outf, length=64 * 1024)
+            self._append_data_to_exe(build_name, append_file)
 
         # Step 3: post-processing
         if is_win:
@@ -944,6 +940,11 @@ class EXE(Target):
                 )
             except Exception as e:
                 raise IOError(f"Failed to embed data file {src_filename!r} as Windows resource") from e
+
+    def _append_data_to_exe(self, build_name, append_file):
+        with open(build_name, 'ab') as outf:
+            with open(append_file, 'rb') as inf:
+                shutil.copyfileobj(inf, outf, length=64 * 1024)
 
     def _copyfile(self, infile, outfile):
         with open(infile, 'rb') as infh:

--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -713,13 +713,13 @@ class EXE(Target):
                 os.remove(self.name)
         if not os.path.exists(os.path.dirname(self.name)):
             os.makedirs(os.path.dirname(self.name))
-        exe = self.exefiles[0][1]  # pathname of bootloader
-        if not os.path.exists(exe):
+        bootloader_exe = self.exefiles[0][1]  # pathname of bootloader
+        if not os.path.exists(bootloader_exe):
             raise SystemExit(_MISSING_BOOTLOADER_ERRORMSG)
 
         # Step 1: copy the bootloader file, and perform any operations that need to be done prior to appending the PKG.
         logger.info("Copying bootloader EXE to %s", build_name)
-        self._copyfile(exe, build_name)
+        shutil.copyfile(bootloader_exe, build_name)
         os.chmod(build_name, 0o755)
 
         if is_win:
@@ -756,7 +756,7 @@ class EXE(Target):
             if not self.exclude_binaries:
                 pkg_dst = os.path.join(os.path.dirname(build_name), os.path.basename(self.pkgname))
                 logger.info("Copying stand-alone PKG archive from %s to %s", self.pkg.name, pkg_dst)
-                self._copyfile(self.pkg.name, pkg_dst)
+                shutil.copyfile(self.pkg.name, pkg_dst)
             else:
                 logger.info("Stand-alone PKG archive will be handled by COLLECT")
 
@@ -945,11 +945,6 @@ class EXE(Target):
         with open(build_name, 'ab') as outf:
             with open(append_file, 'rb') as inf:
                 shutil.copyfileobj(inf, outf, length=64 * 1024)
-
-    def _copyfile(self, infile, outfile):
-        with open(infile, 'rb') as infh:
-            with open(outfile, 'wb') as outfh:
-                shutil.copyfileobj(infh, outfh, length=64 * 1024)
 
     @staticmethod
     def _retry_operation(func, *args, retries=20):

--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -701,9 +701,12 @@ class EXE(Target):
         return bootloader_file
 
     def assemble(self):
-        # On Windows, we must never create a file with a .exe suffix that we then have to (re)write to (see #6467).
-        # Any intermediate/temporary file must have an alternative suffix.
-        build_name = self.name + '.notanexecutable' if is_win or is_cygwin else self.name
+        # On Windows, we used to append .notanexecutable to the intermediate/temporary file name to (attempt to)
+        # prevent interference from anti-virus programs with the build process (see #6467). This is now disabled
+        # as we wrap all processing steps that modify the executable in the `_retry_operation` helper; however,
+        # we keep around the `build_name` variable instead of directly using `self.name`, just in case we need
+        # to re-enable it...
+        build_name = self.name
 
         logger.info("Building EXE from %s", self.tocbasename)
         if os.path.exists(self.name):

--- a/PyInstaller/utils/win32/icon.py
+++ b/PyInstaller/utils/win32/icon.py
@@ -138,7 +138,7 @@ def CopyIcons_FromIco(dstpath, srcpath, id=1):
     :param str srcpath: list of 1 or more .ico file paths
     """
     icons = map(IconFile, srcpath)
-    logger.info("Copying icons from %s", srcpath)
+    logger.debug("Copying icons from %s", srcpath)
 
     hdst = win32api.BeginUpdateResource(dstpath, 0)
 
@@ -149,10 +149,10 @@ def CopyIcons_FromIco(dstpath, srcpath, id=1):
         data = f.grp_icon_dir()
         data = data + f.grp_icondir_entries(iconid)
         win32api.UpdateResource(hdst, RT_GROUP_ICON, i + 1, data)
-        logger.info("Writing RT_GROUP_ICON %d resource with %d bytes", i + 1, len(data))
+        logger.debug("Writing RT_GROUP_ICON %d resource with %d bytes", i + 1, len(data))
         for data in f.images:
             win32api.UpdateResource(hdst, RT_ICON, iconid, data)
-            logger.info("Writing RT_ICON %d resource with %d bytes", iconid, len(data))
+            logger.debug("Writing RT_ICON %d resource with %d bytes", iconid, len(data))
             iconid = iconid + 1
 
     win32api.EndUpdateResource(hdst, 0)
@@ -210,9 +210,9 @@ def CopyIcons(dstpath, srcpath):
 
     # Single source is not .ico, presumably it is .exe (and if not, some error will occur).
     if index is not None:
-        logger.info("Copying icon from %s, %d", srcpath, index)
+        logger.debug("Copying icon from %s, %d", srcpath, index)
     else:
-        logger.info("Copying icons from %s", srcpath)
+        logger.debug("Copying icons from %s", srcpath)
 
     try:
         # Attempt to load the .ico or .exe containing the icon into memory using the same mechanism as if it were a DLL.

--- a/news/7871.core.rst
+++ b/news/7871.core.rst
@@ -1,0 +1,4 @@
+(Windows) The temporary/intermediate executable files are not generated
+with ``.notanexecutable`` suffix anymore, as the retry mechanism from
+:issue:`7840` and :issue:`7871` is now the preferred way of dealing with
+anti-virus program interference during the build.

--- a/news/7871.feature.rst
+++ b/news/7871.feature.rst
@@ -1,0 +1,6 @@
+Extend the operation retry mechanism that was initially introduced by
+:issue:`7840` to cover all processing steps that are performed during
+assembly of a Windows executable. This attempts to mitigate the
+interference from anti-virus programs and other security tools, which
+may temporarily block write access to the executable for a scan between
+individual processing steps.


### PR DESCRIPTION
Extend the operation retry mechanism from #7840 to handle `pywintypes.error`, and apply it to all processing steps involved in the assembly of the Windows executable.

I've promoted the retry message from DEBUG to WARNING, because I want people to know that their security software is getting in our way, even if we manage to retry our way around it.

I've also decided to disable the `.notanexecutable` suffix on intermediate/temporary executable files; partly because I'd like the retry mechanism to get more exposure (so we can address the remaining failure modes sooner rather than later), but also because the original report from #6854 / #6848 seems to imply that something was intentionally targeting the `.notanexecutable` suffix (i.e., the `PermissionDenied` was raised when we tried to copy over the bootloader, without any post-processing - which is where AV usually gets in our way due to race conditions during our executable processing).