### PR TITLE
hooks: update scipy hooks for scipy 1.14.0

### DIFF
--- a/PyInstaller/hooks/hook-scipy.py
+++ b/PyInstaller/hooks/hook-scipy.py
@@ -33,3 +33,8 @@ if check_requirement("scipy >= 1.9.2") and is_win:
 
 # collect library-wide utility extension modules
 hiddenimports = ['scipy._lib.%s' % m for m in ['messagestream', "_ccallback_c", "_fpumode"]]
+
+# In scipy 1.14.0, `scipy._lib.array_api_compat.numpy` added a programmatic import of its `.fft` submodule, which needs
+# to be added to hiddenimports.
+if check_requirement("scipy >= 1.14.0"):
+    hiddenimports += ['scipy._lib.array_api_compat.numpy.fft']

--- a/PyInstaller/hooks/hook-scipy.py
+++ b/PyInstaller/hooks/hook-scipy.py
@@ -13,7 +13,12 @@ import glob
 import os
 
 from PyInstaller.compat import is_win
-from PyInstaller.utils.hooks import get_module_file_attribute, check_requirement, collect_delvewheel_libs_directory
+from PyInstaller.utils.hooks import (
+    get_module_file_attribute,
+    check_requirement,
+    collect_delvewheel_libs_directory,
+    collect_submodules,
+)
 
 binaries = []
 datas = []
@@ -38,3 +43,10 @@ hiddenimports = ['scipy._lib.%s' % m for m in ['messagestream', "_ccallback_c", 
 # to be added to hiddenimports.
 if check_requirement("scipy >= 1.14.0"):
     hiddenimports += ['scipy._lib.array_api_compat.numpy.fft']
+
+# The `scipy._lib.array_api_compat.numpy` module performs a `from numpy import *`; in numpy 2.0.0, `numpy.f2py` was
+# added to `numpy.__all__` attribute, but at the same time, the upstream numpy hook adds `numpy.f2py` to
+# `excludedimports`. Therefore, the `numpy.f2py` sub-package ends up missing. Due to the way exclusion mechanism works,
+# we need to add both `numpy.f2py` and all its submodules to hiddenimports here.
+if check_requirement("numpy >= 2.0.0"):
+    hiddenimports += collect_submodules('numpy.f2py', filter=lambda name: name != 'numpy.f2py.tests')

--- a/PyInstaller/hooks/hook-scipy.special._ufuncs.py
+++ b/PyInstaller/hooks/hook-scipy.special._ufuncs.py
@@ -19,3 +19,7 @@ hiddenimports = ['scipy.special._ufuncs_cxx']
 # `scipy.special._ufuncs` extension, and thus we need a hidden import here.
 if is_module_satisfies('scipy >= 1.13.0'):
     hiddenimports += ['scipy.special._cdflib']
+
+# SciPy 1.14.0 introduced `scipy.special._special_ufuncs`, which is imported from `scipy.special._ufuncs` extension.
+if is_module_satisfies('scipy >= 1.14.0'):
+    hiddenimports += ['scipy.special._special_ufuncs']

--- a/news/8622.hooks.1.rst
+++ b/news/8622.hooks.1.rst
@@ -1,0 +1,2 @@
+Add work-around for incompatibility between ``scipy`` and ``numpy`` 2.0.0
+(the ``ModuleNotFoundError: No module named 'numpy.f2py'`` error).

--- a/news/8622.hooks.rst
+++ b/news/8622.hooks.rst
@@ -1,0 +1,1 @@
+Update ``scipy`` hooks for compatibility with ``scipy`` 1.14.0.

--- a/tests/functional/test_hooks/test_scipy.py
+++ b/tests/functional/test_hooks/test_scipy.py
@@ -12,20 +12,25 @@
 Functional tests for SciPy.
 """
 
-from PyInstaller.compat import is_py312
+import sys
+
 from PyInstaller.utils.tests import importorskip, xfail
 
+pytestmark = [
+    importorskip('scipy'),
+    xfail(
+        sys.version_info[:3] == (3, 12, 0),
+        reason='SciPy is broken with PyInstaller and python 3.12.0 (#7992).',
+    ),
+]
 
-@importorskip('scipy')
-@xfail(is_py312, reason='SciPy is broken with PyInstaller and python 3.12 (#7992).')
+
 def test_scipy_toplevel(pyi_builder):
     pyi_builder.test_source("""
         import scipy
     """)
 
 
-@importorskip('scipy')
-@xfail(is_py312, reason='SciPy is broken with PyInstaller and python 3.12 (#7992).')
 def test_scipy(pyi_builder):
     pyi_builder.test_source(
         """
@@ -47,8 +52,6 @@ def test_scipy(pyi_builder):
     )
 
 
-@importorskip('scipy')
-@xfail(is_py312, reason='SciPy is broken with PyInstaller and python 3.12 (#7992).')
 def test_scipy_special(pyi_builder):
     """
     Test the importability of the `scipy.special` package and related hooks.

--- a/tests/functional/test_hooks/test_scipy.py
+++ b/tests/functional/test_hooks/test_scipy.py
@@ -14,6 +14,8 @@ Functional tests for SciPy.
 
 import sys
 
+import pytest
+
 from PyInstaller.utils.tests import importorskip, xfail
 
 pytestmark = [
@@ -25,39 +27,33 @@ pytestmark = [
 ]
 
 
-def test_scipy_toplevel(pyi_builder):
+# Basic import test for each scipy module, to ensure that each module is importable on its own. Due to amount of tests,
+# run them only in onedir mode.
+@pytest.mark.parametrize(
+    'module', [
+        'scipy',
+        'scipy.cluster',
+        'scipy.constants',
+        'scipy.datasets',
+        'scipy.fft',
+        'scipy.fftpack',
+        'scipy.integrate',
+        'scipy.interpolate',
+        'scipy.io',
+        'scipy.linalg',
+        'scipy.misc',
+        'scipy.ndimage',
+        'scipy.odr',
+        'scipy.optimize',
+        'scipy.signal',
+        'scipy.sparse',
+        'scipy.spatial',
+        'scipy.special',
+        'scipy.stats',
+    ]
+)
+@pytest.mark.parametrize('pyi_builder', ['onedir'], indirect=True)
+def test_scipy(pyi_builder, module):
     pyi_builder.test_source("""
-        import scipy
-    """)
-
-
-def test_scipy(pyi_builder):
-    pyi_builder.test_source(
-        """
-        # Test top-level SciPy importability.
-        import scipy
-
-        # Test hooked SciPy modules.
-        import scipy.io.matlab
-        import scipy.sparse.csgraph
-
-        # Test problematic SciPy modules.
-        import scipy.linalg
-        import scipy.signal
-
-        # SciPy >= 0.16 privatized the previously public "scipy.lib" package as "scipy._lib".
-        # Since this package is problematic, test its importability regardless of its private status.
-        import scipy._lib
-        """
-    )
-
-
-def test_scipy_special(pyi_builder):
-    """
-    Test the importability of the `scipy.special` package and related hooks.
-
-    This importation _must_ be tested independent of the importation of all other problematic SciPy packages
-    and modules. Combining this test with other SciPy tests (e.g., `test_scipy()`) fails to properly exercise
-    the hidden imports required by this package.
-    """
-    pyi_builder.test_source("""import scipy.special""")
+        import {0}
+        """.format(module))

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -24,7 +24,7 @@ ipython==8.25.0; python_version >= '3.10'
 keyring==23.0.1; sys_platform == 'darwin' and python_version < '3.8.7'  # pyup: ignore
 keyring==25.2.1; sys_platform != 'darwin' or python_version >= '3.8.7'
 matplotlib==3.9.0; python_version >= '3.9'
