### PR TITLE
splash: fix license of pyi_splash run-time module [skip ci]

### DIFF
--- a/PyInstaller/fake-modules/pyi_splash.py
+++ b/PyInstaller/fake-modules/pyi_splash.py
@@ -1,12 +1,12 @@
 # -----------------------------------------------------------------------------
 # Copyright (c) 2005-2023, PyInstaller Development Team.
 #
-# Distributed under the terms of the GNU General Public License (version 2
-# or later) with exception for distributing the bootloader.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #
-# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+# SPDX-License-Identifier: Apache-2.0
 # -----------------------------------------------------------------------------
 
 # This module is not a "fake module" in the classical sense, but a real module that can be imported. It acts as an RPC

--- a/news/7896.core.rst
+++ b/news/7896.core.rst
@@ -1,0 +1,4 @@
+Fix the license of the ``pyi_splash`` run-time module; it is now licensed
+under permissive Apache license to avoid unintentionally imposing
+additional license restrictions on the frozen applications that make
+use of this module.


### PR DESCRIPTION
The `pyi_splash` run-time module should be licensed under permissive Apache license instead of GPLv2 with bootloader exception, as to avoid imposing additional license requirements on frozen applications making use of this module.

As far as I'm concerned, this was an oversight during review and merging of #4887, and intention was to have this run-time module freely redistributable. Nevertheless, we need confirmation from the original author (@Chrisg2000) that they consent to the change.