### PR TITLE
news: reword the news fragment for 7836 [skip ci]

### DIFF
--- a/news/7836.core.rst
+++ b/news/7836.core.rst
@@ -1,2 +1,5 @@
-Drop ``pathlib``, ``tokenize`` and their depenedencies (submodules included) in ``base_library.zip``.
-In our test, helloworld-script reduced more than 30% of final size.
+Avoid collecting ``pathlib`` and ``tokenize`` (and their dependencies,
+such as ``urllib``) into ``base_library.zip``. By collecting them into
+PYZ archive, only submodules that the application really requires can
+be collected, which helps reducing the size of applications that, for
+example, do not require the full ``urllib`` package.


### PR DESCRIPTION
I missed this one during the review; the news fragment seems to imply that we are adding packages to `base_library.zip` ("drop in"), whereas we are actually taking them away from there.