### PR TITLE
ci: bump the macOS runner from macos-11 to macos-12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.8, 3.9, '3.10', '3.11', '3.12']
-        os: ['windows-latest', 'ubuntu-22.04', 'macos-11']
+        os: ['windows-latest', 'ubuntu-22.04', 'macos-12']
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
@@ -140,11 +140,11 @@ jobs:
           Xvfb :99 &
           echo "DISPLAY=:99" >> $GITHUB_ENV
 
-      # Required on macOS 11 by tests that register custom URL schema. This could also be achieved by passing
+      # Required on macOS >= 11 by tests that register custom URL schema. This could also be achieved by passing
       # --basetemp to pytest, but using environment variable allows us to have a unified "Run test" step for
       # all OSes.
       - name: Relocate temporary dir
-        if: matrix.os == 'macos-11' || matrix.os == 'macos-latest'
+        if: startsWith(matrix.os, 'macos')
         run: |
           echo "PYTEST_DEBUG_TEMPROOT=$RUNNER_TEMP" >> $GITHUB_ENV
 


### PR DESCRIPTION
Bump the macOS CI runner from `macos-11` to `macos-12`, which has been `macos-latest` for a while now.

The actual motivation for this move is the fact that [`PyQt5-Qt5`](https://pypi.org/project/PyQt5-Qt5/) (and/or `PyQtWebEngine-Qt5`) 5.15.12 that were released on PyPI on 23rd December seem to break QtWebEngine on Big Sur (even in unfrozen programs). And pinning those to earlier versions would be kind of messy, because 5.15.12 and 5.15.11 have binary wheels only for macOS, while Windows and Linux are stuck on 5.15.2.