### PR TITLE
bootloader: fix MSVC target strings for native --target-arch

### DIFF
--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -154,6 +154,7 @@ def options(ctx):
         help='Target architecture format (32bit, 64bit). This option allows to build 32-bit bootloader with a 64-bit '
         'compiler and a 64-bit Python.',
         default=None,
+        choices=('32bit', '64bit', '64bit-arm'),
         dest='target_arch',
     )
     ctx.add_option(

--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -391,6 +391,12 @@ def _msvc_target(ctx):
         target = 'arm64'
     else:
         return []
+    # If we are not cross-compiling, we need to return single-architecture target string.
+    if host == target:
+        if host == 'amd64':
+            return 'x64'  # Native amd64 compiler is actually called 'x64'. See `waflib/Tools/msvc.py`.
+        return host  # x86, arm64
+    # Cross-compiling; set host_target combination: amd64_x86, amd64_arm64, x86_amd64, arm64_amd64, ...
     return [host + "_" + target]
 
 


### PR DESCRIPTION
When user-specified `--target-arch` matches native architecture, ˛`_msvc_target` needs to return single-arch target strings (`x64`, `x86`, or `arm64`) instead of `{host}_{target}` ones (`amd64_amd64`, `x86_x86`, or `arm64_arm64`).

Fixes #7914.

Also enforce the choice validation for `--target-arch` to immediately raise an error when user enters invalid option (such as `32-bit` instead of `32bit`).