### PR TITLE
bootloader: set configure_locale=1 in interpreter pre-config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,27 @@ jobs:
             gir1.2-gtk-3.0 libgirepository1.0-dev \
             libfuse2
 
+      # The following locales are required by test_basic::test_user_preferred_locale
+      #  - en_US.UTF-8
+      #  - en_US.ISO8859-1
+      #  - sl_SI.UTF-8
+      #  - sl_SI.ISO8859-2
+      #
+      # The following locale is used by test_basic::test_time_module_localized
+      #  - cs_CZ.UTF-8
+      - name: Install and enable additional locales
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -qq --no-install-recommends locales
+          sudo locale-gen \
+            en_US.UTF-8 \
+            en_US \
+            sl_SI.UTF-8 \
+            sl_SI \
+            cs_CZ.UTF-8
+          locale -a
+
       - name: Download AppImage tool
         if: startsWith(matrix.os, 'ubuntu')
         run: |

--- a/bootloader/src/pyi_pyconfig.c
+++ b/bootloader/src/pyi_pyconfig.c
@@ -642,8 +642,12 @@ pyi_pyconfig_preinit_python(const PyiRuntimeOptions *runtime_options)
     PyPreConfig_Common config;
 
     PI_PyPreConfig_InitIsolatedConfig((PyPreConfig *)&config);
+
     config.utf8_mode = runtime_options->utf8_mode;
     config.dev_mode = runtime_options->dev_mode;
+
+    /* Set the LC_CTYPE locale to the user-preferred locale, so it can be read using `locale.getlocale()` in python code. */
+    config.configure_locale = 1;
 
     /* Pre-initialize */
     PyStatus status = PI_Py_PreInitialize((const PyPreConfig *)&config);

--- a/news/8306.bootloader.rst
+++ b/news/8306.bootloader.rst
@@ -1,0 +1,3 @@
+Have bootloader set the ``configure_locale`` field in the interpreter
+pre-config structure, so that user-preferred locale is set during
+interpreter pre-initialization.

--- a/news/8306.bugfix.rst
+++ b/news/8306.bugfix.rst
@@ -1,0 +1,3 @@
+(Linux) Fix regression that caused :func:`locale.getlocale` in
+frozen applications created with PyInstaller 6.x return ``(None, None)``
+instead of user-preferred locale.


### PR DESCRIPTION
Have bootloader set the `configure_locale` field in the interpreter pre-config structure, so that user-preferred locale is set during interpreter pre-initialization.

This fixes regression w.r.t. PyInstaller 5.x and unfrozen python, where calling `locale.getlocale` in frozen application returns user-preferred locale, while frozen applications created by PyInstaller 6.x currently return `(None, None)`. By extension, this fixes #8305.

In PyInstaller 5.x bootloader, user-preferred locale was set explicitly by bootloader calling `setlocale` in C code; now, we can let python interpreter (pre)initialization handle that for us.
