### PR TITLE
bindepend: suppress ldd warnings about lack of executable permissions

### DIFF
--- a/PyInstaller/depend/bindepend.py
+++ b/PyInstaller/depend/bindepend.py
@@ -338,6 +338,11 @@ def _get_imports_ldd(filename, search_paths):
         # telling us that those symbols are unfindable. These should be suppressed.
         elif line.startswith("Error relocating ") and line.endswith(" symbol not found"):
             continue
+        # Shared libraries should have the executable bits set; however, this is not the case for shared libraries
+        # shipped in PyPI wheels, which cause ldd to emit `ldd: warning: you do not have execution permission for ...`
+        # warnings. Suppress these.
+        elif line.startswith("ldd: warning: you do not have execution permission for "):
+            continue
         # Propagate any other warnings it might have.
         print(line, file=sys.stderr)
 


### PR DESCRIPTION
On linux, shared libraries typically have executable permissions set, and `ldd` displays a warning when this is not the case. Naturally, shared libraries shipped in PyPI wheels do not have executable bits set, which results in slew of `ldd` warnings during our binary dependency analysis. As the lack of executable permissions does not affect the analysis, suppress the warnings in the output.