### PR TITLE
Fix readthedocs building theme selection. [skip ci]

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -173,22 +173,13 @@ todo_include_todos = False
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 
-if not on_rtd:  # only import and set the theme if we're building docs locally
-    import sphinx_rtd_theme
+import sphinx_rtd_theme
+html_theme = 'sphinx_rtd_theme'
 
-    html_theme = 'sphinx_rtd_theme'
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-    html_style = 'css/pyinstaller.css'
-else:
-    # RTD adds some defaults to conf.py which make it behave
-    # differently. So we need a different way to specify our css.
-    html_context = {
-        'css_files': [
-            'https://media.readthedocs.org/css/sphinx_rtd_theme.css',
-            'https://media.readthedocs.org/css/readthedocs-doc-embed.css',
-            '_static/css/pyinstaller.css',
-        ],
-    }
+
+def setup(app):
+    app.add_css_file('css/pyinstaller.css')
+
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
It appears that the html_theme variable is now mandatory. Replace the two different theme setting approaches and their surrounding *if on readthedocs* logic with something that works everywhere.
