### PR TITLE
Fix TypeError when using UPX compression

### DIFF
--- a/PyInstaller/building/utils.py
+++ b/PyInstaller/building/utils.py
@@ -208,8 +208,8 @@ def process_collected_binary(
             src_name = process_collected_binary(
                 src_name,
                 dest_name,
-                strip=True,
-                upx=False,
+                use_strip=True,
+                use_upx=False,
                 target_arch=target_arch,
                 codesign_identity=codesign_identity,
                 entitlements_file=entitlements_file,

--- a/news/7998.bugfix.rst
+++ b/news/7998.bugfix.rst
@@ -1,0 +1,2 @@
+Fix ``TypeError: process_collected_binary() got an unexpected keyword
+argument 'strip'`` error when UPX compression is enabled.


### PR DESCRIPTION
This fixes `TypeError: process_collected_binary() got an unexpected keyword argument 'strip'` as of **PyInstaller 6.0.0** when using UPX compression, because `strip`and `upx` parameters of `process_collected_binary` were renamed to `use_strip` and `use_upx`.

```py
+ python -O -m PyInstaller pyinstaller.spec --clean
1281 INFO: PyInstaller: 6.0.0
1281 INFO: Python: 3.12.0
1313 INFO: Platform: Windows-2022Server-10.0.20348-SP0
1344 INFO: UPX is available and will be used if enabled on build targets.
...
27594 INFO: checking PKG
27594 INFO: Building PKG because PKG-00.toc is non existent
27594 INFO: Building PKG (CArchive) foo.pkg
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "D:\a\foo\foo\.venv\Lib\site-packages\PyInstaller\__main__.py", line 209, in <module>
    run()
  File "D:\a\foo\foo\.venv\Lib\site-packages\PyInstaller\__main__.py", line 189, in run
    run_build(pyi_config, spec_file, **vars(args))
  File "D:\a\foo\foo\.venv\Lib\site-packages\PyInstaller\__main__.py", line 61, in run_build
    PyInstaller.building.build_main.main(pyi_config, spec_file, **kwargs)
  File "D:\a\foo\foo\.venv\Lib\site-packages\PyInstaller\building\build_main.py", line 1033, in main
    build(specfile, distpath, workpath, clean_build)
  File "D:\a\foo\foo\.venv\Lib\site-packages\PyInstaller\building\build_main.py", line 973, in build
    exec(code, spec_namespace)
  File "pyinstaller.spec", line 66, in <module>
    exe = EXE(pyz,
          ^^^^^^^^
  File "D:\a\foo\foo\.venv\Lib\site-packages\PyInstaller\building\api.py", line 606, in __init__
    self.pkg = PKG(
               ^^^^
  File "D:\a\foo\foo\.venv\Lib\site-packages\PyInstaller\building\api.py", line 238, in __init__
    self.__postinit__()
  File "D:\a\foo\foo\.venv\Lib\site-packages\PyInstaller\building\datastruct.py", line 184, in __postinit__
    self.assemble()
  File "D:\a\foo\foo\.venv\Lib\site-packages\PyInstaller\building\api.py", line 289, in assemble
    src_name = process_collected_binary(
               ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\a\foo\foo\.venv\Lib\site-packages\PyInstaller\building\utils.py", line 208, in process_collected_binary
    src_name = process_collected_binary(
               ^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: process_collected_binary() got an unexpected keyword argument 'strip'
Error: Process completed with exit code 1.
```