### PR TITLE
bootloader: macOS: do not unset DYLD_* environment variables

### DIFF
--- a/bootloader/src/pyi_global.h
+++ b/bootloader/src/pyi_global.h
@@ -245,9 +245,6 @@ void mbvs(const char *fmt, ...);
     #define PYI_CURDIRSTR  "."
 #endif
 
-/* Strings are usually terminated by this character. */
-#define PYI_NULLCHAR       '\0'
-
 /* File seek and tell with large (64-bit) offsets */
 #if defined(_WIN32) && defined(_MSC_VER)
     #define pyi_fseek _fseeki64

--- a/bootloader/src/pyi_path.c
+++ b/bootloader/src/pyi_path.c
@@ -62,18 +62,18 @@ pyi_path_dirname(char *result, const char *path)
     /* Remove separator from the end. */
     len = strlen(result)-1;
     if (len >= 0 && result[len] == PYI_SEP) {
-        result[len] = PYI_NULLCHAR;
+        result[len] = 0;
     }
 
     /* Remove the rest of the string. */
     match = strrchr(result, PYI_SEP);
     if (match != NULL) {
-        *match = PYI_NULLCHAR;
+        *match = 0;
     }
     else {
         /* No dir separator found, so no dir-part, so use current dir */
         *result = PYI_CURDIR;
-        result[1] = PYI_NULLCHAR;
+        result[1] = 0;
     }
 #else /* ifndef HAVE_DIRNAME */
       /* Use dirname() for other platforms. */
@@ -141,7 +141,7 @@ pyi_path_join(char *result, const char *path1, const char *path2)
     /* Append trailing slash if missing. */
     if (result[len-1] != PYI_SEP) {
         result[len++] = PYI_SEP;
-        result[len++] = PYI_NULLCHAR;
+        result[len++] = 0;
     }
     len = PATH_MAX - len;
     len2 = strlen(path2);
@@ -152,7 +152,7 @@ pyi_path_join(char *result, const char *path1, const char *path2)
     if (path2[len2 - 1] == PYI_SEP) {
         /* Append path2 without slash. */
         strncat(result, path2, len);
-        result[strlen(result) - 1] = PYI_NULLCHAR;
+        result[strlen(result) - 1] = 0;
     }
     else {
         /* path2 does not end with slash. */

--- a/bootloader/src/pyi_utils.c
+++ b/bootloader/src/pyi_utils.c
@@ -927,33 +927,7 @@ pyi_utils_set_environment(const ARCHIVE_STATUS *status)
 {
     int rc = 0;
 
-    #ifdef __APPLE__
-    /* On Mac OS X we do not use environment variables DYLD_LIBRARY_PATH
-     * or others to tell OS where to look for dynamic libraries.
-     * There were some issues with this approach. In some cases some
-     * system libraries were trying to load incompatible libraries from
-     * the dist directory. For instance this was experienced with macprots
-     * and PyQt applications.
-     *
-     * To tell the OS where to look for dynamic libraries we modify
-     * .so/.dylib files to use relative paths to other dependent
-     * libraries starting with @executable_path.
-     *
-     * For more information see:
-     * http://blogs.oracle.com/dipol/entry/dynamic_libraries_rpath_and_mac
-     * http://developer.apple.com/library/mac/#documentation/DeveloperTools/  \
-     *     Conceptual/DynamicLibraries/100-Articles/DynamicLibraryUsageGuidelines.html
-     */
-    /* For environment variable details see 'man dyld'. */
-    pyi_unsetenv("DYLD_FRAMEWORK_PATH");
-    pyi_unsetenv("DYLD_FALLBACK_FRAMEWORK_PATH");
-    pyi_unsetenv("DYLD_VERSIONED_FRAMEWORK_PATH");
-    pyi_unsetenv("DYLD_LIBRARY_PATH");
-    pyi_unsetenv("DYLD_FALLBACK_LIBRARY_PATH");
-    pyi_unsetenv("DYLD_VERSIONED_LIBRARY_PATH");
-    pyi_unsetenv("DYLD_ROOT_PATH");
-
-    #else
+    #if !defined(__APPLE__)
 
     /* Set library path to temppath. This is only for onefile mode.*/
     if (status->temppath[0] != PYI_NULLCHAR) {
@@ -963,7 +937,7 @@ pyi_utils_set_environment(const ARCHIVE_STATUS *status)
     else {
         rc = set_dynamic_library_path(status->homepath);
     }
-    #endif /* ifdef __APPLE__ */
+    #endif /* !defined(__APPLE__) */
 
     return rc;
 }

--- a/bootloader/src/pyi_utils.c
+++ b/bootloader/src/pyi_utils.c
@@ -436,7 +436,7 @@ remove_one(wchar_t *wfnm, size_t pos, struct _wfinddata_t wfinfo)
     if (wcscmp(wfinfo.name, L".") == 0  || wcscmp(wfinfo.name, L"..") == 0) {
         return;
     }
-    wfnm[pos] = PYI_NULLCHAR;
+    wfnm[pos] = 0;
     wcscat(wfnm, wfinfo.name);
 
     if ((wfinfo.attrib & _A_SUBDIR)) {
@@ -496,7 +496,7 @@ remove_one(char *pnm, int pos, const char *fnm)
     if (strcmp(fnm, ".") == 0  || strcmp(fnm, "..") == 0) {
         return;
     }
-    pnm[pos] = PYI_NULLCHAR;
+    pnm[pos] = 0;
     strcat(pnm, fnm);
 
     /* Use lstat() instead of stat() to prevent recursion into

--- a/bootloader/src/pyi_utils.c
+++ b/bootloader/src/pyi_utils.c
@@ -934,7 +934,7 @@ pyi_utils_set_library_search_path(const char *path)
  * So the application can detect it and use the LISTEN_FDS created
  * by systemd.
  */
-int
+static int
 set_systemd_env()
 {
     const char * env_var = "LISTEN_PID";

--- a/bootloader/src/pyi_utils.h
+++ b/bootloader/src/pyi_utils.h
@@ -55,9 +55,9 @@ int pyi_utils_create_child(const char *thisfile, const ARCHIVE_STATUS *status,
 pid_t pyi_utils_get_child_pid();
 void pyi_utils_reraise_child_signal();
 #endif
-int pyi_utils_set_environment(const ARCHIVE_STATUS *status);
 
 #if !defined(_WIN32) && !defined(__APPLE__)
+int pyi_utils_set_library_search_path(const char *path);
 int pyi_utils_replace_process(const char *thisfile, const int argc, char *const argv[]);
 #endif
 

--- a/news/7973.bugfix.rst
+++ b/news/7973.bugfix.rst
@@ -1,0 +1,3 @@
+(macOS) Prevent bootloader from clearing ``DYLD_*`` environment variables
+when running in ``onefile`` mode, in order to make behavior consistent
+with ``onedir`` mode.


### PR DESCRIPTION
On macOS, the bootloader is currently explicitly un-setting the `DYLD_*` environment variables, but only in onefile mode. As stated in the comment above the offending code block, we do not rely on `DYLD_*` environment variables, but instead modify the library search paths in collected binaries. By extension, we should be able to not care about `DYLD_*` environment variables, and should not touch them at all.

Closes #7973.