### PR TITLE
ci: lock-threads: lock only PRs and issues

### DIFF
--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -19,5 +19,6 @@ jobs:
     steps:
       - uses: dessant/lock-threads@v5
         with:
+          process-only: 'issues, prs'
           issue-inactive-days: 60
           pr-inactive-days: 60


### PR DESCRIPTION
Avoid locking discussions. If we wanted to process those as well, we would need to add `discussions: write` under  `permissions`; otherwise the workflow with `lock-threads@v5` seems to fail.

See https://github.com/dessant/lock-threads/issues/47#issuecomment-2041019276