### PR TITLE
bootloader: fix splash screen shutdown issues

### DIFF
--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -537,6 +537,7 @@ _pyi_main_onedir_or_onefile_child(PYI_CONTEXT *pyi_ctx)
     pyi_utils_free_args(pyi_ctx);
 #endif
 
+    PYI_DEBUG("LOADER: end of process reached!\n");
     return ret;
 }
 
@@ -674,6 +675,7 @@ _pyi_main_onefile_parent(PYI_CONTEXT *pyi_ctx)
     }
 #endif
 
+    PYI_DEBUG("LOADER: end of process reached!\n");
     return ret;
 }
 

--- a/bootloader/src/pyi_splash.c
+++ b/bootloader/src/pyi_splash.c
@@ -399,14 +399,14 @@ pyi_splash_finalize(SPLASH_CONTEXT *splash)
      * bootloader thread, and we only need to clean up the shared libraries,
      * in case any of them were successfully loaded. */
     if (splash->dlls_fully_loaded != true) {
-        if (splash->dll_tcl != NULL) {
-            pyi_utils_dlclose(splash->dll_tcl);
-            splash->dll_tcl = NULL;
-        }
-
         if (splash->dll_tk != NULL) {
             pyi_utils_dlclose(splash->dll_tk);
             splash->dll_tk = NULL;
+        }
+
+        if (splash->dll_tcl != NULL) {
+            pyi_utils_dlclose(splash->dll_tcl);
+            splash->dll_tcl = NULL;
         }
 
         return 0;
@@ -452,16 +452,20 @@ pyi_splash_finalize(SPLASH_CONTEXT *splash)
 
         /* If the shared libraries are not yet unloaded, unload them here,
          * as otherwise their files cannot be deleted. */
-        if (splash->dll_tcl != NULL) {
-            PYI_DEBUG("SPLASH: unloading Tcl shared library...\n");
-            pyi_utils_dlclose(splash->dll_tcl);
-            splash->dll_tcl = NULL;
-        }
-
         if (splash->dll_tk != NULL) {
             PYI_DEBUG("SPLASH: unloading Tk shared library...\n");
-            pyi_utils_dlclose(splash->dll_tk);
+            if (pyi_utils_dlclose(splash->dll_tk) < 0) {
+                PYI_DEBUG("SPLASH: failed to unload Tk shared library!\n");
+            }
             splash->dll_tk = NULL;
+        }
+
+        if (splash->dll_tcl != NULL) {
+            PYI_DEBUG("SPLASH: unloading Tcl shared library...\n");
+            if (pyi_utils_dlclose(splash->dll_tcl) < 0) {
+                PYI_DEBUG("SPLASH: failed to unload Tcl shared library!\n");
+            }
+            splash->dll_tcl = NULL;
         }
     }
 

--- a/bootloader/src/pyi_splash.c
+++ b/bootloader/src/pyi_splash.c
@@ -438,6 +438,13 @@ pyi_splash_finalize(SPLASH_CONTEXT *splash)
         PYI_DEBUG("SPLASH: splash screen thread has already shut down.\n");
     }
 
+    /* Cleanup mutexes */
+    PI_Tcl_MutexFinalize(&splash->context_mutex);
+    PI_Tcl_MutexFinalize(&splash->call_mutex);
+    PI_Tcl_MutexFinalize(&splash->cleanup_mutex);
+    PI_Tcl_MutexFinalize(&splash->start_mutex);
+    PI_Tcl_MutexFinalize(&splash->exit_mutex);
+
     /* This function should only be called after python has been
      * destroyed with Py_Finalize. Tcl/Tk/tkinter do **not** support
      * multiple instances of themselves due to restrictions of Tcl

--- a/bootloader/src/pyi_splash.h
+++ b/bootloader/src/pyi_splash.h
@@ -61,6 +61,8 @@ typedef struct _splash_context
     Tcl_Mutex context_mutex;
     Tcl_Mutex call_mutex;
 
+    Tcl_Mutex cleanup_mutex;
+
     /* This mutex/condition is to hold the bootloader until the splash screen
      * has been started */
     Tcl_Mutex start_mutex;

--- a/bootloader/src/pyi_splash.h
+++ b/bootloader/src/pyi_splash.h
@@ -61,8 +61,6 @@ typedef struct _splash_context
     Tcl_Mutex context_mutex;
     Tcl_Mutex call_mutex;
 
