### PR TITLE
analysis: automatically exclude  macOS .DS_Store files

### DIFF
--- a/PyInstaller/building/build_main.py
+++ b/PyInstaller/building/build_main.py
@@ -826,6 +826,15 @@ class Analysis(Target):
             else:
                 self.datas.append(entry)
 
+        # On macOS, the Finder app seems to litter visited directories with `.DS_Store` files. These cause issues with
+        # codesigning when placed in mixed-content directories, where our .app bundle generator cross-links data files
+        # from `Resources` to `Frameworks` tree, and the `codesign` utility explicitly forbids a `.DS_Store` file to be
+        # a symbolic link.
+        # But there is no reason for `.DS_Store` files to be collected in the first place, so filter them out.
+        if is_darwin:
+            self.datas = [(dest_name, src_name, typecode) for dest_name, src_name, typecode in self.datas
+                          if os.path.basename(src_name) != '.DS_Store']
+
         # Write warnings about missing modules.
         self._write_warnings()
         # Write debug information about the graph

--- a/news/8042.bugfix.rst
+++ b/news/8042.bugfix.rst
@@ -1,0 +1,3 @@
+(macOS) Prevent collection of ``.DS_Store`` files, which might be present
+in build environment's package directories after user navigated them using
+the Finder app.


### PR DESCRIPTION
On macOS, have Analysis automatically filter `.DS_Store` files from `datas` TOC list. These files might be present in package directories as result of user navigating them in the Finder app.

The `.DS_Store` files are treated as data files, so when placed in a mixed-content directory (i.e., next to binaries), the `BUNDLE` generator cross-links them from `Resources` to `Frameworks` directory tree in the .app bundle. This, however, causes `codesign` to raise the following error: `.DS_Store files cannot be a symlink`.

Since we have no reason to be collecting Finder's `.DS_Store` files in the first place, filter them out at the end of analysis.