### PR TITLE
bootloader: refactor debug/warning/error code

### DIFF
--- a/bootloader/src/pyi_global.h
+++ b/bootloader/src/pyi_global.h
@@ -146,14 +146,14 @@
         void pyi_debug_dialog_perror_w(const wchar_t *funcname, const wchar_t *fmt, ...);
         void pyi_debug_dialog_winerror_w(const wchar_t *funcname, const wchar_t *fmt, ...);
 
-        #define PYI_ERROR pyi_debug_dialog_error
-        #define PYI_WARNING pyi_debug_dialog_warning
-        #define PYI_PERROR pyi_debug_dialog_perror
+        #define PYI_ERROR(...) pyi_debug_dialog_error(__VA_ARGS__)
+        #define PYI_WARNING(...) pyi_debug_dialog_warning(__VA_ARGS__)
+        #define PYI_PERROR(funcname, ...) pyi_debug_dialog_perror(funcname, __VA_ARGS__)
 
-        #define PYI_ERROR_W pyi_debug_dialog_error_w
-        #define PYI_WARNING_W pyi_debug_dialog_warning_w
-        #define PYI_PERROR_W pyi_debug_dialog_perror_w
-        #define PYI_WINERROR_W pyi_debug_dialog_winerror_w
+        #define PYI_ERROR_W(...) pyi_debug_dialog_error_w(__VA_ARGS__)
+        #define PYI_WARNING_W(...) pyi_debug_dialog_warning_w(__VA_ARGS__)
+        #define PYI_PERROR_W(funcname, ...) pyi_debug_dialog_perror_w(funcname, __VA_ARGS__)
+        #define PYI_WINERROR_W(funcname, ...) pyi_debug_dialog_winerror_w(funcname, __VA_ARGS__)
     #else
         /* We have console; emit messages to stderr. */
         void pyi_debug_printf(const char *fmt, ...);
@@ -163,23 +163,23 @@
         void pyi_debug_perror_w(const wchar_t *funcname, const wchar_t *fmt, ...);
         void pyi_debug_winerror_w(const wchar_t *funcname, const wchar_t *fmt, ...);
 
-        #define PYI_ERROR pyi_debug_printf
-        #define PYI_WARNING pyi_debug_printf
-        #define PYI_PERROR pyi_debug_perror
+        #define PYI_ERROR(...) pyi_debug_printf(__VA_ARGS__)
+        #define PYI_WARNING(...) pyi_debug_printf(__VA_ARGS__)
+        #define PYI_PERROR(funcname, ...) pyi_debug_perror(funcname, __VA_ARGS__)
 
-        #define PYI_ERROR_W pyi_debug_printf_w
-        #define PYI_WARNING_W pyi_debug_printf_w
-        #define PYI_PERROR_W pyi_debug_perror_w
-        #define PYI_WINERROR_W pyi_debug_winerror_w
+        #define PYI_ERROR_W(...) pyi_debug_printf_w(__VA_ARGS__)
+        #define PYI_WARNING_W(...) pyi_debug_printf_w(__VA_ARGS__)
+        #define PYI_PERROR_W(funcname, ...) pyi_debug_perror_w(funcname, __VA_ARGS__)
+        #define PYI_WINERROR_W(funcname, ...) pyi_debug_winerror_w(funcname, __VA_ARGS__)
     #endif /* defined(WINDOWED) */
 #else /* defined(_WIN32) */
     /* POSIX; display error messages to stderr. */
     void pyi_debug_printf(const char *fmt, ...);
     void pyi_debug_perror(const char *funcname, const char *fmt, ...);
 
-    #define PYI_ERROR pyi_debug_printf
-    #define PYI_WARNING pyi_debug_printf
-    #define PYI_PERROR pyi_debug_perror
+    #define PYI_ERROR(...) pyi_debug_printf(__VA_ARGS__)
+    #define PYI_WARNING(...) pyi_debug_printf(__VA_ARGS__)
+    #define PYI_PERROR(funcname, ...) pyi_debug_perror(funcname, __VA_ARGS__)
 #endif /* defined(_WIN32) && defined(WINDOWED) */
 
 #ifdef LAUNCH_DEBUG
