### PR TITLE
building: fix randomization of binary dep. analysis search paths

### DIFF
--- a/PyInstaller/building/build_main.py
+++ b/PyInstaller/building/build_main.py
@@ -224,7 +224,9 @@ def find_binary_dependencies(binaries, import_packages):
         extra_libdirs += added_path_directories
 
     # Deduplicate search paths
-    extra_libdirs = list(set(extra_libdirs))
+    # NOTE: `list(set(extra_libdirs))` does not preserve the order of search paths (which matters here), so we need to
+    # de-duplicate using `list(dict.fromkeys(extra_libdirs).keys())` instead.
+    extra_libdirs = list(dict.fromkeys(extra_libdirs).keys())
 
     # Search for dependencies of the given binaries
     return bindepend.binary_dependency_analysis(binaries, search_paths=extra_libdirs)

--- a/news/7978.bugfix.rst
+++ b/news/7978.bugfix.rst
@@ -1,0 +1,9 @@
+(Windows) Fix unintentional randomization of library search path order
+in the binary dependency analysis step. The incorrect order of search
+paths would result in defunct builds when using both ``pywin32``
+and ``PyQt5``, ``PyQt6``, ``PySide2``, or ``PySide6``, as it would prevent
+the python's copy of ``VCRUNTIME140_1.dll`` from being collected into
+the top-level application directory due to it being shadowed by the
+Qt-provided copy. Consequently, the application would fail with
+``ImportError: DLL load failed while importing pywintypes: The specified
+module could not be found.``


### PR DESCRIPTION
De-duplicate the search paths via `list(dict.fromkeys(...).keys())` instead of `list(set(...))` to ensure that the order of search paths is preserved, instead of randomized on each run.

This fixes issues stemming from `sys.base_prefix` not being searched first on Windows; either for python shared library, or for `VCRUNTIME140.dll` or `VCRUNTIME140_1.dll`. For example, in an application using both `pywin32` and `PyQt5`, the `pywintypes3X.dll` references `VCRUNTIME140_1.dll`. If we search `sys.base_prefix` first (as we should), we will pick up a copy from there, and collect it into top-level application directory, where `pywintypes3X.dll` will automatically find it during run-time. But if we search the `PyQt5/Qt5/bin` directory first (one of additional search paths), we will pick up the Qt's copy, and collect it while preserving its parent directory; the `pywintyptes3X.dll` will then find it only if `PyQt5` python modules are loaded before `pywin32` ones, which is not necessarily the case.

Note that in the first case, we pick up the Qt-provided copy of the `VCRUNTIME140_1.dll` in addition to python-provided one, because the collected Qt shared libraries that refer to it are located in the same directory,  and referring binary's location takes precedence over additional search paths.

Closes #7978.