### PR TITLE
Django: fix deprecated DEFAULT_FILE_STORAGE setting that can be None

### DIFF
--- a/PyInstaller/utils/hooks/django.py
+++ b/PyInstaller/utils/hooks/django.py
@@ -74,9 +74,10 @@ def django_dottedstring_imports(django_root_dir):
         for cl in settings.AUTHENTICATION_BACKENDS:
             cl = _remove_class(cl)
             hiddenimports.append(cl)
-    if hasattr(settings, 'DEFAULT_FILE_STORAGE'):
-        cl = _remove_class(settings.DEFAULT_FILE_STORAGE)
-        hiddenimports.append(cl)
+    # Deprecated since 4.2, may be None until it is removed
+    cl = getattr(settings, 'DEFAULT_FILE_STORAGE', None)
+    if cl:
+        hiddenimports.append(_remove_class(cl))
     if hasattr(settings, 'FILE_UPLOAD_HANDLERS'):
         for cl in settings.FILE_UPLOAD_HANDLERS:
             cl = _remove_class(cl)

--- a/news/8633.hooks.rst
+++ b/news/8633.hooks.rst
@@ -1,0 +1,2 @@
+Update ``django`` hook to account for possibility of the deprecated
+``DEFAULT_FILE_STORAGE`` setting being set to ``None``.


### PR DESCRIPTION
While playing with Django 5 and PyInstaller `6.8.0` (with Python 3.12), I got this error:

```python
RuntimeError: Child process call to django_dottedstring_imports() failed with:
  File "<HOME>/.local/lib/python3.12/site-packages/PyInstaller/isolated/_child.py", line 63, in run_next_command
    output = function(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<HOME>/.local/lib/python3.12/site-packages/PyInstaller/utils/hooks/django.py", line 78, in django_dottedstring_imports
    cl = _remove_class(settings.DEFAULT_FILE_STORAGE)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<HOME>/.local/lib/python3.12/site-packages/PyInstaller/utils/hooks/django.py", line 68, in _remove_class
    return '.'.join(class_name.split('.')[0:-1])
                    ^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'split'
```

I removed `DEFAULT_FILE_STORAGE` from my `settings.py` since it is marked as deprecated since Django 4.2 ([documentation](https://docs.djangoproject.com/en/5.0/ref/settings/#default-file-storage)). When running PyInstaller on the Django app and project, the hook fails because it tries to import the hidden classes if the setting is defined.
By using `getattr` instead of using `hasattr`, it does work and is still compatible with older Django versions.