### PR TITLE
loader: fix the `path_finder` arg of the `_NamespacePath`

### DIFF
--- a/PyInstaller/loader/pyimod02_importers.py
+++ b/PyInstaller/loader/pyimod02_importers.py
@@ -284,7 +284,9 @@ class PyiFrozenImporter:
             spec.submodule_search_locations = _NamespacePath(
                 entry_name,
                 [os.path.dirname(self.get_filename(entry_name))],
-                self,
+                # The `path_finder` argument must be a callable with two arguments (`name` and `path`) that
+                # returns the spec - so we need to bind our `find_spec` via lambda.
+                lambda name, path: self.find_spec(name, path),
             )
             return spec
 

--- a/tests/functional/test_importlib_resources.py
+++ b/tests/functional/test_importlib_resources.py
@@ -124,6 +124,7 @@ def test_importlib_resources_namespace_package_data_files(pyi_builder, as_packag
         hidden_imports = ['--hidden-import', 'pyi_test_nspkg']
     pyi_builder.test_source(
         """
+        import importlib
         try:
             import importlib_resources
         except ModuleNotFoundError:
@@ -139,6 +140,15 @@ def test_importlib_resources_namespace_package_data_files(pyi_builder, as_packag
         assert (data_dir / "data_file1.txt").is_file()
         assert (data_dir / "data_file2.txt").is_file()
         assert (data_dir / "data_file3.txt").is_file()
+
+        # Force cache invalidation and check again.
+        # This verifies that our `PyiFrozenImporter` correctly sets the `path_finder` argument when constructing
+        # the `importlib._bootstrap_external._NamespacePath` for the namespace package. The `path_finder` is used
+        # during refresh triggered by cache invalidation.
+        importlib.invalidate_caches()
+
+        data_dir = importlib_resources.files("pyi_test_nspkg.data")
+        assert (data_dir / "data_file1.txt").is_file()
         """,
         pyi_args=['--paths', pathex, *hidden_imports, '--additional-hooks-dir', hooks_dir]
     )


### PR DESCRIPTION
Fix the `path_finder` argument passed to the constructor of `importlib._bootstrap_external._NamespacePath` that we construct for the namespace packages. The argument should not be an object instance, but rather a bound method that retrieves the spec (so we need to bind our `find_spec` implementation via a lambda).

The incorrect type of `path_finder` causes an error during the refresh codepath that is triggered by cache invalidation via `importlib.invalidate_caches()`; therefore, extend the `test_importlib_resources_namespace_package_data_files` with cache invalidation to have this scenario covered by test suite.