### PR TITLE
docs: fix documentation for python interpreter run-time options [skip ci]

### DIFF
--- a/PyInstaller/building/makespec.py
+++ b/PyInstaller/building/makespec.py
@@ -447,7 +447,8 @@ def __add_options(parser):
         action='append',
         default=[],
         help='Specify a command-line option to pass to the Python interpreter at runtime. Currently supports '
-        '"v" (equivalent to "--debug imports"), "u", and "W <warning control>".',
+        '"v" (equivalent to "--debug imports"), "u", "W <warning control>", "X <xoption>", and "hash_seed=<value>". '
+        'For details, see the section "Specifying Python Interpreter Options" in PyInstaller manual.',
     )
     g.add_argument(
         "-s",

--- a/doc/spec-files.rst
+++ b/doc/spec-files.rst
@@ -400,13 +400,13 @@ Further examples to illustrate the syntax::
         ('W ignore::DeprecationWarning', None, 'OPTION')  # disable deprecation warnings
 
         # UTF-8 mode; unless explicitly enabled/disabled, it is auto enabled based on locale
-        ('X utf8_mode', None, 'OPTION),  # force UTF-8 mode on
-        ('X utf8_mode=1', None, 'OPTION),  # force UTF-8 mode on
-        ('X utf8_mode=0', None, 'OPTION),  # force UTF-8 mode off
+        ('X utf8', None, 'OPTION),  # force UTF-8 mode on
+        ('X utf8=1', None, 'OPTION),  # force UTF-8 mode on
+        ('X utf8=0', None, 'OPTION),  # force UTF-8 mode off
 
         # Developer mode; disabled by default
-        ('X dev_mode', None, 'OPTION),  # enable dev mode
-        ('X dev_mode=1', None, 'OPTION),  # enable dev mode
+        ('X dev', None, 'OPTION),  # enable dev mode
+        ('X dev=1', None, 'OPTION),  # enable dev mode
 
         # Hash seed
         ('hash_seed=0', None, 'OPTION'),  # disable hash randomization; sys.flags.hash_randomization=0


### PR DESCRIPTION
Update the argparse description for the `--python-option` command line option to list all options and refer user to the corresponding section in the manual.

Fix the examples in the said "Specifying Python Interpreter Options" section in the manual. The X-options in the example should be `utf8` and `dev` instead of `utf8_mode` and `dev_mode`, to match the corresponding python's X-options.