### PR TITLE
bootloader: make creation of temporary directories AppContainer-aware

### DIFF
--- a/bootloader/src/pyi_win32_utils.h
+++ b/bootloader/src/pyi_win32_utils.h
@@ -26,6 +26,9 @@ wchar_t * pyi_win32_utils_from_utf8(wchar_t *buffer, const char *ostr, size_t n)
 
 char * pyi_win32_utf8_to_mbs(char * dst, const char * src, size_t max);
 
+int pyi_win32_initialize_security_descriptor();
+void pyi_win32_free_security_descriptor();
+
 int pyi_win32_mkdir(const wchar_t *path);
 
 int pyi_win32_is_symlink(const wchar_t *path);

--- a/news/8291.feature.rst
+++ b/news/8291.feature.rst
@@ -1,0 +1,5 @@
+(Windows) Make bootloader codepaths involved in creation of temporary
+directories for ``onefile`` builds AppContainer-aware. If the process
+runs inside an AppContainer, the temporary directory's DACL needs to
+explicitly include the AppContainerSID, otherwise the directory becomes
+inaccessible to the process.


### PR DESCRIPTION
Make bootloader codepaths involved in creation of temporary directories for `onefile` builds on Windows AppContainer-aware. If the process runs inside an AppContainer, the temporary directory's DACL needs to explicitly include the AppContainerSID, otherwise the directory becomes inaccessible to the process. This is bootloader equivalent of #8290.

Refactor `pyi_win32_mkdir` to use pre-initialized security descriptor, instead of constructing descriptor string and parsing it on each call. This also avoids querying user SID and AppContainer SID on every call.