### PR TITLE
Improve collection of QtWebEngineProcess helper and ensure Qt is relocatable

### DIFF
--- a/PyInstaller/building/build_main.py
+++ b/PyInstaller/building/build_main.py
@@ -819,10 +819,15 @@ class Analysis(Target):
                     continue  # Skip symbolic links
                 src_lib_path = pathlib.Path(src_name)
                 src_hmac_path = src_lib_path.with_name(f".{src_lib_path.name}.hmac")
-                if not src_hmac_path.is_file():
-                    continue
-                dest_hmac_path = pathlib.PurePath(dest_name).with_name(src_hmac_path.name)
-                self.datas.append((str(dest_hmac_path), str(src_hmac_path), 'DATA'))
+                if src_hmac_path.is_file():
+                    dest_hmac_path = pathlib.PurePath(dest_name).with_name(src_hmac_path.name)
+                    self.datas.append((str(dest_hmac_path), str(src_hmac_path), 'DATA'))
+
+                # Similarly, look for .chk files that are used by NSS libraries.
+                src_chk_path = src_lib_path.with_suffix(".chk")
+                if src_chk_path.is_file():
+                    dest_chk_path = pathlib.PurePath(dest_name).with_name(src_chk_path.name)
+                    self.datas.append((str(dest_chk_path), str(src_chk_path), 'DATA'))
 
         # Final normalization of `datas` and `binaries`:
         #  - normalize both TOCs together (to avoid having duplicates across the lists)

