### PR TITLE
hookutils: fix collect_entry_point

### DIFF
--- a/PyInstaller/utils/hooks/__init__.py
+++ b/PyInstaller/utils/hooks/__init__.py
@@ -1122,7 +1122,7 @@ def collect_entry_point(name: str):
     imports = []
     for entry_point in importlib_metadata.entry_points(group=name):
         datas += copy_metadata(entry_point.dist.name)
-        imports.append(entry_point.value)
+        imports.append(entry_point.module)
     return datas, imports
 
 

--- a/news/7958.bugfix.rst
+++ b/news/7958.bugfix.rst
@@ -1,0 +1,4 @@
+Fix :func:`PyInstaller.utils.hooks.collect_entry_point` so that it
+returns module names (without class names). This matches the behavior
+of previous PyInstaller versions that regressed during transition
+from ``pkg_resources`` to ``importlib.metadata``.


### PR DESCRIPTION
When constructing the `imports` list, use `entry_point.module` instead of `entry_point.value`, as the latter might contain the class name in addition to module name, while the function should return just module names.

Fixes #7958.