### PR TITLE
 build: make errors when validating macOS SDK version non-fatal

### DIFF
--- a/PyInstaller/building/build_main.py
+++ b/PyInstaller/building/build_main.py
@@ -845,13 +845,19 @@ class Analysis(Target):
         self._write_graph_debug()
 
         # On macOS, check the SDK version of the binaries to be collected, and warn when the SDK version is either
-        # invalid or too low. Such binaries will likely refuse to be loaded when hardened runtime is enabledm and
+        # invalid or too low. Such binaries will likely refuse to be loaded when hardened runtime is enabled and
         # while we cannot do anything about it, we can at least warn the user about it.
         # See: https://developer.apple.com/forums/thread/132526
         if is_darwin:
             binaries_with_invalid_sdk = []
             for dest_name, src_name, typecode in self.binaries:
-                sdk_version = osxutils.get_macos_sdk_version(src_name)
+                try:
+                    sdk_version = osxutils.get_macos_sdk_version(src_name)
+                except Exception:
+                    logger.warning("Failed to query macOS SDK version of %r!", src_name, exc_info=True)
+                    binaries_with_invalid_sdk.append((dest_name, src_name, "unavailable"))
+                    continue
+
                 if sdk_version < (10, 9, 0):
                     binaries_with_invalid_sdk.append((dest_name, src_name, sdk_version))
             if binaries_with_invalid_sdk:

--- a/PyInstaller/utils/osx.py
+++ b/PyInstaller/utils/osx.py
@@ -95,7 +95,8 @@ def _find_version_cmd(header):
     # The SDK version is stored in LC_BUILD_VERSION command (used when targeting the latest versions of macOS) or in
     # older LC_VERSION_MIN_MACOSX command. Check for presence of either.
     version_cmd = [cmd for cmd in header.commands if cmd[0].cmd in {LC_BUILD_VERSION, LC_VERSION_MIN_MACOSX}]
-    assert len(version_cmd) == 1, "Expected exactly one LC_BUILD_VERSION or LC_VERSION_MIN_MACOSX command!"
+    assert len(version_cmd) == 1, \
+        f"Expected exactly one LC_BUILD_VERSION or LC_VERSION_MIN_MACOSX command, found {len(version_cmd)}!"
     return version_cmd[0]
 
 

--- a/news/8220.bugfix.rst
+++ b/news/8220.bugfix.rst
@@ -1,0 +1,4 @@
+(macOS) When validating the macOS SDK version of collected binaries,
+handle errors raised by ``osxutils.get_macos_sdk_version``; log a
+warning about failed version query, and add the offending binary to
+the list of potentially problematic binaries to warn the user about.


### PR DESCRIPTION
When validating the macOS SDK version of collected binaries, handle errors raised by `osxutils.get_macos_sdk_version`; log a warning about failed version query, and add the offending binary to the list of potentially problematic binaries to warn the user about.