### PR TITLE
Improve speed of pkgutil.iter_module

### DIFF
--- a/PyInstaller/loader/pyimod02_importers.py
+++ b/PyInstaller/loader/pyimod02_importers.py
@@ -429,10 +429,9 @@ class PyiFrozenResourceReader:
     """
     Resource reader for importlib.resources / importlib_resources support.
 
-    Currently supports only on-disk resources (support for resources from the embedded archive is missing).
-    However, this should cover the typical use cases (access to data files), as PyInstaller collects data files onto
-    filesystem, and only .pyc modules are collected into embedded archive. One exception are resources collected from
-    zipped eggs (which end up collected into embedded archive), but those should be rare anyway.
+    Supports only on-disk resources, which should cover the typical use cases, i.e., the access to data files;
+    PyInstaller collects data files onto filesystem, and as of v6.0.0, the embedded PYZ archive is guaranteed
+    to contain only .pyc modules.
 
     When listing resources, source .py files will not be listed as they are not collected by default. Similarly,
     sub-directories that contained only .py files are not reconstructed on filesystem, so they will not be listed,

--- a/news/8058.bugfix.rst
+++ b/news/8058.bugfix.rst
@@ -1,0 +1,2 @@
+Improve speed of ``pkgutil.iter_modules`` override, especially in cases
+when the function is called multiple times.

--- a/tests/functional/test_importlib_resources.py
+++ b/tests/functional/test_importlib_resources.py
@@ -26,7 +26,7 @@ import shutil
 import pytest
 
 from PyInstaller.utils.tests import skipif
-from PyInstaller.compat import is_py39, exec_python, exec_python_rc
+from PyInstaller.compat import is_darwin, is_py39, exec_python, exec_python_rc
 from PyInstaller.utils.hooks import check_requirement
 
 # Directory with testing modules used in some tests.
@@ -94,9 +94,12 @@ def test_importlib_resources_frozen(pyi_builder, package_type, tmpdir, script_di
     pathex = __get_test_package_path(package_type, tmpdir, monkeypatch)
     test_script = 'pyi_importlib_resources.py'
     hooks_dir = os.path.join(_MODULES_DIR, 'pyi_pkg_resources_provider', 'hooks')
+    pyi_args = ['--paths', pathex, '--hidden-import', 'pyi_pkgres_testpkg', '--additional-hooks-dir', hooks_dir]
+    if is_darwin:
+        pyi_args += ['--windowed']  # Also build and test .app bundle executable
     pyi_builder.test_script(
         test_script,
-        pyi_args=['--paths', pathex, '--hidden-import', 'pyi_pkgres_testpkg', '--additional-hooks-dir', hooks_dir]
+        pyi_args=pyi_args,
     )
 
 
@@ -122,6 +125,9 @@ def test_importlib_resources_namespace_package_data_files(pyi_builder, as_packag
         hidden_imports = ['--hidden-import', 'pyi_test_nspkg', '--hidden-import', 'pyi_test_nspkg.data']
     else:
         hidden_imports = ['--hidden-import', 'pyi_test_nspkg']
+    pyi_args = ['--paths', pathex, *hidden_imports, '--additional-hooks-dir', hooks_dir]
+    if is_darwin:
+        pyi_args += ['--windowed']  # Also build and test .app bundle executable
     pyi_builder.test_source(
         """
         import importlib
@@ -150,5 +156,5 @@ def test_importlib_resources_namespace_package_data_files(pyi_builder, as_packag
         data_dir = importlib_resources.files("pyi_test_nspkg.data")
         assert (data_dir / "data_file1.txt").is_file()
         """,
-        pyi_args=['--paths', pathex, *hidden_imports, '--additional-hooks-dir', hooks_dir]
+        pyi_args=pyi_args,
     )

--- a/tests/functional/test_pkg_resources_provider.py
+++ b/tests/functional/test_pkg_resources_provider.py
@@ -21,7 +21,7 @@
 import os
 
 from PyInstaller.utils.tests import importorskip
-from PyInstaller.compat import exec_python_rc
+from PyInstaller.compat import is_darwin, exec_python_rc
 
 # Directory with testing modules used in some tests.
 _MODULES_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'modules')
@@ -54,7 +54,10 @@ def test_pkg_resources_provider_frozen(pyi_builder, tmpdir, script_dir, monkeypa
     pathex = os.path.join(_MODULES_DIR, 'pyi_pkg_resources_provider', 'package')
     test_script = 'pyi_pkg_resources_provider.py'
     hooks_dir = os.path.join(_MODULES_DIR, 'pyi_pkg_resources_provider', 'hooks')
+    pyi_args = ['--paths', pathex, '--hidden-import', 'pyi_pkgres_testpkg', '--additional-hooks-dir', hooks_dir]
+    if is_darwin:
+        pyi_args += ['--windowed']  # Also build and test .app bundle executable
     pyi_builder.test_script(
         test_script,
-        pyi_args=['--paths', pathex, '--hidden-import', 'pyi_pkgres_testpkg', '--additional-hooks-dir', hooks_dir]
+        pyi_args=pyi_args,
     )


### PR DESCRIPTION
Improve speed of `pkgutil.iter_modules` override, especially in cases when the function is called multiple times. See #8058.

The main idea is to move the entry comparison from path space back into module-name space, which has less overhead. In addition, we now use prefix tree to avoid always iterating over the whole PYZ TOC. The prefix tree is computed (on-demand) and cached by `PyiFrozenImporter`.

This allows us to also simplify the `pkg_resources` run-time hook, which was already computing prefix trees for its resources provider; now, it can use the prefix tree from `PyiFrozenImporter`.

Update various comments in run-time hooks pertaining embedded resources, to reflect the fact that PYZ can now contain only .pyc modules (no more data files).