### PR TITLE
If argcomplete is available, use it for CLI completions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,14 @@ jobs:
       matrix:
         python-version: [3.8, 3.9, '3.10', '3.11', '3.12-dev']
         os: ['windows-latest', 'ubuntu-22.04', 'macos-11']
+        extra: [null]
+        include:
+          - python-version: '3.12-dev'
+            os: ubuntu-22.04
+            extra: null
+          - python-version: '3.12-dev'
+            os: ubuntu-22.04
+            extra: completion
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
@@ -115,6 +123,10 @@ jobs:
 
           # Make sure the help options print.
           python -m PyInstaller -h
+
+      - name: Install PyInstaller extra dependencies
+        if: ${{ matrix.extra }}
+        run: pip install --progress-bar=off .[${{ matrix.extra }}]
 
       - name: Install test dependencies (tools)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,14 +36,6 @@ jobs:
       matrix:
         python-version: [3.8, 3.9, '3.10', '3.11', '3.12-dev']
         os: ['windows-latest', 'ubuntu-22.04', 'macos-11']
-        extra: [null]
-        include:
-          - python-version: '3.12-dev'
-            os: ubuntu-22.04
-            extra: null
-          - python-version: '3.12-dev'
-            os: ubuntu-22.04
-            extra: completion
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
@@ -119,14 +111,10 @@ jobs:
           cd ..
 
           # Install PyInstaller.
-          pip install --progress-bar=off .
+          pip install --progress-bar=off .[completion]
 
           # Make sure the help options print.
           python -m PyInstaller -h
-
-      - name: Install PyInstaller extra dependencies
-        if: ${{ matrix.extra }}
-        run: pip install --progress-bar=off .[${{ matrix.extra }}]
 
       - name: Install test dependencies (tools)
         run: |

--- a/PyInstaller/__main__.py
+++ b/PyInstaller/__main__.py
@@ -24,6 +24,14 @@ from PyInstaller import log as logging
 # Note: do not import anything else until compat.check_requirements function is run!
 from PyInstaller import compat
 
+try:
+    from argcomplete import autocomplete
+except ImportError:
+
+    def autocomplete(parser):
+        return None
+
+
 logger = logging.getLogger(__name__)
 
 # Taken from https://stackoverflow.com/a/22157136 to format args more flexibly: any help text which beings with ``R|``
@@ -160,6 +168,7 @@ def run(pyi_args: list | None = None, pyi_config: dict | None = None):
     old_sys_argv = sys.argv
     try:
         parser = generate_parser()
+        autocomplete(parser)
         if pyi_args is None:
             pyi_args = sys.argv[1:]
         try:

--- a/PyInstaller/utils/cliutils/archive_viewer.py
+++ b/PyInstaller/utils/cliutils/archive_viewer.py
@@ -19,6 +19,13 @@ import sys
 import PyInstaller.log
 from PyInstaller.archive.readers import CArchiveReader, ZlibArchiveReader
 
+try:
+    from argcomplete import autocomplete
+except ImportError:
+
+    def autocomplete(parser):
+        return None
+
 
 class ArchiveViewer:
     def __init__(self, filename, interactive_mode, recursive_mode, brief_mode):
@@ -241,6 +248,7 @@ def run():
         help="PyInstaller archive to process.",
     )
 
+    autocomplete(parser)
     args = parser.parse_args()
     PyInstaller.log.__process_options(parser, args)
 

--- a/PyInstaller/utils/cliutils/bindepend.py
+++ b/PyInstaller/utils/cliutils/bindepend.py
@@ -18,6 +18,13 @@ import glob
 import PyInstaller.depend.bindepend
 import PyInstaller.log
 
+try:
+    from argcomplete import autocomplete
+except ImportError:
+
+    def autocomplete(parser):
+        return None
+
 
 def run():
     parser = argparse.ArgumentParser()
@@ -29,6 +36,7 @@ def run():
         help="executables or dynamic libraries for which the dependencies should be shown",
     )
 
+    autocomplete(parser)
     args = parser.parse_args()
     PyInstaller.log.__process_options(parser, args)
 

--- a/PyInstaller/utils/cliutils/grab_version.py
+++ b/PyInstaller/utils/cliutils/grab_version.py
@@ -12,6 +12,13 @@
 import argparse
 import codecs
 
+try:
+    from argcomplete import autocomplete
+except ImportError:
+
+    def autocomplete(parser):
+        return None
+
 
 def run():
     parser = argparse.ArgumentParser(
@@ -33,6 +40,7 @@ def run():
         help="filename where the grabbed version info will be saved",
     )
 
+    autocomplete(parser)
     args = parser.parse_args()
 
     try:

--- a/PyInstaller/utils/cliutils/makespec.py
+++ b/PyInstaller/utils/cliutils/makespec.py
@@ -18,6 +18,13 @@ import os
 import PyInstaller.building.makespec
 import PyInstaller.log
 
+try:
+    from argcomplete import autocomplete
+except ImportError:
+
+    def autocomplete(parser):
+        return None
+
 
 def generate_parser():
     p = argparse.ArgumentParser()
@@ -32,6 +39,7 @@ def generate_parser():
 
 def run():
     p = generate_parser()
+    autocomplete(p)
     args = p.parse_args()
     PyInstaller.log.__process_options(p, args)
 

--- a/PyInstaller/utils/cliutils/set_version.py
+++ b/PyInstaller/utils/cliutils/set_version.py
@@ -12,6 +12,13 @@
 import argparse
 import os
 
+try:
+    from argcomplete import autocomplete
+except ImportError:
+
+    def autocomplete(parser):
+        return None
+
 
 def run():
     parser = argparse.ArgumentParser()
@@ -25,6 +32,7 @@ def run():
         metavar='exe-file',
         help="full pathname of a Windows executable",
     )
+    autocomplete(parser)
     args = parser.parse_args()
 
     info_file = os.path.abspath(args.info_file)

--- a/news/8008.feature.rst
+++ b/news/8008.feature.rst
@@ -1,0 +1,6 @@
+- If the ``argcomplete`` Python module is installed,
+  PyInstaller will use it enable tab completion for its CLI tools.
+  PyInstaller CLIs can still be used without this optional dependency.
+  To install ``argcomplete`` with PyInstaller, you can put
+  ``pyinstaller[completion]`` in your dependencies.
+  `See also the argcomplete documentation. <https://kislyuk.github.io/argcomplete/>`_

--- a/setup.cfg
+++ b/setup.cfg
@@ -90,6 +90,9 @@ hook_testing =
     pytest >= 2.7.3
     execnet >= 1.5.0
     psutil
+; for CLI tab completion
+completion =
+    argcomplete
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
[`argcomplete`](https://github.com/kislyuk/argcomplete) adds tab completion for Python CLIs build with the [`argparse`](https://docs.python.org/3/library/argparse.html) module. This pull request sets up the PyInstaller CLIs to use `argcomplete` if it's installed, but if it's not installed, users can still use the PyInstaller CLIs without tab completion. In addition, this PR adds an "extra" requirement named "completion", so if users run `pip install pyinstaller[completion]`, then Pip will install PyInstaller _and_ `argcomplete`.

I've also added a new CI runner to run the tests with this extra installed, just to verify that the code still behaves as expected -- but since this is such a small change, I didn't think it was worth doubling the number of runners (one with `argcomplete` and one without, for every combination of `python-version` and `os`), so this CI runner only runs on Ubuntu with the latest version of Python.