### PR TITLE
ci: lint: use "ruff check <path>"

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,7 +33,7 @@ jobs:
       run: yapf --recursive --parallel --diff .
 
     - name: Run Lint
-      run: ruff --output-format=github .
+      run: ruff check --output-format=github .
 
     - name: Test Packaging
       run: |


### PR DESCRIPTION
Use "ruff check <path>" instead of deprecated "ruff <path>", which raises errors with the latest version of ruff.