--- a/PyInstaller/building/utils.py
+++ b/PyInstaller/building/utils.py
@@ -154,14 +154,18 @@ def process_collected_binary(
         logger.info('Disabling UPX for %s due to it being a Qt plugin!', src_name)
         use_upx = False
 
-    # On linux, if a binary has an accompanying HMAC file, avoid modifying it in any way.
+    # On linux, if a binary has an accompanying HMAC or CHK file, avoid modifying it in any way.
     if (use_upx or use_strip) and is_linux:
         src_path = pathlib.Path(src_name)
         hmac_path = src_path.with_name(f".{src_path.name}.hmac")
+        chk_path = src_path.with_suffix(".chk")
         if hmac_path.is_file():
             logger.info('Disabling UPX and/or strip for %s due to accompanying .hmac file!', src_name)
             use_upx = use_strip = False
-        del src_path, hmac_path
+        elif chk_path.is_file():
+            logger.info('Disabling UPX and/or strip for %s due to accompanying .chk file!', src_name)
+            use_upx = use_strip = False
+        del src_path, hmac_path, chk_path
 
     # Exit early if no processing is required after above rules are applied.
     if not use_strip and not use_upx and not is_darwin:

--- a/PyInstaller/fake-modules/_pyi_rth_utils/qt.py
+++ b/PyInstaller/fake-modules/_pyi_rth_utils/qt.py
@@ -1,0 +1,97 @@
+# -----------------------------------------------------------------------------
+# Copyright (c) 2024, PyInstaller Development Team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: Apache-2.0
+# -----------------------------------------------------------------------------
+
+import os
+import importlib
+import atexit
+
+# Helper for relocating Qt prefix via embedded qt.conf file.
+_QT_CONF_FILENAME = ":/qt/etc/qt.conf"
+
+_QT_CONF_RESOURCE_NAME = (
+    # qt
+    b"\x00\x02"
+    b"\x00\x00\x07\x84"
+    b"\x00\x71"
+    b"\x00\x74"
+    # etc
+    b"\x00\x03"
+    b"\x00\x00\x6c\xa3"
+    b"\x00\x65"
+    b"\x00\x74\x00\x63"
+    # qt.conf
+    b"\x00\x07"
+    b"\x08\x74\xa6\xa6"
+    b"\x00\x71"
+    b"\x00\x74\x00\x2e\x00\x63\x00\x6f\x00\x6e\x00\x66"
+)
+
+_QT_CONF_RESOURCE_STRUCT = (
+    # :
+    b"\x00\x00\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x01"
+    # :/qt
+    b"\x00\x00\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x02"
+    # :/qt/etc
+    b"\x00\x00\x00\x0a\x00\x02\x00\x00\x00\x01\x00\x00\x00\x03"
+    # :/qt/etc/qt.conf
+    b"\x00\x00\x00\x16\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00"
+)
+
+
+def create_embedded_qt_conf(qt_bindings, prefix_path):
+    QtCore = importlib.import_module(qt_bindings + ".QtCore")
+
+    # No-op if embedded qt.conf already exists
+    if QtCore.QFile.exists(_QT_CONF_FILENAME):
+        return
+
+    # Create qt.conf file that relocates Qt prefix.
+    # NOTE: paths should use POSIX-style forward slashes as separator, even on Windows.
+    if os.sep == '\\':
+        prefix_path = prefix_path.replace(os.sep, '/')
+
+    qt_conf = f"[Paths]\nPrefix = {prefix_path}\n"
+    if os.name == 'nt' and qt_bindings in {"PySide2", "PySide6"}:
+        # PySide PyPI wheels on Windows set LibraryExecutablesPath to PrefixPath
+        qt_conf += f"LibraryExecutables = {prefix_path}"
+
+    # Encode the contents; in Qt5, QSettings uses Latin1 encoding, in Qt6, it uses UTF8.
+    if qt_bindings in {"PySide2", "PyQt5"}:
+        qt_conf = qt_conf.encode("latin1")
+    else:
+        qt_conf = qt_conf.encode("utf-8")
+
+    # Prepend data size (32-bit integer, big endian)
+    qt_conf_size = len(qt_conf)
+    qt_resource_data = qt_conf_size.to_bytes(4, 'big') + qt_conf
+
+    # Register
+    succeeded = QtCore.qRegisterResourceData(
+        0x01,
+        _QT_CONF_RESOURCE_STRUCT,
+        _QT_CONF_RESOURCE_NAME,
+        qt_resource_data,
+    )
+    if not succeeded:
+        return  # Tough luck
+
+    # Unregister the resource at exit, to ensure that the registered resource on Qt/C++ side does not outlive the
+    # `_qt_resource_data` python variable and its data buffer. This also adds a reference to the `_qt_resource_data`,
+    # which conveniently ensures that the data is not garbage collected before we perform the cleanup (otherwise garbage
+    # collector might kick in at any time after we exit this helper function, and `qRegisterResourceData` does not seem
+    # to make a copy of the data!).
+    atexit.register(
+        QtCore.qUnregisterResourceData,
+        0x01,
+        _QT_CONF_RESOURCE_STRUCT,
+        _QT_CONF_RESOURCE_NAME,
+        qt_resource_data,
+    )

--- a/PyInstaller/fake-modules/_pyi_rth_utils/qt.py
+++ b/PyInstaller/fake-modules/_pyi_rth_utils/qt.py
@@ -47,7 +47,13 @@ _QT_CONF_RESOURCE_STRUCT = (
 
 
 def create_embedded_qt_conf(qt_bindings, prefix_path):
-    QtCore = importlib.import_module(qt_bindings + ".QtCore")
+    # The QtCore module might be unavailable if we collected just the top-level binding package (e.g., PyQt5) without
+    # any of its submodules. Since this helper is called from run-time hook for the binding package, we need to handle
+    # that scenario here.
+    try:
+        QtCore = importlib.import_module(qt_bindings + ".QtCore")
+    except ImportError:
+        return
 
     # No-op if embedded qt.conf already exists
     if QtCore.QFile.exists(_QT_CONF_FILENAME):

--- a/PyInstaller/hooks/rthooks/pyi_rth_pyqt5.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_pyqt5.py
@@ -18,6 +18,7 @@ def _pyi_rthook():
     import sys
 
     from _pyi_rth_utils import is_macos_app_bundle, prepend_path_to_environment_variable
+    from _pyi_rth_utils import qt as qt_rth_utils
 
     # Try PyQt5 5.15.4-style path first...
     pyqt_path = os.path.join(sys._MEIPASS, 'PyQt5', 'Qt5')
@@ -52,6 +53,12 @@ def _pyi_rthook():
     # location).
     if sys.platform.startswith('win'):
         prepend_path_to_environment_variable(sys._MEIPASS, 'PATH')
+
+    # Qt bindings package installed via PyPI wheels typically ensures that its bundled Qt is relocatable, by creating
+    # embedded `qt.conf` file during its initialization. This run-time generated qt.conf dynamically sets the Qt prefix
+    # path to the package's Qt directory. For bindings packages that do not create embedded `qt.conf` during their
+    # initialization (for example, conda-installed packages), try to perform this step ourselves.
+    qt_rth_utils.create_embedded_qt_conf("PyQt5", pyqt_path)
 
 
 _pyi_rthook()

--- a/PyInstaller/hooks/rthooks/pyi_rth_pyqt6.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_pyqt6.py
@@ -18,6 +18,7 @@ def _pyi_rthook():
     import sys
 
     from _pyi_rth_utils import is_macos_app_bundle, prepend_path_to_environment_variable
+    from _pyi_rth_utils import qt as qt_rth_utils
 
     # Try PyQt6 6.0.3-style path first...
     pyqt_path = os.path.join(sys._MEIPASS, 'PyQt6', 'Qt6')
@@ -54,6 +55,12 @@ def _pyi_rthook():
     # as Homebrew. For .app bundles, this is unnecessary because `QtNetwork` explicitly searches `Contents/Frameworks`.
     if sys.platform == 'darwin' and not is_macos_app_bundle:
         prepend_path_to_environment_variable(sys._MEIPASS, 'DYLD_LIBRARY_PATH')
+
+    # Qt bindings package installed via PyPI wheels typically ensures that its bundled Qt is relocatable, by creating
+    # embedded `qt.conf` file during its initialization. This run-time generated qt.conf dynamically sets the Qt prefix
+    # path to the package's Qt directory. For bindings packages that do not create embedded `qt.conf` during their
+    # initialization (for example, conda-installed packages), try to perform this step ourselves.
+    qt_rth_utils.create_embedded_qt_conf("PyQt6", pyqt_path)
 
 
 _pyi_rthook()

--- a/PyInstaller/hooks/rthooks/pyi_rth_pyside2.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_pyside2.py
@@ -18,6 +18,7 @@ def _pyi_rthook():
     import sys
 
     from _pyi_rth_utils import is_macos_app_bundle, prepend_path_to_environment_variable
+    from _pyi_rth_utils import qt as qt_rth_utils
 
     if sys.platform.startswith('win'):
         pyqt_path = os.path.join(sys._MEIPASS, 'PySide2')
@@ -47,6 +48,12 @@ def _pyi_rthook():
     # collected there (i.e., when they were not shipped with the package, and were collected from an external location).
     if sys.platform.startswith('win'):
         prepend_path_to_environment_variable(sys._MEIPASS, 'PATH')
+
+    # Qt bindings package installed via PyPI wheels typically ensures that its bundled Qt is relocatable, by creating
+    # embedded `qt.conf` file during its initialization. This run-time generated qt.conf dynamically sets the Qt prefix
+    # path to the package's Qt directory. For bindings packages that do not create embedded `qt.conf` during their
+    # initialization (for example, conda-installed packages), try to perform this step ourselves.
+    qt_rth_utils.create_embedded_qt_conf("PySide2", pyqt_path)
 
 
 _pyi_rthook()

--- a/PyInstaller/hooks/rthooks/pyi_rth_pyside6.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_pyside6.py
@@ -18,6 +18,7 @@ def _pyi_rthook():
     import sys
 
     from _pyi_rth_utils import is_macos_app_bundle, prepend_path_to_environment_variable
+    from _pyi_rth_utils import qt as qt_rth_utils
 
     if sys.platform.startswith('win'):
         pyqt_path = os.path.join(sys._MEIPASS, 'PySide6')
@@ -53,6 +54,12 @@ def _pyi_rthook():
     # as Homebrew. For .app bundles, this is unnecessary because `QtNetwork` explicitly searches `Contents/Frameworks`.
     if sys.platform == 'darwin' and not is_macos_app_bundle:
         prepend_path_to_environment_variable(sys._MEIPASS, 'DYLD_LIBRARY_PATH')
+
+    # Qt bindings package installed via PyPI wheels typically ensures that its bundled Qt is relocatable, by creating
+    # embedded `qt.conf` file during its initialization. This run-time generated qt.conf dynamically sets the Qt prefix
+    # path to the package's Qt directory. For bindings packages that do not create embedded `qt.conf` during their
+    # initialization (for example, conda-installed packages), try to perform this step ourselves.
+    qt_rth_utils.create_embedded_qt_conf("PySide6", pyqt_path)
 
 
 _pyi_rthook()

--- a/news/8315.bugfix.1.rst
+++ b/news/8315.bugfix.1.rst
@@ -1,0 +1,4 @@
+(Windows) Fix collection of ``QtWebEngineProcess`` helper when
+collecting ``PySide2`` and Qt installed via Anaconda on Windows.
+The helper executable is now collected into top-level ``PySide2``
+package directory, in order to match the PyPI wheel layout.

--- a/news/8315.bugfix.rst
+++ b/news/8315.bugfix.rst
@@ -1,0 +1,5 @@
+(Linux) Fix collection of ``QtWebEngineProcess`` helper when collecting
+Qt (and ``PySide``/``PyQt`` bindings) installed via Linux distribution
+packages. In such scenarios, we now force collection of the helper
+executable into ``libexec`` directory inside the Qt sub-directory of
+the bindings' package directory, in order to match the PyPI wheel layout.

--- a/news/8315.feature.rst
+++ b/news/8315.feature.rst
@@ -1,0 +1,2 @@
+(Linux) Extend the mechanism for collection of ``.hmac`` files from
+:issue:`8288` to ``.chk`` files that are used by NSS libraries.

--- a/news/8315.hooks.1.rst
+++ b/news/8315.hooks.1.rst
@@ -1,0 +1,6 @@
+(Linux) When searching for dynamically-loaded NSS libraries during
+collection of ``QtWebEnginge``, account for the possibility of said
+libraries being either in a separate ``nss`` directory or in the main
+library directory. This fixes problems with missing NSS libraries on
+contemporary Linux distributions that do not use separate ``nss``
+directory (anymore).

--- a/news/8315.hooks.rst
+++ b/news/8315.hooks.rst
@@ -1,0 +1,8 @@
+Have run-time hooks for Qt bindings (``PySide2``, ``PySide6``, ``PyQt5``,
+and ``PyQt6``) check for presence of the embedded ``:/qt/etc/qt.conf``
+resource, and if not present, inject their own version. This
+aims to ensure that the bundled Qt is always relocatable, even if the
+package does not perform injection of embedded ``qt.conf`` file (most
+notably, this seems to be the case with ``PySide2`` collected from
+Linux distribution packages, and ``PySide2`` collected from Anaconda
+on Windows, Linux, and macOS).


### PR DESCRIPTION
Improve collection of `QtWebEngineProcess` helper in two specific cases:
- collecting from Qt installed via Linux distribution packages (i.e., system package manager)
- collecting from PySide2 and Qt installed via Anaconda on Windows
In both cases, we need to override the auto-computed relative destination path to match the standard PyPI wheel layout, which our Qt collection approach is trying to reconstruct. 

Fixes #8307.

When trying to test the above changes, it turned out that `PySide2`, collected either from Fedora RPMs or from Anaconda (on Windows, Linux, or macOS), does not inject the embedded `qt.conf` resource to make the Qt relocatable, and consequently the paths returned by `QLibraryInfo` are incorrect (and the `QtWebEngineProcess` helper fails to be discovered, although it is collected into correct location). Curiously enough, the Fedora- or Anaconda-installed `PyQt` packages (both 5 and 6) do not seem to inject the embedded `qt.conf` when located in their original standard library directory, but they do once they are collected into PyInstaller-frozen application. So it looks like that they have dynamic switch, whereas with `PySide` packages, this switch is static. (Sidenote: PyPI wheels of all four bindings always seem to inject the embedded `qt.conf`, because they always need to be fully relocatable).

So now our run-time hooks for all four Qt bindings check for the presence of embedded `qt.conf` resource, and on the off chance that it is not present, inject their own version, in an attempt to ensure that the collected Qt is always relocatable and that paths in `QLibraryInfo` are correct (that they point to the collected Qt directories, and that the layout matches the layout of PyPI wheels that our Qt collection approach is trying to reconstruct).