-    Tcl_Mutex cleanup_mutex;
-
     /* This mutex/condition is to hold the bootloader until the splash screen
      * has been started */
     Tcl_Mutex start_mutex;

--- a/bootloader/src/pyi_splash.h
+++ b/bootloader/src/pyi_splash.h
@@ -83,6 +83,11 @@ typedef struct _splash_context
      * the Tcl interpreter's (i.e., secondary) thread. */
     Tcl_ThreadId thread_id;
 
+    /* Flag indicating whether thread was created in joinable mode or
+     * not. At the time of writing, Tcl on Windows does not support
+     * joinable threads. */
+    bool thread_joinable;
+
     /* The paths to Tcl/Tk shared libraries and Tk module library directory.
      * These are anchored to application's top-level directory (static
      * or temporary, depending on onedir vs. onefile mode). */

--- a/bootloader/src/pyi_splashlib.c
+++ b/bootloader/src/pyi_splashlib.c
@@ -38,6 +38,7 @@ PYI_DECLPROC(Tcl_DeleteInterp);
 /* Threading */
 PYI_DECLPROC(Tcl_CreateThread);
 PYI_DECLPROC(Tcl_GetCurrentThread);
+PYI_DECLPROC(Tcl_JoinThread);
 PYI_DECLPROC(Tcl_MutexLock);
 PYI_DECLPROC(Tcl_MutexUnlock);
 PYI_DECLPROC(Tcl_MutexFinalize);
@@ -87,6 +88,7 @@ pyi_splashlib_bind_functions(pyi_dylib_t dll_tcl, pyi_dylib_t dll_tk)
     /* Threading */
     PYI_GETPROC(dll_tcl, Tcl_CreateThread);
     PYI_GETPROC(dll_tcl, Tcl_GetCurrentThread);
+    PYI_GETPROC(dll_tcl, Tcl_JoinThread);
     PYI_GETPROC(dll_tcl, Tcl_MutexLock);
     PYI_GETPROC(dll_tcl, Tcl_MutexUnlock);
     PYI_GETPROC(dll_tcl, Tcl_MutexFinalize);

--- a/bootloader/src/pyi_splashlib.c
+++ b/bootloader/src/pyi_splashlib.c
@@ -40,6 +40,7 @@ PYI_DECLPROC(Tcl_CreateThread);
 PYI_DECLPROC(Tcl_GetCurrentThread);
 PYI_DECLPROC(Tcl_MutexLock);
 PYI_DECLPROC(Tcl_MutexUnlock);
+PYI_DECLPROC(Tcl_MutexFinalize);
 PYI_DECLPROC(Tcl_ConditionFinalize);
 PYI_DECLPROC(Tcl_ConditionNotify);
 PYI_DECLPROC(Tcl_ConditionWait);
@@ -88,6 +89,7 @@ pyi_splashlib_bind_functions(pyi_dylib_t dll_tcl, pyi_dylib_t dll_tk)
     PYI_GETPROC(dll_tcl, Tcl_GetCurrentThread);
     PYI_GETPROC(dll_tcl, Tcl_MutexLock);
     PYI_GETPROC(dll_tcl, Tcl_MutexUnlock);
+    PYI_GETPROC(dll_tcl, Tcl_MutexFinalize);
     PYI_GETPROC(dll_tcl, Tcl_ConditionFinalize);
     PYI_GETPROC(dll_tcl, Tcl_ConditionNotify);
     PYI_GETPROC(dll_tcl, Tcl_ConditionWait);

