### PR TITLE
splash: clear bindepend.seen before analyzing Tcl/Tk shared libraries

### DIFF
--- a/PyInstaller/building/splash.py
+++ b/PyInstaller/building/splash.py
@@ -215,7 +215,11 @@ class Splash(Target):
         # existing spec files depend on this naming). We specify these binary dependencies (which include the
         # Tcl and Tk shared libaries themselves) even if the user's program uses tkinter and they would be collected
         # anyway; let the collection mechanism deal with potential duplicates.
+        #
+        # NOTE: make sure to clear `bindepend.seen` and force a "clean" dependency analysis - otherwise we will miss
+        # the binaries that were already seen during the main analysis.
         tcltk_libs = [(dest_name, src_name, 'BINARY') for dest_name, src_name in (self.tcl_lib, self.tk_lib)]
+        bindepend.seen.clear()
         self.binaries = bindepend.Dependencies(tcltk_libs)
 
         # Put all shared library dependencies in `splash_requirements`, so they are made available in onefile mode.

--- a/news/7935.bugfix.rst
+++ b/news/7935.bugfix.rst
@@ -1,0 +1,2 @@
+(Windows) Fix ``vcruntime140.dll`` not being properly extracted as a splash
+screen dependency in onefile builds (regression caused by issue:`7679`).


### PR DESCRIPTION
Clear the `bindepend.seen` set before running `bindepend.Dependencies` to analyze dependencies of the Tcl and Tk shared libraries for splash screen. Failing to do so causes us to miss librries that were already seen by previous run of `bindepend.Dependencies` in the main Analysis, such as `vcruntime140.dll`. Consequently, we fail to list the library among splash requirements, which causes failure in onefile mode.

Applicable to `v5` only - `bindepend.seen` has already been removed in `develop`.

Fixes #7935.