### PR TITLE
winutils: do not use keyword argument with win32api.UpdateResource

### DIFF
--- a/PyInstaller/utils/win32/winresource.py
+++ b/PyInstaller/utils/win32/winresource.py
@@ -148,7 +148,7 @@ def add_or_update_resource(filename, data, res_type, names=None, languages=None)
     module_handle = win32api.BeginUpdateResource(filename, 0)
     for res_name in resources.keys():
         for res_lang in resources[res_name].keys():
-            win32api.UpdateResource(module_handle, res_type, res_name, data, language=res_lang)
+            win32api.UpdateResource(module_handle, res_type, res_name, data, res_lang)
     win32api.EndUpdateResource(module_handle, 0)
 
 


### PR DESCRIPTION
Pass the resource language as a regular (positional) argument instead of a keyword argument, to decrease chances of provoking inexplicable issue from #8038.

Closes #8038.