### PR TITLE
building: retry mechanism: enable retry on winerror 110

### DIFF
--- a/news/8138.bugfix.rst
+++ b/news/8138.bugfix.rst
@@ -1,0 +1,3 @@
+(Windows) Add Windows error code 110 (``ERROR_OPEN_FAILED``) to the
+list of error codes eligible for the retry mechanism that attempts to
+mitigate build failures due to anti-virus program interference.


### PR DESCRIPTION
Add winerror 110 (`ERROR_OPEN_FAILED`) to the list of permissible error codes for the retry mechanism that attempts to mitigate build failures due to anti-virus program interference.

At the same time, reorganize the exception-checking code by merging all Windows specific code into a single branch. This allows us to re-use `_ALLOWED_WINERROR` with both `pywintypes.error` and `OSError`. With the latter, we now compare the `winerror` attribute as a fall back after `errno` comparison.

Closes #8138.