### PR TITLE
tests: repin PyQt6 packages to v6.6.0

### DIFF
--- a/tests/functional/test_qt.py
+++ b/tests/functional/test_qt.py
@@ -498,6 +498,10 @@ def test_Qt_QtWebEngineWidgets_PyQt6(pyi_builder):
 
 @requires('PyQt6 >= 6.2.2')
 @requires('PyQt6-WebEngine')  # NOTE: base Qt6 must be 6.2.2 or newer, QtWebEngine can be older
+@pytest.mark.skipif(
+    check_requirement('PyQt6 == 6.6.0'),
+    reason='PyQt6 6.6.0 PyPI wheels are missing Qt6WebChannelQuick shared library.'
+)
 def test_Qt_QtWebEngineQuick_PyQt6(pyi_builder):
     _test_Qt_QtWebEngineQuick(pyi_builder, 'PyQt6')
 

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -41,13 +41,13 @@ PyQtPurchasing==5.15.5
 QScintilla==2.14.1
 PyQtWebEngine==5.15.6
 # PyQt6 and add-on packages
-PyQt6==6.5.3
-PyQt6-3D==6.5.0
-PyQt6-Charts==6.5.0
-PyQt6-DataVisualization==6.5.0
-PyQt6-NetworkAuth==6.5.0
+PyQt6==6.6.0
+PyQt6-3D==6.6.0
+PyQt6-Charts==6.6.0
+PyQt6-DataVisualization==6.6.0
+PyQt6-NetworkAuth==6.6.0
 PyQt6-QScintilla==2.14.1
-PyQt6-WebEngine==6.5.0
+PyQt6-WebEngine==6.6.0
 python-dateutil==2.8.2
 pytz==2023.3.post1
 requests==2.31.0


### PR DESCRIPTION
xfail the `test_Qt_QtWebEngineQuick_PyQt6` due to PyPI wheels missing  the `Qt6WebChannelQuick` shared library, which became dependency of `Qt6WebEngineQuick` shared library with Qt6 6.6.0.