### PR TITLE
Qt: extend OpenSSL collection for QtNetwork & implement strict Qt/QML plugin dependency validation

### DIFF
--- a/PyInstaller/depend/bindepend.py
+++ b/PyInstaller/depend/bindepend.py
@@ -234,7 +234,7 @@ def get_imports(filename, search_paths=None):
     platform-specific resolution mechanism fails to resolve a library fullpath.
     """
     if compat.is_win:
-        if filename.lower().endswith(".manifest"):
+        if str(filename).lower().endswith(".manifest"):
             return []
         return _get_imports_pefile(filename, search_paths)
     elif compat.is_darwin:

--- a/PyInstaller/fake-modules/_pyi_rth_utils/__init__.py
+++ b/PyInstaller/fake-modules/_pyi_rth_utils/__init__.py
@@ -10,6 +10,25 @@
 # -----------------------------------------------------------------------------
 
 import sys
+import os
 
 # A boolean indicating whether the frozen application is a macOS .app bundle.
 is_macos_app_bundle = sys.platform == 'darwin' and sys._MEIPASS.endswith("Contents/Frameworks")
+
+
+def prepend_path_to_environment_variable(path, variable_name):
+    """
+    Prepend the given path to the list of paths stored in the given environment variable (separated by `os.pathsep`).
+    If the given path is already specified in the environment variable, no changes are made. If the environment variable
+    is not set or is empty, it is set/overwritten with the given path.
+    """
+    stored_paths = os.environ.get(variable_name)
+    if stored_paths:
+        # If path is already included, make this a no-op.
+        if path in stored_paths:
+            return
+        # Otherwise, prepend the path
+        stored_paths = path + os.pathsep + stored_paths
+    else:
+        stored_paths = path
+    os.environ[variable_name] = stored_paths

--- a/PyInstaller/hooks/rthooks/pyi_rth_pyqt6.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_pyqt6.py
@@ -17,7 +17,7 @@ def _pyi_rthook():
     import os
     import sys
 
-    from _pyi_rth_utils import is_macos_app_bundle
+    from _pyi_rth_utils import is_macos_app_bundle, prepend_path_to_environment_variable
 
     # Try PyQt6 6.0.3-style path first...
     pyqt_path = os.path.join(sys._MEIPASS, 'PyQt6', 'Qt6')
@@ -44,22 +44,16 @@ def _pyi_rthook():
     else:
         os.environ['QML2_IMPORT_PATH'] = os.path.join(pyqt_path, 'qml')
 
-    # Modelled after similar PATH modification in PyQt5 rthook. With PyQt6, this modification seems necessary for SSL
-    # DLLs to be found in onefile builds.
-    if sys.platform.startswith('win') and 'PATH' in os.environ:
-        os.environ['PATH'] = sys._MEIPASS + os.pathsep + os.environ['PATH']
+    # Add `sys._MEIPASS` to `PATH` in order to ensure that `QtNetwork` can discover OpenSSL DLLs that might have been
+    # collected there (i.e., when they were not shipped with the package, and were collected from an external location).
+    if sys.platform.startswith('win'):
+        prepend_path_to_environment_variable(sys._MEIPASS, 'PATH')
 
     # For macOS POSIX builds, we need to add `sys._MEIPASS` to `DYLD_LIBRARY_PATH` so that QtNetwork can discover
     # OpenSSL dynamic libraries for its `openssl` TLS backend. This also prevents fallback to external locations, such
-    # as Homebrew. For .app bundles, this is unnecessary because QtNetwork explicitly searches `Contents/Frameworks`.
+    # as Homebrew. For .app bundles, this is unnecessary because `QtNetwork` explicitly searches `Contents/Frameworks`.
     if sys.platform == 'darwin' and not is_macos_app_bundle:
-        search_paths = os.environ.get('DYLD_LIBRARY_PATH')
-        if search_paths:
-            if sys._MEIPASS not in search_paths:
-                search_paths = os.pathsep.join([sys._MEIPASS, *search_paths.split(os.pathsep)])
-        else:
-            search_paths = sys._MEIPASS
-        os.environ['DYLD_LIBRARY_PATH'] = search_paths
+        prepend_path_to_environment_variable(sys._MEIPASS, 'DYLD_LIBRARY_PATH')
 
 
 _pyi_rthook()

--- a/PyInstaller/hooks/rthooks/pyi_rth_pyside2.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_pyside2.py
@@ -17,7 +17,7 @@ def _pyi_rthook():
     import os
     import sys
 
-    from _pyi_rth_utils import is_macos_app_bundle
+    from _pyi_rth_utils import is_macos_app_bundle, prepend_path_to_environment_variable
 
     if sys.platform.startswith('win'):
         pyqt_path = os.path.join(sys._MEIPASS, 'PySide2')
@@ -43,10 +43,10 @@ def _pyi_rthook():
     else:
         os.environ['QML2_IMPORT_PATH'] = os.path.join(pyqt_path, 'qml')
 
-    # Modelled after similar PATH modification in PyQt5 rthook. With PySide2, this modification seems necessary for SSL
-    # DLLs to be found in onefile builds (provided they were available during collection).
-    if sys.platform.startswith('win') and 'PATH' in os.environ:
-        os.environ['PATH'] = sys._MEIPASS + os.pathsep + os.environ['PATH']
+    # Add `sys._MEIPASS` to `PATH` in order to ensure that `QtNetwork` can discover OpenSSL DLLs that might have been
+    # collected there (i.e., when they were not shipped with the package, and were collected from an external location).
+    if sys.platform.startswith('win'):
+        prepend_path_to_environment_variable(sys._MEIPASS, 'PATH')
 
 
 _pyi_rthook()

--- a/PyInstaller/hooks/rthooks/pyi_rth_pyside6.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_pyside6.py
@@ -48,6 +48,18 @@ def _pyi_rthook():
     if sys.platform.startswith('win') and 'PATH' in os.environ:
         os.environ['PATH'] = sys._MEIPASS + os.pathsep + os.environ['PATH']
 
+    # For macOS POSIX builds, we need to add `sys._MEIPASS` to `DYLD_LIBRARY_PATH` so that QtNetwork can discover
+    # OpenSSL dynamic libraries for its `openssl` TLS backend. This also prevents fallback to external locations, such
+    # as Homebrew. For .app bundles, this is unnecessary because QtNetwork explicitly searches `Contents/Frameworks`.
+    if sys.platform == 'darwin' and not is_macos_app_bundle:
+        search_paths = os.environ.get('DYLD_LIBRARY_PATH')
+        if search_paths:
+            if sys._MEIPASS not in search_paths:
+                search_paths = os.pathsep.join([sys._MEIPASS, *search_paths.split(os.pathsep)])
+        else:
+            search_paths = sys._MEIPASS
+        os.environ['DYLD_LIBRARY_PATH'] = search_paths
+
 
 _pyi_rthook()
 del _pyi_rthook

--- a/PyInstaller/utils/hooks/qt/__init__.py
+++ b/PyInstaller/utils/hooks/qt/__init__.py
@@ -534,7 +534,7 @@ class QtLibraryInfo:
             if valid:
                 binaries.append((plugin_file, plugin_dst_dir))
             else:
-                logger.warning("%s: excluding plugin %r (%r)! Reason: %s", self, plugin_file, plugin_type, reason)
+                logger.debug("%s: excluding plugin %r (%r)! Reason: %s", self, plugin_file, plugin_type, reason)
         return binaries
 
     def _validate_plugin_dependencies(self, plugin_file):
@@ -1011,14 +1011,12 @@ class QtLibraryInfo:
         for plugin_binary in plugin_binaries:
             valid, reason = self._validate_plugin_dependencies(plugin_binary)
             if not valid:
-                logger.warning("%s: excluding QML plugin binary %r! Reason: %s", self, str(plugin_binary), reason)
+                logger.debug("%s: excluding QML plugin binary %r! Reason: %s", self, str(plugin_binary), reason)
                 invalid_binaries = True
 
         # If there was an invalid binary, discard the plugin.
         if invalid_binaries:
-            logger.warning(
-                "%s: excluding QML plugin directory %r due to invalid plugin binaries!", self, str(plugin_dir)
-            )
+            logger.debug("%s: excluding QML plugin directory %r due to invalid plugin binaries!", self, str(plugin_dir))
             return [], []
 
         # Generate binaries list.

--- a/PyInstaller/utils/hooks/qt/__init__.py
+++ b/PyInstaller/utils/hooks/qt/__init__.py
@@ -698,7 +698,7 @@ class QtLibraryInfo:
                 'libcrypto-1_1-x64.dll' if compat.is_64bits else 'libcrypto-1_1.dll',
             )
             logger.debug("%s: QtNetwork: looking for OpenSSL 1.1.x DLLs: %r", self, dll_names)
-        elif openssl_version >= 0x30000000 and openssl_version < 0x30100000:
+        elif openssl_version >= 0x30000000 and openssl_version < 0x40000000:
             # OpenSSL 3.0.x
             dll_names = (
                 'libssl-3-x64.dll' if compat.is_64bits else 'libssl-3.dll',
@@ -784,7 +784,7 @@ class QtLibraryInfo:
                 'libssl.1.1.dylib',
             )
             logger.debug("%s: QtNetwork: looking for OpenSSL 1.1.x dylibs: %r", self, dylib_names)
-        elif openssl_version >= 0x30000000 and openssl_version < 0x30100000:
+        elif openssl_version >= 0x30000000 and openssl_version < 0x40000000:
             # OpenSSL 3.0.x
             dylib_names = (
                 'libcrypto.3.dylib',
@@ -836,7 +836,7 @@ class QtLibraryInfo:
                 'libssl.so.1.1',
             )
             logger.debug("%s: QtNetwork: looking for OpenSSL 1.1.x shared libraries: %r", self, shlib_names)
-        elif openssl_version >= 0x30000000 and openssl_version < 0x30100000:
+        elif openssl_version >= 0x30000000 and openssl_version < 0x40000000:
             # OpenSSL 3.0.x
             shlib_names = (
                 'libcrypto.so.3',

--- a/news/8087.bugfix.rst
+++ b/news/8087.bugfix.rst
@@ -1,0 +1,6 @@
+Prevent Qt and QML plugins with missing Qt dependencies in the
+``PySide2``, ``PyQt5``, ``PySide6``, and ``PyQt6`` PyPI wheels from
+pulling in Qt shared libraries from alternative locations (for example,
+system-installed Qt on Linux, Homebrew-installed Qt on macOS, or
+a custom Windows Qt build that happens to be in ``PATH``), and resulting
+in a frozen application that contains an incompatible mix of Qt libraries.

--- a/news/8226.feature.rst
+++ b/news/8226.feature.rst
@@ -1,0 +1,12 @@
+Implement strict Qt dependency validation for collection of Qt plugins
+and QML components/plugins. We now perform preliminary binary dependency
+analysis of the plugins, and automatically exclude plugins that
+have at least one missing Qt dependency. This prevents collection of
+plugins that cannot be used anyway because of a missing Qt shared library
+(that is, for example, omitted from a PyPI wheel). Furthermore, we disallow
+Qt dependencies of a plugin to be resolved outside of the primary location
+of Qt shared libraries, in order to prevent missing dependencies from
+pulling in Qt libraries from alternative locations that happen to be in
+the search path (for example, when using ``PyQt5`` PyPI wheels while also
+having a system-installed Qt5 on Linux, a Homebrew-installed Qt5 on macOS,
+or a custom Windows Qt5 build that happens to be in ``PATH``).

--- a/news/8226.hooks.1.rst
+++ b/news/8226.hooks.1.rst
@@ -1,0 +1,4 @@
+(macOS) Have ``PySide6`` and ``PyQt6`` run-time hooks prepend
+``sys._MEIPASS`` to ``DYLD_LIBRARY_PATH`` in POSIX builds, in order
+to ensure that ``QtNetwork`` discovers the bundled copy of the OpenSSL
+shared library.

--- a/news/8226.hooks.rst
+++ b/news/8226.hooks.rst
@@ -1,0 +1,5 @@
+Extend the OpenSSL shared library collection in the ``QtNetwork`` hook
+helper for ``PySide2``, ``PyQt5``, ``PySide6``, and ``PyQt6`` to
+cover all applicable versions of OpenSSL (1.0.2, 1.1.x, 3.x). In
+addition to Windows, the OpenSSL shared libary is now also collected
+on Linux and macOS.

--- a/tests/functional/test_qt.py
+++ b/tests/functional/test_qt.py
@@ -185,15 +185,30 @@ def test_Qt_QtNetwork_SSL_support(pyi_builder, QtPyLib):
 
         app = QCoreApplication(sys.argv)
 
-        assert QSslSocket.supportsSsl()
+        # Make sure SSL is supported
+        assert QSslSocket.supportsSsl(), "SSL not supported!"
 
+        # Display OpenSSL info
+        print(
+            f"OpenSSL build version: {{QSslSocket.sslLibraryBuildVersionNumber():X}} "
+            f"({{QSslSocket.sslLibraryBuildVersionString()}})"
+        )
+        print(
+            f"OpenSSL run-time version: {{QSslSocket.sslLibraryVersionNumber():X}} "
+            f"({{QSslSocket.sslLibraryVersionString()}})"
+        )
+
+        # Obtain Qt version
         try:
             qt_version = QLibraryInfo.version().segments()
         except AttributeError:
             qt_version = []  # Qt <= 5.8
 
+        # If Qt supports TLS backends (>= 6.1), make sure OpenSSL backend is available.
         if qt_version >= [6, 1]:
-            assert 'openssl' in QSslSocket.availableBackends()
+            print(f"Active TLS backend: {{QSslSocket.activeBackend()}}")
+            print(f"Available TLS backends: {{QSslSocket.availableBackends()}}")
+            assert 'openssl' in QSslSocket.availableBackends(), "OpenSSL TLS backend not available!"
         """.format(QtPyLib), **USE_WINDOWED_KWARG
     )
 


