### PR TITLE
depend: fix library path resolution in POSIX non-ldconfig branches

### DIFF
--- a/PyInstaller/depend/bindepend.py
+++ b/PyInstaller/depend/bindepend.py
@@ -693,18 +693,7 @@ def _resolve_library_path_unix(name):
             paths.append('/usr/local/lib')
         lib = lib_search_func(name, paths)
 
-    # Give up :(
-    if lib is None:
-        return None
-
-    # Resolve the file name into the soname
-    if compat.is_freebsd or compat.is_aix or compat.is_openbsd:
-        # On FreeBSD objdump does not show SONAME, and on AIX objdump does not exist, so we just return the lib we
-        # have found.
-        return lib
-    else:
-        dir = os.path.dirname(lib)
-        return os.path.join(dir, _get_so_name(lib))
+    return lib
 
 
 def _which_library(name, dirs):
@@ -732,22 +721,6 @@ def _library_matcher(name):
     Create a callable that matches libraries if **name** is a valid library prefix for input library full names.
     """
     return re.compile(name + r"[0-9]*\.").match
-
-
-def _get_so_name(filename):
-    """
-    Return the soname of a library.
-
-    Soname is useful when there are multiple symplinks to one library.
-    """
-    # TODO verify that objdump works on other unixes and not Linux only.
-    cmd = ["objdump", "-p", filename]
-    pattern = r'\s+SONAME\s+([^\s]+)'
-    if compat.is_solar:
-        cmd = ["elfdump", "-d", filename]
-        pattern = r'\s+SONAME\s+[^\s]+\s+([^\s]+)'
-    m = re.search(pattern, compat.exec_command(*cmd))
-    return m.group(1)
 
 
 #- Python shared library search

--- a/news/8422.bugfix.rst
+++ b/news/8422.bugfix.rst
@@ -1,0 +1,6 @@
+(POSIX) Fix ``PyInstaller.depend.bindepend.resolve_library_path`` for
+cases when ``ldconfig`` cache is not available (e.g., ``musl libc`` on
+Alpine Linux). In such cases, the search code now distinguishes between
+the case when fully suffixed library name is given (i.e., search for
+exact match) and the case when library name has no suffix (i.e., search
+for library with matching basename).


### PR DESCRIPTION
When resolving library path on POSIX systems and we do not have `ldconfig` cache available (e.g., Alpine linux), use `_resolve_library_path_in_search_paths` instead of `_which_library`, because the former expects the name to have (versioned) .so suffix (which is usually the case), and the latter expects the name to not have suffix. For backwards compatibility reasons, keep using `_which_library` in case we are given a name without suffix. 

See https://github.com/pyinstaller/pyinstaller-hooks-contrib/issues/724#issuecomment-2067586152.

While we're at it, remove the replacement of resolved library's filename with its soname; because either it is the same and it is a no-op (most of the cases), or it will end up pointing to incorrect name (i.e., the other binary is referring to the library via the name we were given, so it expects to find the library under *that* name) which may not even exist (e.g., if the library was renamed to its current name, that differs from its soname, for whatever reason).