### PR TITLE
building: avoid importing PySimpleGUI prior to binary dep. analysis

### DIFF
--- a/PyInstaller/building/build_main.py
+++ b/PyInstaller/building/build_main.py
@@ -246,6 +246,11 @@ def find_binary_dependencies(binaries, import_packages):
         # well as https://github.com/pyqtgraph/pyqtgraph/issues/2838.
         suppressed_imports += ['pyqtgraph.canvas']
 
+        # PySimpleGUI 5.x displays a "first-run" dialog when imported for the first time, which blocks the loop below.
+        # This is a problem for building on CI, where the dialog cannot be closed, and where PySimpleGUI runs "for the
+        # first time" every time. See #8396.
+        suppressed_imports += ['PySimpleGUI']
+
         # Processing in isolated environment.
         with isolated.Python() as child:
             child.call(setup, suppressed_imports)

--- a/news/8396.bugfix.rst
+++ b/news/8396.bugfix.rst
@@ -1,0 +1,6 @@
+(Windows) Avoid trying to import ``PySimpleGUI`` in the subprocess that
+analyzes dynamic library search modifications made by packages prior to
+the binary dependency analysis. When imported for the first time,
+``PySimpleGUI`` 5.x displays a "first-run" dialog, which poses a problem
+for unattended PyInstaller builds running in a clean environment, for
+example, in a CI pipeline.


### PR DESCRIPTION
Add `PySimpleGUI` to the list of packages whose import should be explicitly suppressed when importing packages for tracking of dynamic library search path modifications prior to binary dependency analysis.

`PySimpleGUI` 5.x displays a "first-run" dialog when imported for the first time, which breaks unattended PyInstaller builds (for example, building on CI, where the dialog cannot be closed but will be shown every time due to clean environment).

Closes #8396.