### PR TITLE
Future-proof the linux CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.8, 3.9, '3.10', '3.11', '3.12-dev']
-        os: ['windows-latest', 'ubuntu-20.04', 'macos-11']
+        os: ['windows-latest', 'ubuntu-22.04', 'macos-11']
       fail-fast: false
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu')
         run: |
           sudo apt-get update -qq
+          sudo apt-get upgrade -qq
           sudo apt-get install -qq --no-install-recommends \
             libcmocka-dev \
             libxml2-dev libxslt1-dev gfortran libatlas-base-dev \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,8 @@ jobs:
             libopengl0 libegl1 \
             libpulse0 libpulse-mainloop-glib0 \
             gstreamer1.0-plugins-base libgstreamer-gl1.0-0 \
-            gir1.2-gtk-3.0 libgirepository1.0-dev
+            gir1.2-gtk-3.0 libgirepository1.0-dev \
+            libfuse2
 
       - name: Download AppImage tool
         if: startsWith(matrix.os, 'ubuntu')


### PR DESCRIPTION
With Ubuntu 22.04 finally pushing the glibc fix that takes care of #7197, we could start considering the switch from `ubuntu-20.04` to `ubuntu-22.04` for our CI runner, even if there is little practical benefit in doing so at the moment.

This PR takes care of remaining issues preventing us from switching once we want to (or are forced to by GHA):
- the CI workflow is missing the `apt-get upgrade` step - in `ubuntu-22.04` this is currently necessary to get the fixed glibc. Might not be necessary in the future (depending on the base image), but is probably a good idea anyway.
- `libfuse2` (required by the AppImage test) needs to be explicitly installed, as it may not be installed by default (due to whatever required it before now using `libfuse3`).
- glibc >= 2.34 is incompatible with sandboxing in QtWebEngine (QTBUG-96214). This was fixed in Qt5 5.15.7, but even the latest PyPI wheels for PySide2 and PyQt5 still ship 5.15.2 (even if the PySide2/PyQt5 itself is more recent). This means that sandboxing needs to be disabled to get QtWebEngine from PyQt5/PySide2 PyPI wheels running at all (PyInstaller or not). So we disable it, but only in the tests (as the user will need to disable it in their program to run it unfrozen as well), and only if absolutely necessary (i.e., we detect glibc >= 2.34 and Qt5 < 5.15.7).