### PR TITLE
bootloader: various fixes for building with clang on Windows

### DIFF
--- a/bootloader/src/main.c
+++ b/bootloader/src/main.c
@@ -35,7 +35,8 @@
  * wildcard expansion of command-line arguments. This keeps behavior
  * consistent between applications that use MinGW-compiled and MSVC-compiled
  * bootloader. */
-extern int _CRT_glob = 0;
+extern int _CRT_glob;
+int _CRT_glob = 0;
 
 #if defined(WINDOWED)
 

--- a/bootloader/src/pyi_exception_dialog.c
+++ b/bootloader/src/pyi_exception_dialog.c
@@ -213,8 +213,8 @@ _exception_dialog_initialze(DIALOG_CONTEXT *dialog)
     /* Load the icon; LoadIconMetric() gives modern icon, but requires
      * Microsoft.Windows.Common-Controls version='6.0.0.0' dependency
      * in the manifest. */
-    // dialog->hErrorIcon = LoadIconW(NULL, MAKEINTRESOURCEW(IDI_ERROR));
-    LoadIconMetric(NULL, MAKEINTRESOURCEW(IDI_ERROR), LIM_LARGE, &dialog->hErrorIcon);
+    // dialog->hErrorIcon = LoadIconW(NULL, IDI_ERROR);
+    LoadIconMetric(NULL, IDI_ERROR, LIM_LARGE, &dialog->hErrorIcon);
 
     /*
      * Create UI controls

--- a/bootloader/src/pyi_global.h
+++ b/bootloader/src/pyi_global.h
@@ -205,8 +205,9 @@
 #else /* ifdef LAUNCH_DEBUG */
     /* Release mode - disable PYI_DEBUG macro (no-op) */
     #if defined(_WIN32)
-        /* Windows; MSVC does not allow empty vararg macro... */
-        #if defined(_MSC_VER)
+        /* Windows; MSVC does not allow empty vararg macro...
+         * (but clang + MSVC does) */
+        #if defined(_MSC_VER) && !defined(__clang__)
             #define PYI_DEBUG
             #define PYI_DEBUG_W
         #else

--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -671,11 +671,10 @@ def configure(ctx):
             # Use Unicode entry point wmain/wWinMain and wchar_t WinAPI
             ctx.env.append_value('CFLAGS', '-DUNICODE')
             ctx.env.append_value('CFLAGS', '-D_UNICODE')
-            # Set XP target as the minimum target OS version when using Windows and MSVC
-            # https://blogs.msdn.microsoft.com/vcblog/2012/10/08/windows-xp-targeting-with-c-in-visual-studio-2012/
-            ctx.env.append_value(
-                'LINKFLAGS', '/SUBSYSTEM:CONSOLE,%s' % ('5.01' if ctx.env.PYI_ARCH == '32bit' else '5.02')
-            )
+
+            # Specify CONSOLE subsystem, without major/minor version. At the time of writing, the compiler's default
+            # 6.00 (x86, x64) and 6.02 (ARM) should be fine for our purposes.
+            ctx.env.append_value('LINKFLAGS', '/SUBSYSTEM:CONSOLE')
 
             # Enable support for Control Flow Guard
             # https://docs.microsoft.com/en-us/windows/win32/secbp/control-flow-guard
@@ -747,13 +746,15 @@ def configure(ctx):
                 # redundant.
                 ctx.env.append_value('LINKFLAGS', '-mwindows')
             else:
+                # Remove any /SUBSYSTEM flag already present in LINKFLAGS
                 _link_flags = ctx.env._get_list_value_for_modification('LINKFLAGS')
                 _subsystem = [x for x in _link_flags if x.startswith('/SUBSYSTEM:')]
                 for parameter in _subsystem:
                     _link_flags.remove(parameter)
-                ctx.env.append_value(
-                    'LINKFLAGS', '/SUBSYSTEM:WINDOWS,%s' % ('5.01' if ctx.env.PYI_ARCH == '32bit' else '5.02')
-                )
+
+                # Specify WINDOWS subsystem, without major/minor version. At the time of writing, the compiler's
+                # default 6.00 (x86, x64) and 6.02 (ARM) should be fine for our purposes.
+                ctx.env.append_value('LINKFLAGS', '/SUBSYSTEM:WINDOWS')
         elif ctx.env.DEST_OS == 'darwin':
             # To support catching AppleEvents and running as ordinary Mac OS GUI app, we have to link against the
             # Carbon framework. This linkage only needs to be there for the windowed bootloaders.

--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -721,10 +721,23 @@ def configure(ctx):
 
         if ctx.env.DEST_OS == 'win32':
             if ctx.env.CC_NAME != 'msvc':
-                # For MinGW disable console window on Windows - MinGW option
-                # TODO Is it necessary to have -mwindows for C and LINK flags?
+                # For MinGW disable console window on Windows - MinGW option.
+                # This option is for linker, and thus needs to be specified under
+                # LINKFLAGS.
+                #
+                # While gcc does not seem to mind having it under CFLAGS
+                # as well, clang seems to complain about it:
+                # `clang: warning: argument unused during compilation:
+                # '-mwindows' [-Wunused-command-line-argument]`. Recent
+                # versions, when coupled with MSVC linker, raise an error:
+                # `clang: error: unsupported option '-mwindows' for target
+                # 'x86_64-pc-windows-msvc'`.
+                #
+                # NOTE: under both contemporary gcc and clang, the
+                # subsystem seems automatically inferred from available
+                # entry-point, so explicitly specifiying it here is likely
+                # redundant.
                 ctx.env.append_value('LINKFLAGS', '-mwindows')
-                ctx.env.append_value('CFLAGS', '-mwindows')
             else:
                 _link_flags = ctx.env._get_list_value_for_modification('LINKFLAGS')
                 _subsystem = [x for x in _link_flags if x.startswith('/SUBSYSTEM:')]

--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -693,6 +693,14 @@ def configure(ctx):
             # Define UNICODE and _UNICODE for wchar_t WinAPI
             ctx.env.append_value('CFLAGS', '-municode')
 
+            # NOTE: the following two defines are added on the off-chance
+            # that we are building with clang + MSVC. For pure MSVC, they
+            # are specified in `set_arch_flags()`.
+            # Disable warnings about deprecated POSIX function names.
+            ctx.env.append_value('CFLAGS', '-D_CRT_NONSTDC_NO_WARNINGS')
+            # Disable warnings about unsafe CRT functions.
+            ctx.env.append_value('CFLAGS', '-D_CRT_SECURE_NO_WARNINGS')
+
             # Use Unicode entry point wmain/wWinMain
             ctx.env.append_value('LINKFLAGS', '-municode')
 


### PR DESCRIPTION
Fixes for warnings emitted while building bootloader with clang on Windows (both clang in msys/mingw environment, and clang + msvc variant), as well as the error that popped up in https://github.com/pyinstaller/pyinstaller/actions/runs/9482260836.