### PR TITLE
bindepend: make erorrs during DLL architecture probe non-fatal

### DIFF
--- a/PyInstaller/depend/bindepend.py
+++ b/PyInstaller/depend/bindepend.py
@@ -590,7 +590,12 @@ def _resolve_library_path_in_search_paths(name, search_paths=None):
 
         # On Windows, ensure that architecture matches that of running python interpreter.
         if compat.is_win:
-            if winutils.get_pe_file_machine_type(fullpath) != _exe_machine_type:
+            try:
+                dll_machine_type = winutils.get_pe_file_machine_type(fullpath)
+            except Exception:
+                # A search path might contain a DLL that we cannot analyze; for example, a stub file. Skip over.
+                continue
+            if dll_machine_type != _exe_machine_type:
                 continue
 
         return os.path.normpath(fullpath)

--- a/news/7874.bugfix.rst
+++ b/news/7874.bugfix.rst
@@ -1,0 +1,4 @@
+(Windows) Avoid aborting the build process if machine type (architecture)
+cannot be determined for a DLL in a candidate search path; instead, skip
+over such files, and search in other candidate paths. Fixes build errors
+when a search path contains an invalid DLL file (for example, a stub file).


### PR DESCRIPTION
If we cannot determine the architecture of a DLL in a candidate search path due to an error, skip over and search on instead of aborting the build process. Fixes build errors when a candidate search path for some reason contains an invalid DLL file.

Fixes #7874.