### PR TITLE
Doc: Add note to Splash Screen on Linux limitations

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -204,7 +204,11 @@ Splash Screen *(Experimental)*
 .. Note::
     This feature is incompatible with macOS. In the current design, the
     splash screen operates in a secondary thread, which is disallowed by
-    the Tcl/Tk (or rather, the underlying GUI toolkit) on macOS.
+    the Tcl/Tk (or rather, the underlying GUI toolkit) on macOS. On Linux 
+    there is a platform-specific limitation of Tcl/Tk in regard to wm 
+    attributes -alpha. For an opacity change to take effect, a compositing 
+    window manager is required. Tcl/Tk does not natively support this on 
+    Linux platforms.
 
 Some applications may require a splash screen as soon as the application
 (bootloader) has been started, because especially in onefile mode large

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -219,7 +219,7 @@ image, so non-rectangular splash screens can also be displayed.
 
 .. Note::
     Splash images with transparent regions are not supported on Linux due to
-    Tcl/Tk platform limitations. The -transparentcolor and -transparent wm attributes
+    Tcl/Tk platform limitations. The ``-transparentcolor`` and ``-transparent`` wm attributes
     used by pyinstaller are not available to Linux.
 
 This splash screen is based on `Tcl/Tk`_, which is the same library used by the Python

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -204,7 +204,10 @@ Splash Screen *(Experimental)*
 .. Note::
     This feature is incompatible with macOS. In the current design, the
     splash screen operates in a secondary thread, which is disallowed by
-    the Tcl/Tk (or rather, the underlying GUI toolkit) on macOS.
+    the Tcl/Tk (or rather, the underlying GUI toolkit) on macOS. On Linux
+    there is a platform-specific limitation of Tcl/Tk in regard to wm attributes
+    -alpha. For an opacity change to take effect, a compositin window manager
+    is required.Tcl/Tk does not natively support this on Linux.
 
 Some applications may require a splash screen as soon as the application
 (bootloader) has been started, because especially in onefile mode large

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -204,10 +204,7 @@ Splash Screen *(Experimental)*
 .. Note::
     This feature is incompatible with macOS. In the current design, the
     splash screen operates in a secondary thread, which is disallowed by
-    the Tcl/Tk (or rather, the underlying GUI toolkit) on macOS. On Linux
-    there is a platform-specific limitation of Tcl/Tk in regard to wm attributes
-    -alpha. For an opacity change to take effect, a compositin window manager
-    is required.Tcl/Tk does not natively support this on Linux.
+    the Tcl/Tk (or rather, the underlying GUI toolkit) on macOS.
 
 Some applications may require a splash screen as soon as the application
 (bootloader) has been started, because especially in onefile mode large
@@ -219,6 +216,11 @@ The bootloader is able to display a one-image (i.e. only an image) splash
 screen, which is displayed before the actual main extraction process starts.
 The splash screen supports non-transparent and hard-cut-transparent images as background
 image, so non-rectangular splash screens can also be displayed.
+
+.. Note::
+    Splash images with transparent regions are not supported on Linux due to
+    Tcl/Tk platform limitations. The -transparentcolor and -transparent wm attributes
+    used by pyinstaller are not available to Linux.
 
 This splash screen is based on `Tcl/Tk`_, which is the same library used by the Python
 module `tkinter`_. PyInstaller bundles the dynamic libraries of tcl and tk into the

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -204,11 +204,7 @@ Splash Screen *(Experimental)*
 .. Note::
     This feature is incompatible with macOS. In the current design, the
     splash screen operates in a secondary thread, which is disallowed by
-    the Tcl/Tk (or rather, the underlying GUI toolkit) on macOS. On Linux 
-    there is a platform-specific limitation of Tcl/Tk in regard to wm 
-    attributes -alpha. For an opacity change to take effect, a compositing 
-    window manager is required. Tcl/Tk does not natively support this on 
-    Linux platforms.
+    the Tcl/Tk (or rather, the underlying GUI toolkit) on macOS.
 
 Some applications may require a splash screen as soon as the application
 (bootloader) has been started, because especially in onefile mode large

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -220,7 +220,7 @@ image, so non-rectangular splash screens can also be displayed.
 .. Note::
     Splash images with transparent regions are not supported on Linux due to
     Tcl/Tk platform limitations. The ``-transparentcolor`` and ``-transparent`` wm attributes
-    used by pyinstaller are not available to Linux.
+    used by PyInstaller are not available to Linux.
 
 This splash screen is based on `Tcl/Tk`_, which is the same library used by the Python
 module `tkinter`_. PyInstaller bundles the dynamic libraries of tcl and tk into the


### PR DESCRIPTION
resolves #6987 

Added onto note in Splash Screen section of doc/usage.rst

Tcl/Tk does not natively support opacity changes with wm attributes -alpha on Linux. The user is required to install a compositing window manager to support this functionality.