@@ -191,16 +191,16 @@
             void pyi_debug_win32debug(const char *fmt, ...);
             void pyi_debug_win32debug_w(const wchar_t *fmt, ...);
 
-            #define PYI_DEBUG pyi_debug_win32debug
-            #define PYI_DEBUG_W pyi_debug_win32debug_w
+            #define PYI_DEBUG(...) pyi_debug_win32debug(__VA_ARGS__)
+            #define PYI_DEBUG_W(...) pyi_debug_win32debug_w(__VA_ARGS__)
         #else
             /* We have console; emit messages to stderr */
-            #define PYI_DEBUG pyi_debug_printf
-            #define PYI_DEBUG_W pyi_debug_printf_w
+            #define PYI_DEBUG(...) pyi_debug_printf(__VA_ARGS__)
+            #define PYI_DEBUG_W(...) pyi_debug_printf_w(__VA_ARGS__)
         #endif /* defined(WINDOWED) */
     #else
         /* POSIX; display messages to stderr */
-        #define PYI_DEBUG pyi_debug_printf
+        #define PYI_DEBUG(...) pyi_debug_printf(__VA_ARGS__)
     #endif /* defined(_WIN32) */
 #else /* ifdef LAUNCH_DEBUG */
     /* Release mode - disable PYI_DEBUG macro (no-op) */

--- a/bootloader/src/pyi_global.h
+++ b/bootloader/src/pyi_global.h
@@ -133,53 +133,55 @@
  *  - PYI_WINERROR_W
  */
 
+#include <errno.h>  /* errno */
+
 #if defined(_WIN32)
     #if defined(WINDOWED)
         /* On Windows in windowed/noconsole mode, we display error
          * messages  via message box, due to lack of console. */
         void pyi_debug_dialog_error(const char *fmt, ...);
         void pyi_debug_dialog_warning(const char *fmt, ...);
-        void pyi_debug_dialog_perror(const char *funcname, const char *fmt, ...);
+        void pyi_debug_dialog_perror(const char *funcname, int error_code, const char *fmt, ...);
 
         void pyi_debug_dialog_error_w(const wchar_t *fmt, ...);
         void pyi_debug_dialog_warning_w(const wchar_t *fmt, ...);
-        void pyi_debug_dialog_perror_w(const wchar_t *funcname, const wchar_t *fmt, ...);
-        void pyi_debug_dialog_winerror_w(const wchar_t *funcname, const wchar_t *fmt, ...);
+        void pyi_debug_dialog_perror_w(const wchar_t *funcname, int error_code, const wchar_t *fmt, ...);
+        void pyi_debug_dialog_winerror_w(const wchar_t *funcname, DWORD error_code, const wchar_t *fmt, ...);
 
         #define PYI_ERROR(...) pyi_debug_dialog_error(__VA_ARGS__)
         #define PYI_WARNING(...) pyi_debug_dialog_warning(__VA_ARGS__)
-        #define PYI_PERROR(funcname, ...) pyi_debug_dialog_perror(funcname, __VA_ARGS__)
+        #define PYI_PERROR(funcname, ...) pyi_debug_dialog_perror(funcname, errno, __VA_ARGS__)
 
         #define PYI_ERROR_W(...) pyi_debug_dialog_error_w(__VA_ARGS__)
         #define PYI_WARNING_W(...) pyi_debug_dialog_warning_w(__VA_ARGS__)
-        #define PYI_PERROR_W(funcname, ...) pyi_debug_dialog_perror_w(funcname, __VA_ARGS__)
-        #define PYI_WINERROR_W(funcname, ...) pyi_debug_dialog_winerror_w(funcname, __VA_ARGS__)
+        #define PYI_PERROR_W(funcname, ...) pyi_debug_dialog_perror_w(funcname, errno, __VA_ARGS__)
+        #define PYI_WINERROR_W(funcname, ...) pyi_debug_dialog_winerror_w(funcname, GetLastError(), __VA_ARGS__)
     #else
         /* We have console; emit messages to stderr. */
         void pyi_debug_printf(const char *fmt, ...);
