### PR TITLE
Explicitly disallow multiple Qt bindings packages in a frozen application

### DIFF
--- a/PyInstaller/fake-modules/_pyi_rth_utils/qt.py
+++ b/PyInstaller/fake-modules/_pyi_rth_utils/qt.py
@@ -13,6 +13,21 @@ import os
 import importlib
 import atexit
 
+# Helper for ensuring that only one Qt bindings package is registered at run-time via run-time hooks.
+_registered_qt_bindings = None
+
+
+def ensure_single_qt_bindings_package(qt_bindings):
+    global _registered_qt_bindings
+    if _registered_qt_bindings is not None:
+        raise RuntimeError(
+            f"Cannot execute run-time hook for {qt_bindings!r} because run-time hook for {_registered_qt_bindings!r} "
+            "has been run before, and PyInstaller-frozen applications do not support multiple Qt bindings in the same "
+            "application!"
+        )
+    _registered_qt_bindings = qt_bindings
+
+
 # Helper for relocating Qt prefix via embedded qt.conf file.
 _QT_CONF_FILENAME = ":/qt/etc/qt.conf"
 

--- a/PyInstaller/hooks/hook-PyQt5.py
+++ b/PyInstaller/hooks/hook-PyQt5.py
@@ -9,7 +9,10 @@
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
 
-from PyInstaller.utils.hooks.qt import pyqt5_library_info
+from PyInstaller.utils.hooks.qt import pyqt5_library_info, ensure_single_qt_bindings_package
+
+# Allow only one Qt bindings package to be collected in frozen application.
+ensure_single_qt_bindings_package("PyQt5")
 
 # Only proceed if PyQt5 can be imported.
 if pyqt5_library_info.version is not None:

--- a/PyInstaller/hooks/hook-PyQt6.py
+++ b/PyInstaller/hooks/hook-PyQt6.py
@@ -9,7 +9,10 @@
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
 
-from PyInstaller.utils.hooks.qt import pyqt6_library_info
+from PyInstaller.utils.hooks.qt import pyqt6_library_info, ensure_single_qt_bindings_package
+
+# Allow only one Qt bindings package to be collected in frozen application.
+ensure_single_qt_bindings_package("PyQt6")
 
 # Only proceed if PyQt6 can be imported.
 if pyqt6_library_info.version is not None:

--- a/PyInstaller/hooks/hook-PySide2.py
+++ b/PyInstaller/hooks/hook-PySide2.py
@@ -9,7 +9,10 @@
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
 
-from PyInstaller.utils.hooks.qt import pyside2_library_info
+from PyInstaller.utils.hooks.qt import pyside2_library_info, ensure_single_qt_bindings_package
+
+# Allow only one Qt bindings package to be collected in frozen application.
+ensure_single_qt_bindings_package("PySide2")
 
 # Only proceed if PySide2 can be imported.
 if pyside2_library_info.version is not None:

--- a/PyInstaller/hooks/hook-PySide6.py
+++ b/PyInstaller/hooks/hook-PySide6.py
@@ -10,7 +10,10 @@
 #-----------------------------------------------------------------------------
 
 from PyInstaller.utils.hooks import check_requirement
-from PyInstaller.utils.hooks.qt import pyside6_library_info
+from PyInstaller.utils.hooks.qt import pyside6_library_info, ensure_single_qt_bindings_package
+
+# Allow only one Qt bindings package to be collected in frozen application.
+ensure_single_qt_bindings_package("PySide6")
 
 # Only proceed if PySide6 can be imported.
 if pyside6_library_info.version is not None:

--- a/PyInstaller/hooks/hook-matplotlib.backends.backend_qtagg.py
+++ b/PyInstaller/hooks/hook-matplotlib.backends.backend_qtagg.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2024, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+# This module conditionally imports PyQt6:
+# https://github.com/matplotlib/matplotlib/blob/9e18a343fb58a2978a8e27df03190ed21c61c343/lib/matplotlib/backends/backend_qtagg.py#L52-L53
+# Suppress this import to prevent PyQt6 from being accidentally pulled in; the actually relevant Qt bindings are
+# determined by our hook for `matplotlib.backends.qt_compat` module.
+excludedimports = ['PyQt6']

