### PR TITLE
Fix AMD64 Python running on Windows ARM64

### DIFF
--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -231,7 +231,12 @@ else:
 system = 'Cygwin' if is_cygwin else platform.system()
 
 # Machine suffix for bootloader.
-machine = _pyi_machine(platform.machine(), platform.system())
+if is_win:
+    # On Windows ARM64 using an x64 Python environment, platform.machine() returns ARM64 but
+    # we really want the bootloader that matches the Python environment instead of the OS.
+    machine = _pyi_machine(os.environ.get("PROCESSOR_ARCHITECTURE", platform.machine()), platform.system())
+else:
+    machine = _pyi_machine(platform.machine(), platform.system())
 
 
 # Wine detection and support

--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -379,31 +379,52 @@ int main ()
 
 
 def _msvc_target(ctx):
+    if getattr(ctx.options, "msvc_targets", False):
+        return re.findall(r"[^, ]+", ctx.options.msvc_targets)
+
     try:
-        host = {"AMD64": "amd64", "x86": "x86", "ARM64": "arm64"}[platform.machine()]
+        _msvc_names = {"AMD64": "amd64", "x86": "x86", "ARM64": "arm64"}
+        host = _msvc_names[os.environ.get("PROCESSOR_ARCHITECTURE", platform.machine())]
     except KeyError:
         return []
+
     if ctx.options.target_arch == '32bit':
         target = 'x86'
     elif ctx.options.target_arch == '64bit':
-        target = 'amd64'
+        target = 'x64'
     elif ctx.options.target_arch == '64bit-arm':
         target = 'arm64'
     else:
-        return []
-    # If we are not cross-compiling, we need to return single-architecture target string.
-    if host == target:
-        if host == 'amd64':
-            return 'x64'  # Native amd64 compiler is actually called 'x64'. See `waflib/Tools/msvc.py`.
-        return host  # x86, arm64
-    # Cross-compiling; set host_target combination: amd64_x86, amd64_arm64, x86_amd64, arm64_amd64, ...
-    return [host + "_" + target]
+        target = "x64" if host == "amd64" else host
+
+    if host == 'x86':
+        if target == 'x86':
+            return ['x86']
+        elif target == 'x64':
+            return ['x86_amd64']
+        else:  # arm64
+            return ['x86_arm64']
+    elif host == 'amd64':
+        if target == 'x86':
+            return ['amd64_x86', 'x86']
+        elif target == 'x64':
+            return ['x64', 'x86_amd64']
+        else:  # arm64
+            return ['amd64_arm64', 'x86_arm64']
+    else:  # arm64
+        if target == 'x86':
+            return ['arm64_x86', 'x86', 'amd64_x86']
+        elif target == 'x64':
+            return ['arm64_amd64', 'x64', 'x86_amd64']
+        else:  # arm64
+            return ['arm64']
 
 
 def configure(ctx):
     ctx.msg('Python Version', sys.version.replace(os.linesep, ''))
     # For MSVC the target arch must have already been set when the compiler is searched.
     ctx.env['MSVC_TARGETS'] = _msvc_target(ctx)
+    ctx.msg('MSVC target(s)', ctx.env['MSVC_TARGETS'])
 
     # ** C compiler **
 

--- a/news/8219.bugfix.rst
+++ b/news/8219.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bootloaders not being found when running an Intel build of Python on Windows ARM64.

--- a/news/8219.build.rst
+++ b/news/8219.build.rst
@@ -1,0 +1,2 @@
+The target architecture on Windows using MSVC now defaults to that of the
+current Python environment – not the current OS.


### PR DESCRIPTION
When running an `x86` or `AMD64` Python environment on Windows `ARM64`, `platform.machine()` is set to the host architecture (`ARM64`) rather than the runtime one (the opposite behaviour to a `x86_64` Python environment on `arm64` macOS). This means we expect the wrong bootloaders to be present.

Change the current architecture detection on Windows to read the `PROCESSOR_ARCHITECTURE` environment variable instead. This is the only way that gave the right answer without extensive normalisation on both conventional Python and MSYS2 python. I'm not sure if that variable always existed so I've kept `platform.machine()` as a fallback value.

Change the default target architecture for the bootloader build so that anyone rebuilding the bootloader during a pip install get the right architecture.

---

I'm really not convinced that the waf change is the right way to do it.