### PR TITLE
rthook utils: add missing argtypes annotations for ctypes-bound functions

### DIFF
--- a/PyInstaller/fake-modules/_pyi_rth_utils/__init__.py
+++ b/PyInstaller/fake-modules/_pyi_rth_utils/__init__.py
@@ -1,12 +1,12 @@
 # -----------------------------------------------------------------------------
 # Copyright (c) 2023, PyInstaller Development Team.
 #
-# Distributed under the terms of the GNU General Public License (version 2
-# or later) with exception for distributing the bootloader.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #
-# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+# SPDX-License-Identifier: Apache-2.0
 # -----------------------------------------------------------------------------
 
 import os

--- a/PyInstaller/fake-modules/_pyi_rth_utils/_win32.py
+++ b/PyInstaller/fake-modules/_pyi_rth_utils/_win32.py
@@ -1,12 +1,12 @@
 # -----------------------------------------------------------------------------
 # Copyright (c) 2023, PyInstaller Development Team.
 #
-# Distributed under the terms of the GNU General Public License (version 2
-# or later) with exception for distributing the bootloader.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #
-# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+# SPDX-License-Identifier: Apache-2.0
 # -----------------------------------------------------------------------------
 
 import ctypes


### PR DESCRIPTION
Add missing argument type annotations for ctypes-bound functions used in _pyi_rth_utils/_win32.py.

Most notably, the missing  argtypes for `CreateDirectoryW` is causing  `OSError: exception: access violation reading 0x00000010` under 32-bit python.