### PR TITLE
bootloader: make pyi_arch_find_by_name case-insensitive on Windows

### DIFF
--- a/bootloader/src/pyi_archive.c
+++ b/bootloader/src/pyi_archive.c
@@ -663,9 +663,9 @@ pyi_arch_find_by_name(const ARCHIVE_STATUS *status, const char *name)
     const TOC *ptoc = status->tocbuff;
 
     while (ptoc < status->tocend) {
-#ifdef WIN32
-        /* On Windows, we must perform case-insensitive comparison for
-         * extractable entries. */
+#if defined(_WIN32) || defined(__APPLE__)
+        /* On Windows and macOS, use case-insensitive comparison to
+         * simulate case-insensitive filesystem for extractable entries. */
         if (_pyi_arch_is_extractable(ptoc)) {
             if (strcasecmp(ptoc->name, name) == 0) {
                 return ptoc;

--- a/bootloader/src/pyi_global.h
+++ b/bootloader/src/pyi_global.h
@@ -254,6 +254,11 @@ void mbvs(const char *fmt, ...);
     #define pyi_ftell ftello
 #endif
 
+/* MSVC provides _stricmp() in-lieu of POSIX strcasecmp() */
+#if defined(_WIN32) && defined(_MSC_VER)
+    #define strcasecmp(string1, string2) _stricmp(string1, string2)
+#endif
+
 /* Byte-order conversion macros */
 #ifdef _WIN32
     /* On Windows, use compiler specific functions/macros to avoid

--- a/bootloader/src/pyi_launch.c
+++ b/bootloader/src/pyi_launch.c
@@ -167,7 +167,12 @@ _extract_dependency_from_archive(ARCHIVE_STATUS *status, const char *filename)
     VS("LOADER: Extracting dependency %s from archive\n", filename);
 
     while (ptoc < status->tocend) {
+#ifdef WIN32
+        /* On Windows, use case-insensitive comparison, just in case... */
+        if (strcasecmp(ptoc->name, filename) == 0) {
+#else
         if (strcmp(ptoc->name, filename) == 0) {
+#endif
             return pyi_arch_extract2fs(status, ptoc);
         }
         ptoc = pyi_arch_increment_toc_ptr(status, ptoc);

--- a/bootloader/src/pyi_launch.c
+++ b/bootloader/src/pyi_launch.c
@@ -167,8 +167,9 @@ _extract_dependency_from_archive(ARCHIVE_STATUS *status, const char *filename)
     VS("LOADER: Extracting dependency %s from archive\n", filename);
 
     while (ptoc < status->tocend) {
-#ifdef WIN32
-        /* On Windows, use case-insensitive comparison, just in case... */
+#if defined(_WIN32) || defined(__APPLE__)
+        /* On Windows and macOS, use case-insensitive comparison to
+         * simulate case-insensitive filesystem... */
         if (strcasecmp(ptoc->name, filename) == 0) {
 #else
         if (strcmp(ptoc->name, filename) == 0) {

--- a/news/8103.bugfix.rst
+++ b/news/8103.bugfix.rst
@@ -1,0 +1,4 @@
+(Windows) Fix issue with splash screen in ``onefile`` mode failing to
+extract ``VCRUNTIME140.dll`` from the archive due to character-case
+mismatch. We now perform case-insensitive comparison between the name
+listed in splash dependency list and the names in archive TOC.


### PR DESCRIPTION
Make `pyi_arch_find_by_name` archive helper case-insensitive on Windows for TOC entries that correspond to extractable files (e.g., BINARY, DATA, DEPENDENCY).

This fixes splash screen in onefile mode failing to find `VCRUNTIME140.dll` (as listed in the splash dependency list) in the archive, where it may be listed as `vcruntime140.dll`.

Fixes #8103.