### PR TITLE
depend: prevent collection of libcuda.so* and libcudadebugger.so*

### DIFF
--- a/PyInstaller/depend/dylib.py
+++ b/PyInstaller/depend/dylib.py
@@ -216,6 +216,10 @@ _unix_excludes = {
     r'libnvidia-egl-(gbm|wayland)\.so(\..*)?',
     r'libnvidia-(cfg|compiler|e?glcore|glsi|glvkspirv|rtcore|allocator|tls|ml)\.so(\..*)?',
     r'lib(EGL|GLX)_nvidia\.so(\..*)?',
+    # libcuda.so, libcuda.so.1, and libcuda.so.{version} are run-time part of NVIDIA driver, and should not be
+    # collected, as they need to match the rest of driver components on the target system.
+    r'libcuda\.so(\..*)?',
+    r'libcudadebugger\.so(\..*)?',
     # libxcb-dri changes ABI frequently (e.g.: between Ubuntu LTS releases) and is usually installed as dependency of
     # the graphics stack anyway. No need to bundle it.
     r'libxcb\.so(\..*)?',

--- a/news/8278.bugfix.rst
+++ b/news/8278.bugfix.rst
@@ -1,0 +1,4 @@
+(Linux) Prevent collection of ``libcuda.so.1``, which is part of NVIDIA
+driver and must match the rest of the driver's components. Collecting
+a copy might lead to issues when build and target system use different
+versions of NVIDIA driver.


### PR DESCRIPTION
`libcuda.so`, `libcuda.so.1`, and `libcuda.so.{version}` are run-time part of NVIDIA driver; therefore, they should not be collected, as they need to match the rest of driver components on the target system.

Same goes for `libcudadebugger.so*`.