### PR TITLE
tests: bump PySide6 to 6.7.0 and update PySide6 hooks

### DIFF
--- a/PyInstaller/hooks/hook-PySide6.Qt3DRender.py
+++ b/PyInstaller/hooks/hook-PySide6.Qt3DRender.py
@@ -9,6 +9,12 @@
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
 
-from PyInstaller.utils.hooks.qt import add_qt6_dependencies
+from PyInstaller.utils.hooks.qt import add_qt6_dependencies, pyside6_library_info
 
 hiddenimports, binaries, datas = add_qt6_dependencies(__file__)
+
+# In PySide 6.7.0, Qt3DRender module added a reference to QtOpenGL type system. The hidden import is required on
+# Windows, while on macOS and Linux we seem to pick it up automatically due to the corresponding Qt shared library
+# appearing among binary dependencies. Keep it around on all OSes, though - just in case this ever changes.
+if pyside6_library_info.version is not None and pyside6_library_info.version >= [6, 7]:
+    hiddenimports += ['PySide6.QtOpenGL']

--- a/news/8404.hooks.rst
+++ b/news/8404.hooks.rst
@@ -1,0 +1,2 @@
+Update ``PySide6.Qt3DRender`` hook for compatibility with ``PySide6``
+6.7.0 (add hidden import for ``PySide6.QtOpenGL`` module).

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -32,9 +32,9 @@ PyGObject==3.48.2; sys_platform == 'linux'
 PySide2==5.15.2.1; python_version < '3.11'
 # PySide6 is a metapackage that depends on PySide6-Essentials and PySide6-Addons. Their versions are
 # usually kept in sync.
-PySide6==6.6.3.1
-PySide6-Addons==6.6.3.1
-PySide6-Essentials==6.6.3.1
+PySide6==6.7.0; python_version >= '3.9'
+PySide6-Addons==6.7.0; python_version >= '3.9'
+PySide6-Essentials==6.7.0; python_version >= '3.9'
 # PyQt5 and add-on packages
 # We do not pin *-Qt5 packages (which contain Qt shared libraries), as Qt5 is not actively developed
 # anymore, and thus 5.15.x has a stable ABI. Plus, it seems that *-Qt5 5.15.2 wheels are available for
@@ -93,3 +93,8 @@ sphinx==7.1.2; python_version == '3.8'  # pyup: ignore
 
 # Django dropped support for python < 3.10 in v5.0
 Django==4.2.8; python_version < '3.10'  # pyup: ignore
+
+# PySide6 dropped support for python < 3.9 in v6.7.0
+PySide6==6.6.3.1; python_version == '3.8'  # pyup: ignore
+PySide6-Addons==6.6.3.1; python_version == '3.8'  # pyup: ignore
+PySide6-Essentials==6.6.3.1; python_version == '3.8'  # pyup: ignore


### PR DESCRIPTION
Looks like PySide6/Qt6 6.7.0 is quite benign from our perspective; only thing that needs to be fixed is adding a hidden import of `PySide6.QtOpenGL` to the `PySide6.Qt3DRender` hook, to fix tests that import individual modules.