### PR TITLE
bootloader: set PyConfig.install_signal_handlers=1

### DIFF
--- a/bootloader/src/pyi_pyconfig.c
+++ b/bootloader/src/pyi_pyconfig.c
@@ -604,6 +604,14 @@ pyi_pyconfig_set_runtime_options(PyConfig *config, const PyiRuntimeOptions *runt
                 return -1; \
             } \
         } \
+        /* Set install_signal_handlers to match behavior of bootloader from PyInstaller 5.x and earlier.
+         * There, interpreter was initialized via Py_Initialize(), which in turn calls Py_InitializeEx(1),
+         * i.e., with initsigs=1). Failing to install signal handlers leads to problems with `time.sleep()`
+         * on Python <= 3.8.6 and Python 3.9.0 under Windows; see:
+         * https://github.com/pyinstaller/pyinstaller/issues/8104
+         * https://bugs.python.org/issue41686
+         */ \
+        config_impl->install_signal_handlers = 1; \
         return 0; \
     }
     /* Macro end */

--- a/news/8104.bugfix.rst
+++ b/news/8104.bugfix.rst
@@ -1,0 +1,2 @@
+(Windows) Fix issue with non-functional ``time.sleep()`` when building
+program with Python <= 3.8.6 or Python 3.9.0.

--- a/news/8105.bootloader.rst
+++ b/news/8105.bootloader.rst
@@ -1,0 +1,5 @@
+When setting up embedded Python interpreter configuration, set
+``PyConfig.install_signal_handlers=1`` to install signal handlers.
+This matches the behavior of PyInstaller 5.x bootloaders, where interpreter
+was initialized via ``Py_Initialize()``, which in turn calls
+``Py_InitializeEx(1)``, i.e., with ``install_sigs=1``.


### PR DESCRIPTION
When setting up embedded Python interpreter configuration, set `PyConfig.install_signal_handlers=1` to install signal handlers. This matches the behavior of PyInstaller 5.x bootloaders, where interpreter was initialized via ``Py_Initialize()``, which in turn calls `Py_InitializeEx(1)`, i.e., with `install_sigs=1`.

Failing to install signal handlers leads to problems with `time.sleep()` in Windows applications built with Python <= 3.8.6 or Python 3.9.0 (https://bugs.python.org/issue41686).

Fixes #8104.