### PR TITLE
analysis: warn about binaries with invalid macOS SDK version

### DIFF
--- a/news/8043.feature.rst
+++ b/news/8043.feature.rst
@@ -1,0 +1,4 @@
+(macOS) At the end of analysis, verify the macOS SDK version reported
+by binaries to be collected, and warn when the version is either invalid
+(0.0.0) or too low (< 10.9.0). Such binaries will likely cause issues
+with code-signing and hardened runtime.


### PR DESCRIPTION
At the end of analysis, verify the macOS SDK version reported by binaries to be collected, and warn when the version is lower than 10.9.0 (this includes cases when version is invalid, i.e., 0.0.0).

According to https://developer.apple.com/forums/thread/132526, hardened runtime requires at least macOS 10.9.0 SDK, so we should warn users about binaries that are expected to cause problems with codesigning and hardened runtime.