### PR DESCRIPTION
Part 1: extend OpenSSL collection for QtNetwork
-----------------------------------------------

The first part of this PR extends the collection of OpenSSL shared libraries for `QtNetwork`, to handle different OpenSSL versions - 1.0.2 for very old PyQt5 wheels, 1.1.x for PySide2 and PyQt5, and >= 3.x for PySide6 and PyQt6 (and sometimes for Qt5, if using custom build). We also extend the collection, which was previously done only on Windows, to Linux (where PyPI wheels for all four bindings expect the shared lib to be provided by the environment) and macOS (where `openssl` TLS backend in Qt6 is enabled if OpenSSL dylib is available in the environment, e.g. from Homebrew).

To make collected OpenSSL dylib visible to `QtNetwork` in macOS POSIX builds, we need to add `sys._MEIPASS` to `DYLD_LIBRARY_PATH`, so have the run-time hook do that. This does not seem to be necessary for .app bundles, because `Contents/Frameworks` is automatically searched by `QtNetwork`.

Extend the `QtNetwork` OpenSSL test for Qt6, where we need to check if `openssl` TLS backend is available, instead of just checking for SSL/TLS support.

Part 2: implement strict Qt/QML plugin dependency validation
------------------------------------------------------------

The second part implements strict dependency validation for Qt plugins and for QML plugins.

