### PR TITLE
modulegraph: prevent collection of top-level module on missing relative import

### DIFF
--- a/PyInstaller/lib/modulegraph/modulegraph.py
+++ b/PyInstaller/lib/modulegraph/modulegraph.py
@@ -1511,16 +1511,15 @@ class ModuleGraph(ObjectGraph):
         target_package = self._safe_import_module(
             target_module_headname, target_package_name, source_package)
 
-        #FIXME: Why exactly is this necessary again? This doesn't quite seem
-        #right but maybe it is. Shouldn't absolute imports only be performed if
-        #the passed "level" is either "ABSOLUTE_IMPORT_LEVEL" or
-        #"ABSOLUTE_OR_RELATIVE_IMPORT_LEVEL" -- or, more succinctly:
-        #
-        #    if level < 1:
-
         # If this target package is *NOT* importable and a source package was
         # passed, attempt to import this target package as an absolute import.
-        if target_package is None and source_package is not None:
+        #
+        # ADDENDUM: but do this only if the passed "level" is either
+        # ABSOLUTE_IMPORT_LEVEL (0) or ABSOLUTE_OR_RELATIVE_IMPORT_LEVEL (-1).
+        # Otherwise, an attempt at relative import of a missing sub-module
+        # (from .module import something) might pull in an unrelated
+        # but eponymous top-level module, which should not happen.
+        if target_package is None and source_package is not None and level <= ABSOLUTE_IMPORT_LEVEL:
             target_package_name = target_module_headname
             source_package = None
 

--- a/news/8010.bugfix.rst
+++ b/news/8010.bugfix.rst
@@ -1,0 +1,4 @@
+Prevent an attempt at relative import of a missing (optional) sub-module
+within a package (e.g., ``from .module import something``) from tricking
+the modulegraph/analysis into collecting an unrelated but eponymous
+top-level module.

--- a/tests/functional/modules/pyi_missing_relative_import/hooks/hook-myotherpackage.py
+++ b/tests/functional/modules/pyi_missing_relative_import/hooks/hook-myotherpackage.py
@@ -1,0 +1,1 @@
+raise Exception("This package must not be collected!")

--- a/tests/functional/modules/pyi_missing_relative_import/myotherpackage/__init__.py
+++ b/tests/functional/modules/pyi_missing_relative_import/myotherpackage/__init__.py
@@ -1,0 +1,1 @@
+# Nothing to do here.

--- a/tests/functional/modules/pyi_missing_relative_import/mypackage/__init__.py
+++ b/tests/functional/modules/pyi_missing_relative_import/mypackage/__init__.py
@@ -1,0 +1,11 @@
+# Different forms of relative-import for an optional sub-module. While the said sub-module does not exist, an
+# unrelated eponymous top-level module does - and these import attempts should *NOT* trigger its collection!
+try:
+    from . import myotherpackage  # noqa: F401
+except ImportError:
+    pass
+
+try:
+    from .myotherpackage import something  # noqa: F401
+except ImportError:
+    pass

--- a/tests/unit/test_modulegraph_more.py
+++ b/tests/unit/test_modulegraph_more.py
@@ -492,11 +492,8 @@ def test_swig_import_from_top_level_missing(tmpdir):
     mg.add_script(str(script))
     assert isinstance(mg.find_node('pyi_test_osgeo'), modulegraph.Package)
     assert isinstance(mg.find_node('pyi_test_osgeo.pyi_gdal'), modulegraph.SourceModule)
-    # BUG: Again, this is unecpected behaviour in modulegraph: While MissingModule('_pyi_gdal') is (arguably) removed
-    # when trying to import the SWIG C module, there is no MissingModule('pyi_test_osgeo.pyi_gdal') added, but again
-    # MissingModule('_pyi_gdal'). I still need to understand why.
-    assert mg.find_node('pyi_test_osgeo._pyi_gdal') is None
-    assert isinstance(mg.find_node('_pyi_gdal'), modulegraph.MissingModule)
+    assert isinstance(mg.find_node('pyi_test_osgeo._pyi_gdal'), modulegraph.MissingModule)
+    assert mg.find_node('_pyi_gdal') is None
 
 
 def test_swig_import_from_top_level_but_nested(tmpdir):


### PR DESCRIPTION
Prevent an attempt at relative import of a missing (optional) sub-module within a package (e.g., `from .module import something`) from tricking the modulegraph/analysis into collecting an unrelated but eponymous top-level module.

Fixes #8010.