--- a/bootloader/src/pyi_splashlib.h
+++ b/bootloader/src/pyi_splashlib.h
@@ -89,6 +89,7 @@ PYI_EXTDECLPROC(int, Tcl_CreateThread, (Tcl_ThreadId *, Tcl_ThreadCreateProc *, 
 PYI_EXTDECLPROC(Tcl_ThreadId, Tcl_GetCurrentThread, (void));
 PYI_EXTDECLPROC(void, Tcl_MutexLock, (Tcl_Mutex *));
 PYI_EXTDECLPROC(void, Tcl_MutexUnlock, (Tcl_Mutex *));
+PYI_EXTDECLPROC(void, Tcl_MutexFinalize, (Tcl_Mutex *));
 PYI_EXTDECLPROC(void, Tcl_ConditionFinalize, (Tcl_Condition *));
 PYI_EXTDECLPROC(void, Tcl_ConditionNotify, (Tcl_Condition *));
 PYI_EXTDECLPROC(void, Tcl_ConditionWait, (Tcl_Condition *, Tcl_Mutex *, const Tcl_Time *));

--- a/bootloader/src/pyi_splashlib.h
+++ b/bootloader/src/pyi_splashlib.h
@@ -30,6 +30,7 @@
 
 #define TCL_GLOBAL_ONLY 1
 
+#define TCL_THREAD_NOFLAGS 0
 #define TCL_THREAD_JOINABLE 1
 
 /* Opaque Tcl/Tk types */

--- a/bootloader/src/pyi_splashlib.h
+++ b/bootloader/src/pyi_splashlib.h
@@ -30,6 +30,8 @@
 
 #define TCL_GLOBAL_ONLY 1
 
+#define TCL_THREAD_JOINABLE 1
+
 /* Opaque Tcl/Tk types */
 typedef struct Tcl_Interp_ Tcl_Interp;
 typedef struct Tcl_ThreadId_ *Tcl_ThreadId;
@@ -87,6 +89,7 @@ PYI_EXTDECLPROC(void, Tcl_DeleteInterp, (Tcl_Interp *));
 /* Threading */
 PYI_EXTDECLPROC(int, Tcl_CreateThread, (Tcl_ThreadId *, Tcl_ThreadCreateProc *, ClientData, int, int));
 PYI_EXTDECLPROC(Tcl_ThreadId, Tcl_GetCurrentThread, (void));
+PYI_EXTDECLPROC(int, Tcl_JoinThread, (Tcl_ThreadId, int *));
 PYI_EXTDECLPROC(void, Tcl_MutexLock, (Tcl_Mutex *));
 PYI_EXTDECLPROC(void, Tcl_MutexUnlock, (Tcl_Mutex *));
 PYI_EXTDECLPROC(void, Tcl_MutexFinalize, (Tcl_Mutex *));

--- a/bootloader/src/pyi_utils.h
+++ b/bootloader/src/pyi_utils.h
@@ -74,6 +74,10 @@ void pyi_win32_hide_console();
 void pyi_win32_minimize_console();
 #endif
 
+/* Force-unload of bundled DLLs from onefile parent process (Windows only) */
+#if defined(_WIN32)
+void pyi_win32_force_unload_bundled_dlls(PYI_CONTEXT *pyi_ctx);
+#endif
 
 /* Windows low-level helpers */
 #ifdef _WIN32

--- a/news/7106.bugfix.rst
+++ b/news/7106.bugfix.rst
@@ -1,0 +1,3 @@
+(Windows) Work around the problem with ``VCRUNTIME140.dll`` DLL file not
+being removed from application's temporary directory when building
+splash-screen-enabled onefile application with UPX enabled.

--- a/news/8587.bootloader.1.rst
+++ b/news/8587.bootloader.1.rst
@@ -1,0 +1,8 @@
+(Windows) Implement last-ditch attempt at force-unloading bundled DLLs
+from onefile parent process: if onefile application fails to remove its
+temporary directory, it now iterates over all DLLs loaded in the process,
+identifies the ones that originate from its temporary directory, and
+attempts to force-unload them, before trying to remove the temporary
+directory again. This should work around for issues with Tcl/Tk DLLs
+used by splash screen, which may load additional DLLs, and fail to
+automatically unload them when they are unloaded themselves.

--- a/news/8587.bootloader.rst
+++ b/news/8587.bootloader.rst
@@ -1,0 +1,3 @@
+Fix the order in which Tcl and Tk shared library are unloaded from the
+splash-screen enabled frozen application, to prevent the process from
+crashing during application cleanup (observed on Windows).

--- a/news/8587.bugfix.rst
+++ b/news/8587.bugfix.rst
@@ -1,0 +1,4 @@
+(Windows) Work around the problem with ``libgcc_s_dw2-1.dll`` and
+``libwinpthread-1.dll`` DLLs files not being removed from application's
+temporary directory when building splash-screen-enabled onefile
+application with 32-bit msys2/mingw32 environment.

--- a/tests/functional/test_interactive.py
+++ b/tests/functional/test_interactive.py
@@ -17,7 +17,7 @@ Note: All tests in this file should use the argument 'runtime'.
 import pytest
 
 from PyInstaller.utils.tests import importorskip
-from PyInstaller.compat import is_win, is_darwin, is_musl
+from PyInstaller.compat import is_win
 
 _RUNTIME = 10  # In seconds.
 
@@ -29,21 +29,3 @@ def test_ipython(pyi_builder):
         from IPython import embed
         embed()
         """, runtime=_RUNTIME)
-
-
-# Splash screen is not supported on macOS due to incompatible design.
-@pytest.mark.skipif(is_darwin, reason="Splash screen is not supported on macOS.")
-@pytest.mark.parametrize("build_mode", ['onedir', 'onefile'])
-@pytest.mark.parametrize("with_tkinter", [False, True], ids=['notkinter', 'tkinter'])
-@pytest.mark.xfail(is_musl, reason="musl + tkinter is known to cause mysterious segfaults.")
-def test_pyi_splash(pyi_builder_spec, capfd, monkeypatch, build_mode, with_tkinter):
-    if build_mode == 'onefile':
-        monkeypatch.setenv('_TEST_SPLASH_BUILD_MODE', 'onefile')
-    if with_tkinter:
-        monkeypatch.setenv('_TEST_SPLASH_WITH_TKINTER', '1')
-
-    pyi_builder_spec.test_spec('spec_with_splash.spec', runtime=_RUNTIME)
-
-    out, err = capfd.readouterr()
-    assert 'SPLASH: splash screen started' in err, \
-        f"Cannot find log entry indicating start of splash screen in:\n{err}"

--- a/tests/functional/test_splash.py
+++ b/tests/functional/test_splash.py
@@ -1,0 +1,42 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2005-2023, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+"""
+Tests for splash screen.
+
+NOTE: splash screen is not supported on macOS due to incompatible design.
+"""
+
+import pytest
+
+from PyInstaller.compat import is_darwin, is_musl
+
+
+# Test that splash screen is successfully started. This is an "interactive"
+# test (see test_interactive.py), where we expect the program to run for
+# specified amount of time, before we terminate it.
+@pytest.mark.skipif(is_darwin, reason="Splash screen is not supported on macOS.")
+@pytest.mark.parametrize("build_mode", ['onedir', 'onefile'])
+@pytest.mark.parametrize("with_tkinter", [False, True], ids=['notkinter', 'tkinter'])
+@pytest.mark.xfail(is_musl, reason="musl + tkinter is known to cause mysterious segfaults.")
+def test_splash_screen_running(pyi_builder_spec, capfd, monkeypatch, build_mode, with_tkinter):
+    if build_mode == 'onefile':
+        monkeypatch.setenv('_TEST_SPLASH_BUILD_MODE', 'onefile')
+    if with_tkinter:
+        monkeypatch.setenv('_TEST_SPLASH_WITH_TKINTER', '1')
+
+    pyi_builder_spec.test_spec(
+        'spec_with_splash.spec',
+        runtime=10,  # Interactive test - terminate test program after 10 seconds.
+    )
+
+    out, err = capfd.readouterr()
+    assert 'SPLASH: splash screen started' in err, \
+        f"Cannot find log entry indicating start of splash screen in:\n{err}"

--- a/tests/functional/test_splash.py
+++ b/tests/functional/test_splash.py
@@ -14,18 +14,23 @@ Tests for splash screen.
 NOTE: splash screen is not supported on macOS due to incompatible design.
 """
 
+import os
+
 import pytest
 
 from PyInstaller.compat import is_darwin, is_musl
+
+pytestmark = [
+    pytest.mark.skipif(is_darwin, reason="Splash screen is not supported on macOS."),
+    pytest.mark.xfail(is_musl, reason="musl + tkinter is known to cause mysterious segfaults."),
+]
 
 
 # Test that splash screen is successfully started. This is an "interactive"
 # test (see test_interactive.py), where we expect the program to run for
 # specified amount of time, before we terminate it.
-@pytest.mark.skipif(is_darwin, reason="Splash screen is not supported on macOS.")
 @pytest.mark.parametrize("build_mode", ['onedir', 'onefile'])
 @pytest.mark.parametrize("with_tkinter", [False, True], ids=['notkinter', 'tkinter'])
-@pytest.mark.xfail(is_musl, reason="musl + tkinter is known to cause mysterious segfaults.")
 def test_splash_screen_running(pyi_builder_spec, capfd, monkeypatch, build_mode, with_tkinter):
     if build_mode == 'onefile':
         monkeypatch.setenv('_TEST_SPLASH_BUILD_MODE', 'onefile')
@@ -40,3 +45,49 @@ def test_splash_screen_running(pyi_builder_spec, capfd, monkeypatch, build_mode,
     out, err = capfd.readouterr()
     assert 'SPLASH: splash screen started' in err, \
         f"Cannot find log entry indicating start of splash screen in:\n{err}"
+
+
+# Check that splash-enabled program properly exits (e.g., there are no crashes in bootloader during shutdown).
+# This is not coveved by the `test_splash_screen_running`, because that one terminates the program.
+# There are three variants of this test:
+# - splash screen is kept running until the end
+# - user imports pyi_splash, which calls pyi_splash.close() via atexit()
+# - user imports pyi_splash and calls pyi_splash.close()
+def test_splash_screen_shutdown_auto(pyi_builder, script_dir):
+    splash_image = os.path.join(script_dir, '..', 'data', 'splash', 'image.png')
+    pyi_builder.test_source(
+        """
+        print("Done!")
+        """,
+        pyi_args=["--splash", splash_image],
+    )
+
+
+def test_splash_screen_shutdown_atexit(pyi_builder, script_dir):
+    splash_image = os.path.join(script_dir, '..', 'data', 'splash', 'image.png')
+    pyi_builder.test_source(
+        """
+        # Importing pyi_splash registers pyi_splash.close() call via atexit().
+        print("Importing pyi_splash...")
+        import pyi_splash
+
+        print("Done!")
+        """,
+        pyi_args=["--splash", splash_image],
+    )
+
+
+def test_splash_screen_shutdown_manual(pyi_builder, script_dir):
+    splash_image = os.path.join(script_dir, '..', 'data', 'splash', 'image.png')
+    pyi_builder.test_source(
+        """
+        print("Importing pyi_splash...")
+        import pyi_splash
+
+        print("Closing splash screen from program...")
+        pyi_splash.close()
+
+        print("Done!")
+        """,
+        pyi_args=["--splash", splash_image],
+    )


### PR DESCRIPTION
This PR starts by adding bunch of new tests for splash screen - in particular, its *shutdown*. The one test that we had up until now is, in fact, "interactive test", where we expect the application to be alive for at least the specified amount of time (10 seconds), before we *terminate* it. Would the frozen application shut down without crashing? Would the onefile build leak its temporary directory? [Those who know less sleep better...](https://github.com/rokm/pyinstaller/actions/runs/9384136834/job/25839289530).

We then instrument the bootloader's cleanup code with couple of additional debug messages in an attempt to pin-point the issues that the new tests flushed out.

Turns out that in splash screen cleanup code, we are unloading Tcl shared library before Tk one. Reverting the order seems to deal with crashes in the new tests. However, the `DllMain` function in Tk seems to contain provisions for Tcl being unloaded before Tk; although on the other hand, the surrounding comments imply that this is considered an abnormal situation... Either way, the correct order seems to improve the situation, so let's go with it. And keep an eye on CI to see if we have any sporadic failures of those tests.

The above seems to take care of all issues but one - now the onefile variant of new tests seems to be consistently failing on test-msys2 (mingw32, i686). The frozen application is failing to clean up its temporary directory, and with the recently-refactored bootloader, this now triggers an error on our CI (as per `PYINSTALLER_STRICT_UNPACK_MODE` environment variable).

Again, we add couple of debug messages to make debugging such problems easier, and we learn that `libgcc_s_dw2-1.dll` and `libwinpthread-1.dll` cannot be removed. Those are dependencies of `tcl86.dll`, so we are dealing with a variant of #7106 - loading Tcl and Tk DLLs for splash screen loads additional DLLs into the process, but when we unload Tk and Tcl, those additional DLLs are not unloaded, and thus they become un-removable.

So as a work-around, if we fail to remove the temporary directory, we now enumerate all loaded DLLs, look up their file name to identify the ones that originate from the application's temporary directory, and attempt to force-unload them by repeatedly calling `FreeLibrary` until the call fails. And then try removing the temporary directory again. As questionable and hacky as this sounds, it does seem to do the trick; both for msys2/mingw32 and for UPX-processed Tcl/Tk DLLs - so we can close #7106.
