### PR TITLE
hooks: sqlalchemy: collect plugins and dialects via entry-points

### DIFF
--- a/news/8465.hooks.rst
+++ b/news/8465.hooks.rst
@@ -1,0 +1,4 @@
+Have ``sqlalchemy`` hook collect all dialects and plugins that are
+registered via ``sqlalchemy.dialects`` and ``sqlalchemy.plugins``
+entry-points. This ensures collection of 3rd party dialects and plugins
+that may be available in the build environment (e.g., ``ibm-db-sa``).


### PR DESCRIPTION
Have `sqlalchemy` hook collect all dialects and plugins that are registered via `sqlalchemy.dialects` and `sqlalchemy.plugins` entry-points. This ensures collection of 3rd party dialects and plugins that may be available in the build environment (e.g., `ibm-db-sa`).

Closes #3518.