### PR TITLE
Refactor antivirus issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/antivirus.md
+++ b/.github/ISSUE_TEMPLATE/antivirus.md
@@ -29,20 +29,42 @@ Instead of randomly changing your code or PyInstaller configuration in the hope 
 
 You can never know for sure if an executable is trustworthy but we have recompiled our bootloaders plenty of times on different machines giving bit for bit (or [as close as MSVC lets you get](https://bytepointer.com/articles/the_microsoft_rich_header.htm)) reproducibility. So unless they are all identically infected then this can't be it.
 
-On the other hand, we have seen through repeatedly submitting the same files for analysis at intervals that the results are far even from being consistent which puts their accuracy under serious question.
+On the other hand, we have seen through repeatedly submitting the same files for analysis at intervals that the results are far even from being consistent which puts their accuracy under serious question. We've also observed that it's not until a few days after a new release that antiviruses suddenly decide that our bootloaders are malicious.
 
-If you're still not convinced then audit the [source code](https://github.com/pyinstaller/pyinstaller/tree/master/bootloader/src) and [build the bootloaders](https://pyinstaller.readthedocs.io/en/latest/bootloader-building.html) yourself.
+Some of classifications we receive (such as an *Artemis*) aren't even based on the behaviour of a program but on the rate at which it goes from having never been seen before to being seen across many devices (its *going viral*). Imagine how this *viral* detection would play out when a new PyInstaller version gets released and 25,000 Windows users download it from PyPI each day, build applications with it, then distribute those applications to yet more people.
+
+If you're still not convinced then audit the [source code](https://github.com/pyinstaller/pyinstaller/tree/develop/bootloader/src) and [build the bootloaders](https://pyinstaller.readthedocs.io/en/latest/bootloader-building.html) yourself.
+
+
+### How can so many antiviruses think its malware simultaneously and all be wrong?
+
+Many antiviruses are connected to the *Global Threat Intelligence Database* which is a highly marketable way for different antivirus vendors to quickly share their classifications. Whilst this sounds great in theory, in practice it means that if one antivirus mistakenly thinks that PyInstaller is malware, it'll upload misleading information to this database so that many other vendors will then parrot the same incorrect results.
+
+
+### Some prior version of PyInstaller has significantly fewer antivirus detections. Doesn't that make it a regression in PyInstaller?
+
+No, most antiviruses do not read code. Instead they memorise parts of files and hope that the parts of the files they are memorising really are the parts that make said files either malicious or not. If one version of PyInstaller receives less false positives than another it is **not** an indication that the first version was doing something right and the other was doing something wrong – it's just that they are different, have different checksums and therefore need to be memorised all over again. We can achieve similar dramatic changes in detection rates by making benign changes to our bootloaders such as changing the C compiler version or even passing `.c` files to the compiler in a different order.
+
+
+# Using `-w/--windowed` mode cause a higher detection rate. Is that a bug?
+
+No, it's just a reflection of the fact that most people distributing malware using PyInstaller will be using windowed mode.
 
 
 ### What can you do to get it to run on your computer?
 
-* Disable your antivirus completely. This may sound radical but consider, it's clearly demonstrated that it doesn't work - what's the point in keeping it? You will also be amazed at how much faster your computer runs without it.
-* Replace your antivirus with a better one (Kaspersky or Avira to name a couple).
+* The preferred way is to disable your antivirus. Now that you know how it works, you also know that it doesn't work and that all along it was just giving you a false sense of security.
+* Replace your antivirus with a better one (preferably one that doesn't use AI or the Global Threat Intelligence Database).
 
 
 ### What can you do to get it working for users?
 
 * [Reporting false positives to AV vendors](#reporting-false-positives-to-av-vendors) is the correct way and some providers even provide APIs to do so automatically. They should eventually whitelist your software as OK. Bear in mind that users will likely need to first install some form of security update for that whitelist to propagate to their own computer before they stop seeing warnings.
-* [Recompiling the bootloaders](https://pyinstaller.readthedocs.io/en/latest/bootloader-building.html) yourself can make applications better accepted by the heuristics based AVs just because it makes yours different. In particular, use gcc instead of the MSVC compiler on Windows to completely throw them off. Note that this is a double edged sword however - by being different your application will not benefit if PyInstaller's bootloaders get whitelisted. Also be aware that if enough people do this, the heuristics will swing the other way and you're back to square one again.
+* [Recompiling the bootloaders](https://pyinstaller.readthedocs.io/en/latest/bootloader-building.html) yourself can make applications better accepted by the heuristics based AVs just because it makes yours different. In particular, use gcc instead of the MSVC compiler on Windows to differentiate yourself even more from the norm. Note that this is a double edged sword however - by being different your application will not benefit if PyInstaller's bootloaders get whitelisted. Also be aware that if enough people do this, the heuristics will swing the other way and you're back to square one again.
 * Tell your users to follow the steps [above](#what-can-you-do-to-get-it-to-run-on-your-computer).
-* Purchase [codesign certificate](https://www.digicert.com/signing/code-signing-certificates) for few hundred dollars a year (open source projects can get them [a fair bit cheaper](https://shop.certum.eu/open-source-code-signing-on-simplysign.html)). Note that this is not guaranteed to fix AV false positives but it should make them less common.
+* Purchase [codesign certificate](https://www.digicert.com/signing/code-signing-certificates) for few hundred dollars a year. Note that this is not guaranteed to fix AV false positives but it should make them less common. Feedback wanted on to what extent this helps from people who've tried it.
+
+
+### This is not good enough. Why is there no proper solution?
+
+Because we have no control over other organisations' broken antivirus software. Believe me, I'm just as frustrated and unable to do anything about it as you are.


### PR DESCRIPTION
* Remove suggestion of using Certum since we've had bad feedback about them (#8324) and replace it with something to encourage people to tell us if code signing really does help since we currently have no idea.

* Remove apparent endorsements of *good* antiviruses since I can't really vouch for their trustworthiness.

* Add some more FAQs that I'm sick of answering in issues/discussions (the global threat intelligence database, alleged *regressions* in detection rates across PyInstaller versions, why windowed mode is hit the most).

* Point out the existence of Artemis classifications and how antiviruses really *analyse* code.

* Reword some of the more cringe-worthy bits of wording.

* Add yet another sentence at the end to say we're helpless in a probably vain attempt to dissuade people from ignoring it when we say as much at the beginning of the template.