### PR TITLE
bootloader: implement support for resolving executable symlinks on Windows

### DIFF
--- a/bootloader/src/pyi_path.h
+++ b/bootloader/src/pyi_path.h
@@ -24,7 +24,7 @@
 bool pyi_path_basename(char *result, const char *path);
 bool pyi_path_dirname(char *result, const char *path);
 char *pyi_path_join(char *result, const char *path1, const char *path2);
-int pyi_path_fullpath(char *abs, size_t abs_size, const char *rel);
+int pyi_path_resolve(const char *path, char *resolved_path);
 /* TODO implement. */
 /* void *pyi_path_abspath(char *result, const char *path); */
 int pyi_path_exists(char *path);

--- a/news/8300.feature.rst
+++ b/news/8300.feature.rst
@@ -1,0 +1,2 @@
+(Windows) Implement support for resolving executable's true location
+when launched via a symbolic link.


### PR DESCRIPTION
Implement support for resolving true location of the executable when launched via a symbolic link on Windows. Closes #8300.

Also clean up the surrounding code (i.e., remove `pyi_path_fullpath_keep_basename` in the POSIX codepath).