### PR TITLE
depend: fix suppression of api-ms-win-*.dll warnings on Windows 11

### DIFF
--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -73,6 +73,7 @@ is_py312 = sys.version_info >= (3, 12)
 
 is_win = sys.platform.startswith('win')
 is_win_10 = is_win and (platform.win32_ver()[0] == '10')
+is_win_11 = is_win and (platform.win32_ver()[0] == '11')
 is_win_wine = False  # Running under Wine; determined later on.
 is_cygwin = sys.platform == 'cygwin'
 is_darwin = sys.platform == 'darwin'  # Mac OS X

--- a/PyInstaller/depend/dylib.py
+++ b/PyInstaller/depend/dylib.py
@@ -356,8 +356,8 @@ _warning_suppressions = []
 if compat.is_linux:
     _warning_suppressions.append(r'ldd')
 
-# Suppress false warnings on win 10 and UCRT (see issue #1566).
-if compat.is_win_10:
+# Suppress warnings about unresolvable UCRT DLLs (see issue #1566) on Windows 10 and 11.
+if compat.is_win_10 or compat.is_win_11:
     _warning_suppressions.append(r'api-ms-win-.*\.dll')
 
 

--- a/news/8339.bugfix.rst
+++ b/news/8339.bugfix.rst
@@ -1,0 +1,2 @@
+(Windows) Suppress warnings about unresolvable UCRT DLLs
+(``api-ms-win-*.dll``) on Windows 11.


### PR DESCRIPTION
Fix suppression of warnings about unresolvable UCRT DLLs (i.e., the `api-ms-win-*.dll` files) on Windows 11, which was previously enabled only for Windows 10.