### PR TITLE
Explicit setting for bytecode optimization level in collected python code

### DIFF
--- a/PyInstaller/building/datastruct.py
+++ b/PyInstaller/building/datastruct.py
@@ -330,8 +330,10 @@ def normalize_toc(toc):
 def normalize_pyz_toc(toc):
     # Default priority: 0
     _TOC_TYPE_PRIORITIES = {
-        # Ensure that modules are never shadowed by PYZ-embedded data files.
-        'PYMODULE': 1,
+        # Ensure that entries with higher optimization level take precedence.
+        'PYMODULE-2': 2,
+        'PYMODULE-1': 1,
+        'PYMODULE': 0,
     }
 
     return _normalize_toc(toc, _TOC_TYPE_PRIORITIES)

--- a/PyInstaller/building/makespec.py
+++ b/PyInstaller/building/makespec.py
@@ -448,7 +448,8 @@ def __add_options(parser):
         type=int,
         choices={-1, 0, 1, 2},
         default=None,
-        help='Bytecode optimization level used for collected python modules and scripts.',
+        help='Bytecode optimization level used for collected python modules and scripts. For details, see the section '
+        '“Bytecode Optimization Level” in PyInstaller manual.',
     )
     g.add_argument(
         '--python-option',

--- a/PyInstaller/building/templates.py
+++ b/PyInstaller/building/templates.py
@@ -26,6 +26,7 @@ a = Analysis(
     runtime_hooks=%(runtime_hooks)r,
     excludes=%(excludes)s,
     noarchive=%(noarchive)s,
+    optimize=%(optimize)r,
 )
 pyz = PYZ(a.pure)
 %(splash_init)s
@@ -65,6 +66,7 @@ a = Analysis(
     runtime_hooks=%(runtime_hooks)r,
     excludes=%(excludes)s,
     noarchive=%(noarchive)s,
+    optimize=%(optimize)r,
 )
 pyz = PYZ(a.pure)
 %(splash_init)s

--- a/doc/spec-files.rst
+++ b/doc/spec-files.rst
@@ -376,6 +376,16 @@ The following options are supported by this mechanism:
 * ``'O'`` or ``'optimize'``: increment the value of ``sys.flags.optimize``.
   Equivalent to Python's ``-O`` command-line option.
 
+.. note::
+    The optimization level reflected by ``sys.flags.optimize`` affects
+    only bytecode that python interpreter would end up compiling at the
+    run time. In a PyInstaller-frozen application, however, most of
+    python modules are available as pre-compiled bytecode, hence the
+    run-time bytecode optimization level does not affect them at all.
+
+    For details on how to enforce the bytecode optimization level for
+    collected modules, see :ref:`bytecode optimization level`.
+
 * ``'W <arg>'``: a pass-through for `Python's W-options
   <https://docs.python.org/3/using/cmdline.html#cmdoption-W>`_ that
   control warning messages.

--- a/news/6345.bugfix.rst
+++ b/news/6345.bugfix.rst
@@ -1,0 +1,6 @@
+(Windows) Implement a work-around for running PyInstaller under python
+process with ``-OO`` (or ``PYTHONOPTIMIZE=2``) with ``cffi`` installed.
+We now temporarily disable import of ``cffi`` while importing
+``pywin32-ctypes`` in ``PyInstaller.compat`` to ensure that ``ctypes``
+backend is always used, as the ``cffi`` backend uses ``pycparser`` and
+requires docstrings, which makes it incompatible with the ``-OO`` mode.

--- a/news/8252.doc.1.rst
+++ b/news/8252.doc.1.rst
@@ -1,0 +1,3 @@
+Add a new documentation section, :ref:`bytecode optimization level`,
+which the describes the new canonical way to control bytecode
+optimization level of the collected python code.

--- a/news/8252.doc.rst
+++ b/news/8252.doc.rst
@@ -1,0 +1,5 @@
+Add a note to :ref:`specifying python interpreter options` to inform
+user that setting the optimization level to the application's embedded
+python interpreter by itself does not result in bytecode optimization of
+modules that have been collected in byte-compiled form (i.e., the majority
+of them).

--- a/news/8252.feature.rst
+++ b/news/8252.feature.rst
@@ -1,0 +1,9 @@
+Implement an option to explicitly specify the bytecode optimization level
+for collected python code, independent of the optimization level in the
+python process under which PyInstaller is running. At the .spec file level,
+this is controlled by optional ``optimize`` argument in the ``Analysis``
+constructor. At the CLI level, this is controlled by new
+:option:`--optimize` command-line option, which sets the ``optimize``
+argument for ``Analysis`` as well as :ref:`interpreter run-time options
+<specifying python interpreter options>` in the generated spec file.
+See :ref:`bytecode optimization level` for details.

--- a/tests/functional/modules/pyi_optimization/mypackage/__init__.py
+++ b/tests/functional/modules/pyi_optimization/mypackage/__init__.py
@@ -1,0 +1,32 @@
+# -----------------------------------------------------------------------------
+# Copyright (c) 2024, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+# -----------------------------------------------------------------------------
+
+# A test package for use with `pyi_optimization.py` test program.
+
+# Module's docstring
+"""Test package."""
+
+# Check if __debug__ is set
+has_debug = __debug__
+
+# Check if assert works
+has_assert = True
+try:
+    assert False
+    has_assert = False
+except Exception:
+    pass
+
+
+# Function with a docstring
+def test_function():
+    """Test function."""
+    pass

--- a/tests/functional/scripts/pyi_optimization.py
+++ b/tests/functional/scripts/pyi_optimization.py
@@ -1,0 +1,59 @@
+# -----------------------------------------------------------------------------
+# Copyright (c) 2024, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+# -----------------------------------------------------------------------------
+
+# This script checks for availability of features/flags that are turned off at higher optimization levels.
+
+import sys
+import json
+
+# Test package that implements similar checks.
+import mypackage
+
+# Check if __debug__ is set
+has_debug = __debug__
+
+# Check if assert works
+has_assert = True
+try:
+    assert False
+    has_assert = False
+except Exception:
+    pass
+
+
+# Function with a docstring
+def test_function():
+    """Test function."""
+    pass
+
+
+# Collect results from both entry-point script and test package.
+results = {
+    "sys.flags.optimize": sys.flags.optimize,
+    "script": {
+        "has_debug": has_debug,
+        "has_assert": has_assert,
+        "function_has_doc": test_function.__doc__ is not None,
+    },
+    "module": {
+        "has_debug": mypackage.has_debug,
+        "has_assert": mypackage.has_assert,
+        "module_has_doc": mypackage.__doc__ is not None,
+        "function_has_doc": mypackage.test_function.__doc__ is not None,
+    }
+}
+
+# Write to JSON file, or dump to stdout
+if len(sys.argv) > 1:
+    with open(sys.argv[1], "w") as fp:
+        json.dump(results, fp, indent=2)
+else:
+    json.dump(results, sys.stdout, indent=2)

--- a/tests/functional/test_binary_vs_data_reclassification.py
+++ b/tests/functional/test_binary_vs_data_reclassification.py
@@ -55,8 +55,8 @@ def _create_test_build(pyi_builder, tmpdir, datas=None, binaries=None):
     # The indices correspond to the lists' location in the `Analysis._guts`.
     analysis_data = miscutils.load_py_data_struct(analysis_toc_file)
     return (
-        analysis_data[14],  # binaries
-        analysis_data[17],  # datas
+        analysis_data[15],  # binaries
+        analysis_data[18],  # datas
     )
 
 

--- a/tests/unit/test_toc_normalization.py
+++ b/tests/unit/test_toc_normalization.py
@@ -193,23 +193,3 @@ def test_normalize_pyz_toc_case_sensitivity():
 
     normalized_toc = normalize_pyz_toc(toc)
     assert normalized_toc == expected_toc
-
-
-def test_normalize_pyz_toc_module_and_data1():
-    # In PYZ TOC, a DATA entry should not mask a PYMODULE one.
-    toc = copy.copy(_BASE_PYZ_TOC)
-    toc.insert(5, ('mymodule1', 'data-dir/mymodule1', 'DATA'))
-    expected_toc = _BASE_PYZ_TOC
-
-    normalized_toc = normalize_pyz_toc(toc)
-    assert normalized_toc == expected_toc
-
-
-def test_normalize_pyz_toc_module_and_data2():
-    # In PYZ TOC, a DATA entry should not mask a PYMODULE one. Variant with switched order.
-    toc = copy.copy(_BASE_PYZ_TOC)
-    toc.insert(6, ('mymodule1', 'data-dir/mymodule1', 'DATA'))
-    expected_toc = _BASE_PYZ_TOC
-
-    normalized_toc = normalize_pyz_toc(toc)
-    assert normalized_toc == expected_toc


### PR DESCRIPTION
An attempt to address #8252 and #8357 by introducing an explicit option for bytecode optimization level, which is then used in low-level components when byte-compiling collected python code, i.e., modules and program script.

At the level of PyInstaller structures in the spec file, this requires a new argument to `Analysis`; and because the only way we can pass info from `Analysis` to low-level objects where byte-compilation takes place (such as `PYZ` and `PKG`) is via TOC lists, the optimization level is embedded in the TOC typecode (e.g., `PYMODULE-1` and `PYMODULE-2` in addition to `PYMODULE`). This means that the run-time optimization setting (`sys.flags.optimize`) still needs to be controlled via `OPTION` entries passed to `EXE`, and at this level, the two settings are not coupled - i.e., user that edits their spec manually can specify `optimize=2` and forget to add `OPTION` entries to `EXE`, and end up with bytecode that has no `assert` statements and no docstrings, even though `sys.flags.optimize` in the frozen application will be 0. That's not great, but it's not much different from the current situation anyway.

So to make things easier for users, there is also `--optimize` command-line switch that affects spec generation. It specifies the optimization level that is passed to `Analysis` via `optimize`, but it also generates corresponding number of `OPTION` entries for `EXE`. Furthermore, if `--optimize` is not used but `--python-option O` is, the makespec infers the optimization level from that. Lastly, if neither `--optimize` nor `--python-option O` is used, the optimization level is taken from `sys.flags.optimize` - since it is written to the generated spec, this means that it is now fixed for subsequent builds (the ones that use the spec file without regenerating it).

This makes it possible to "cross-compile" bytecode for target optimization level that differs from optimization level of python process under which PyInstaller is running. When the two optimization levels differ, however, we cannot re-use the modulegraph's code-object cache, so it might still be preferable to (manually) set python's optimization level to match the target one. Therefore, in order to fix `-OO` issues with `pywin32-ctypes` under Windows, we now temporarily block the import of `cffi` while importing `pywin32-ctypes` in `PyInstaller.compat`.

Closes #8252.