### PR TITLE
Allow users to re-enable the old onedir layout

### DIFF
--- a/PyInstaller/building/makespec.py
+++ b/PyInstaller/building/makespec.py
@@ -269,7 +269,8 @@ def __add_options(parser):
     g.add_argument(
         "--contents-directory",
         help="For onedir builds only, specify the name of the directory in which all supporting files (i.e. everything "
-        "except the executable itself) will be placed in.",
+        "except the executable itself) will be placed in. Use \".\" to re-enable old onedir layout without contents "
+        "directory.",
     )
 
     g = parser.add_argument_group('What to bundle, where to search')

--- a/bootloader/src/pyi_archive.c
+++ b/bootloader/src/pyi_archive.c
@@ -521,13 +521,18 @@ pyi_arch_setup(ARCHIVE_STATUS *status, char const *archive_path, char const *exe
         pyi_path_join(status->homepath, contents_dir, "Frameworks");
     } else {
         const char *contents_directory = pyi_arch_get_option(status, "pyi-contents-directory");
-        if (!contents_directory) {
-            FATALERROR("pyi-contents-directory option not found in onedir bundle archive!");
-            return false;
+        if (contents_directory) {
+            /* NOTE: this also applies contents-directory to status->homepath
+             * in onefile mode, which is, strictly speaking, incorrect. But
+             * it does not seem to cause any issues, because corresponding
+             * codepaths use status->temppath
+             */
+            char root_path[PATH_MAX];
+            pyi_path_dirname(root_path, archive_path);
+            pyi_path_join(status->homepath, root_path, contents_directory);
+        } else {
+            pyi_path_dirname(status->homepath, archive_path);
         }
-        char root_path[PATH_MAX];
-        pyi_path_dirname(root_path, archive_path);
-        pyi_path_join(status->homepath, root_path, contents_directory);
     }
 
     /*

--- a/bootloader/src/pyi_archive.h
+++ b/bootloader/src/pyi_archive.h
@@ -85,6 +85,10 @@ typedef struct _archive_status {
      * is used for example to set sys.path, sys.prefix, and sys._MEIPASS.
      */
     char mainpath[PATH_MAX];
+    /* Flag indicating that contents of the archive need to be extracted
+     * to the temporary directory (onefile mode).
+     */
+    bool needs_to_extract;
     /*
      * Flag if temporary directory is available. This usually means running
      * executable in onefile mode. Bootloader has to behave differently

--- a/bootloader/src/pyi_launch.c
+++ b/bootloader/src/pyi_launch.c
@@ -287,29 +287,6 @@ _extract_dependency(ARCHIVE_STATUS *archive_pool[], const char *item)
 }
 
 /*
- * Check if binaries need to be extracted. If not, this is probably a onedir solution,
- * and a child process will not be required on windows.
- */
-int
-pyi_launch_need_to_extract_binaries(const ARCHIVE_STATUS *archive_status)
-{
-    const TOC *ptoc = archive_status->tocbuff;
-
-    while (ptoc < archive_status->tocend) {
-        if (ptoc->typcd == ARCHIVE_ITEM_BINARY || ptoc->typcd == ARCHIVE_ITEM_DATA ||
-            ptoc->typcd == ARCHIVE_ITEM_ZIPFILE || ptoc->typcd == ARCHIVE_ITEM_SYMLINK) {
-            return true;
-        }
-
-        if (ptoc->typcd == ARCHIVE_ITEM_DEPENDENCY) {
-            return true;
-        }
-        ptoc = pyi_arch_increment_toc_ptr(archive_status, ptoc);
-    }
-    return false;
-}
-
-/*
  * Extract all binaries (type 'b') and all data files (type 'x') to the filesystem
  * and checks for dependencies (type 'd'). If dependencies are found, extract them.
  *

--- a/bootloader/src/pyi_launch.h
+++ b/bootloader/src/pyi_launch.h
@@ -41,12 +41,6 @@ int pyi_launch_extract_binaries(ARCHIVE_STATUS *archive_status,
                                 SPLASH_STATUS *splash_status);
 
 /*
- * Check if binaries need to be extracted. If not, this is probably a onedir
- * solution, and a child process will not be required on windows.
- */
-int pyi_launch_need_to_extract_binaries(const ARCHIVE_STATUS *archive_status);
-
-/*
  * Wrapped platform specific initialization before loading Python and executing
  * all scripts in the archive.
  */

--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -98,7 +98,6 @@ pyi_main(int argc, char * argv[])
     char archivefile[PATH_MAX];
     int rc = 0;
     int in_child = 0;
-    int needs_to_extract = 0;
     char *extractionpath = NULL;
 
 #ifdef _MSC_VER
@@ -215,8 +214,7 @@ pyi_main(int argc, char * argv[])
 
     /* Check if we need to unpack the embedded archive (onefile build, or onedir
      * build in MERGE mode). If we do, create the temporary directory. */
-    needs_to_extract = pyi_launch_need_to_extract_binaries(archive_status);
-    if (!in_child && needs_to_extract) {
+    if (!in_child && archive_status->needs_to_extract) {
         VS("LOADER: creating temporary directory...\n");
         if (pyi_arch_create_tempdir(archive_status) == -1) {
             return -1;
@@ -227,7 +225,7 @@ pyi_main(int argc, char * argv[])
 #if defined(_WIN32) || defined(__APPLE__)
 
     /* On Windows and Mac use single-process for --onedir mode. */
-    if (!extractionpath && !needs_to_extract) {
+    if (!extractionpath && !archive_status->needs_to_extract) {
         VS("LOADER: No need to extract files to run; setting extractionpath to homepath\n");
         extractionpath = archive_status->homepath;
     }
@@ -239,7 +237,7 @@ pyi_main(int argc, char * argv[])
      * set environment (i.e., LD_LIBRARY_PATH) and then restart/replace the
      * process via exec() without fork() for the environment changes (library
      * search path) to take effect. */
-     if (!extractionpath && !needs_to_extract) {
+     if (!extractionpath && !archive_status->needs_to_extract) {
         VS("LOADER: No need to extract files to run; setting up environment and restarting bootloader...\n");
 
         /* Set _MEIPASS2, so that the restarted bootloader process will enter

--- a/news/7968.feature.rst
+++ b/news/7968.feature.rst
@@ -1,0 +1,3 @@
+Allow users to re-enable the old onedir layout (without contents directory)
+by settings the :option:`--contents-directory` option (or the equivalent
+``contents_directory`` argument to ``EXE`` in the .spec file) to ``.``.

--- a/tests/functional/test_basic.py
+++ b/tests/functional/test_basic.py
@@ -784,8 +784,8 @@ def test_contents_directory(pyi_builder):
     assert not (bundle / "foo").exists()
     assert (bundle / "é³þ³źć🚀").is_dir()
 
-    with pytest.raises(SystemExit, match='Invalid value "\\." passed'):
-        pyi_builder.test_source("", pyi_args=["--contents-directory=.", "--noconfirm"])
+    with pytest.raises(SystemExit, match='Invalid value "\\.\\." passed'):
+        pyi_builder.test_source("", pyi_args=["--contents-directory=..", "--noconfirm"])
 
 
 def test_spec_options(pyi_builder, SPEC_DIR, capsys):

--- a/tests/functional/test_basic.py
+++ b/tests/functional/test_basic.py
@@ -788,6 +788,24 @@ def test_contents_directory(pyi_builder):
         pyi_builder.test_source("", pyi_args=["--contents-directory=..", "--noconfirm"])
 
 
+def test_legacy_onedir_layout(pyi_builder):
+    """
+    Test the --contents-directory=., which re-enables the legacy onedir layout.
+    """
+    if pyi_builder._mode != 'onedir':
+        pytest.skip('--contents-directory does not affect onefile builds.')
+
+    pyi_builder.test_source(
+        """
+        import sys
+        import os
+        assert sys._MEIPASS == os.path.dirname(sys.executable)
+        assert os.path.dirname(__file__) == os.path.dirname(sys.executable)
+        """,
+        pyi_args=["--contents-directory", "."]
+    )
+
+
 def test_spec_options(pyi_builder, SPEC_DIR, capsys):
     if pyi_builder._mode != 'onedir':
         pytest.skip('spec file is onedir mode only')


### PR DESCRIPTION
Allow users to re-enable the old onedir layout (without contents directory) by settings the `--contents-directory` option (or the equivalent `contents_directory` argument to `EXE` in the .spec file) to `.`.