### PR TITLE
building: use `shutil.copyfile` when copying files into onedir build

### DIFF
--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -1140,8 +1140,12 @@ class COLLECT(Target):
                     raise ValueError(
                         f"Attempting to collect a duplicated file into COLLECT: {dest_name} (type: {typecode})"
                     )
-                shutil.copy2(src_name, dest_path)  # Use copy2 to (attempt to) preserve metadata
-            if typecode in ('EXTENSION', 'BINARY'):
+                # Use `shutil.copyfile` to copy file with default permissions. We do not attempt to preserve original
+                # permissions nor metadata, as they might be too restrictive and cause issues either during subsequent
+                # re-build attempts or when trying to move the application bundle. For binaries, we manually set the
+                # executable bits after copying the file.
+                shutil.copyfile(src_name, dest_path)
+            if typecode in ('EXTENSION', 'BINARY', 'EXECUTABLE'):
                 os.chmod(dest_path, 0o755)
         logger.info("Building COLLECT %s completed successfully.", self.tocbasename)
 

--- a/PyInstaller/building/osx.py
+++ b/PyInstaller/building/osx.py
@@ -555,7 +555,7 @@ class BUNDLE(Target):
         self.icon = os.path.abspath(self.icon)
 
         # Copy icns icon to Resources directory.
-        shutil.copy(self.icon, os.path.join(self.name, 'Contents', 'Resources'))
+        shutil.copyfile(self.icon, os.path.join(self.name, 'Contents', 'Resources', os.path.basename(self.icon)))
 
         # Key/values for a minimal Info.plist file
         info_plist_dict = {
@@ -644,7 +644,11 @@ class BUNDLE(Target):
                     raise ValueError(
                         f"Attempting to collect a duplicated file into BUNDLE: {dest_name} (type: {typecode})"
                     )
-                shutil.copy2(src_name, dest_path)  # Use copy2 to (attempt to) preserve metadata
+                # Use `shutil.copyfile` to copy file with default permissions. We do not attempt to preserve original
+                # permissions nor metadata, as they might be too restrictive and cause issues either during subsequent
+                # re-build attempts or when trying to move the application bundle. For binaries, we manually set the
+                # executable bits after copying the file.
+                shutil.copyfile(src_name, dest_path)
             if typecode in ('EXTENSION', 'BINARY', 'EXECUTABLE'):
                 os.chmod(dest_path, 0o755)
 

--- a/news/7938.bugfix.rst
+++ b/news/7938.bugfix.rst
@@ -1,0 +1,3 @@
+When copying files into ``onedir`` application bundles, use
+:func:`shutil.copyfile` instead of :func:`shutil.copy2` to avoid issues
+with original permissions/metadata being too restrictive.


### PR DESCRIPTION
Use `shutil.copyfile` instead of `shutil.copy` / `shutil.copy2` when copying files into onedir build. Preserving original file permissions (and/or metadata) may lead to issues when those are too restrictive (e.g., read-only permissions, or immutable flag on FreeBSD); for example, during application re-build attempt (as the file cannot be removed or overwritten), or when trying to move the application bundle.

Fixes #7938.