### PR TITLE
building: osx: explicitly convert BUNDLE version to string

### DIFF
--- a/PyInstaller/building/osx.py
+++ b/PyInstaller/building/osx.py
@@ -58,7 +58,10 @@ class BUNDLE(Target):
         self.name = os.path.join(CONF['distpath'], base_name)
 
         self.appname = os.path.splitext(base_name)[0]
-        self.version = kwargs.get("version", "0.0.0")
+        # Ensure version is a string, even if user accidentally passed an int or a float.
+        # Having a `CFBundleShortVersionString` entry of non-string type in `Info.plist` causes the .app bundle to
+        # crash at start (#4466).
+        self.version = str(kwargs.get("version", "0.0.0"))
         self.toc = []
         self.strip = False
         self.upx = False

--- a/news/4466.bugfix.rst
+++ b/news/4466.bugfix.rst
@@ -1,0 +1,6 @@
+(macOS) Explicitly convert the value of ``version`` argument to ``BUNDLE``
+into a string, in order to mitigate cases when user accidentally enters
+an integer or a float. The version value ends up being written to
+``Info.plist`` as the ``CFBundleShortVersionString`` entry, and if this
+entry is not of a string type (for example, is an integer), the
+generated .app bundle crashes at start.


### PR DESCRIPTION
Explicitly convert the value of `version` argument to `BUNDLE` into a string, in order to mitigate cases when user accidentally enters an integer or a float. The version value ends up being written to `Info.plist` as the `CFBundleShortVersionString` entry, and if this entry is not of a string type (for example, is an integer), the generated .app bundle crashes at start.

Closes #4466.