### PR TITLE
rth_utils: add is_macos_app_bundle flag

### DIFF
--- a/PyInstaller/fake-modules/_pyi_rth_utils/__init__.py
+++ b/PyInstaller/fake-modules/_pyi_rth_utils/__init__.py
@@ -8,3 +8,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # -----------------------------------------------------------------------------
+
+import sys
+
+# A boolean indicating whether the frozen application is a macOS .app bundle.
+is_macos_app_bundle = sys.platform == 'darwin' and sys._MEIPASS.endswith("Contents/Frameworks")

--- a/PyInstaller/hooks/rthooks/pyi_rth_pkgutil.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_pkgutil.py
@@ -29,6 +29,7 @@ def _pyi_rthook():
     import sys
 
     from pyimod02_importers import PyiFrozenImporter
+    from _pyi_rth_utils import is_macos_app_bundle
 
     _orig_pkgutil_iter_modules = pkgutil.iter_modules
 
@@ -59,10 +60,8 @@ def _pyi_rthook():
 
             # For macOS .app bundles, the "true" sys._MEIPASS is `name.app/Contents/Frameworks`, but due to
             # cross-linking, we must also consider `name.app/Contents/Resources`. See #7884.
-            is_macos_app_bundle = False
-            if sys.platform == 'darwin' and sys._MEIPASS.endswith("Contents/Frameworks"):
+            if is_macos_app_bundle:
                 ALT_MEIPASS = (pathlib.Path(sys._MEIPASS).parent / "Resources").resolve()
-                is_macos_app_bundle = True
 
             # Process all given paths
             seen_pkg_prefices = set()

--- a/PyInstaller/hooks/rthooks/pyi_rth_pyqt5.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_pyqt5.py
@@ -17,6 +17,8 @@ def _pyi_rthook():
     import os
     import sys
 
+    from _pyi_rth_utils import is_macos_app_bundle
+
     # Try PyQt5 5.15.4-style path first...
     pyqt_path = os.path.join(sys._MEIPASS, 'PyQt5', 'Qt5')
     if not os.path.isdir(pyqt_path):
@@ -25,7 +27,7 @@ def _pyi_rthook():
 
     os.environ['QT_PLUGIN_PATH'] = os.path.join(pyqt_path, 'plugins')
 
-    if sys.platform == 'darwin' and sys._MEIPASS.endswith("Contents/Frameworks"):
+    if is_macos_app_bundle:
         # Special handling for macOS .app bundles. To satisfy codesign requirements, we are forced to split `qml`
         # directory into two parts; one that keeps only binaries (rooted in `Contents/Frameworks`) and one that keeps
         # only data files (rooted in `Contents/Resources), with files from one directory tree being symlinked to the

--- a/PyInstaller/hooks/rthooks/pyi_rth_pyqt6.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_pyqt6.py
@@ -17,6 +17,8 @@ def _pyi_rthook():
     import os
     import sys
 
+    from _pyi_rth_utils import is_macos_app_bundle
+
     # Try PyQt6 6.0.3-style path first...
     pyqt_path = os.path.join(sys._MEIPASS, 'PyQt6', 'Qt6')
     if not os.path.isdir(pyqt_path):
@@ -25,7 +27,7 @@ def _pyi_rthook():
 
     os.environ['QT_PLUGIN_PATH'] = os.path.join(pyqt_path, 'plugins')
 
-    if sys.platform == 'darwin' and sys._MEIPASS.endswith("Contents/Frameworks"):
+    if is_macos_app_bundle:
         # Special handling for macOS .app bundles. To satisfy codesign requirements, we are forced to split `qml`
         # directory into two parts; one that keeps only binaries (rooted in `Contents/Frameworks`) and one that keeps
         # only data files (rooted in `Contents/Resources), with files from one directory tree being symlinked to the

--- a/PyInstaller/hooks/rthooks/pyi_rth_pyside2.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_pyside2.py
@@ -17,6 +17,8 @@ def _pyi_rthook():
     import os
     import sys
 
+    from _pyi_rth_utils import is_macos_app_bundle
+
     if sys.platform.startswith('win'):
         pyqt_path = os.path.join(sys._MEIPASS, 'PySide2')
     else:
@@ -24,7 +26,7 @@ def _pyi_rthook():
 
     os.environ['QT_PLUGIN_PATH'] = os.path.join(pyqt_path, 'plugins')
 
-    if sys.platform == 'darwin' and sys._MEIPASS.endswith("Contents/Frameworks"):
+    if is_macos_app_bundle:
         # Special handling for macOS .app bundles. To satisfy codesign requirements, we are forced to split `qml`
         # directory into two parts; one that keeps only binaries (rooted in `Contents/Frameworks`) and one that keeps
         # only data files (rooted in `Contents/Resources), with files from one directory tree being symlinked to the

--- a/PyInstaller/hooks/rthooks/pyi_rth_pyside6.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_pyside6.py
@@ -17,6 +17,8 @@ def _pyi_rthook():
     import os
     import sys
 
+    from _pyi_rth_utils import is_macos_app_bundle
+
     if sys.platform.startswith('win'):
         pyqt_path = os.path.join(sys._MEIPASS, 'PySide6')
     else:
@@ -24,7 +26,7 @@ def _pyi_rthook():
 
     os.environ['QT_PLUGIN_PATH'] = os.path.join(pyqt_path, 'plugins')
 
-    if sys.platform == 'darwin' and sys._MEIPASS.endswith("Contents/Frameworks"):
+    if is_macos_app_bundle:
         # Special handling for macOS .app bundles. To satisfy codesign requirements, we are forced to split `qml`
         # directory into two parts; one that keeps only binaries (rooted in `Contents/Frameworks`) and one that keeps
         # only data files (rooted in `Contents/Resources), with files from one directory tree being symlinked to the


### PR DESCRIPTION
Centralize the logic for detection of macOS .app bundle in `_pyi_rth_utils`, which now provides a `is_macos_app_bundle` flag for run-time hooks to use.