-        void pyi_debug_perror(const char *funcname, const char *fmt, ...);
+        void pyi_debug_perror(const char *funcname, int error_code, const char *fmt, ...);
 
         void pyi_debug_printf_w(const wchar_t *fmt, ...);
-        void pyi_debug_perror_w(const wchar_t *funcname, const wchar_t *fmt, ...);
-        void pyi_debug_winerror_w(const wchar_t *funcname, const wchar_t *fmt, ...);
+        void pyi_debug_perror_w(const wchar_t *funcname, int error_code, const wchar_t *fmt, ...);
+        void pyi_debug_winerror_w(const wchar_t *funcname, DWORD error_code, const wchar_t *fmt, ...);
 
         #define PYI_ERROR(...) pyi_debug_printf(__VA_ARGS__)
         #define PYI_WARNING(...) pyi_debug_printf(__VA_ARGS__)
-        #define PYI_PERROR(funcname, ...) pyi_debug_perror(funcname, __VA_ARGS__)
+        #define PYI_PERROR(funcname, ...) pyi_debug_perror(funcname, errno, __VA_ARGS__)
 
         #define PYI_ERROR_W(...) pyi_debug_printf_w(__VA_ARGS__)
         #define PYI_WARNING_W(...) pyi_debug_printf_w(__VA_ARGS__)
-        #define PYI_PERROR_W(funcname, ...) pyi_debug_perror_w(funcname, __VA_ARGS__)
-        #define PYI_WINERROR_W(funcname, ...) pyi_debug_winerror_w(funcname, __VA_ARGS__)
+        #define PYI_PERROR_W(funcname, ...) pyi_debug_perror_w(funcname, errno, __VA_ARGS__)
+        #define PYI_WINERROR_W(funcname, ...) pyi_debug_winerror_w(funcname, GetLastError(), __VA_ARGS__)
     #endif /* defined(WINDOWED) */
 #else /* defined(_WIN32) */
     /* POSIX; display error messages to stderr. */
     void pyi_debug_printf(const char *fmt, ...);
-    void pyi_debug_perror(const char *funcname, const char *fmt, ...);
+    void pyi_debug_perror(const char *funcname, int error_code, const char *fmt, ...);
 
     #define PYI_ERROR(...) pyi_debug_printf(__VA_ARGS__)
     #define PYI_WARNING(...) pyi_debug_printf(__VA_ARGS__)
-    #define PYI_PERROR(funcname, ...) pyi_debug_perror(funcname, __VA_ARGS__)
+    #define PYI_PERROR(funcname, ...) pyi_debug_perror(funcname, errno, __VA_ARGS__)
 #endif /* defined(_WIN32) && defined(WINDOWED) */
 
 #ifdef LAUNCH_DEBUG

--- a/bootloader/src/pyi_global_posix.c
+++ b/bootloader/src/pyi_global_posix.c
@@ -21,6 +21,7 @@
 #include <stdio.h>
 #include <stdarg.h> /* va_list, va_start(), va_end() */
 #include <unistd.h> /* getpid() */
+#include <string.h> /* strerror() */
 #include <sys/types.h>
 
 /* On macOS, have windowed bootloader also send messages to syslog. */
@@ -36,59 +37,129 @@
 /**********************************************************************\
  *               Debug and error message implementation               *
 \**********************************************************************/
-/* On POSIX platforms, these are straight-forward. We have console
- * available, so print messages to stderr. */
+/* On POSIX platforms, these are relatively straight-forward.
+ *
+ * We have console available, so print messages to stderr.
+ *
+ * In macOS .app bundle bootloaders, also send a copy of message to syslog.
+ * This allows user to see bootloader debug messages in the Console.app
+ * log viewer: https://en.wikipedia.org/wiki/Console_(OS_X)
+ * Levels DEBUG and INFO seem to be ignored, so use level NOTICE.
+ */
 
