### PR TITLE
ci: set up basic msys2-based CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,3 +220,61 @@ jobs:
             pyinstaller test.py
             ./dist/test/test
           "
+
+  test-msys2:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        include:
+          - { sys: mingw64, env: x86_64 }
+          - { sys: mingw32, env: i686 }
+          - { sys: ucrt64,  env: ucrt-x86_64 }
+      fail-fast: false
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: msys2/setup-msys2@v2
+        with:
+          update: true
+          msystem: ${{matrix.sys}}
+          # mingw-w64-${{matrix.env}}-python-pefile seems unavailable for i686, so omit it here and install it via pip. Same as altgraph, which does not seem to be packaged.
+          install: >-
+            mingw-w64-${{matrix.env}}-gcc
+            mingw-w64-${{matrix.env}}-python
+            mingw-w64-${{matrix.env}}-python-pip
+            mingw-w64-${{matrix.env}}-python-wheel
+            mingw-w64-${{matrix.env}}-python-setuptools
+            mingw-w64-${{matrix.env}}-python-pywin32-ctypes
+            mingw-w64-${{matrix.env}}-python-packaging
+            mingw-w64-${{matrix.env}}-python-pytest
+            mingw-w64-${{matrix.env}}-python-pytest-xdist
+            mingw-w64-${{matrix.env}}-python-pytest-timeout
+            mingw-w64-${{matrix.env}}-python-psutil
+            mingw-w64-${{matrix.env}}-python-pywin32
+            mingw-w64-${{matrix.env}}-python-numpy
+            mingw-w64-${{matrix.env}}-python-pillow
+
+      - uses: actions/checkout@v4
+
+      - run: |
+          uname -a
+          python --version
+
+      - name: Install PyInstaller
+        run: |
+          # Compile bootloader
+          cd bootloader
+          python waf --gcc --tests all
+          cd ..
+
+          # Install PyInstaller.
+          pip install --progress-bar=off .[completion]
+
+          # Make sure the help options print.
+          python -m PyInstaller -h
+
+      - name: Run tests
+        run: >
+            pytest
+            -n 3 --maxfail 3 --durations 10 tests/unit tests/functional

--- a/PyInstaller/archive/writers.py
+++ b/PyInstaller/archive/writers.py
@@ -179,6 +179,11 @@ class CArchiveWriter:
             # manually.
             dest_name = dest_name.replace(os.path.sep, '\\')
 
+            # For symbolic link entries, also ensure that the symlink target path (stored in src_name) is using
+            # Windows-style back slash separators.
+            if typecode == 'n':
+                src_name = src_name.replace(os.path.sep, '\\')
+
         # Strict pack/collect mode: keep track of the destination names, and raise an error if we try to add a duplicate
         # (a file with same destination name, subject to OS case normalization rules).
         if strict_collect_mode:

--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -1162,6 +1162,11 @@ class COLLECT(Target):
                     strict_arch_validation=(typecode == 'EXTENSION'),
                 )
             if typecode == 'SYMLINK':
+                # On Windows, ensure that symlink target path (stored in src_name) is using Windows-style back slash
+                # separators.
+                if is_win and os.path.sep == '/':
+                    src_name = src_name.replace(os.path.sep, '\\')
+
                 os.symlink(src_name, dest_path)  # Create link at dest_path, pointing at (relative) src_name
             elif typecode != 'DEPENDENCY':
                 # At this point, `src_name` should be a valid file.

--- a/PyInstaller/utils/tests.py
+++ b/PyInstaller/utils/tests.py
@@ -37,8 +37,8 @@ def _check_for_compiler():
     old_wd = os.getcwd()
     tmp = tempfile.mkdtemp()
     os.chdir(tmp)
-    cc = distutils.ccompiler.new_compiler()
-    if is_win:
+    cc = distutils.ccompiler.new_compiler()  # NOTE: Mingw32CCompiler on Windows does not have `initialize` method.
+    if is_win and hasattr(cc, 'initialize'):
         try:
             cc.initialize()
             has_compiler = True

--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -100,10 +100,13 @@ pyi_main(int argc, char * argv[])
     int in_child = 0;
     char *extractionpath = NULL;
 
-#ifdef _MSC_VER
-    /* Visual C runtime incorrectly buffers stderr */
+#ifdef _WIN32
+    /* On Windows, both Visual C runtime and MinGW seem to buffer stderr
+     * when redirected. This might cause the output to not appear at all
+     * if the application crashes or is terminated, which in turn makes
+     * debugging difficult. So make sure that stderr is unbuffered. */
     setbuf(stderr, (char *)NULL);
-#endif  /* _MSC_VER */
+#endif  /* _WIN32 */
 
     VS("PyInstaller Bootloader 6.x\n");
 

--- a/tests/functional/scripts/pyi_lib_tkinter.py
+++ b/tests/functional/scripts/pyi_lib_tkinter.py
@@ -25,6 +25,7 @@ import tkinter  # noqa: F401
 
 def compare(test_name, expect, frozen):
     expect = os.path.normpath(expect)
+    frozen = os.path.normpath(frozen)
     print(test_name)
     print(('  Expected: ' + expect))
     print(('  Current:  ' + frozen))

--- a/tests/functional/test_basic.py
+++ b/tests/functional/test_basic.py
@@ -851,8 +851,12 @@ def test_legacy_onedir_layout(pyi_builder):
         """
         import sys
         import os
-        assert sys._MEIPASS == os.path.dirname(sys.executable)
-        assert os.path.dirname(__file__) == os.path.dirname(sys.executable)
+
+        # NOTE: the paths set by bootloader (`sys._MEIPASS`, `__file__`) may end up using different separator than
+        # paths set by the python interpreter itself (e.g., `sys.executable`) - for example, under msys2/mingw
+        # python on Windows). Therefore, we normalize the separator via `os.path.normpath` before comparison.
+        assert os.path.normpath(sys._MEIPASS) == os.path.dirname(sys.executable)
+        assert os.path.normpath(os.path.dirname(__file__)) == os.path.dirname(sys.executable)
         """,
         pyi_args=["--contents-directory", "."]
     )

--- a/tests/functional/test_symlinks.py
+++ b/tests/functional/test_symlinks.py
@@ -62,9 +62,14 @@ def test_bootloader_symlinked_executable(pyi_builder, tmpdir):
 
 
 # Wrapper for os.symlink that skips the test if symlink cannot be created on Windows.
-def _create_symlink(*args, **kwargs):
+def _create_symlink(src, dst, *args, **kwargs):
+    # On Windows, symlinks need to use Windows-style backslashes, even if we are under msys2/mingw python that uses
+    # POSIX-style separators. `src` might be a Path-like object, so explicitly convert it to string.
+    if is_win and os.sep == '/':
+        src = str(src).replace(os.sep, '\\')
+
     try:
-        os.symlink(*args, **kwargs)
+        os.symlink(src, dst, **kwargs)
     except OSError:
         if is_win:
             pytest.skip("OS does not support creation of symbolic links.")


### PR DESCRIPTION
Set up basic CI workflow in MSYS2 environment (mingw64, mingw32, ucrt64) and sort out issues that it flushes out.