### PR TITLE
bootloader: onefile: set executable bit only on extracted binaries

### DIFF
--- a/PyInstaller/building/osx.py
+++ b/PyInstaller/building/osx.py
@@ -646,10 +646,13 @@ class BUNDLE(Target):
                     )
                 # Use `shutil.copyfile` to copy file with default permissions. We do not attempt to preserve original
                 # permissions nor metadata, as they might be too restrictive and cause issues either during subsequent
-                # re-build attempts or when trying to move the application bundle. For binaries, we manually set the
-                # executable bits after copying the file.
+                # re-build attempts or when trying to move the application bundle. For binaries (and data files with
+                # executable bit set), we manually set the executable bits after copying the file.
                 shutil.copyfile(src_name, dest_path)
-            if typecode in ('EXTENSION', 'BINARY', 'EXECUTABLE'):
+            if (
+                typecode in ('EXTENSION', 'BINARY', 'EXECUTABLE')
+                or (typecode == 'DATA' and os.access(src_name, os.X_OK))
+            ):
                 os.chmod(dest_path, 0o755)
 
         # Sign the bundle

--- a/bootloader/src/pyi_archive.c
+++ b/bootloader/src/pyi_archive.c
@@ -341,7 +341,11 @@ pyi_arch_extract2fs(const ARCHIVE_STATUS *status, const TOC *ptoc)
         rc = _pyi_arch_extract2fs_uncompressed(archive_fp, ptoc, out_fp);
     }
 #ifndef WIN32
-    fchmod(fileno(out_fp), S_IRUSR | S_IWUSR | S_IXUSR);
+    if (ptoc->typcd == ARCHIVE_ITEM_BINARY) {
+        fchmod(fileno(out_fp), S_IRUSR | S_IWUSR | S_IXUSR);
+    } else {
+        fchmod(fileno(out_fp), S_IRUSR | S_IWUSR);
+    }
 #endif
 
 cleanup:

--- a/news/7950.bootloader.rst
+++ b/news/7950.bootloader.rst
@@ -1,0 +1,5 @@
+(Linux, macOS) When extracting files from ``onefile`` archive, the
+executable bit is now set only on binaries (files whose TOC type code
+was either ``BINARY``, ``EXECUTABLE``, or ``EXTENSION``). Therefore,
+binaries are now extracted with permissions bits set to ``0700``, while
+all other files have permissions bits set to ``0600``.

--- a/news/7950.bootloader.rst
+++ b/news/7950.bootloader.rst
@@ -1,5 +1,6 @@
 (Linux, macOS) When extracting files from ``onefile`` archive, the
 executable bit is now set only on binaries (files whose TOC type code
-was either ``BINARY``, ``EXECUTABLE``, or ``EXTENSION``). Therefore,
-binaries are now extracted with permissions bits set to ``0700``, while
-all other files have permissions bits set to ``0600``.
+was either ``BINARY``, ``EXECUTABLE``, or ``EXTENSION``) or data files
+that originally had the executable bit set. Therefore, binaries are now
+extracted with permissions bits set to ``0700``, while all other files
+have permissions bits set to ``0600``.


### PR DESCRIPTION
When extracting files from onefile archive, restore the executable bits only on binary files (those that were collected with TOC type codes `EXECUTABLE`, `BINARY`, or `EXTENSION˙, which all end up having PKG type code `b`), as opposed to all files.

Binaries are now extracted with permissions bit set to `0700`, while other files are extracted with permissions bit set to `0600`.

This synchronizes `onefile` mode with `onedir` mode in terms of files that end up with executable bit being set.