### PR TITLE
compat: load PyInstaller hooks via PEP451 exec_module

### DIFF
--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -23,6 +23,7 @@ import site
 import subprocess
 import sys
 import shutil
+import types
 
 from PyInstaller._shared_with_waf import _pyi_machine
 from PyInstaller.exceptions import ExecCommandFailed
@@ -623,7 +624,10 @@ getsitepackages = getattr(site, 'getsitepackages', getsitepackages)
 def importlib_load_source(name: str, pathname: str):
     # Import module from a file.
     mod_loader = importlib.machinery.SourceFileLoader(name, pathname)
-    return mod_loader.load_module()
+    mod = types.ModuleType(mod_loader.name)
+    mod.__file__ = mod_loader.get_filename()  # Some hooks require __file__ attribute in their namespace
+    mod_loader.exec_module(mod)
+    return mod
 
 
 # Patterns of module names that should be bundled into the base_library.zip to be available during bootstrap.

--- a/news/8031.bugfix.rst
+++ b/news/8031.bugfix.rst
@@ -1,0 +1,2 @@
+Load PyInstaller hooks using PEP451 ``importlib.abc.Loader.exec_module``
+instead of deprecated PEP302 ``importlib.abc.Loader.load_module``.


### PR DESCRIPTION
Use PEP451 `importlib.abc.Loader.exec_module` instead of deprecated `load_module` to load PyInstaller hooks. Fixes related deprecation warnings when running in python environment with warnings enabled.

Closes #8031.