--- a/PyInstaller/hooks/hook-matplotlib.backends.backend_qtcairo.py
+++ b/PyInstaller/hooks/hook-matplotlib.backends.backend_qtcairo.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2024, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+# This module conditionally imports PyQt6:
+# https://github.com/matplotlib/matplotlib/blob/9e18a343fb58a2978a8e27df03190ed21c61c343/lib/matplotlib/backends/backend_qtcairo.py#L24-L25
+# Suppress this import to prevent PyQt6 from being accidentally pulled in; the actually relevant Qt bindings are
+# determined by our hook for `matplotlib.backends.qt_compat` module.
+excludedimports = ['PyQt6']

--- a/PyInstaller/hooks/hook-matplotlib.backends.qt_compat.py
+++ b/PyInstaller/hooks/hook-matplotlib.backends.qt_compat.py
@@ -1,0 +1,26 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2024, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import qt as qtutils
+
+# This module conditionally imports all Qt bindings. Prevent all available bindings from being pulled in by trying to
+# select the most applicable one.
+#
+# The preference order for this module appears to be: PyQt6, PySide6, PyQt5, PySide2 (or just PyQt5, PySide2 if Qt5
+# bindings are forced). See:
+# https://github.com/matplotlib/matplotlib/blob/9e18a343fb58a2978a8e27df03190ed21c61c343/lib/matplotlib/backends/qt_compat.py#L113-L125
+#
+# We, however, use the default preference order of the helper function, in order to keep it consistent across multiple
+# hooks that use the same helper.
+excludedimports = qtutils.exclude_extraneous_qt_bindings(
+    hook_name="hook-matplotlib.backends.qt_compat",
+    qt_bindings_order=None,
+)

--- a/PyInstaller/hooks/hook-pandas.io.clipboard.py
+++ b/PyInstaller/hooks/hook-pandas.io.clipboard.py
@@ -1,0 +1,19 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2024, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+# This module conditionally imports PyQt5:
+# https://github.com/pandas-dev/pandas/blob/95308514e1221200e4526dfaf248283f3d7ade06/pandas/io/clipboard/__init__.py#L578-L597
+# Suppress this import to prevent PyQt5 from being accidentally pulled in; the actually relevant Qt bindings are
+# determined by our hook for `qtpy` module, which contemporary versions of pandas mandate as part of `clipboard` and
+# `all` extras:
+# https://github.com/pandas-dev/pandas/blob/95308514e1221200e4526dfaf248283f3d7ade06/pyproject.toml#L86
+# https://github.com/pandas-dev/pandas/blob/95308514e1221200e4526dfaf248283f3d7ade06/pyproject.toml#L115
+excludedimports = ['PyQt5']

--- a/PyInstaller/hooks/hook-qtpy.py
+++ b/PyInstaller/hooks/hook-qtpy.py
@@ -1,0 +1,25 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2024, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks import qt as qtutils
+
+# This module conditionally imports all Qt bindings. Prevent all available bindings from being pulled in by trying to
+# select the most applicable one.
+#
+# The preference order for this module appears to be: PyQt5, PySide2, PyQt6, PySide6. See:
+# https://github.com/spyder-ide/qtpy/blob/3238de7a3e038daeb585c1a76fd9a0c4baf22f11/qtpy/__init__.py#L199-L289
+#
+# We, however, use the default preference order of the helper function, in order to keep it consistent across multiple
+# hooks that use the same helper.
+excludedimports = qtutils.exclude_extraneous_qt_bindings(
+    hook_name="hook-qtpy",
+    qt_bindings_order=None,
+)

--- a/PyInstaller/hooks/rthooks/pyi_rth_pyqt5.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_pyqt5.py
@@ -20,6 +20,9 @@ def _pyi_rthook():
     from _pyi_rth_utils import is_macos_app_bundle, prepend_path_to_environment_variable
     from _pyi_rth_utils import qt as qt_rth_utils
 
+    # Ensure this is the only Qt bindings package in the application.
+    qt_rth_utils.ensure_single_qt_bindings_package("PyQt5")
+
     # Try PyQt5 5.15.4-style path first...
     pyqt_path = os.path.join(sys._MEIPASS, 'PyQt5', 'Qt5')
     if not os.path.isdir(pyqt_path):