-/* Print a formatted message. Used by PYI_ERROR and PYI_WARNING macros,
- * and by PYI_DEBUG macro in debug-enabled builds. */
-void
-pyi_debug_printf(const char *fmt, ...)
+/* Maximum length of debug/warning/error messages */
+#define PYI_MESSAGE_LEN 4096
+
+
+/* Print a formatted debug/warning/error message to stderr. */
+static void
+_pyi_debug_printf(const char *severity, const char *fmt, va_list args)
 {
-    va_list v;
+    char message_buffer[PYI_MESSAGE_LEN]; /* Local buffer to ensure thread-safety! */
+    char *msg_ptr = message_buffer;
+    int buflen = PYI_MESSAGE_LEN;
+    int ret;
 
-    /* Print the [PID] prefix. */
-    fprintf(stderr, "[%d] ", getpid());
+    /* Prefix: [PYI-{PID}:{SEVERITY}]. */
+    ret = snprintf(msg_ptr, buflen, "[PYI-%d:%s] ", getpid(), severity);
+    if (ret >= 0) {
+        msg_ptr += ret;
+        buflen -= ret;
+        if (buflen < 0) {
+            buflen = 0;
+        }
+    }
 
-    /* Print the message */
-    va_start(v, fmt);
-    vfprintf(stderr, fmt, v);
-    va_end(v);
+    /* Formatted message */
+    vsnprintf(msg_ptr, buflen, fmt, args);
 
-    /* In macOS .app bundle bootloaders, send a copy of debug message
-     * to syslog. This allows user to see bootloader debug messages in
-     * the Console.app log viewer. */
-    /* https://en.wikipedia.org/wiki/Console_(OS_X) */
-    /* Levels DEBUG and INFO are ignored so use level NOTICE. */
+    /* Write to stderr */
+    fprintf(stderr, "%s", message_buffer);
+
+    /* Write to syslog */
 #if defined(__APPLE__) && defined(WINDOWED)
-    va_start(v, fmt);
-    vsyslog(LOG_NOTICE, fmt, v);
-    va_end(v);
+    syslog(LOG_NOTICE, "%s", message_buffer);
 #endif
 }
+
+
+/* Used by PYI_DEBUG macro. */
+#if defined(LAUNCH_DEBUG)
+
+void pyi_debug_message(const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    _pyi_debug_printf("DEBUG", fmt, args);
+    va_end(args);
+}
+
+#endif /* defined(LAUNCH_DEBUG) */
+
+/* Used by PYI_WARNING macro. */
+void pyi_warning_message(const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    _pyi_debug_printf("WARNING", fmt, args);
+    va_end(args);
+}
+
+/* Used by PYI_ERROR macro. */
+void pyi_error_message(const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    _pyi_debug_printf("ERROR", fmt, args);
+    va_end(args);
+}
+
 
 /* Print a formatted message, followed by the name of the function that
  * resulted in an error and a textual description of the error, obtained
  * via strerror(). Used by PYI_PERROR macro. */
 void
-pyi_debug_perror(const char *funcname, int error_code, const char *fmt, ...)
+pyi_perror_message(const char *funcname, int error_code, const char *fmt, ...)
 {
-    (void)error_code; /* FIXME: replace perror() call with strerror() */
+    char message_buffer[PYI_MESSAGE_LEN]; /* Local buffer to ensure thread-safety! */
+    char *msg_ptr = message_buffer;
+    int buflen = PYI_MESSAGE_LEN;
+    int ret;
 
-    va_list v;
+    va_list args;
+
+    /* Prefix: [PYI-{PID}:{SEVERITY}]. */
+    ret = snprintf(msg_ptr, buflen, "[PYI-%d:ERROR] ", getpid());
+    if (ret >= 0) {
+        msg_ptr += ret;
+        buflen -= ret;
+        if (buflen < 0) {
+            buflen = 0;
+        }
+    }
 
     /* Formatted message */
-    va_start(v, fmt);
-    vfprintf(stderr, fmt, v);
-    va_end(v);
+    va_start(args, fmt);
+    ret = vsnprintf(msg_ptr, buflen, fmt, args);
+    va_end(args);
 
-    /* Perror-formatted error message */
-    perror(funcname); /* perror() writes to stderr */
+    if (ret >= 0) {
+        msg_ptr += ret;
+        buflen -= ret;
+        if (buflen < 0) {
+            buflen = 0;
+        }
+    }
 
+    /* Function name and error message (perror equivalent) */
+    snprintf(msg_ptr, buflen, "%s: %s\n", funcname, strerror(error_code));
+
+    /* Write to stderr */
+    fprintf(stderr, "%s", message_buffer);
+
+    /* Write to syslog */
 #if defined(__APPLE__) && defined(WINDOWED)
-    va_start(v, fmt);
-    vsyslog(LOG_NOTICE, fmt, v);
-    vsyslog(LOG_NOTICE, "%m\n", NULL);  /* %m emits the result of strerror() */
-    va_end(v);
+    syslog(LOG_NOTICE, "%s", message_buffer);
 #endif
 }
 

