### PR TITLE
building: prevent pyqtgraph.canvas from crashing binary dependency analysis

### DIFF
--- a/PyInstaller/building/build_main.py
+++ b/PyInstaller/building/build_main.py
@@ -242,6 +242,10 @@ def find_binary_dependencies(binaries, import_packages):
         if "PySide6" in suppressed_imports:
             suppressed_imports += ["shiboken6"]
 
+        # Suppress import of `pyqtgraph.canvas`, which is known to crash python interpreter. See #7452 and #8322, as
+        # well as https://github.com/pyqtgraph/pyqtgraph/issues/2838.
+        suppressed_imports += ['pyqtgraph.canvas']
+
         # Processing in isolated environment.
         with isolated.Python() as child:
             child.call(setup, suppressed_imports)

--- a/PyInstaller/isolated/__init__.py
+++ b/PyInstaller/isolated/__init__.py
@@ -28,4 +28,4 @@ This submodule provides:
 """
 
 # ruff: noqa
-from ._parent import Python, call, decorate
+from ._parent import Python, call, decorate, SubprocessDiedError

--- a/news/8322.bugfix.rst
+++ b/news/8322.bugfix.rst
@@ -1,0 +1,5 @@
+(Windows) Avoid trying to import ``pyqtgraph.canvas`` in the subprocess
+that analyzes dynamic library search modifications made by packages prior
+to the binary dependency analysis. Trying to import ``pyqtgraph.canvas``
+causes python interpreter to crash under certain circumstances (the
+issue is present in ``pyqtgraph`` <= 0.13.3).


### PR DESCRIPTION
When the isolated subprocess crashes while importing packages prior to binary dependency analysis (to infer dynamic DLL search paths on Windows), include the list of planned package imports in the exception message.

This improves our chances of reproducing the issue when the crash is related to the order in which packages are imported.