### PR TITLE
hooks: matplotlib.backends: add QtAgg and Gtk4Agg as backend candidates

### DIFF
--- a/PyInstaller/hooks/hook-matplotlib.backends.py
+++ b/PyInstaller/hooks/hook-matplotlib.backends.py
@@ -135,7 +135,9 @@ def _autodetect_used_backends(hook_api):
         logger.info("Found configured default matplotlib backend: %s", default_backend)
         return [default_backend]
 
-    candidates = ["Qt5Agg", "Gtk3Agg", "TkAgg", "WxAgg"]
+    # `QtAgg` supersedes `Qt5Agg`; however, we keep `Qt5Agg` in the candidate list to support older versions of
+    # matplotlib that do not have `QtAgg`.
+    candidates = ["QtAgg", "Qt5Agg", "Gtk4Agg", "Gtk3Agg", "TkAgg", "WxAgg"]
     if is_darwin:
         candidates = ["MacOSX"] + candidates
     logger.info("Trying determine the default backend as first importable candidate from the list: %r", candidates)

--- a/news/8334.hooks.rst
+++ b/news/8334.hooks.rst
@@ -1,0 +1,2 @@
+Update hook for ``matplotlib.backends`` to include ``QtAgg`` and ``Gtk4Agg``
+in the list of backend candidates.


### PR DESCRIPTION
Update the backend candidates list to include `QtAgg` and `Gtk4Agg`, to match the list used by `matplotlib.pyplot.switch_backend()` in contemporary `matplotlib` versions.

This allows us the hook to select Qt-based backend when PyQt6 or PySide6 is available (`Qt5Agg` specifically forces Qt5 bindings).

For compatibility with older `matplotlib` versions that do not have `QtAgg`, we keep `Qt5Agg` in the list of candidates, right after `QtAgg`.