### PR TITLE
hookutils: fix pre-release matching in check_requirement / is_module_satisfies

### DIFF
--- a/PyInstaller/utils/hooks/__init__.py
+++ b/PyInstaller/utils/hooks/__init__.py
@@ -406,8 +406,9 @@ def check_requirement(requirement: str):
     if not parsed_requirement.specifier:
         return True
 
-    # Parse specifier, and compare version
-    return version in parsed_requirement.specifier
+    # Parse specifier, and compare version. Enable pre-release matching,
+    # because we need "package >= 2.0.0" to match "2.5.0b1".
+    return parsed_requirement.specifier.contains(version, prereleases=True)
 
 
 # Keep the `is_module_satisfies` as an alias for backwards compatibility with existing hooks. The old fallback

--- a/news/8093.bugfix.rst
+++ b/news/8093.bugfix.rst
@@ -1,0 +1,6 @@
+Fix matching of pre-release versions in
+:func:`PyInstaller.utils.hooks.check_requirement` and
+:func:`PyInstaller.utils.hooks.is_module_satisfies`. Both functions now
+match pre-release versions, which restores the behavior of the old
+``pkg_resources``-based implementation from PyInstaller < 6.0
+that is implicitly expected by existing hooks.


### PR DESCRIPTION
Fix `check_requirement` to allow matching of pre-release versions, and have it match pre-release versions by default.

Similarly, have `is_module_satisfies` call `check_requirement` with pre-release matching enabled, to match behavior of old `pkg_resources`-based implementation, which is what existing hooks implicitily expect.

See https://github.com/pyinstaller/pyinstaller-hooks-contrib/pull/663