### PR TITLE
Optimize binary vs. data reclassification on Linux

### DIFF
--- a/PyInstaller/building/build_main.py
+++ b/PyInstaller/building/build_main.py
@@ -636,6 +636,8 @@ class Analysis(Target):
         # their origin.
         combined_toc = normalize_toc(self.datas + self.binaries)
 
+        logger.info('Performing binary vs. data reclassification (%d entries)', len(combined_toc))
+
         self.datas = []
         self.binaries = []
 

--- a/news/8148.bugfix.rst
+++ b/news/8148.bugfix.rst
@@ -1,0 +1,4 @@
+(Linux) Optimize the automatic binary-vs-data classification by
+avoiding `objdump` based check on files that do not have ELF signature.
+This mitigates noticeably longer analysis times for projects with large
+number of (data) files.


### PR DESCRIPTION
Avoid running `objdump` on every file, as that becomes prohibitively costly for projects with a lot of (data) files.

First, perform a check for 4-byte ELF header to filter out most (if not all) data files; only then, validate the likely binary using `objdump` to ensure that it is a valid ELF file.