### PR TITLE
hooks: matplotlib.backends: deduplicate list of discovered/selected backends

### DIFF
--- a/PyInstaller/hooks/hook-matplotlib.backends.py
+++ b/PyInstaller/hooks/hook-matplotlib.backends.py
@@ -105,6 +105,9 @@ def _autodetect_used_backends(hook_api):
             )
             used_backends += co_backends
 
+    # Deduplicate and sort the list of used backends before displaying it.
+    used_backends = sorted(set(used_backends))
+
     if used_backends:
         HOOK_CONFIG_DOCS = 'https://pyinstaller.org/en/stable/hooks-config.html#matplotlib-hooks'
         logger.info(
@@ -210,6 +213,9 @@ def hook(hook_api):
         else:
             assert isinstance(backends_method, list), "User-provided backend name(s) must be either a string or a list!"
             backend_names = backends_method
+
+    # Deduplicate and sort the list of selected backends before displaying it.
+    backend_names = sorted(set(backend_names))
 
     logger.info("Selected matplotlib backends: %r", backend_names)
 

--- a/news/8009.hooks.rst
+++ b/news/8009.hooks.rst
@@ -1,0 +1,3 @@
+Deduplicate and sort the list of discovered/selected ``matplotlib``
+backends before displaying it in log messages, to avoid giving
+impression that they are collected multiple times.


### PR DESCRIPTION
Deduplicate and sort the list of discovered/selected `matplotlib` backends before displaying it in log messages, to avoid giving impression that backends are collected multiple times.

Closes #8009.