### PR TITLE
tests: re-enable test_unbuffered_stdio on CI

### DIFF
--- a/tests/functional/test_unbuffered_stdio.py
+++ b/tests/functional/test_unbuffered_stdio.py
@@ -20,10 +20,6 @@ import pytest
 from PyInstaller.compat import is_win
 
 
-@pytest.mark.skipif(
-    os.environ.get('CI', 'false').lower() == 'true',
-    reason="The test does not support CI (pytest-xdist sometimes runs it in secondary thread)."
-)
 @pytest.mark.parametrize('stream_mode', ['binary', 'text'])
 @pytest.mark.parametrize('output_stream', ['stdout', 'stderr'])
 def test_unbuffered_stdio(tmp_path, output_stream, stream_mode, pyi_builder_spec):


### PR DESCRIPTION
The contemporary versions of pytest-xdist and execnet are said to have sorted out the issue with tests sometimes not running in the main thread, so we should be able to run this test on our CI now.

Let's see if that is indeed the case.