### PR TITLE
Allow hyphenated module names in `hiddenimports`

### DIFF
--- a/PyInstaller/building/build_main.py
+++ b/PyInstaller/building/build_main.py
@@ -489,7 +489,7 @@ class Analysis(Target):
         self.hiddenimports.extend(CONF.get('hiddenimports', []))
 
         for modnm in self.hiddenimports:
-            if re.search(r"[\\/-]", modnm):
+            if re.search(r"[\\/]", modnm):
                 raise SystemExit(
                     f"Error: Invalid hiddenimport '{modnm}'. Hidden imports should be importable module names – not "
                     "file paths. i.e. use --hiddenimport=foo.bar instead of --hiddenimport=.../site-packages/foo/bar.py"

--- a/news/8601.bugfix.rst
+++ b/news/8601.bugfix.rst
@@ -1,0 +1,1 @@
+Re-allow ``hiddenimports`` with hyphenated names during Analysis (was blocked in v6.8.0) 

--- a/tests/functional/test_basic.py
+++ b/tests/functional/test_basic.py
@@ -651,6 +651,18 @@ def test_several_scripts2(pyi_builder_spec):
     pyi_builder_spec.test_spec('several-scripts2.spec')
 
 
+def test_hyphenated_hiddenimport(pyi_builder):
+    """
+    Verify that a spec whose hiddenimports include a hyphenated module name is valid
+    See issue #8591
+    """
+    pyi_builder.test_source(
+        """
+        print("hello!")
+        """, pyi_args=['--hiddenimport', 'fake-hyphenated-module']
+    )
+
+
 @pytest.mark.win32
 def test_pe_checksum(pyi_builder):
     import ctypes


### PR DESCRIPTION
Fixes #8591

This changeset removes hyphens from the sanity check on `hiddenimports` as part of `Analysis`, as it is possible (if not a bit unwise) for modules to have a hyphen in their name.