### PR TITLE
bootloader: Windows: shorten the duration of spinning-wheel cursor

### DIFF
--- a/news/8359.bootloader.rst
+++ b/news/8359.bootloader.rst
@@ -1,0 +1,2 @@
+(Windows) Attempt to shorten the duration of spinning-wheel cursor when
+launching applications built in ``windowed`` / ``noconsole`` mode.


### PR DESCRIPTION
When using windowed/noconsole mode, attempt to shorten the duration of the spinning-wheel cursor that Windows uses to indicate that the process is starting.

For programs using `/SUBSYSTEM:WINDOWS`, Windows displays the spinning wheel cursor for a fixed amount of time, or until the process makes use of UI functions (creates a window, uses message queue).

In PyInstaller onefile applications, the parent process displays a window only if splash screen is used. Therefore, the spinning wheel cursor might be still shown well after the child process displays its UI. To prevent this, use `PeekMessage` to access the message queue, which apparently suffices to convince Windows that the process is alive. Do this right before we spawn the child process, i.e., after the parent process finishes unpacking the program; this is to ensure that the spinning-wheel cursor is displayed for the whole duration of unpacking.

In onedir applications, the spinning wheel should generally not be an issue (as there is only one process), except for background-style applications that do not display any UI. Such progams will appear to start faster if we have Windows hide the spinning-wheel cursor before we launch the python interpreter. So add a call to `PeekMessage` in that codepath as well.