--- a/bootloader/src/pyi_global_posix.c
+++ b/bootloader/src/pyi_global_posix.c
@@ -39,8 +39,8 @@
 /* On POSIX platforms, these are straight-forward. We have console
  * available, so print messages to stderr. */
 
-/* Print a message. Used by PYI_ERROR and PYI_WARNING macros, and by
- * PYI_DEBUG macro in debug-enabled builds. */
+/* Print a formatted message. Used by PYI_ERROR and PYI_WARNING macros,
+ * and by PYI_DEBUG macro in debug-enabled builds. */
 void
 pyi_debug_printf(const char *fmt, ...)
 {
@@ -66,12 +66,14 @@ pyi_debug_printf(const char *fmt, ...)
 #endif
 }
 
-/* Print a debug message, followed by the name of the function that
+/* Print a formatted message, followed by the name of the function that
  * resulted in an error and a textual description of the error, obtained
- * via perror(). Used by PYI_PERROR macro. */
+ * via strerror(). Used by PYI_PERROR macro. */
 void
-pyi_debug_perror(const char *funcname, const char *fmt, ...)
+pyi_debug_perror(const char *funcname, int error_code, const char *fmt, ...)
 {
+    (void)error_code; /* FIXME: replace perror() call with strerror() */
+
     va_list v;
 
     /* Formatted message */

--- a/bootloader/src/pyi_global_win32.c
+++ b/bootloader/src/pyi_global_win32.c
@@ -127,11 +127,10 @@ pyi_debug_dialog_warning(const char *fmt, ...)
 }
 
 void
-pyi_debug_dialog_perror(const char *funcname, const char *fmt, ...)
+pyi_debug_dialog_perror(const char *funcname, int error_code, const char *fmt, ...)
 {
     char fullmsg[MBTXTLEN];
     char msg[MBTXTLEN];
-    int error_code = errno; /* Store a copy before calling other functions */
     va_list args;
 
     va_start(args, fmt);
@@ -176,11 +175,10 @@ pyi_debug_dialog_warning_w(const wchar_t *fmt, ...)
 }
 
 void
-pyi_debug_dialog_perror_w(const wchar_t *funcname, const wchar_t *fmt, ...)
+pyi_debug_dialog_perror_w(const wchar_t *funcname, int error_code, const wchar_t *fmt, ...)
 {
     wchar_t fullmsg[MBTXTLEN];
     wchar_t msg[MBTXTLEN];
-    int error_code = errno; /* Store a copy before calling other functions */
     va_list args;
 
     va_start(args, fmt);
@@ -198,11 +196,10 @@ pyi_debug_dialog_perror_w(const wchar_t *funcname, const wchar_t *fmt, ...)
 }
 
 void
-pyi_debug_dialog_winerror_w(const wchar_t *funcname, const wchar_t *fmt, ...)
+pyi_debug_dialog_winerror_w(const wchar_t *funcname, DWORD error_code, const wchar_t *fmt, ...)
 {
     wchar_t fullmsg[MBTXTLEN];
     wchar_t msg[MBTXTLEN];
-    DWORD error_code = GetLastError();
     va_list args;
 
     va_start(args, fmt);
@@ -303,8 +300,8 @@ _pyi_vprintf_to_stderr(const char *fmt, va_list v)
     }
 }
 
