### PR TITLE
hooks: update pkg_resources hook for setuptools >= 70.0.0

### DIFF
--- a/PyInstaller/hooks/hook-pkg_resources.py
+++ b/PyInstaller/hooks/hook-pkg_resources.py
@@ -55,3 +55,9 @@ elif check_requirement("setuptools >= 60.7.1"):
         'pkg_resources._vendor.jaraco.context',
         'pkg_resources._vendor.jaraco.text',
     ]
+
+# As of setuptools 70.0.0, we need pkg_resources.extern added to hidden imports.
+if check_requirement("setuptools >= 70.0.0"):
+    hiddenimports += [
+        'pkg_resources.extern',
+    ]

--- a/news/8554.hooks.rst
+++ b/news/8554.hooks.rst
@@ -1,0 +1,2 @@
+Update ``pkg_resources`` hook for compatibility with ``setuptools`` v70.0.0
+and later (fix ``ModuleNotFoundError: No module named 'pkg_resources.extern'``).


### PR DESCRIPTION
As of setuptools 70.0.0, we need to add `pkg_resources.extern` to hidden imports.

Closes #8554.