### PR TITLE
bindepend: exclude unresolved `sys.base_prefix` from DLL parent path preservation

### DIFF
--- a/PyInstaller/depend/bindepend.py
+++ b/PyInstaller/depend/bindepend.py
@@ -61,9 +61,12 @@ def _get_paths_for_parent_directory_preservation():
     orig_paths.append(site.getusersitepackages())
 
     # Explicitly excluded paths. `site.getsitepackages` seems to include `sys.prefix`, which we need to exclude, to
-    # avoid issue swith DLLs in its sub-directories.
+    # avoid issue swith DLLs in its sub-directories. We need both resolved and unresolved variant to handle cases
+    # where `base_prefix` itself is a symbolic link (e.g., `scoop`-installed python on Windows, see #8023).
     excluded_paths = {
+        pathlib.Path(sys.base_prefix),
         pathlib.Path(sys.base_prefix).resolve(),
+        pathlib.Path(sys.prefix),
         pathlib.Path(sys.prefix).resolve(),
     }
 

--- a/news/8023.bugfix.rst
+++ b/news/8023.bugfix.rst
@@ -1,0 +1,9 @@
+Fix erroneous DLL parent path preservation when ``sys.base_prefix``
+itself is a symbolic link. In such case, we need to exclude both
+resolved and unresolved path variant for ``sys.base_prefix``, in order to
+prevent either from ending up in the list of directories for which DLL
+parent paths are preserved. Failing to do so, for example, caused
+``_ctypes`` failing to load in an application build on Windows with
+python installed via ``scoop``, due to ``libffi-8.dll`` having spuriously
+preserved the parent directory path instead of being collected to top-level
+application directory.


### PR DESCRIPTION
Exclude unresolved `sys.base_prefix` and `sys.prefix`  from paths used in DLL path preservation, in addition to already-excluded resolved paths. This prevents `sys.base_prefix`  from being erroneously included among DLL parent path preservation directories in case when `sys.base_prefix` itself is a symbolic link.

This seems to happen with `scoop`-installed python on Windows, where `%USERPROFILE%\scoop\apps\python311\current` points for example to `%USERPROFILE%\scoop\apps\python311\3.11.6`. Failing to exclude the unresolved path causes `DLLs\libffi-8.dll`  to be collected into DLLs sub-directory instead top-level application directory, and consequently `_ctypes` extension fails to load due to DLL not being in the search path.

Fixes #8023.