### PR TITLE
building: MERGE: fix symlink bookkeeping

### DIFF
--- a/news/8124.bugfix.rst
+++ b/news/8124.bugfix.rst
@@ -1,0 +1,4 @@
+Fix symbolic link tracking in ``MERGE`` processing, so that distinct
+symbolic links with same relative target (e.g. ``Current -> A``
+symbolic links in Qt .framework bundles collected on macOS) are properly
+processed, and kept in the original TOC upon their first occurrence.


### PR DESCRIPTION
Implement separate bookkeeping for SYMLINK entries in the MERGE processing. With symlinks, we must track `(dest_path, src_path)` pairs instead of just `src_path`, because the `src_path` encodes the relative link destination, and might appear multiple times in different context. For example, on macOS, each Qt .framework bundle has a symlink `Current -> A`.

So if the bookkeeping is done only based on `src_path`, only one .framework bundle in first `Analysis` (where these bundles occur) retains its symlink in the `binaries`/`datas` TOC, while the rest are moved into `dependencies` TOC. This means that such executable unncessarily gains onefile copy/extraction semantics if `dependencies` are properly set to `EXE` (if it was originally a onedir executable); on the other hand, if `dependencies` are not passed on to `EXE` (mis-use of `MERGE`), the symlinks would end up missing in the otherwise unchanged executable.

Closes #8120.