### PR TITLE
building: collect .hmac files for linux shared libraries

### DIFF
--- a/PyInstaller/building/utils.py
+++ b/PyInstaller/building/utils.py
@@ -304,7 +304,7 @@ def process_collected_binary(
 
 
 def _compute_file_digest(filename):
-    hasher = hashlib.md5()
+    hasher = hashlib.sha1()
     with open(filename, "rb") as fp:
         for chunk in iter(lambda: fp.read(16 * 1024), b""):
             hasher.update(chunk)

--- a/PyInstaller/building/utils.py
+++ b/PyInstaller/building/utils.py
@@ -237,7 +237,22 @@ def process_collected_binary(
 
         cmd = ["strip", *strip_options, cached_name]
         logger.info("Executing: %s", " ".join(cmd))
-        subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        try:
+            p = subprocess.run(
+                cmd,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                check=True,
+                errors='ignore',
+                encoding='utf-8',
+            )
+            logger.debug("Output from strip command:\n%s", p.stdout)
+        except subprocess.CalledProcessError as e:
+            logger.warning("Failed to run strip on %r!", cached_name, exc_info=True)
+            logger.warning("Output from strip command:\n%s", e.stdout)
+        except Exception:
+            logger.warning("Failed to run strip on %r!", cached_name, exc_info=True)
 
     # Apply UPX
     if use_upx:
@@ -260,7 +275,22 @@ def process_collected_binary(
 
         cmd = [upx_exe, *upx_options, cached_name]
         logger.info("Executing: %s", " ".join(cmd))
-        subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        try:
+            p = subprocess.run(
+                cmd,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                check=True,
+                errors='ignore',
+                encoding='utf-8',
+            )
+            logger.debug("Output from upx command:\n%s", p.stdout)
+        except subprocess.CalledProcessError as e:
+            logger.warning("Failed to upx strip on %r!", cached_name, exc_info=True)
+            logger.warning("Output from upx command:\n%s", e.stdout)
+        except Exception:
+            logger.warning("Failed to run upx on %r!", cached_name, exc_info=True)
 
     # On macOS, we need to modify the given binary's paths to the dependent libraries, in order to ensure they are
     # relocatable and always refer to location within the frozen application. Specifically, we make all dependent

--- a/PyInstaller/building/utils.py
+++ b/PyInstaller/building/utils.py
@@ -130,12 +130,6 @@ def process_collected_binary(
     if not use_strip and not use_upx and not is_darwin:
         return src_name
 
-    # Skip processing if this is Windows .manifest file. We used to process these as part of support for collecting
-    # WinSxS assemblies, but that was removed in PyInstaller 6.0. So in case we happen to get a .manifest file here,
-    # return it as-is.
-    if is_win and src_name.lower().endswith(".manifest"):
-        return src_name
-
     # Match against provided UPX exclude patterns.
     upx_exclude = upx_exclude or []
     if use_upx:

--- a/news/8273.feature.rst
+++ b/news/8273.feature.rst
@@ -1,0 +1,4 @@
+(Linux) Collect ``.hmac`` files accompanying shared libraries, if such
+files are available. This allows frozen application to run on FIPS-enabled
+Red Hat Enterprise systems, where HMAC is required by self-check
+implemented by the OpenSSL crypto library.

--- a/news/8273.feature.rst
+++ b/news/8273.feature.rst
@@ -1,4 +1,7 @@
 (Linux) Collect ``.hmac`` files accompanying shared libraries, if such
 files are available. This allows frozen application to run on FIPS-enabled
 Red Hat Enterprise systems, where HMAC is required by self-check
-implemented by the OpenSSL crypto library.
+implemented by the OpenSSL crypto library. Furthermore, ensure that
+shared libraries with accompanying ``.hmac`` files are exempted from
+any additional processing (for example, when building with ``--strip``
+option) to avoid invalidating the HMAC.

--- a/news/8288.bugfix.rst
+++ b/news/8288.bugfix.rst
@@ -1,0 +1,3 @@
+Switch the hashing function in PyInstaller's binary cache from MD5 to
+SHA1, as the former cannot be used on FIPS-enabled Red Hat Enterprise
+Linux systems.


### PR DESCRIPTION
Implement collection of `.hmac` files that may accompany shared library `.so` files on some linux systems (Red Hat Enterprise Linux, Fedora Linux). As per #8287, these HMACs are used in crypto library validation/self-check that is enforced when RHEL system is running in FIPS-enabled mode:

https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/assembly_installing-a-rhel-8-system-with-fips-mode-enabled_security-hardening

Closes #8273.

When running in FIPS-mode, `hashlib.md5()` cannot be used - therefore, switch the binary cache hashes from md5 to sha1. This allows to run PyInstaller with `--strip` option on FIPS-enabled RHEL system.

A shared library with HMAC should not be modified in any way (as this invalidates the HMAC), so exempt such shared libraries from processing in `process_collected_binaries` (strip and/or upx, although upx is currently disabled on linux).

At the same time, refactor `process_collected_binaries` to remove call to itself when both strip and upx are used; instead, both utilities are called one after another (i.e., without separately caching the intermediate result). The main goal here is to simplify the processing flow to make it easier to eventually introduce support for code-signing on Windows.