### PR TITLE
tests: split off the base part of requirements-tools.txt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,11 +118,11 @@ jobs:
           # Make sure the help options print.
           python -m PyInstaller -h
 
-      - name: Install test dependencies (tools)
+      - name: Install test dependencies (base tools)
         run: |
-          pip install --progress-bar=off --upgrade --requirement tests/requirements-tools.txt
+          pip install --progress-bar=off --upgrade --requirement tests/requirements-base.txt
 
-      - name: Install test dependencies (libraries)
+      - name: Install test dependencies (tools and libraries)
         if: ${{ !endsWith(matrix.python-version, '-dev') }}
         run: |
           pip install --progress-bar=off --upgrade --requirement tests/requirements-libraries.txt

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -29,6 +29,7 @@ RUN apk add linux-headers
 # Build/download wheels for all test requirements.
 RUN mkdir -p /io/tests
 WORKDIR /io
+COPY tests/requirements-base.txt tests/
 COPY tests/requirements-tools.txt tests/
 RUN pip wheel -r tests/requirements-tools.txt -w wheels
 

--- a/tests/requirements-base.txt
+++ b/tests/requirements-base.txt
@@ -1,0 +1,27 @@
+# This is the pip requirements file for running the
+# PyInstaller test-suite. It includes the base test tools, which should
+# be available also for pre-release python version.
+#
+# For the full set of requirements to run the test suite, see
+# requirements-tools.txt and requirements-libraries.txt.
+
+# Work-around for a bug in execnet 1.4.1
+execnet >= 1.5.0
+
+# Testing framework.
+pytest >= 2.7.3
+
+# Plugin allowing running tests in parallel.
+pytest-xdist
+
+# Plugin to abort hanging tests.
+pytest-timeout >= 2.0.0
+
+# Allows specifying order without duplicates
+pytest-drop-dup-tests
+
+# Ability to retry a failed test
+flaky
+
+# Better subprocess alternative with implemented timeout.
+psutil

--- a/tests/requirements-tools.txt
+++ b/tests/requirements-tools.txt
@@ -9,31 +9,16 @@
 #   python -m pip install -r tests/requirements-tools.txt
 #   python -m pip install -r tests/requirements-libraries.txt  # extensive
 
-# Work-around for a bug in execnet 1.4.1
-execnet >= 1.5.0
-
-# Testing framework.
-pytest >= 2.7.3
-
-# Plugin allowing running tests in parallel.
-pytest-xdist
-
-# Plugin to abort hanging tests.
-pytest-timeout >= 2.0.0
-
-# Allows specifying order without duplicates
-pytest-drop-dup-tests
-
-# Ability to retry a failed test
-flaky
-
-# Better subprocess alternative with implemented timeout.
-psutil
+# Base test requirements
+-r requirements-base.txt
 
 # Check new linter violations on pull requests
 ruff
 
-# These are required by some of basic tests
+# The following libraries are required by some basic tests, but their
+# binary PyPI wheels may be available only for released python versions
+# (i.e., they might be unavailable for pre-release versions).
+
 pywin32; sys_platform == 'win32'
 
 lxml


### PR DESCRIPTION
Split the base part of `requirements-tools.txt` into a separate `requirements-tools-base.txt`; this includes the requirements that we expect to be also available for pre-release python versions.

This allows us to set up basic CI for pre-release python early in that python version's development cycle, when some of the additional requirements for basic tests might not be yet available in the form of binary PyPI wheels (e.g., `pywin32`, `lxml`, and `xattr` with its `cffi` dependency).