### PR TITLE
pre-safe-import-hooks: gracefully handle cases when six is unavailable

### DIFF
--- a/PyInstaller/hooks/pre_safe_import_module/hook-setuptools.extern.six.moves.py
+++ b/PyInstaller/hooks/pre_safe_import_module/hook-setuptools.extern.six.moves.py
@@ -26,13 +26,14 @@ def pre_safe_import_module(api):
             try:
                 import setuptools.extern.six as six
             except ImportError:
-                return {}  # unavailable
+                return None  # unavailable
 
         return {
             moved.mod: 'setuptools.extern.six.moves.' + moved.name
             for moved in six._moved_attributes if isinstance(moved, (six.MovedModule, six.MovedAttribute))
         }
 
-    api.add_runtime_package(api.module_name)
-    for real_module_name, six_module_name in real_to_six_module_name.items():
-        api.add_alias_module(real_module_name, six_module_name)
+    if real_to_six_module_name is not None:
+        api.add_runtime_package(api.module_name)
+        for real_module_name, six_module_name in real_to_six_module_name.items():
+            api.add_alias_module(real_module_name, six_module_name)

--- a/PyInstaller/hooks/pre_safe_import_module/hook-setuptools.extern.six.moves.py
+++ b/PyInstaller/hooks/pre_safe_import_module/hook-setuptools.extern.six.moves.py
@@ -23,7 +23,10 @@ def pre_safe_import_module(api):
         try:
             import setuptools._vendor.six as six
         except ImportError:
-            import setuptools.extern.six as six
+            try:
+                import setuptools.extern.six as six
+            except ImportError:
+                return {}  # unavailable
 
         return {
             moved.mod: 'setuptools.extern.six.moves.' + moved.name

--- a/PyInstaller/hooks/pre_safe_import_module/hook-six.moves.py
+++ b/PyInstaller/hooks/pre_safe_import_module/hook-six.moves.py
@@ -36,7 +36,7 @@ def pre_safe_import_module(api):
         try:
             import six
         except ImportError:
-            return {}  # unavailable
+            return None  # unavailable
 
         # Iterate over the "six._moved_attributes" list rather than the "six._importer.known_modules" dictionary, as
         # "urllib"-specific moved modules are overwritten in the latter with unhelpful "LazyModule" objects. If this is
@@ -56,6 +56,7 @@ def pre_safe_import_module(api):
     # * Attributes imported from packages could be submodules. To disambiguate non-ignorable submodules from ignorable
     #   non-submodules (e.g., classes, variables), ModuleGraph first attempts to import these attributes as submodules.
     #   This is exactly what we want.
-    api.add_runtime_package(api.module_name)
-    for real_module_name, six_module_name in real_to_six_module_name.items():
-        api.add_alias_module(real_module_name, six_module_name)
+    if real_to_six_module_name is not None:
+        api.add_runtime_package(api.module_name)
+        for real_module_name, six_module_name in real_to_six_module_name.items():
+            api.add_alias_module(real_module_name, six_module_name)

--- a/PyInstaller/hooks/pre_safe_import_module/hook-six.moves.py
+++ b/PyInstaller/hooks/pre_safe_import_module/hook-six.moves.py
@@ -33,7 +33,10 @@ def pre_safe_import_module(api):
         Generate a dictionary from conventional module names to "six.moves" attribute names (e.g., from `tkinter.tix` to
         `six.moves.tkinter_tix`).
         """
-        import six
+        try:
+            import six
+        except ImportError:
+            return {}  # unavailable
 
         # Iterate over the "six._moved_attributes" list rather than the "six._importer.known_modules" dictionary, as
         # "urllib"-specific moved modules are overwritten in the latter with unhelpful "LazyModule" objects. If this is
@@ -53,8 +56,6 @@ def pre_safe_import_module(api):
     # * Attributes imported from packages could be submodules. To disambiguate non-ignorable submodules from ignorable
     #   non-submodules (e.g., classes, variables), ModuleGraph first attempts to import these attributes as submodules.
     #   This is exactly what we want.
-    if isinstance(real_to_six_module_name, str):
-        raise SystemExit("pre-safe-import-module hook failed, needs fixing.")
     api.add_runtime_package(api.module_name)
     for real_module_name, six_module_name in real_to_six_module_name.items():
         api.add_alias_module(real_module_name, six_module_name)

--- a/PyInstaller/hooks/pre_safe_import_module/hook-urllib3.packages.six.moves.py
+++ b/PyInstaller/hooks/pre_safe_import_module/hook-urllib3.packages.six.moves.py
@@ -21,13 +21,14 @@ def pre_safe_import_module(api):
         try:
             import urllib3.packages.six as six
         except ImportError:
-            return {}  # unavailable
+            return None  # unavailable
 
         return {
             moved.mod: 'urllib3.packages.six.moves.' + moved.name
             for moved in six._moved_attributes if isinstance(moved, (six.MovedModule, six.MovedAttribute))
         }
 
-    api.add_runtime_package(api.module_name)
-    for real_module_name, six_module_name in real_to_six_module_name.items():
-        api.add_alias_module(real_module_name, six_module_name)
+    if real_to_six_module_name is not None:
+        api.add_runtime_package(api.module_name)
+        for real_module_name, six_module_name in real_to_six_module_name.items():
+            api.add_alias_module(real_module_name, six_module_name)

--- a/PyInstaller/hooks/pre_safe_import_module/hook-urllib3.packages.six.moves.py
+++ b/PyInstaller/hooks/pre_safe_import_module/hook-urllib3.packages.six.moves.py
@@ -18,7 +18,10 @@ from PyInstaller import isolated
 def pre_safe_import_module(api):
     @isolated.call
     def real_to_six_module_name():
-        import urllib3.packages.six as six
+        try:
+            import urllib3.packages.six as six
+        except ImportError:
+            return {}  # unavailable
 
         return {
             moved.mod: 'urllib3.packages.six.moves.' + moved.name

--- a/news/8145.bugfix.rst
+++ b/news/8145.bugfix.rst
@@ -1,0 +1,4 @@
+Fix pre-safe-import hooks for ``six.moves``, ``urllib3.packages.six.moves``,
+and ``setuptools.extern.six.moves`` to gracefully handle cases when the
+corresponding ``six`` package is unavailable, as the hook may end up
+being executed even in that case.


### PR DESCRIPTION
In pre-safe-import hooks that deal with `six` (or vendored `six`), gracefully handle the cases when the `six` module is unavailable.

In general, the pre-safe-import hooks might end up being called for non-existent modules, and the hooks need to account for that (even though the behavior seems to depend on how the missing module is imported).

For example, a program with a duplicated import,

```
import six.moves
import six.moves
```

seems to end up triggerring the `six.moves` pre-safe-import hook on the second import. The same happens in more complex scenarios where these imports are scattered across different modules.