### PR TITLE
hooks: update PySide6.QtHttpServer hook for PySide6 6.5.3

### DIFF
--- a/PyInstaller/hooks/hook-PySide6.QtHttpServer.py
+++ b/PyInstaller/hooks/hook-PySide6.QtHttpServer.py
@@ -12,3 +12,7 @@
 from PyInstaller.utils.hooks.qt import add_qt6_dependencies
 
 hiddenimports, binaries, datas = add_qt6_dependencies(__file__)
+
+# This seems to be necessary on Windows; on other OSes, it is inferred automatically because the extension is linked
+# against the Qt6Concurrent shared library.
+hiddenimports += ['PySide6.QtConcurrent']

--- a/news/7994.hooks.rst
+++ b/news/7994.hooks.rst
@@ -1,0 +1,2 @@
+Update ``PySide6.QtHttpServer`` hook for compatibility with ``PySide6``
+6.5.3 on Windows.

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -30,7 +30,7 @@ pygments==2.16.1
 PyGObject==3.46.0; sys_platform == 'linux'
 # Current PySide2 wheels explicitly require python < 3.11
 PySide2==5.15.2.1; python_version < '3.11'
-PySide6==6.5.2
+PySide6==6.5.3
 # PyQt5 and add-on packages
 PyQt5==5.15.9
 PyQt3D==5.15.6


### PR DESCRIPTION
Explicitly add `PySide6.QtConcurrent` to hidden imports of `QtHttpServer` to fix missing module error in basic import test with PySide6 6.5.3 on Windows.

On other OSes, the `QtConcurrent` dependency seems to be automatically  inferred due to the  `QtHttpServer` extension being linked against the  `Qt6Concurrent` shared library. But the explicit hidden import does not hurt in that case, either.