### PR TITLE
bincache: update cache index after macOS-specific binary processing

### DIFF
--- a/PyInstaller/building/utils.py
+++ b/PyInstaller/building/utils.py
@@ -259,10 +259,6 @@ def process_collected_binary(
         logger.info("Executing: %s", " ".join(cmd))
         subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
-    # Update cache index
-    cache_index[cached_id] = src_digest
-    misc.save_py_data_struct(cache_index_file, cache_index)
-
     # On macOS, we need to modify the given binary's paths to the dependent libraries, in order to ensure they are
     # relocatable and always refer to location within the frozen application. Specifically, we make all dependent
     # library paths relative to @rpath, and set @rpath to point to the top-level application directory, relative to
@@ -299,6 +295,10 @@ def process_collected_binary(
             logger.debug("File %s failed optional architecture validation - collecting as-is!", src_name)
         except Exception as e:
             raise SystemError(f"Failed to process binary {cached_name!r}!") from e
+
+    # Update cache index
+    cache_index[cached_id] = src_digest
+    misc.save_py_data_struct(cache_index_file, cache_index)
 
     return cached_name
 

--- a/news/8068.bugfix.rst
+++ b/news/8068.bugfix.rst
@@ -1,0 +1,9 @@
+(macOS) Fix the bug in binary processing and caching that would update
+the binary cache index before performing macOS-specific processing
+(architecture validation, path rewriting). If, for example, architecture
+validation failed during a build, subsequent build attempts with
+enabled binary cache (i.e., without the :option:`--clean` option) would
+pick up the partially-processed binary file from the cache, bypassing the
+architecture validation. NOTE: the existing binary caches need to be
+purged manually (using :option:`--clean` option once) for the fix to take
+effect!


### PR DESCRIPTION
Due to an oversight, the cache index is currently updated before the macOS-specific binary processing. So if this part raises an error (either path rewriting fails, or binary architecture validation raises an exception), the subsequent build attempts that do not clear the cache (via the `--clean` option) end up picking the partially-processed binary from the cache.

So move the update of cache index to the very end of the `process_collected_binary` function, where it should have been in the first place.

Fixes #8068. The fix is *not* applied retroactively to existing bincache, so manual purge using `--clean` is required.