### PR TITLE
bindepend: improve ldd warning handling

### DIFF
--- a/PyInstaller/depend/bindepend.py
+++ b/PyInstaller/depend/bindepend.py
@@ -344,6 +344,10 @@ def _get_imports_ldd(filename, search_paths):
         # warnings. Suppress these.
         elif line.startswith("ldd: warning: you do not have execution permission for "):
             continue
+        # When `ldd` is ran against a file that is not a dynamic binary (i.e., is not a binary at all, or is a static
+        # binary), it emits a "not a dynamic executable" warning. Suppress it.
+        elif "not a dynamic executable" in line:
+            continue
         # Propagate any other warnings it might have.
         ldd_warnings.append(line)
     if ldd_warnings:

--- a/PyInstaller/depend/bindepend.py
+++ b/PyInstaller/depend/bindepend.py
@@ -330,6 +330,7 @@ def _get_imports_ldd(filename, search_paths):
         encoding='utf-8',
     )
 
+    ldd_warnings = []
     for line in p.stderr.splitlines():
         if not line:
             continue
@@ -344,7 +345,9 @@ def _get_imports_ldd(filename, search_paths):
         elif line.startswith("ldd: warning: you do not have execution permission for "):
             continue
         # Propagate any other warnings it might have.
-        print(line, file=sys.stderr)
+        ldd_warnings.append(line)
+    if ldd_warnings:
+        logger.warning("ldd warnings for %r:\n%s", filename, "\n".join(ldd_warnings))
 
     for line in p.stdout.splitlines():
         name = None  # Referenced name


### PR DESCRIPTION
Instead of directly dumping unhandled lines from `ldd` stderr output to stderr via `print()`, collect them into a list, and if non-empty, display it via `logging.warning()`, preceded by the filename.

This way, we can see which file generated the warnings. For example,

```
5480 INFO: Looking for dynamic libraries
	not a dynamic executable
9134 INFO: Warnings written to ...
```

becomes,

```
5321 INFO: Looking for dynamic libraries
6999 WARNING: ldd warnings for '[...]/venv/lib64/python3.10/site-packages/PySide2/Qt/libexec/QtWebEngineProcess.debug':
	not a dynamic executable
9353 INFO: Warnings written to ...
```

and reduces amount of mystery.

In the second commit, we suppress that `not a dynamic executable` warning, which is emitted when `ldd` is called with a file that is not a binary at all, or is a static binary. 

So the above warning is not displayed at all.