-numpy==1.26.4; python_version >= '3.9'
+numpy==2.0.0; python_version >= '3.9'
 pandas==2.2.2; python_version >= '3.9'
 pygments==2.18.0
 PyGObject==3.48.2; sys_platform == 'linux'
@@ -68,7 +68,7 @@ PyQt6-WebEngine-Qt6==6.7.1
 python-dateutil==2.9.0.post0
 pytz==2024.1
 requests==2.32.3
-scipy==1.13.1; python_version >= '3.9'
+scipy==1.14.0; python_version >= '3.10'
 # simplejson is used for text_c_extension
 simplejson==3.19.2
 sphinx==7.3.7; python_version >= '3.9'
@@ -84,6 +84,7 @@ Pillow==10.3.0
 numpy==1.24.3; python_version == '3.8'  # pyup: ignore
 pandas==2.0.3; python_version == '3.8'  # pyup: ignore
 scipy==1.10.1; python_version == '3.8'  # pyup: ignore
+scipy==1.13.1; python_version == '3.9'  # pyup: ignore
 matplotlib==3.7.3; python_version == '3.8'  # pyup: ignore
 
 ipython==8.12.1; python_version == '3.8'  # pyup: ignore


### PR DESCRIPTION
Update `scipy` hooks for compatibility with scipy 1.14.0.

Replace existing `scipy` tests with per-module import tests, so we can test each module on its own.

Add work-around for numpy 2.0.0 - collect submodules of `numpy.f2py` in the `scipy` hook. Hopefully `from numpy import *` is not too widespread beyond the `scipy`'s vendored copy of `array_api_compat`.