### PR TITLE
Misc. smaller changes

### DIFF
--- a/PyInstaller/__main__.py
+++ b/PyInstaller/__main__.py
@@ -197,6 +197,15 @@ def run(pyi_args: list | None = None, pyi_config: dict | None = None):
             )
             spec_file = args.filenames[0]
         else:
+            # Ensure that the given script files exist, before trying to generate the .spec file.
+            # This prevents us from overwriting an existing (and customized) .spec file if user makes a typo in the
+            # .spec file's suffix when trying to  build it, for example, `pyinstaller program.cpes` (see #8276).
+            # It also prevents creation of a .spec file when `pyinstaller program.py` is accidentally ran from a
+            # directory that does not contain the script (for example, due to failing to change the directory prior
+            # to running the command).
+            for filename in args.filenames:
+                if not os.path.isfile(filename):
+                    raise SystemExit(f"Script file {filename!r} does not exist.")
             spec_file = run_makespec(**vars(args))
 
         sys.argv = [spec_file, *spec_args]

--- a/PyInstaller/__main__.py
+++ b/PyInstaller/__main__.py
@@ -181,9 +181,14 @@ def run(pyi_args: list | None = None, pyi_config: dict | None = None):
 
         # Print PyInstaller version, Python version, and platform as the first line to stdout. This helps us identify
         # PyInstaller, Python, and platform version when users report issues.
-        logger.info('PyInstaller: %s' % __version__)
+        try:
+            from _pyinstaller_hooks_contrib import __version__ as contrib_hooks_version
+        except Exception:
+            contrib_hooks_version = 'unknown'
+
+        logger.info('PyInstaller: %s, contrib hooks: %s', __version__, contrib_hooks_version)
         logger.info('Python: %s%s', platform.python_version(), " (conda)" if compat.is_conda else "")
-        logger.info('Platform: %s' % platform.platform())
+        logger.info('Platform: %s', platform.platform())
 
         # Skip creating .spec when .spec file is supplied.
         if args.filenames[0].endswith('.spec'):

--- a/news/8279.bugfix.rst
+++ b/news/8279.bugfix.rst
@@ -1,0 +1,5 @@
+When trying to run ``pyinstaller`` (or equivalent ``python -m PyInstaller``)
+against non-existing script file(s), exit immediately - without trying
+to write the .spec file and building it. This prevents us from overwriting
+an existing (and customized) .spec file if user makes a typo in the .spec
+file's suffix when trying to build it, for example, ``pyinstaller program.cpes``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,12 +15,12 @@ exclude = [
    "tests/functional/modules/pyi_module_with_invalid_encoding/mymodule2.py",
 ]
 line-length=120
-select = [
+lint.select = [
   "E",       # pycodestyle errors
   "F",       # pyflakes
   "W",       # pycodestyle warnings
 ]
-show-source = true
+output-format = "full"
 
 [tool.towncrier]
 	filename = "doc/CHANGES.rst"


### PR DESCRIPTION
Miscellaneous smaller changes based on this week's issue tracker activity:

- display version of `pyinstaller-hooks-contrib` next to PyInstaller version at program start, to make it easier to determine the user's actual setup

- when trying to run `pyinstaller` (or equivalent `python -m PyInstaller`) against non-existing script file(s), exit immediately - without trying to write the .spec file and building it. Mainly to avoid scenario with overwriting a customized .spec file due to typo in command's arguments (#8276), but also because I sometimes fail to change the directory prior to trying to build a test program, and then have to deal with stay .spec files.

- fix deprecation warnings emitted by `ruff` 0.2.0

- bump the required `pyinstaller-hooks-contrib` version to the latest release, in attempt to minimize amount of issues reported due to old hooks.