### PR TITLE
building: fix marshal error during DLL search path extension

### DIFF
--- a/PyInstaller/building/build_main.py
+++ b/PyInstaller/building/build_main.py
@@ -201,7 +201,9 @@ def find_binary_dependencies(binaries, import_packages):
             """
             import os
 
-            dll_directories = os._added_dll_directories
+            # `os.add_dll_directory` might be called with a `pathlib.Path`, which cannot be marhsalled out of the helper
+            # process. So explicitly convert all entries to strings.
+            dll_directories = [str(path) for path in os._added_dll_directories]
 
             orig_path = set(os._original_path_env.split(os.pathsep))
             modified_path = os.environ.get('PATH', '').split(os.pathsep)

--- a/news/8081.bugfix.rst
+++ b/news/8081.bugfix.rst
@@ -1,0 +1,3 @@
+(Windows) Fix marshal error at the start of binary dependency analysis,
+caused by inferred DLL search path ending up an instance of
+``pathlib.Path`` instead of ``str``.


### PR DESCRIPTION
Explicitly convert all DLL search paths obtained via capture of the `os.add_dll_directory` calls to strings. The `add_dll_directory` might be called with `pathlib.Path` paths, which cannot be marshalled out of the child process in which we import packages and track the search path modifications.

Fixes #8081.