Inside our Qt hook helpers, we now perform binary dependency analysis of Qt plugins, and discard the plugins that have missing Qt dependencies - for example, PyPI wheels ship Qt plugins with Qt dependencies that are missing from the wheels (they are missing completely, or require installation of an optional wheel). Such plugins are non-functional, so there is no point in collecting them. Plus, the missing dependencies would raise warnings later on during general binary dependency analysis. Same applies to the QML plugins.

Qt plugins with Qt dependencies not shipped by PyPI wheels have an even darker side - those dependencies might be available somewhere else in the system; for example, the underlying Linux distribution, a Homebrew environment on macOS, or an arbitrary Qt build that happens to be in `PATH` on Windows (see #8087). Even if they are of compatible versions, the Qt libs shipped with PyPI wheels and the external ones might not be fully compatible (e.g., different symbol visibility on Linux), so mixing the two is never a good idea.

That's why we also ensure that resolved Qt dependencies of plugins reside in the Qt shared library directory, as declared by `QLibraryInfo.PrefixPath` / `QLibraryInfo.BinariesPath` /  `QLibraryInfo.LibrariesPath` (whichever is applicable to the OS and wheel/non-wheel), and discard plugins with Qt dependencies that are resolved outside of that directory (note: "Qt dependencies" means Qt shared libraries - `Qt*.dll` or `libQt*.{so, dylib}`, as opposed to lower-level dependencies that might need to be collected from the host system).

For QML plugins, we now need to scan the QML directory for `qmldir` files to identify individual components, and parse them for lists of corresponding plugins (usually one plugin per component, though).

Examples of the new system in action, on Windows (without "fall-back" Qt installation in `PATH`):

<details><summary>PySide2</summary><p>

On Windows, `PySide2` does not seem to include any problematic plugins.

</p></details>

<details><summary>PySide6</summary><p>

With `PySide6` (which installed both `PySide6-Essential` and `PySide6-AddOns`), we now get the following warnings:
```
7156 INFO: Loading module hook 'hook-PySide6.QtQml.py' from '[...]\\pyinstaller\\PyInstaller\\hooks'...
13303 WARNING: QtLibraryInfo(PySide6): excluding QML plugin binary '[...]\\venv\\Lib\\site-packages\\PySide6\\qml\\QtQuick3D\\Helpers\\impl\\qtquick3dhelpersimplplugin.dll'! Reason: Missing Qt dependency 'Qt6Quick3DHelpersImpl.dll'.
13303 WARNING: QtLibraryInfo(PySide6): excluding QML plugin directory '[...]\\venv\\Lib\\site-packages\\PySide6\\qml\\QtQuick3D\\Helpers\\impl' due to invalid plugin binaries!
13767 WARNING: QtLibraryInfo(PySide6): excluding QML plugin binary '[...]\\venv\\Lib\\site-packages\\PySide6\\qml\\QtQuick3D\\SpatialAudio\\quick3dspatialaudioplugin.dll'! Reason: Missing Qt dependency 'Qt6Quick3DSpatialAudio.dll'.
13767 WARNING: QtLibraryInfo(PySide6): excluding QML plugin directory '[...]\\venv\\Lib\\site-packages\\PySide6\\qml\\QtQuick3D\\SpatialAudio' due to invalid plugin binaries!
```

</p></details>


<details><summary>PyQt5</summary><p>

With just `PyQt5` and `PyQtWebEngine` installed, we now get the following warnings:

```
6169 INFO: Loading module hook 'hook-PyQt5.QtQml.py' from '[...]\\PyInstaller\\hooks'...
6613 WARNING: QtLibraryInfo(PyQt5): excluding QML plugin binary '[...]\\venv\\Lib\\site-packages\\PyQt5\\Qt5\\qml\\QtMultimedia\\declarative_multimedia.dll'! Reason: Missing Qt dependency 'Qt5MultimediaQuick.dll'.
6613 WARNING: QtLibraryInfo(PyQt5): excluding QML plugin directory '[...]\\venv\\Lib\\site-packages\\PyQt5\\Qt5\\qml\\QtMultimedia' due to invalid plugin binaries!
7021 WARNING: QtLibraryInfo(PyQt5): excluding QML plugin binary '[...]\\venv\\Lib\\site-packages\\PyQt5\\Qt5\\qml\\QtQuick\\Scene2D\\qtquickscene2dplugin.dll'! Reason: Missing Qt dependency 'Qt53DQuickScene2D.dll'.
7021 WARNING: QtLibraryInfo(PyQt5): excluding QML plugin directory '[...]\\venv\\Lib\\site-packages\\PyQt5\\Qt5\\qml\\QtQuick\\Scene2D' due to invalid plugin binaries!
7055 WARNING: QtLibraryInfo(PyQt5): excluding QML plugin binary '[...]\\venv\\Lib\\site-packages\\PyQt5\\Qt5\\qml\\QtQuick\\Scene3D\\qtquickscene3dplugin.dll'! Reason: Missing Qt dependency 'Qt53DLogic.dll'.
7055 WARNING: QtLibraryInfo(PyQt5): excluding QML plugin directory '[...]\\venv\\Lib\\site-packages\\PyQt5\\Qt5\\qml\\QtQuick\\Scene3D' due to invalid plugin binaries!
```

If we install extra packages (`PyQt3D`, in particular), the warnings are reduced to:

```
6702 INFO: Loading module hook 'hook-PyQt5.QtQml.py' from '[...]\\PyInstaller\\hooks'...
8129 WARNING: QtLibraryInfo(PyQt5): excluding QML plugin binary '[...]\\venv\\Lib\\site-packages\\PyQt5\\Qt5\\qml\\QtMultimedia\\declarative_multimedia.dll'! Reason: Missing Qt dependency 'Qt5MultimediaQuick.dll'.
8129 WARNING: QtLibraryInfo(PyQt5): excluding QML plugin directory '[...]\\venv\\Lib\\site-packages\\PyQt5\\Qt5\\qml\\QtMultimedia' due to invalid plugin binaries!
```

</p></details>

<details><summary>PyQt6</summary><p>

With just `PyQt6` and `PyQt6-WebEngine` installed, we now get the following warnings:

Similarly, for PyQt6 (`PyQt6` and `PyQt6-WebEngine` only):

```
5681 INFO: Loading module hook 'hook-PyQt6.QtQml.py' from '[...]\\PyInstaller\\hooks'...
6907 WARNING: QtLibraryInfo(PyQt6): excluding QML plugin binary '[...]\\venv\\Lib\\site-packages\\PyQt6\\Qt6\\qml\\QtQml\\XmlListModel\\qmlxmllistmodelplugin.dll'! Reason: Missing Qt dependency 'Qt6QmlXmlListModel.dll'.
6907 WARNING: QtLibraryInfo(PyQt6): excluding QML plugin directory '[...]\\venv\\Lib\\site-packages\\PyQt6\\Qt6\\qml\\QtQml\\XmlListModel' due to invalid plugin binaries!
8052 WARNING: QtLibraryInfo(PyQt6): excluding QML plugin binary '[...]\\venv\\Lib\\site-packages\\PyQt6\\Qt6\\qml\\QtQuick\\Effects\\effectsplugin.dll'! Reason: Missing Qt dependency 'Qt6QuickEffects.dll'.
8052 WARNING: QtLibraryInfo(PyQt6): excluding QML plugin directory '[...]\\venv\\Lib\\site-packages\\PyQt6\\Qt6\\qml\\QtQuick\\Effects' due to invalid plugin binaries!
8159 WARNING: QtLibraryInfo(PyQt6): excluding QML plugin binary '[...]\\venv\\Lib\\site-packages\\PyQt6\\Qt6\\qml\\QtQuick\\LocalStorage\\qmllocalstorageplugin.dll'! Reason: Missing Qt dependency 'Qt6QmlLocalStorage.dll'.
8160 WARNING: QtLibraryInfo(PyQt6): excluding QML plugin directory '[...]\\venv\\Lib\\site-packages\\PyQt6\\Qt6\\qml\\QtQuick\\LocalStorage' due to invalid plugin binaries!
8423 WARNING: QtLibraryInfo(PyQt6): excluding QML plugin binary '[...]\\venv\\Lib\\site-packages\\PyQt6\\Qt6\\qml\\QtQuick\\Scene2D\\qtquickscene2dplugin.dll'! Reason: Missing Qt dependency 'Qt63DRender.dll'.
8423 WARNING: QtLibraryInfo(PyQt6): excluding QML plugin directory '[...]\\venv\\Lib\\site-packages\\PyQt6\\Qt6\\qml\\QtQuick\\Scene2D' due to invalid plugin binaries!
8701 WARNING: QtLibraryInfo(PyQt6): excluding QML plugin binary '[...]\\venv\\Lib\\site-packages\\PyQt6\\Qt6\\qml\\QtQuick\\Scene3D\\qtquickscene3dplugin.dll'! Reason: Missing Qt dependency 'Qt63DLogic.dll'.
8701 WARNING: QtLibraryInfo(PyQt6): excluding QML plugin directory '[...]\\venv\\Lib\\site-packages\\PyQt6\\Qt6\\qml\\QtQuick\\Scene3D' due to invalid plugin binaries!
9197 WARNING: QtLibraryInfo(PyQt6): excluding QML plugin binary '[...]\\venv\\Lib\\site-packages\\PyQt6\\Qt6\\qml\\QtQuick3D\\Helpers\\impl\\qtquick3dhelpersimplplugin.dll'! Reason: Missing Qt dependency 'Qt6Quick3DHelpersImpl.dll'.
9197 WARNING: QtLibraryInfo(PyQt6): excluding QML plugin directory '[...]\\venv\\Lib\\site-packages\\PyQt6\\Qt6\\qml\\QtQuick3D\\Helpers\\impl' due to invalid plugin binaries!
9319 WARNING: QtLibraryInfo(PyQt6): excluding QML plugin binary '[...]\\venv\\Lib\\site-packages\\PyQt6\\Qt6\\qml\\QtQuick3D\\ParticleEffects\\qtquick3dparticleeffectsplugin.dll'! Reason: Missing Qt dependency 'Qt6Quick3DParticleEffects.dll'.
9320 WARNING: QtLibraryInfo(PyQt6): excluding QML plugin directory '[...]\\venv\\Lib\\site-packages\\PyQt6\\Qt6\\qml\\QtQuick3D\\ParticleEffects' due to invalid plugin binaries!
9428 WARNING: QtLibraryInfo(PyQt6): excluding QML plugin binary '[...]\\venv\\Lib\\site-packages\\PyQt6\\Qt6\\qml\\QtQuick3D\\Physics\\Helpers\\qtquick3dphysicshelpersplugin.dll'! Reason: Missing Qt dependency 'Qt6Quick3DPhysicsHelpers.dll'.
9428 WARNING: QtLibraryInfo(PyQt6): excluding QML plugin directory '[...]\\venv\\Lib\\site-packages\\PyQt6\\Qt6\\qml\\QtQuick3D\\Physics\\Helpers' due to invalid plugin binaries!
9475 WARNING: QtLibraryInfo(PyQt6): excluding QML plugin binary '[...]\\venv\\Lib\\site-packages\\PyQt6\\Qt6\\qml\\QtQuick3D\\Physics\\qquick3dphysicsplugin.dll'! Reason: Missing Qt dependency 'Qt6Quick3DPhysics.dll'.
9475 WARNING: QtLibraryInfo(PyQt6): excluding QML plugin directory '[...]\\venv\\Lib\\site-packages\\PyQt6\\Qt6\\qml\\QtQuick3D\\Physics' due to invalid plugin binaries!
```

Installing `PyQt6-3D` fixes some of the missing dependencies, but also brings additional plugins with missing dependencies:

```
6668 INFO: Loading module hook 'hook-PyQt6.QtQml.py' from '[...]\\PyInstaller\\hooks'...
6930 WARNING: QtLibraryInfo(PyQt6): excluding QML plugin binary '[...]\\venv\\Lib\\site-packages\\PyQt6\\Qt6\\qml\\Qt3D\\Core\\quick3dcoreplugin.dll'! Reason: Missing Qt dependency 'Qt63DQuick.dll'.
6930 WARNING: QtLibraryInfo(PyQt6): excluding QML plugin directory '[...]\\venv\\Lib\\site-packages\\PyQt6\\Qt6\\qml\\Qt3D\\Core' due to invalid plugin binaries!
6995 WARNING: QtLibraryInfo(PyQt6): excluding QML plugin binary '[...]\\venv\\Lib\\site-packages\\PyQt6\\Qt6\\qml\\Qt3D\\Render\\quick3drenderplugin.dll'! Reason: Missing Qt dependency 'Qt63DQuick.dll'.
6995 WARNING: QtLibraryInfo(PyQt6): excluding QML plugin directory '[...]\\venv\\Lib\\site-packages\\PyQt6\\Qt6\\qml\\Qt3D\\Render' due to invalid plugin binaries!
7093 WARNING: QtLibraryInfo(PyQt6): excluding QML plugin binary '[...]\\venv\\Lib\\site-packages\\PyQt6\\Qt6\\qml\\QtQml\\XmlListModel\\qmlxmllistmodelplugin.dll'! Reason: Missing Qt dependency 'Qt6QmlXmlListModel.dll'.
7093 WARNING: QtLibraryInfo(PyQt6): excluding QML plugin directory '[...]\\venv\\Lib\\site-packages\\PyQt6\\Qt6\\qml\\QtQml\\XmlListModel' due to invalid plugin binaries!
7373 WARNING: QtLibraryInfo(PyQt6): excluding QML plugin binary '[...]\\venv\\Lib\\site-packages\\PyQt6\\Qt6\\qml\\QtQuick\\Effects\\effectsplugin.dll'! Reason: Missing Qt dependency 'Qt6QuickEffects.dll'.
7373 WARNING: QtLibraryInfo(PyQt6): excluding QML plugin directory '[...]\\venv\\Lib\\site-packages\\PyQt6\\Qt6\\qml\\QtQuick\\Effects' due to invalid plugin binaries!
7404 WARNING: QtLibraryInfo(PyQt6): excluding QML plugin binary '[...]\\venv\\Lib\\site-packages\\PyQt6\\Qt6\\qml\\QtQuick\\LocalStorage\\qmllocalstorageplugin.dll'! Reason: Missing Qt dependency 'Qt6QmlLocalStorage.dll'.
7404 WARNING: QtLibraryInfo(PyQt6): excluding QML plugin directory '[...]\\venv\\Lib\\site-packages\\PyQt6\\Qt6\\qml\\QtQuick\\LocalStorage' due to invalid plugin binaries!
7616 WARNING: QtLibraryInfo(PyQt6): excluding QML plugin binary '[...]\\venv\\Lib\\site-packages\\PyQt6\\Qt6\\qml\\QtQuick3D\\Helpers\\impl\\qtquick3dhelpersimplplugin.dll'! Reason: Missing Qt dependency 'Qt6Quick3DHelpersImpl.dll'.
7616 WARNING: QtLibraryInfo(PyQt6): excluding QML plugin directory '[...]\\venv\\Lib\\site-packages\\PyQt6\\Qt6\\qml\\QtQuick3D\\Helpers\\impl' due to invalid plugin binaries!
7648 WARNING: QtLibraryInfo(PyQt6): excluding QML plugin binary '[...]\\venv\\Lib\\site-packages\\PyQt6\\Qt6\\qml\\QtQuick3D\\ParticleEffects\\qtquick3dparticleeffectsplugin.dll'! Reason: Missing Qt dependency 'Qt6Quick3DParticleEffects.dll'.
7648 WARNING: QtLibraryInfo(PyQt6): excluding QML plugin directory '[...]\\venv\\Lib\\site-packages\\PyQt6\\Qt6\\qml\\QtQuick3D\\ParticleEffects' due to invalid plugin binaries!
7665 WARNING: QtLibraryInfo(PyQt6): excluding QML plugin binary '[...]\\venv\\Lib\\site-packages\\PyQt6\\Qt6\\qml\\QtQuick3D\\Physics\\Helpers\\qtquick3dphysicshelpersplugin.dll'! Reason: Missing Qt dependency 'Qt6Quick3DPhysicsHelpers.dll'.
7665 WARNING: QtLibraryInfo(PyQt6): excluding QML plugin directory '[...]\\venv\\Lib\\site-packages\\PyQt6\\Qt6\\qml\\QtQuick3D\\Physics\\Helpers' due to invalid plugin binaries!
7681 WARNING: QtLibraryInfo(PyQt6): excluding QML plugin binary '[...]\\venv\\Lib\\site-packages\\PyQt6\\Qt6\\qml\\QtQuick3D\\Physics\\qquick3dphysicsplugin.dll'! Reason: Missing Qt dependency 'Qt6Quick3DPhysics.dll'.
7681 WARNING: QtLibraryInfo(PyQt6): excluding QML plugin directory '[...]\\venv\\Lib\\site-packages\\PyQt6\\Qt6\\qml\\QtQuick3D\\Physics' due to invalid plugin binaries!
```

</p></details>


On my Fedora linux (which has Qt5 and Qt6 installed as part of the system):

<details><summary>PySide6</summary><p>

```
3454 INFO: Loading module hook 'hook-PySide6.QtQml.py' from '[...]/PyInstaller/hooks'...
4535 WARNING: QtLibraryInfo(PySide6): excluding QML plugin binary '[...]/venv/lib/python3.10/site-packages/PySide6/Qt/qml/QtQuick3D/Helpers/impl/libqtquick3dhelpersimplplugin.so'! Reason: Qt dependency 'libQt6QmlModels.so.6' ('/usr/lib64/libQt6QmlModels.so.6.6.0') has been resolved outside of the Qt shared library directory ('[...]/venv/lib/python3.10/site-packages/PySide6/Qt/lib').
4535 WARNING: QtLibraryInfo(PySide6): excluding QML plugin directory '[...]/venv/lib/python3.10/site-packages/PySide6/Qt/qml/QtQuick3D/Helpers/impl' due to invalid plugin binaries!
4586 WARNING: QtLibraryInfo(PySide6): excluding QML plugin binary '[...]/venv/lib/python3.10/site-packages/PySide6/Qt/qml/QtQuick3D/SpatialAudio/libquick3dspatialaudioplugin.so'! Reason: Missing Qt dependency 'libQt6Quick3DSpatialAudio.so.6'.
4587 WARNING: QtLibraryInfo(PySide6): excluding QML plugin directory '[...]/venv/lib/python3.10/site-packages/PySide6/Qt/qml/QtQuick3D/SpatialAudio' due to invalid plugin binaries!
```

</p></details>


<details><summary>PyQt5</summary><p>

```
3291 INFO: Loading module hook 'hook-PyQt5.QtGui.py' from '[...]/PyInstaller/hooks'...
3359 WARNING: QtLibraryInfo(PyQt5): excluding plugin '[...]/venv/lib64/python3.10/site-packages/PyQt5/Qt5/plugins/egldeviceintegrations/libqeglfs-x11-integration.so' ('egldeviceintegrations')! Reason: Qt dependency 'libQt5EglFSDeviceIntegration.so.5' ('/usr/lib64/libQt5EglFSDeviceIntegration.so.5.15.11') has been resolved outside of the Qt shared library directory ('[...]/venv/lib/python3.10/site-packages/PyQt5/Qt5/lib').
3371 WARNING: QtLibraryInfo(PyQt5): excluding plugin '[...]/venv/lib64/python3.10/site-packages/PyQt5/Qt5/plugins/egldeviceintegrations/libqeglfs-kms-egldevice-integration.so' ('egldeviceintegrations')! Reason: Qt dependency 'libQt5EglFsKmsSupport.so.5' ('/usr/lib64/libQt5EglFsKmsSupport.so.5.15.11') has been resolved outside of the Qt shared library directory ('[...]/venv/lib/python3.10/site-packages/PyQt5/Qt5/lib').
3381 WARNING: QtLibraryInfo(PyQt5): excluding plugin '[...]/venv/lib64/python3.10/site-packages/PyQt5/Qt5/plugins/egldeviceintegrations/libqeglfs-emu-integration.so' ('egldeviceintegrations')! Reason: Qt dependency 'libQt5EglFSDeviceIntegration.so.5' ('/usr/lib64/libQt5EglFSDeviceIntegration.so.5.15.11') has been resolved outside of the Qt shared library directory ('[...]/venv/lib/python3.10/site-packages/PyQt5/Qt5/lib').
3569 WARNING: QtLibraryInfo(PyQt5): excluding plugin '[...]/venv/lib64/python3.10/site-packages/PyQt5/Qt5/plugins/platforms/libqeglfs.so' ('platforms')! Reason: Qt dependency 'libQt5EglFSDeviceIntegration.so.5' ('/usr/lib64/libQt5EglFSDeviceIntegration.so.5.15.11') has been resolved outside of the Qt shared library directory ('[...]/venv/lib/python3.10/site-packages/PyQt5/Qt5/lib').
...
4351 INFO: Loading module hook 'hook-PyQt5.QtQml.py' from '[...]/PyInstaller/hooks'...
4570 WARNING: QtLibraryInfo(PyQt5): excluding QML plugin binary '[...]/venv/lib/python3.10/site-packages/PyQt5/Qt5/qml/QtMultimedia/libdeclarative_multimedia.so'! Reason: Qt dependency 'libQt5MultimediaQuick.so.5' ('/usr/lib64/libQt5MultimediaQuick.so.5.15.11') has been resolved outside of the Qt shared library directory ('[...]/venv/lib/python3.10/site-packages/PyQt5/Qt5/lib').
4570 WARNING: QtLibraryInfo(PyQt5): excluding QML plugin directory '[...]/venv/lib/python3.10/site-packages/PyQt5/Qt5/qml/QtMultimedia' due to invalid plugin binaries!
4824 WARNING: QtLibraryInfo(PyQt5): excluding QML plugin binary '[...]/venv/lib/python3.10/site-packages/PyQt5/Qt5/qml/QtQuick/Scene2D/libqtquickscene2dplugin.so'! Reason: Qt dependency 'libQt53DLogic.so.5' ('/usr/lib64/libQt53DLogic.so.5.15.11') has been resolved outside of the Qt shared library directory ('[...]/venv/lib/python3.10/site-packages/PyQt5/Qt5/lib').
4824 WARNING: QtLibraryInfo(PyQt5): excluding QML plugin directory '[...]/venv/lib/python3.10/site-packages/PyQt5/Qt5/qml/QtQuick/Scene2D' due to invalid plugin binaries!
4833 WARNING: QtLibraryInfo(PyQt5): excluding QML plugin binary '[...]/venv/lib/python3.10/site-packages/PyQt5/Qt5/qml/QtQuick/Scene3D/libqtquickscene3dplugin.so'! Reason: Qt dependency 'libQt53DLogic.so.5' ('/usr/lib64/libQt53DLogic.so.5.15.11') has been resolved outside of the Qt shared library directory ('[...]/venv/lib/python3.10/site-packages/PyQt5/Qt5/lib').
4833 WARNING: QtLibraryInfo(PyQt5): excluding QML plugin directory '[...]/venv/lib/python3.10/site-packages/PyQt5/Qt5/qml/QtQuick/Scene3D' due to invalid plugin binaries!
```

</p></details>


<details><summary>PyQt6</summary><p>

```
3198 INFO: Loading module hook 'hook-PyQt6.QtGui.py' from '[...]/PyInstaller/hooks'...
3422 WARNING: QtLibraryInfo(PyQt6): excluding plugin '[...]/venv/lib64/python3.10/site-packages/PyQt6/Qt6/plugins/platforms/libqeglfs.so' ('platforms')! Reason: Qt dependency 'libQt6EglFSDeviceIntegration.so.6' ('/usr/lib64/libQt6EglFSDeviceIntegration.so.6.6.0') has been resolved outside of the Qt shared library directory ('[...]/venv/lib/python3.10/site-packages/PyQt6/Qt6/lib').
3978 WARNING: QtLibraryInfo(PyQt6): excluding plugin '[...]/venv/lib64/python3.10/site-packages/PyQt6/Qt6/plugins/egldeviceintegrations/libqeglfs-x11-integration.so' ('egldeviceintegrations')! Reason: Qt dependency 'libQt6EglFSDeviceIntegration.so.6' ('/usr/lib64/libQt6EglFSDeviceIntegration.so.6.6.0') has been resolved outside of the Qt shared library directory ('[...]/venv/lib/python3.10/site-packages/PyQt6/Qt6/lib').
4071 WARNING: QtLibraryInfo(PyQt6): excluding plugin '[...]/venv/lib64/python3.10/site-packages/PyQt6/Qt6/plugins/egldeviceintegrations/libqeglfs-kms-egldevice-integration.so' ('egldeviceintegrations')! Reason: Qt dependency 'libQt6EglFsKmsSupport.so.6' ('/usr/lib64/libQt6EglFsKmsSupport.so.6.6.0') has been resolved outside of the Qt shared library directory ('[...]/venv/lib/python3.10/site-packages/PyQt6/Qt6/lib').
4091 WARNING: QtLibraryInfo(PyQt6): excluding plugin '[...]/venv/lib64/python3.10/site-packages/PyQt6/Qt6/plugins/egldeviceintegrations/libqeglfs-emu-integration.so' ('egldeviceintegrations')! Reason: Qt dependency 'libQt6EglFSDeviceIntegration.so.6' ('/usr/lib64/libQt6EglFSDeviceIntegration.so.6.6.0') has been resolved outside of the Qt shared library directory ('[...]/venv/lib/python3.10/site-packages/PyQt6/Qt6/lib').
...
4349 INFO: Loading module hook 'hook-PyQt6.QtQml.py' from '[...]/PyInstaller/hooks'...
4514 WARNING: QtLibraryInfo(PyQt6): excluding QML plugin binary '[...]/venv/lib/python3.10/site-packages/PyQt6/Qt6/qml/QtQml/XmlListModel/libqmlxmllistmodelplugin.so'! Reason: Qt dependency 'libQt6QmlXmlListModel.so.6' ('/usr/lib64/libQt6QmlXmlListModel.so.6.6.0') has been resolved outside of the Qt shared library directory ('[...]/venv/lib/python3.10/site-packages/PyQt6/Qt6/lib').
4514 WARNING: QtLibraryInfo(PyQt6): excluding QML plugin directory '[...]/venv/lib/python3.10/site-packages/PyQt6/Qt6/qml/QtQml/XmlListModel' due to invalid plugin binaries!
4772 WARNING: QtLibraryInfo(PyQt6): excluding QML plugin binary '[...]/venv/lib/python3.10/site-packages/PyQt6/Qt6/qml/QtQuick/Effects/libeffectsplugin.so'! Reason: Qt dependency 'libQt6QuickEffects.so.6' ('/usr/lib64/libQt6QuickEffects.so.6.6.0') has been resolved outside of the Qt shared library directory ('[...]/venv/lib/python3.10/site-packages/PyQt6/Qt6/lib').
4772 WARNING: QtLibraryInfo(PyQt6): excluding QML plugin directory '[...]/venv/lib/python3.10/site-packages/PyQt6/Qt6/qml/QtQuick/Effects' due to invalid plugin binaries!
4803 WARNING: QtLibraryInfo(PyQt6): excluding QML plugin binary '[...]/venv/lib/python3.10/site-packages/PyQt6/Qt6/qml/QtQuick/LocalStorage/libqmllocalstorageplugin.so'! Reason: Qt dependency 'libQt6QmlLocalStorage.so.6' ('/usr/lib64/libQt6QmlLocalStorage.so.6.6.0') has been resolved outside of the Qt shared library directory ('[...]/venv/lib/python3.10/site-packages/PyQt6/Qt6/lib').
4803 WARNING: QtLibraryInfo(PyQt6): excluding QML plugin directory '[...]/venv/lib/python3.10/site-packages/PyQt6/Qt6/qml/QtQuick/LocalStorage' due to invalid plugin binaries!
4880 WARNING: QtLibraryInfo(PyQt6): excluding QML plugin binary '[...]/venv/lib/python3.10/site-packages/PyQt6/Qt6/qml/QtQuick/Scene2D/libqtquickscene2dplugin.so'! Reason: Qt dependency 'libQt63DQuickScene2D.so.6' ('/usr/lib64/libQt63DQuickScene2D.so.6.6.0') has been resolved outside of the Qt shared library directory ('[...]/venv/lib/python3.10/site-packages/PyQt6/Qt6/lib').
4880 WARNING: QtLibraryInfo(PyQt6): excluding QML plugin directory '[...]/venv/lib/python3.10/site-packages/PyQt6/Qt6/qml/QtQuick/Scene2D' due to invalid plugin binaries!
4906 WARNING: QtLibraryInfo(PyQt6): excluding QML plugin binary '[...]/venv/lib/python3.10/site-packages/PyQt6/Qt6/qml/QtQuick/Scene3D/libqtquickscene3dplugin.so'! Reason: Qt dependency 'libQt63DAnimation.so.6' ('/usr/lib64/libQt63DAnimation.so.6.6.0') has been resolved outside of the Qt shared library directory ('[...]/venv/lib/python3.10/site-packages/PyQt6/Qt6/lib').
4906 WARNING: QtLibraryInfo(PyQt6): excluding QML plugin directory '[...]/venv/lib/python3.10/site-packages/PyQt6/Qt6/qml/QtQuick/Scene3D' due to invalid plugin binaries!
5025 WARNING: QtLibraryInfo(PyQt6): excluding QML plugin binary '[...]/venv/lib/python3.10/site-packages/PyQt6/Qt6/qml/QtQuick3D/Helpers/impl/libqtquick3dhelpersimplplugin.so'! Reason: Qt dependency 'libQt6OpenGL.so.6' ('/usr/lib64/libQt6OpenGL.so.6.6.0') has been resolved outside of the Qt shared library directory ('[...]/venv/lib/python3.10/site-packages/PyQt6/Qt6/lib').
5025 WARNING: QtLibraryInfo(PyQt6): excluding QML plugin directory '[...]/venv/lib/python3.10/site-packages/PyQt6/Qt6/qml/QtQuick3D/Helpers/impl' due to invalid plugin binaries!
5057 WARNING: QtLibraryInfo(PyQt6): excluding QML plugin binary '[...]/venv/lib/python3.10/site-packages/PyQt6/Qt6/qml/QtQuick3D/ParticleEffects/libqtquick3dparticleeffectsplugin.so'! Reason: Qt dependency 'libQt6Quick3DParticleEffects.so.6' ('/usr/lib64/libQt6Quick3DParticleEffects.so.6.6.0') has been resolved outside of the Qt shared library directory ('[...]/venv/lib/python3.10/site-packages/PyQt6/Qt6/lib').
5057 WARNING: QtLibraryInfo(PyQt6): excluding QML plugin directory '[...]/venv/lib/python3.10/site-packages/PyQt6/Qt6/qml/QtQuick3D/ParticleEffects' due to invalid plugin binaries!
5085 WARNING: QtLibraryInfo(PyQt6): excluding QML plugin binary '[...]/venv/lib/python3.10/site-packages/PyQt6/Qt6/qml/QtQuick3D/Physics/Helpers/libqtquick3dphysicshelpersplugin.so'! Reason: Missing Qt dependency 'libQt6Quick3DPhysicsHelpers.so.6'.
5085 WARNING: QtLibraryInfo(PyQt6): excluding QML plugin directory '[...]/venv/lib/python3.10/site-packages/PyQt6/Qt6/qml/QtQuick3D/Physics/Helpers' due to invalid plugin binaries!
5100 WARNING: QtLibraryInfo(PyQt6): excluding QML plugin binary '[...]/venv/lib/python3.10/site-packages/PyQt6/Qt6/qml/QtQuick3D/Physics/libqquick3dphysicsplugin.so'! Reason: Missing Qt dependency 'libQt6Quick3DPhysics.so.6'.
5100 WARNING: QtLibraryInfo(PyQt6): excluding QML plugin directory '[...]/venv/lib/python3.10/site-packages/PyQt6/Qt6/qml/QtQuick3D/Physics' due to invalid plugin binaries!
```
</p></details>

