### PR TITLE
hooks: exclude docutils from distutils.command.check

### DIFF
--- a/PyInstaller/hooks/hook-distutils.command.check.py
+++ b/PyInstaller/hooks/hook-distutils.command.check.py
@@ -1,0 +1,13 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2023, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+# Conditionally imported in this module; should not trigger collection.
+excludedimports = ['docutils']

--- a/PyInstaller/hooks/hook-setuptools._distutils.command.check.py
+++ b/PyInstaller/hooks/hook-setuptools._distutils.command.check.py
@@ -1,0 +1,13 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2023, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+# Conditionally imported in this module; should not trigger collection.
+excludedimports = ['docutils']

--- a/news/8053.hooks.rst
+++ b/news/8053.hooks.rst
@@ -1,0 +1,4 @@
+Add hooks for ``distutils.command.check`` and
+``setuptools._distutils.command.check`` that prevent unnecessary
+collection of ``docutils`` (which in turn triggers collection of
+``pygments``, ``PIL``, etc.).


### PR DESCRIPTION
Add hooks for `distutils.command.check` from stdlib and `setuptools` (`setuptools._distutils.command.check`) that exclude conditionally-imported `docutils`.

The latter is quite heavy-weight, as it triggers collection of various modules from `pygments` and `PIL`; so try avoiding its collection if not necessary.

See:

https://github.com/python/cpython/blob/v3.8.0/Lib/distutils/command/check.py#L8-L34

https://github.com/pypa/setuptools/blob/v68.2.2/setuptools/_distutils/command/check.py#L10-L36