-/* Print a message. Used by PYI_ERROR and PYI_WARNING macros, and by
- * PYI_DEBUG macro in debug-enabled builds. */
+/* Print a formatted message. Used by PYI_ERROR and PYI_WARNING macros,
+ * and by PYI_DEBUG macro in debug-enabled builds. */
 void
 pyi_debug_printf(const char *fmt, ...)
 {
@@ -335,12 +332,13 @@ pyi_debug_printf_w(const wchar_t *fmt, ...)
 }
 
 
-/* Print a message, followed by the name of the function that resulted
- * in an error and a textual description of the error, obtained via
- * perror(). Used by PYI_PERROR macro. */
+/* Print a formatted message, followed by the name of the function that
+ * resulted in an error and a textual description of the error, obtained
+ * via strerror(). Used by PYI_PERROR macro. */
 void
-pyi_debug_perror(const char *funcname, const char *fmt, ...)
+pyi_debug_perror(const char *funcname, int error_code, const char *fmt, ...)
 {
+    (void)error_code; /* FIXME: replace perror() call with strerror() */
     va_list v;
 
     /* Formatted message */
@@ -356,8 +354,9 @@ pyi_debug_perror(const char *funcname, const char *fmt, ...)
 }
 
 void
-pyi_debug_perror_w(const wchar_t *funcname, const wchar_t *fmt, ...)
+pyi_debug_perror_w(const wchar_t *funcname, int error_code, const wchar_t *fmt, ...)
 {
+    (void)error_code; /* FIXME: replace _wperror() call with _wcserror() */
     va_list v;
 
     /* Formatted message */
@@ -370,14 +369,13 @@ pyi_debug_perror_w(const wchar_t *funcname, const wchar_t *fmt, ...)
 }
 
 
-/* Print a message, followed by the name of the function that resulted
- * in an error and a textual description of the error, obtained via
- * FormatMessage win32 API. Used by PYI_WINERROR macro. */
+/* Print a formatted message, followed by the name of the function that
+ * resulted in an error and a textual description of the error, obtained
+ * via FormatMessage() win32 API. Used by PYI_WINERROR macro. */
 void
-pyi_debug_winerror_w(const wchar_t *funcname, const wchar_t *fmt, ...)
+pyi_debug_winerror_w(const wchar_t *funcname, DWORD error_code, const wchar_t *fmt, ...)
 {
     va_list v;
-    DWORD error_code = GetLastError();
 
     va_start(v, fmt);
     vfwprintf(stderr, fmt, v);

--- a/bootloader/src/pyi_launch.c
+++ b/bootloader/src/pyi_launch.c
@@ -123,7 +123,7 @@ pyi_launch_extract_files_from_archive(PYI_CONTEXT *pyi_ctx)
                 retcode = -1;
                 break;
             } else {
-                PYI_WARNING("WARNING: file already exists but should not: %s\n", output_filename);
+                PYI_WARNING("File already exists but should not: %s\n", output_filename);
             }
         }
 

--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -688,10 +688,10 @@ _pyi_main_onefile_parent(PYI_CONTEXT *pyi_ctx)
         /* Return error if we failed to remove temporary directory while
          * strict unpack mode is enabled. */
         if (pyi_ctx->strict_unpack_mode) {
-            PYI_ERROR("ERROR: failed to remove temporary directory: %s\n", pyi_ctx->application_home_dir);
+            PYI_ERROR("Failed to remove temporary directory: %s\n", pyi_ctx->application_home_dir);
             ret = -1;
         } else {
-            PYI_WARNING("WARNING: failed to remove temporary directory: %s\n", pyi_ctx->application_home_dir);
+            PYI_WARNING("Failed to remove temporary directory: %s\n", pyi_ctx->application_home_dir);
         }
     }
 

--- a/bootloader/src/pyi_splash.c
+++ b/bootloader/src/pyi_splash.c
@@ -314,7 +314,7 @@ pyi_splash_extract(SPLASH_CONTEXT *splash, const PYI_CONTEXT *pyi_ctx)
                 PYI_ERROR("SPLASH: file already exists but should not: %s\n", output_filename);
                 return -1;
             } else {
-                PYI_WARNING("SPLASH: WARNING: file already exists but should not: %s\n", output_filename);
+                PYI_WARNING("SPLASH: file already exists but should not: %s\n", output_filename);
             }
         }
 