--- a/PyInstaller/hooks/rthooks/pyi_rth_pyqt6.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_pyqt6.py
@@ -20,6 +20,9 @@ def _pyi_rthook():
     from _pyi_rth_utils import is_macos_app_bundle, prepend_path_to_environment_variable
     from _pyi_rth_utils import qt as qt_rth_utils
 
+    # Ensure this is the only Qt bindings package in the application.
+    qt_rth_utils.ensure_single_qt_bindings_package("PyQt6")
+
     # Try PyQt6 6.0.3-style path first...
     pyqt_path = os.path.join(sys._MEIPASS, 'PyQt6', 'Qt6')
     if not os.path.isdir(pyqt_path):

--- a/PyInstaller/hooks/rthooks/pyi_rth_pyside2.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_pyside2.py
@@ -20,6 +20,9 @@ def _pyi_rthook():
     from _pyi_rth_utils import is_macos_app_bundle, prepend_path_to_environment_variable
     from _pyi_rth_utils import qt as qt_rth_utils
 
+    # Ensure this is the only Qt bindings package in the application.
+    qt_rth_utils.ensure_single_qt_bindings_package("PySide2")
+
     if sys.platform.startswith('win'):
         pyqt_path = os.path.join(sys._MEIPASS, 'PySide2')
     else:

--- a/PyInstaller/hooks/rthooks/pyi_rth_pyside6.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_pyside6.py
@@ -20,6 +20,9 @@ def _pyi_rthook():
     from _pyi_rth_utils import is_macos_app_bundle, prepend_path_to_environment_variable
     from _pyi_rth_utils import qt as qt_rth_utils
 
+    # Ensure this is the only Qt bindings package in the application.
+    qt_rth_utils.ensure_single_qt_bindings_package("PySide6")
+
     if sys.platform.startswith('win'):
         pyqt_path = os.path.join(sys._MEIPASS, 'PySide6')
     else:

--- a/doc/hooks-config.rst
+++ b/doc/hooks-config.rst
@@ -373,15 +373,42 @@ importable or not.
     )
 
 .. note::
-    The ``Qt5Agg`` backend conditionally imports both the ``PyQt5`` and
-    the ``PySide2`` package. Therefore, if both are installed in your
-    environment, PyInstaller will end up collecting both. In addition
-    to increasing the frozen application's size, this might also cause
-    conflicts between the collected versions of the shared libraries.
-    To prevent that, use the :option:`--exclude-module` option to exclude
-    one of the two packages (i.e., ``--exclude-module PyQt5`` or
-    ``--exclude-module PySide2``).
+    The ``Qt5Agg`` backend code conditionally imports all Qt bindings
+    packages (``PySide2``, ``PyQt5``, ``PySide6``, and ``PyQt6``).
+    Therefore, if all are installed in your environment, PyInstaller will
+    end up collecting all. In addition to increasing the frozen
+    application's size, this might also cause conflicts between the
+    collected versions of the shared libraries. To prevent that, use
+    the :option:`--exclude-module` option to exclude the extraneous
+    Qt bindings packags (i.e., if you want to use ``PyQt5``, use
+    ``--exclude-module PySide2``, ``--exclude-module PyQt6``, and
+    ``--exclude-module PySide6``).
 
+    Starting with PyInstaller 6.5, multiple Qt bindings in a frozen
+    application are explicitly disallowed - the build process aborts
+    with an error if hooks for more than one Qt bindings package are
+    executed. Therefore, ``matplotlib`` hook automatically attempts to
+    select Qt bindings to use, based on the following heuristics: first,
+    we check whether hooks for any Qt bindings have already been run; if
+    they have, those bindings are selected. If not, the ``QT_API``
+    environment variable is read; if it is set and contains a valid
+    Qt bindings package name, those bindings are selected. If not, one
+    of the available Qt bindings is selected. Once a Qt bindings package
+    is selected, all other (potentially available) Qt bindings packages
+    are excluded from the hooked module, to prevent their collection
+    due to conditional imports in the hooked module.
+
+    This means that if your entry-point script explicitly imports a
+    Qt bindings package before importing ``matplotlib``, those bindings
+    should be chosen automatically. On the other hand, if your program
+    uses ``matplotlib`` without importing Qt bindings on its own, the
+    Qt bindings to be collected are auto-selected, based on what is
+    available in the build environment. This auto-selection can be
+    overridden by setting the ``QT_API`` environment variable before
+    running PyInstaller. In this particular case, an environment
+    variable is used instead of hooks configuration mechanism because
+    Qt bindings selection might be performed across several hooks for
+    different packages.
 
 
 Adding an option to the hook

