### PR TITLE
building: do not raise errors on Info.plist missing from .framework bundles

### DIFF
--- a/news/7959.core.rst
+++ b/news/7959.core.rst
@@ -1,0 +1,7 @@
+(macOS) Lower the severity of a missing ``Info.plist`` file in a
+collected macOS .framework bundle from an error to a warning (unless
+strict collection mode is enabled). While missing ``Info.plist`` in a
+collected .framework bundle will cause ``codesign`` to refuse to sign
+the generated .app bundle, the user might be interested in building
+just the POSIX application or may not plan to sign their .app bundle.
+Fixes building with old ``PyQt5`` PyPI wheels (< 5.14.1).


### PR DESCRIPTION
Lower the severity of a missing `Info.plist` file in a collected macOS .framework bundle from an error to a warning (unless strict collection mode is enabled). Turns out that PyQt shipped PyPI wheels that contain Qt .framework bundles without `Info.plist` files up until v5.14.1. So be more tolerant to cases like that, especially since the user might be interested in a regular POSIX application instead of an .app bundle, or they might not plan to code-sign the generated .app bundle.

Closes #7959.