### PR TITLE
building: add .py suffix to entry-point scripts without suffix

### DIFF
--- a/PyInstaller/building/utils.py
+++ b/PyInstaller/building/utils.py
@@ -523,6 +523,15 @@ def get_code_object(modname, filename):
             with open(filename, 'rb') as f:
                 source = f.read()
 
+            # If entry-point script has no suffix, append .py when compiling the source. In POSIX builds, the executable
+            # has no suffix either; this causes issues with `traceback` module, as it tries to read the executable file
+            # when trying to look up the code for the entry-point script (when current working directory contains the
+            # executable).
+            _, ext = os.path.splitext(filename)
+            if not ext:
+                logger.debug("Appending .py to compiled entry-point name...")
+                filename += '.py'
+
             try:
                 code_object = compile(source, filename, 'exec')
             except SyntaxError:

--- a/news/8046.bugfix.rst
+++ b/news/8046.bugfix.rst
@@ -1,0 +1,10 @@
+If the entry-point script has no suffix, append the ``.py`` suffix
+to the filename passed to the ``compile`` function when byte-compiling
+the script for collection. This ensures that the entry-point script
+filename never coincides with executable filename, especially in POSIX
+builds, where executables have no suffix either (and their name is based
+on the entry-point script basename by default). Entry-point script having
+the same filename as the executable causes issues when ``traceback``
+(and ``linecache``) try to access source code for it, an in the process
+end up reading the executable file if it happens to be in the current
+working directory.


### PR DESCRIPTION
If the entry-point script has no suffix, append the `.py` suffix to the filename passed to the `compile` function when byte-compiling the script for collection.

This ensures that the entry-point script filename never coincides with executable filename, especially in POSIX builds, where executables have no suffix either (and their name is based on the entry-point script basename by default). Entry-point script having the same filename as the executable causes issues when `traceback` (and `linecache`) try to access source code for it, an in the process end up reading the executable file if it happens to be in the current working directory.

Fixes #8046.