--- a/news/8329.breaking.rst
+++ b/news/8329.breaking.rst
@@ -1,0 +1,16 @@
+PyInstaller now explicitly disallows attempts to collect multiple Qt
+bindings packages (``PySide2``, ``PySide6``, ``PyQt5``, ``PyQt6``) into
+a frozen application. When hooks for more than one top-level Qt bindings
+package are executed, the build process is aborted with error message.
+This restriction applies across all instances of ``Analysis`` within
+a single build (i.e., a single .spec file).
+
+If you encounter build errors caused by this new restriction, either
+clean up your build environment (remove the bindings that you are not
+using), or explicitly exclude the extraneous bindings using :option:`--exclude`
+(or equivalent ``excludes`` list passed as argument to ``Analysis`` in
+the .spec file).
+
+The automatic exclusion of extraneous bindings needs to be done via hooks
+on per-package basis, so please report problematic packages on PyInstaller's
+issue tracker, so that we can write hooks for them.

--- a/news/8329.hooks.1.rst
+++ b/news/8329.hooks.1.rst
@@ -1,0 +1,11 @@
+Extend hooks for ``matplotlib`` to prevent collection of multiple
+available Qt bindings. The new hook for ``matplotlib.backends.qt_compat``
+attempts to select a single Qt bindings package via the following
+logic implemented in the ``PyInstaller.utils.hooks.qt.exclude_extraneous_qt_bindings``
+helper: first, we check if hooks for any Qt bindings package have already
+been run; if they had, those bindings are selected. If not, we check for
+user-specified bindings in the ``QT_API`` environment variable; if valid
+bindings name is specified, those bindings are selected. Otherwise, we
+select one of available bindings. Once a Qt bindings package is selected,
+the imports of all other Qt bindings packages are excluded from the
+hooked package.

--- a/news/8329.hooks.2.rst
+++ b/news/8329.hooks.2.rst
@@ -1,0 +1,5 @@
+Add hook for ``qtpy`` to prevent collection of multiple available Qt
+bindings. The hook attempts to select a single Qt bindings package
+and exclude all other Qt bindings packages with the help of the
+``PyInstaller.utils.hooks.qt.exclude_extraneous_qt_bindings``
+helper.

--- a/news/8329.hooks.3.rst
+++ b/news/8329.hooks.3.rst
@@ -1,0 +1,4 @@
+Add a hook for ``pandas.io.clipboard`` to exclude the conditional
+import of ``PyQt5`` from this module; the module primarily uses ``qtpy``
+as its Qt bindings abstraction, and the conditional import of ``PyQt5``
+interferes with Qt bindings selection done by our ``qtpy`` hook.

--- a/news/8329.hooks.rst
+++ b/news/8329.hooks.rst
@@ -1,0 +1,7 @@
+PyInstaller now explicitly disallows attempts to collect multiple Qt
+bindings packages (``PySide2``, ``PySide6``, ``PyQt5``, ``PyQt6``) into
+a frozen application. When hooks for more than one top-level Qt bindings
+package are executed, the build process is aborted with error message
+that informs user of the situation and what to do about it (i.e., exclusion
+of extraneous packages). The limitation applies to all analyses within a
+spec file.


### PR DESCRIPTION
Explicitly disallow multiple Qt bindings packages in a frozen application. 

Due to the way that collected Qt environment is set up (the paths set up by embedded `qt.conf` resource that is injected either via bindings packages themselves, or by our run-time hooks, as well as environment variables set by our run-time hooks), only one Qt bindings package can be properly configured (i.e., the paths point to Qt directories belonging to that package). Other binding packages usually end up broken, and fail to load either due to incompatible shared libraries or missing (or rather, unloadable) Qt platform plugins.

Therefore, we now raise an error if we detect attempts to run hooks for more than one Qt bindings package. This is done both at build time (in hooks for top-level bindings packages) as well as run-time (in run-time hooks for Qt bindings packages).