### PR TITLE
Add missing f-identifier to ValueError description

### DIFF
--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -882,7 +882,7 @@ class EXE(Target):
 
         # Ensure file exists.
         if not os.path.isfile(src_filename):
-            raise ValueError("Resource file {src_filename!r} does not exist!")
+            raise ValueError(f"Resource file {src_filename!r} does not exist!")
 
         # Check if src_filename points to a PE file or an arbitrary (data) file.
         try:


### PR DESCRIPTION
Value error isn't formatted.

Error looks like this:
```batch
  File "C:\some_path_to_installer\pyinstaller\PyInstaller\building\api.py", line 885, in _copy_windows_resource
    raise ValueError("Resource file {src_filename!r} does not exist!")
ValueError: Resource file {src_filename!r} does not exist!
```

Fixed by added f-identifier:
```bath
File "C:\some_path_to_installer\pyinstaller\PyInstaller\building\api.py", line 885, in _copy_windows_resource
    raise ValueError(f"Resource file {src_filename!r} does not exist!")
ValueError: Resource file 'C:\\some_missing_resource_file' does not exist!
```