### PR TITLE
building: do not attempt to expand env. vars in paths

### DIFF
--- a/PyInstaller/building/makespec.py
+++ b/PyInstaller/building/makespec.py
@@ -20,7 +20,7 @@ import sys
 from PyInstaller import DEFAULT_SPECPATH, HOMEPATH
 from PyInstaller import log as logging
 from PyInstaller.building.templates import bundleexetmplt, bundletmplt, onedirtmplt, onefiletmplt, splashtmpl
-from PyInstaller.compat import expand_path, is_darwin, is_win
+from PyInstaller.compat import is_darwin, is_win
 
 logger = logging.getLogger(__name__)
 
@@ -715,8 +715,9 @@ def main(
     if specpath is None:
         specpath = DEFAULT_SPECPATH
     else:
-        # Expand tilde to user's home directory.
-        specpath = expand_path(specpath)
+        # Expand starting tilde into user's home directory, as a work-around for tilde not being expanded by shell when
+        # using ˙--specpath=~/path/abc` instead of ˙--specpath ~/path/abc` (or when the path argument is quoted).
+        specpath = os.path.expanduser(specpath)
     # If cwd is the root directory of PyInstaller, generate the .spec file in ./appname/ subdirectory.
     if specpath == HOMEPATH:
         specpath = os.path.join(HOMEPATH, name)

--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -542,14 +542,6 @@ def exec_python_rc(*args: str, **kwargs: str | None):
 # Path handling.
 
 
-def expand_path(path: str | os.PathLike):
-    """
-    Replace initial tilde '~' in path with user's home directory, and also expand environment variables
-    (i.e., ${VARNAME} on Unix, %VARNAME% on Windows).
-    """
-    return os.path.expandvars(os.path.expanduser(path))
-
-
 # Site-packages functions - use native function if available.
 def getsitepackages(prefixes: list | None = None):
     """

--- a/PyInstaller/depend/imphook.py
+++ b/PyInstaller/depend/imphook.py
@@ -19,7 +19,7 @@ import weakref
 
 from PyInstaller import log as logging
 from PyInstaller.building.utils import format_binaries_and_datas
-from PyInstaller.compat import expand_path, importlib_load_source
+from PyInstaller.compat import importlib_load_source
 from PyInstaller.depend.imphookapi import PostGraphAPI
 from PyInstaller.exceptions import ImportErrorWhenRunningHook
 
@@ -104,7 +104,7 @@ class ModuleHookCache(dict):
 
         for hook_dir in hook_dirs:
             # Canonicalize this directory's path and validate its existence.
-            hook_dir = os.path.abspath(expand_path(hook_dir))
+            hook_dir = os.path.abspath(hook_dir)
             if not os.path.isdir(hook_dir):
                 raise FileNotFoundError('Hook directory "{}" not found.'.format(hook_dir))
 

--- a/news/8434.bugfix.rst
+++ b/news/8434.bugfix.rst
@@ -1,0 +1,3 @@
+(Windows) Fix mangling of path to the entry-point script when the script
+is in the current working directory, and the path to this directory
+contains two or more consecutive ``$`` or ``%`` characters.

--- a/news/8441.breaking.rst
+++ b/news/8441.breaking.rst
@@ -1,0 +1,8 @@
+PyInstaller does not attempt to expand environment variables in paths
+given via :option:`--workpath`, :option:`--distpath`, :option:`--specpath`,
+and :option:`--additional-hooks-dir` anymore (note that other paths were
+never subject to environment variable expansion in the first place).
+Expansion of the starting tilde (``~``) into user's home directory is
+still performed, as a work-around for tilde not being expanded by the
+shell when passing arguments as ``--workpath=~/path/abc`` instead of
+``--workpath ~/path/abc``.


### PR DESCRIPTION
Remove the `compat.expand_path` helper, and stop attempting to expand environment variables in paths given via `--workpath`, `--distpath`, `--specpath`, and `--additional-hooks-dir`.

The Windows implementation of `expandvars` found in `ntpath` translates `$$` and `%%` into `$` and `%`, respectively, which mangles the paths that contain such sequences (as literal characters, without using environment variables at all).

While the above issue could be worked around by duplicating characters in the problematic character sequences, the whole environment variable expansion in paths seems rather unnecessary. It was introduced in response to #696, which was caused by the fact that shell does not expand the tilde when using `--argname=~/path/abc` argument syntax instead of `--argname ~/path/abc` (or when the path argument is quoted).

As that seems like legitimate shortcoming, keep the tilde expansion part (`os.path.expanduser`) around, but remove the general environment variable expansion attempts (`os.path.expandvars`), which should be left to the shell.