### PR TITLE
macOS: hard-code path to the codesign utility

### DIFF
--- a/PyInstaller/building/osx.py
+++ b/PyInstaller/building/osx.py
@@ -681,7 +681,7 @@ class BUNDLE(Target):
     @staticmethod
     def verify_bundle_signature(bundle_dir):
         # First, verify the bundle signature using codesign.
-        cmd_args = ['codesign', '--verify', '--all-architectures', '--deep', '--strict', bundle_dir]
+        cmd_args = ['/usr/bin/codesign', '--verify', '--all-architectures', '--deep', '--strict', bundle_dir]
         p = subprocess.run(cmd_args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, encoding='utf8')
         if p.returncode:
             raise SystemError(

--- a/PyInstaller/utils/osx.py
+++ b/PyInstaller/utils/osx.py
@@ -359,7 +359,7 @@ def remove_signature_from_binary(filename):
     Remove the signature from all architecture slices of the given binary file using the codesign utility.
     """
     logger.debug("Removing signature from file %r", filename)
-    cmd_args = ['codesign', '--remove', '--all-architectures', filename]
+    cmd_args = ['/usr/bin/codesign', '--remove', '--all-architectures', filename]
     p = subprocess.run(cmd_args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, encoding='utf-8')
     if p.returncode:
         raise SystemError(f"codesign command ({cmd_args}) failed with error code {p.returncode}!\noutput: {p.stdout}")
@@ -381,7 +381,9 @@ def sign_binary(filename, identity=None, entitlements_file=None, deep=False):
         extra_args.append('--deep')
 
     logger.debug("Signing file %r", filename)
-    cmd_args = ['codesign', '-s', identity, '--force', '--all-architectures', '--timestamp', *extra_args, filename]
+    cmd_args = [
+        '/usr/bin/codesign', '-s', identity, '--force', '--all-architectures', '--timestamp', *extra_args, filename
+    ]
     p = subprocess.run(cmd_args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, encoding='utf-8')
     if p.returncode:
         raise SystemError(f"codesign command ({cmd_args}) failed with error code {p.returncode}!\noutput: {p.stdout}")

--- a/news/8581.bugfix.rst
+++ b/news/8581.bugfix.rst
@@ -1,0 +1,3 @@
+(macOS) When running ``codesign`` utility on macOS, use hard-coded absolute
+path (``/usr/bin/codesign``) to avoid errors when user has the ``codesign``
+from ``sigtool`` (https://github.com/thefloweringash/sigtool) in their ``PATH``.


### PR DESCRIPTION
When running `codesign` utility on macOS, use hard-coded absolute path (`/usr/bin/codesign`) to avoid errors when user has the `codesign` from `sigtool` (https://github.com/thefloweringash/sigtool) in their `PATH`.

See #7533 and #8581.