### PR TITLE
setup.cfg: bump packaging requirement to >= 22.0

### DIFF
--- a/news/8061.bugfix.rst
+++ b/news/8061.bugfix.rst
@@ -1,0 +1,2 @@
+Bump the required ``packaging`` version to 22.0, which is required for
+proper handling of metadata that contains markers with ``extra``s.

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,7 +67,7 @@ install_requires =
     macholib >= 1.8 ; sys_platform == 'darwin'
     pyinstaller-hooks-contrib >= 2021.4
     importlib_metadata >= 4.6 ; python_version < "3.10"
-    packaging >= 20.0
+    packaging >= 22.0
 
 [options.packages.find]
 include =


### PR DESCRIPTION
Bump `packaging` requirement to `packaging >= 22.0`, as this version is required for proper handling of metadata that contains markers with `extra`.

See #8061.