--- a/bootloader/src/pyi_utils_posix.c
+++ b/bootloader/src/pyi_utils_posix.c
@@ -549,7 +549,7 @@ pyi_utils_create_child(PYI_CONTEXT *pyi_ctx)
         char *const *argv = (pyi_ctx->pyi_argv != NULL) ? pyi_ctx->pyi_argv : pyi_ctx->argv;
 
         if (_pyi_set_systemd_env() != 0) {
-            PYI_WARNING("WARNING: application is started by systemd socket, but we cannot set proper LISTEN_PID on it.\n");
+            PYI_WARNING("LOADER: application is started by systemd socket, but we cannot set proper LISTEN_PID on it.\n");
         }
 
         if (execvp(pyi_ctx->executable_filename, argv) < 0) {

--- a/news/8642.bootloader.1.rst
+++ b/news/8642.bootloader.1.rst
@@ -1,0 +1,4 @@
+Bootloader's debug/error/warning messages are now always formatted in
+the temporary buffer (even when they are written to ``stderr``), in
+order to ensure their atomicity and avoid interleaving of message parts
+in multi-process scenarios.

--- a/news/8642.bootloader.2.rst
+++ b/news/8642.bootloader.2.rst
@@ -1,0 +1,7 @@
+(Windows) In debug-enabled bootloader variants, copies of debug/warning/error
+messages are now submitted to ``OutputDebugString`` win32 API in addition
+to their primary output mechanism (i.e., ``stderr`` or message dialog).
+This applies to both console and noconsole/windowed bootloader variants.
+(Previously, ``OutputDebugString`` was used only for debug messages in
+debug-enabled noconsole/windowed bootloader variant, where it serves as
+the primary output mechanism.)

--- a/news/8642.bootloader.rst
+++ b/news/8642.bootloader.rst
@@ -1,0 +1,3 @@
+Change the prefix of debug/warning/error messages from `[{PID}]` to
+`[PYI-{PID}:{SEVERITY}]`, and apply it consistently across all
+bootloader-generated messages.


### PR DESCRIPTION
This PR further refactors the implementation of functions behind our `PYI_DEBUG`, `PYI_WARNING`, `PYI_ERROR`, etc., macros for generating debug/warning/error messages.

Aside from internal code reorganization, the main user-facing changes are:

1. the prefix of messages that are written to stderr (or on Windows, to `OutputDebugString`) has been changed from `[{PID}]` to `[PYI-{PID}:{SEVERITY}]`. This aims to make bootloader's messages easier to recognize in mixed debug output, and identifies the message severity. So we can avoid putting ERROR/WARNING into part of the formatted message itself (which was done in relatively few places). The prefix is now consistently applied to all messages (previously, perror/winerror formatting helpers did not apply it); the error/warning message dialogs used by noconsole/windowed bootloader explicitly skip the prefix in the messages they display.

2. bootloader's debug/error/warning messages are now always formatted in the temporary buffer (even when they are written only to `stderr`), in order to ensure their atomicity and avoid interleaving of message parts in multi-process scenarios. It also makes the message re-usable when multiple output mechanisms are used (e.g., stderr + `OutputDebugString` on Windows, stderr + `syslog` on macOS).

3. in debug-enabled bootloader variants, copies of debug/warning/error messages are now submitted to `OutputDebugString` win32 API in addition to their primary output mechanism (i.e., `stderr` or message dialog).
This applies to both console and noconsole/windowed bootloader variants. Previously, `OutputDebugString` was used only for debug messages in debug-enabled noconsole/windowed bootloader variant, where it serves as
the primary output mechanism.

The primary motivation here was the last point; in order to properly debug onefile clean-up behavior when user closes console window (#8640) or shuts down their Windows session, we need the bootloader's messages visible in `DebugView` in both console and noconsole mode.