### PR TITLE
analysis: ensure __main__ is always among excludes

### DIFF
--- a/PyInstaller/depend/analysis.py
+++ b/PyInstaller/depend/analysis.py
@@ -898,6 +898,14 @@ def initialize_modgraph(excludes=(), user_hook_dirs=()):
     user_hook_dirs = user_hook_dirs or ()
     excludes = excludes or ()
 
+    # Ensure that __main__ is always excluded from the modulegraph, to prevent accidentally pulling PyInstaller itself
+    # into the modulegraph. This seems to happen on Windows, because modulegraph is able to resolve `__main__` as
+    # `.../PyInstaller.exe/__main__.py` and analyze it. The `__main__` has a different meaning during analysis compared
+    # to the program run-time, when it refers to the program's entry-point (which would always be part of the
+    # modulegraph anyway, by virtue of being the starting point of the analysis).
+    if "__main__" not in excludes:
+        excludes += ("__main__",)
+
     # If there is a graph cached with the same excludes, reuse it. See ``PyiModulegraph._reset()`` for what is
     # reset. This cache is used primarily to speed up the test-suite. Fixture `pyi_modgraph` calls this function with
     # empty excludes, creating a graph suitable for the huge majority of tests.

--- a/news/7956.bugfix.rst
+++ b/news/7956.bugfix.rst
@@ -1,0 +1,3 @@
+Ensure that ``__main__`` is always in the list of modules to exclude,
+to prevent a program or a library that attempts to import ``__main__``
+from pulling PyInstaller itself into frozen application bundle.

--- a/tests/functional/modules/pyi_import_main/hooks/hook-PyInstaller.py
+++ b/tests/functional/modules/pyi_import_main/hooks/hook-PyInstaller.py
@@ -1,0 +1,2 @@
+# Disallow PyInstaller to be collected.
+raise Exception("Attempting to collect PyInstaller!")

--- a/tests/functional/modules/pyi_import_main/hooks/hook-pytest.py
+++ b/tests/functional/modules/pyi_import_main/hooks/hook-pytest.py
@@ -1,0 +1,2 @@
+# Disallow pytest to be collected.
+raise Exception("Attempting to collect pytest!")


### PR DESCRIPTION
Ensure that `__main__` is always excluded from the modulegraph, to prevent accidentally pulling `PyInstaller` itself into the modulegraph. This seems to happen on Windows, because modulegraph is able to resolve `__main__` as `.../PyInstaller.exe/__main__.py` and analyze it.
    
The `__main__` has a different meaning during analysis compared to the program run-time, when it refers to the program's entry-point (which would always be part of the modulegraph anyway, by virtue of being the starting point of the analysis).

The hook for `pkg_resources` hook already contains [a localized attempt](https://github.com/pyinstaller/pyinstaller/blame/1e18e1483f58107c2c7634f2eb6f7df65c2da5c0/PyInstaller/hooks/hook-pkg_resources.py#L31) at solving the problem with `__main__`, but that does not work with vendored versions of `pkg_resources` (like the one `pip` has - ee https://github.com/orgs/pyinstaller/discussions/7955#discussioncomment-7122438).

This could have been done deep in the bowels of modulegraph itself, but I think it is less hassle to have it done at the higher level (plus, this way it may be more noticeable if we ever get around to replacing the modulegraph). 

