### PR TITLE
rthooks: pkgutil: fix error when iter_modules is given a path to module

### DIFF
--- a/PyInstaller/hooks/rthooks/pyi_rth_pkgutil.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_pkgutil.py
@@ -99,7 +99,10 @@ def _pyi_rthook():
                 tree_node = importer.toc_tree
                 for pkg_name_part in pkg_prefix.parts:
                     tree_node = tree_node.get(pkg_name_part)
-                    if tree_node is None:
+                    if not isinstance(tree_node, dict):
+                        # This check handles two cases:
+                        #  a) path does not exist (`tree_node` is `None`)
+                        #  b) path corresponds to a module instead of a package (`tree_node` is a leaf node (`str`)).
                         tree_node = {}
                         break
 

--- a/PyInstaller/utils/hooks/django.py
+++ b/PyInstaller/utils/hooks/django.py
@@ -89,7 +89,7 @@ def django_dottedstring_imports(django_root_dir):
     if hasattr(settings, 'TEMPLATES'):
         for templ in settings.TEMPLATES:
             backend = _remove_class(templ['BACKEND'])
-            hiddenimports += backend
+            hiddenimports.append(backend)
             # Include context_processors.
             if hasattr(templ, 'OPTIONS'):
                 if hasattr(templ['OPTIONS'], 'context_processors'):

--- a/news/8191.bugfix.rst
+++ b/news/8191.bugfix.rst
@@ -1,0 +1,2 @@
+Fix ``pkgutil.iter_modules`` override to gracefully handle cases when
+the given path corresponds to a module instead of a package.


### PR DESCRIPTION
Fix the `iter_modules` override to gracefully handle cases when the given path corresponds to a module instead of a package. Fixes #8191.

Add tests that call `iter_modules` with path to a module and with path to sub-directory under the path to a module.

Fix the django hook utility function's handling of `BACKEND` field of `TEMPLATES` entries in `settings.py`, to prevent the module name from being split into individual letters and causing bunch of "Hidden import not found" warnings.