### PR TITLE
hook: win32ctypes.core: always collect the ctypes backend

### DIFF
--- a/PyInstaller/hooks/hook-win32ctypes.core.py
+++ b/PyInstaller/hooks/hook-win32ctypes.core.py
@@ -13,9 +13,10 @@
 
 from PyInstaller.utils.hooks import can_import_module, collect_submodules
 
-# We need to collect submodules from win32ctypes.core.cffi or win32ctypes.core.ctypes for win32ctypes.core to work. The
-# use of the backend is determined by availability of cffi.
+# We need to collect submodules from win32ctypes.core.cffi or win32ctypes.core.ctypes for win32ctypes.core to work.
+# Always collect the `ctypes` backend, and add the `cffi` one if `cffi` is available. Having the `ctypes` backend always
+# available helps in situations when `cffi` is available in the build environment, but is disabled at run-time or not
+# collected (e.g., due to `--exclude cffi`).
+hiddenimports = collect_submodules('win32ctypes.core.ctypes')
 if can_import_module('cffi'):
-    hiddenimports = collect_submodules('win32ctypes.core.cffi')
-else:
-    hiddenimports = collect_submodules('win32ctypes.core.ctypes')
+    hiddenimports += collect_submodules('win32ctypes.core.cffi')

--- a/news/8544.hooks.rst
+++ b/news/8544.hooks.rst
@@ -1,0 +1,7 @@
+The ``pywin32-ctypes`` hook now always collects the ``win32ctypes.core.ctypes``
+modules, so that the ``ctypes`` backend is always available (i.e., even
+if we also collect the ``cffi`` backend due to availability of ``cffi``
+in the build environment). This fixes issues when ``cffi`` ends up
+unavailable at run-time in spite of being available in the build environment
+at build time (for example, due to explicit exclusion via :option:`--exclude-module`
+option).


### PR DESCRIPTION
Always collect the `ctypes` backend (`win32ctypes.core.ctypes` modules), even if we are also collecting the `cffi` backend due to `cffi` being available in the build environment.

This prevents issues when import of `cffi` is blocked at run-time (similarly to how we do it to avoid issues with -OO optimization level) or when `cffi` is excluded from collection by user (for example, by using `--exclude-module cffi`).

Closes #8543.