### PR TITLE
bootloader: increase amount of pedantry allowed from C compiler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,13 @@ jobs:
           cd bootloader
           CC="gcc -std=gnu90" python waf --tests all
 
+      - name: Check if bootloader code conforms to c99 ISO C standard (pedantic mode)
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+          # Compile bootloader
+          cd bootloader
+          CC="gcc -std=c99 -pedantic" python waf --tests all
+
       - name: Check if bootloader is buildable with --static-zlib option
         if: startsWith(matrix.os, 'ubuntu')
         run: cd bootloader && python waf --static-zlib --tests all

--- a/bootloader/src/pyi_apple_events.h
+++ b/bootloader/src/pyi_apple_events.h
@@ -25,33 +25,33 @@
 
 #if defined(__APPLE__) && defined(WINDOWED)
 
-typedef struct _pyi_context PYI_CONTEXT;
-typedef struct _apple_event_handler_context APPLE_EVENT_HANDLER_CONTEXT;
+struct PYI_CONTEXT;
+struct APPLE_EVENT_HANDLER_CONTEXT;
 
 
 /* Install Apple Event handlers, and return instance of allocated context
  * structure. Requires PYI_CONTEXT as argument, in order to pass the
  * pointer to callbacks. */
-APPLE_EVENT_HANDLER_CONTEXT *pyi_apple_install_event_handlers(PYI_CONTEXT *pyi_ctx);
+struct APPLE_EVENT_HANDLER_CONTEXT *pyi_apple_install_event_handlers(struct PYI_CONTEXT *pyi_ctx);
 
 /* Uninstall Apple Event handlers */
-void pyi_apple_uninstall_event_handlers(APPLE_EVENT_HANDLER_CONTEXT **ae_ctx_ref);
+void pyi_apple_uninstall_event_handlers(struct APPLE_EVENT_HANDLER_CONTEXT **ae_ctx_ref);
 
 /*
  * Process Apple Events, either appending them to sys.argv (if argv-emu
  * is enabled and child process is not (yet) running, or forwarding
  * them to the child process.
  */
-void pyi_apple_process_events(APPLE_EVENT_HANDLER_CONTEXT *ae_ctx, float timeout);
+void pyi_apple_process_events(struct APPLE_EVENT_HANDLER_CONTEXT *ae_ctx, float timeout);
 
 /* Check if we have a pending event that we need to forward. */
-int pyi_apple_has_pending_event(const APPLE_EVENT_HANDLER_CONTEXT *ae_ctx);
+int pyi_apple_has_pending_event(const struct APPLE_EVENT_HANDLER_CONTEXT *ae_ctx);
 
 /* Attempt to re-send the pending event after the specified delay. */
-int pyi_apple_send_pending_event(APPLE_EVENT_HANDLER_CONTEXT *ae_ctx, float delay);
+int pyi_apple_send_pending_event(struct APPLE_EVENT_HANDLER_CONTEXT *ae_ctx, float delay);
 
 /* Clean-up the pending event data and status. */
-void pyi_apple_cleanup_pending_event(APPLE_EVENT_HANDLER_CONTEXT *ae_ctx);
+void pyi_apple_cleanup_pending_event(struct APPLE_EVENT_HANDLER_CONTEXT *ae_ctx);
 
 /*
  * Attempt to submit oapp event to ourselves in order to mitigate

--- a/bootloader/src/pyi_archive.h
+++ b/bootloader/src/pyi_archive.h
@@ -36,7 +36,7 @@
 #define ARCHIVE_ITEM_SYMLINK          'n'  /* symbolic link */
 
 /* Entry in PKG/CArchive TOC */
-typedef struct _toc_entry
+struct TOC_ENTRY
 {
     uint32_t entry_length; /* length of this TOC entry, including full length of the name field */
     uint32_t offset; /* position of entry's data blob, relative to the start of PKG archive */
@@ -45,10 +45,10 @@ typedef struct _toc_entry
     unsigned char compression_flag; /* compression flag (1 = compressed, 0 = uncompressed) */
     char typecode; /* type code - see ARCHIVE_ITEM_* definitions */
     char name[1];  /* entry name; padded to multiple of 16 */
-} TOC_ENTRY;
+};
 
 /* The PKG/CArchive cookie, from the end of the archive. */
-typedef struct _archive_cookie
+struct ARCHIVE_COOKIE
 {
     char magic[8]; /* 'MEI\014\013\012\013\016' */
     uint32_t pkg_length; /* length of the entire PKG archive */
@@ -56,18 +56,18 @@ typedef struct _archive_cookie
     uint32_t toc_length; /* length of TOC data */
     uint32_t python_version; /* integer representing python version */
     char python_libname[64]; /* Name of the of Python shared library (e.g., "python3.10.dll"). */
-} ARCHIVE_COOKIE;
+};
 
 /* The archive structure */
-typedef struct _archive
+struct ARCHIVE
 {
     /* Full path to archive file. */
     char filename[PYI_PATH_MAX];
 
     uint64_t pkg_offset; /* Offset of the PKG archive in the file */
 
-    TOC_ENTRY *toc; /* Buffer containing all TOC entries */
-    const TOC_ENTRY *toc_end; /* The address at which the TOC buffer ends */
+    struct TOC_ENTRY *toc; /* Buffer containing all TOC entries */
+    const struct TOC_ENTRY *toc_end; /* The address at which the TOC buffer ends */
 
     /* Flag indicating that the archive contains extractable files,
      * and thus has onefile semantics */
@@ -78,18 +78,18 @@ typedef struct _archive
 
     /* The name of python shared library */
     char python_libname[64];
-} ARCHIVE;
+};
 
 
 /* The API */
-ARCHIVE *pyi_archive_open(const char *filename);
-void pyi_archive_free(ARCHIVE **archive_ref);
+struct ARCHIVE *pyi_archive_open(const char *filename);
+void pyi_archive_free(struct ARCHIVE **archive_ref);
 
-const TOC_ENTRY *pyi_archive_next_toc_entry(const ARCHIVE *archive, const TOC_ENTRY *toc_entry);
+const struct TOC_ENTRY *pyi_archive_next_toc_entry(const struct ARCHIVE *archive, const struct TOC_ENTRY *toc_entry);
 
-unsigned char *pyi_archive_extract(const ARCHIVE *archive, const TOC_ENTRY *toc_entry);
-int pyi_archive_extract2fs(const ARCHIVE *archive, const TOC_ENTRY *toc_entry, const char *output_filename);
+unsigned char *pyi_archive_extract(const struct ARCHIVE *archive, const struct TOC_ENTRY *toc_entry);
+int pyi_archive_extract2fs(const struct ARCHIVE *archive, const struct TOC_ENTRY *toc_entry, const char *output_filename);
 
-const TOC_ENTRY *pyi_archive_find_entry_by_name(const ARCHIVE *archive, const char *name);
+const struct TOC_ENTRY *pyi_archive_find_entry_by_name(const struct ARCHIVE *archive, const char *name);
 
 #endif /* PYI_ARCHIVE_H */

--- a/bootloader/src/pyi_global_posix.c
+++ b/bootloader/src/pyi_global_posix.c
@@ -16,6 +16,10 @@
  * contains implementations that are specific to POSIX platforms.
  */
 
+/* Having a header included outside of the ifdef block prevents the compilation
+ * unit from becoming empty, which is disallowed by pedantic ISO C. */
+#include "pyi_global.h"
+
 #ifndef _WIN32
 
 #include <stdio.h>
@@ -30,7 +34,6 @@
 #endif
 
 /* PyInstaller headers. */
-#include "pyi_global.h"
 #include "pyi_utils.h"
 
 

--- a/bootloader/src/pyi_global_win32.c
+++ b/bootloader/src/pyi_global_win32.c
@@ -16,6 +16,10 @@
  * contains implementations that are specific to Windows.
  */
 
+/* Having a header included outside of the ifdef block prevents the compilation
+ * unit from becoming empty, which is disallowed by pedantic ISO C. */
+#include "pyi_global.h"
+
 #ifdef _WIN32
 
 #include <stdio.h>
@@ -27,7 +31,6 @@
 #include <io.h>
 
 /* PyInstaller headers. */
-#include "pyi_global.h"
 #include "pyi_utils.h"
 
 

--- a/bootloader/src/pyi_launch.c
+++ b/bootloader/src/pyi_launch.c
@@ -49,15 +49,15 @@
  * during the extraction with the name of currently processed TOC entry.
  */
 int
-pyi_launch_extract_files_from_archive(PYI_CONTEXT *pyi_ctx)
+pyi_launch_extract_files_from_archive(struct PYI_CONTEXT *pyi_ctx)
 {
-    const ARCHIVE *archive = pyi_ctx->archive;
-    const TOC_ENTRY *toc_entry;
+    const struct ARCHIVE *archive = pyi_ctx->archive;
+    const struct TOC_ENTRY *toc_entry;
     ptrdiff_t index;
     int retcode = 0;
     char output_filename[PYI_PATH_MAX];
 
-    ARCHIVE *multipkg_archive_pool[PYI_MULTIPKG_ARCHIVE_POOL_SIZE];
+    struct ARCHIVE *multipkg_archive_pool[PYI_MULTIPKG_ARCHIVE_POOL_SIZE];
     char multipkg_ref[PYI_PATH_MAX];
     char multipkg_name[PYI_PATH_MAX];
 
@@ -275,12 +275,12 @@ _pyi_extract_exception_traceback(
  * Return non zero on failure
  */
 static int
-_pyi_launch_run_scripts(const PYI_CONTEXT *pyi_ctx)
+_pyi_launch_run_scripts(const struct PYI_CONTEXT *pyi_ctx)
 {
-    const ARCHIVE *archive = pyi_ctx->archive;
+    const struct ARCHIVE *archive = pyi_ctx->archive;
     unsigned char *data;
     char buf[PYI_PATH_MAX];
-    const TOC_ENTRY *toc_entry;
+    const struct TOC_ENTRY *toc_entry;
     PyObject *__main__;
     PyObject *__file__;
     PyObject *main_dict;
@@ -417,7 +417,7 @@ _pyi_launch_run_scripts(const PYI_CONTEXT *pyi_ctx)
 }
 
 void
-pyi_launch_initialize(PYI_CONTEXT *pyi_ctx)
+pyi_launch_initialize(struct PYI_CONTEXT *pyi_ctx)
 {
     /* Nothing to do here at the moment. */
 }
@@ -430,7 +430,7 @@ pyi_launch_initialize(PYI_CONTEXT *pyi_ctx)
  * to pyi_launch_execute(), which is the important part.
  */
 int
-pyi_launch_execute(PYI_CONTEXT *pyi_ctx)
+pyi_launch_execute(struct PYI_CONTEXT *pyi_ctx)
 {
     int rc = 0;
 
@@ -471,7 +471,7 @@ pyi_launch_execute(PYI_CONTEXT *pyi_ctx)
 }
 
 void
-pyi_launch_finalize(PYI_CONTEXT *pyi_ctx)
+pyi_launch_finalize(struct PYI_CONTEXT *pyi_ctx)
 {
     /* CLean up the python interpreter */
     pyi_pylib_finalize(pyi_ctx);

--- a/bootloader/src/pyi_launch.h
+++ b/bootloader/src/pyi_launch.h
@@ -17,31 +17,31 @@
 #ifndef PYI_LAUNCH_H
 #define PYI_LAUNCH_H
 
-typedef struct _pyi_context PYI_CONTEXT;
+struct PYI_CONTEXT;
 
 /*
  * Extract files from embedded archive (onefile mode).
  */
-int pyi_launch_extract_files_from_archive(PYI_CONTEXT *pyi_ctx);
+int pyi_launch_extract_files_from_archive(struct PYI_CONTEXT *pyi_ctx);
 
 /*
  * Wrapped platform specific initialization before loading Python and executing
  * all scripts in the archive.
  */
-void pyi_launch_initialize(PYI_CONTEXT *pyi_ctx);
+void pyi_launch_initialize(struct PYI_CONTEXT *pyi_ctx);
 
 /*
  * Wrapped platform specific finalization before loading Python and executing
  * all scripts in the archive.
  */
-void pyi_launch_finalize(PYI_CONTEXT *pyi_ctx);
+void pyi_launch_finalize(struct PYI_CONTEXT *pyi_ctx);
 
 /*
  * Load Python and execute all scripts in the archive
  *
  * @return -1 for internal failures, or the rc of the last script.
  */
-int pyi_launch_execute(PYI_CONTEXT *pyi_ctx);
+int pyi_launch_execute(struct PYI_CONTEXT *pyi_ctx);
 
 
 #endif /* PYI_LAUNCH_H */

--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -777,7 +777,7 @@ _pyi_main_onefile_parent(struct PYI_CONTEXT *pyi_ctx)
 #if defined(__APPLE__) && defined(WINDOWED)
     if (1) {
         ProcessSerialNumber psn = { 0, kCurrentProcess };
-        OSStatus returnCode = TransformProcessType(&psn, kProcessTransformToBackgroundApplication);
+        TransformProcessType(&psn, kProcessTransformToBackgroundApplication);
     }
 #endif
 

--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -64,35 +64,35 @@
  * NOTE: per C standard, static objects are default-initialized, so
  * we do not need explicit zero-initialization.
  */
-static PYI_CONTEXT _pyi_ctx;
+static struct PYI_CONTEXT _pyi_ctx;
 
 
 /* Pointer to global PYI_CONTEXT structure. Intended for use in signal
  * handlers that have no user data / context */
-PYI_CONTEXT *global_pyi_ctx = &_pyi_ctx;
+struct PYI_CONTEXT *global_pyi_ctx = &_pyi_ctx;
 
 
 /* Large parts of `pyi_main` are implemented as helper functions. We
  * keep their definitions below that of `pyi_main`, in an attempt to
  * keep code organized in top-down fashion. Hence, we need forward
  * declarations here */
-static void _pyi_main_read_runtime_options(PYI_CONTEXT *pyi_ctx);
+static void _pyi_main_read_runtime_options(struct PYI_CONTEXT *pyi_ctx);
 
-static void _pyi_main_setup_splash_screen(PYI_CONTEXT *pyi_ctx);
+static void _pyi_main_setup_splash_screen(struct PYI_CONTEXT *pyi_ctx);
 
-static int _pyi_main_onedir_or_onefile_child(PYI_CONTEXT *pyi_ctx);
-static int _pyi_main_onefile_parent(PYI_CONTEXT *pyi_ctx);
+static int _pyi_main_onedir_or_onefile_child(struct PYI_CONTEXT *pyi_ctx);
+static int _pyi_main_onefile_parent(struct PYI_CONTEXT *pyi_ctx);
 
-static int _pyi_main_resolve_executable(PYI_CONTEXT *pyi_context);
-static int _pyi_main_resolve_pkg_archive(PYI_CONTEXT *pyi_context);
+static int _pyi_main_resolve_executable(struct PYI_CONTEXT *pyi_context);
+static int _pyi_main_resolve_pkg_archive(struct PYI_CONTEXT *pyi_context);
 
 #if !defined(_WIN32) && !defined(__APPLE__)
-static int _pyi_main_handle_posix_onedir(PYI_CONTEXT *pyi_ctx);
+static int _pyi_main_handle_posix_onedir(struct PYI_CONTEXT *pyi_ctx);
 #endif
 
 
 int
-pyi_main(PYI_CONTEXT *pyi_ctx)
+pyi_main(struct PYI_CONTEXT *pyi_ctx)
 {
     char *env_var_value;
     bool reset_environment;
@@ -419,10 +419,10 @@ pyi_main(PYI_CONTEXT *pyi_ctx)
 }
 
 static void
-_pyi_main_read_runtime_options(PYI_CONTEXT *pyi_ctx)
+_pyi_main_read_runtime_options(struct PYI_CONTEXT *pyi_ctx)
 {
-    const ARCHIVE *archive = pyi_ctx->archive;
-    const TOC_ENTRY *toc_entry;
+    const struct ARCHIVE *archive = pyi_ctx->archive;
+    const struct TOC_ENTRY *toc_entry;
 
     for (toc_entry = archive->toc; toc_entry < archive->toc_end; toc_entry = pyi_archive_next_toc_entry(archive, toc_entry)) {
         if (toc_entry->typecode != ARCHIVE_ITEM_RUNTIME_OPTION) {
@@ -509,7 +509,7 @@ _pyi_main_read_runtime_options(PYI_CONTEXT *pyi_ctx)
  *                        Splash screen setup                         *
 \**********************************************************************/
 static void
-_pyi_main_setup_splash_screen(PYI_CONTEXT *pyi_ctx)
+_pyi_main_setup_splash_screen(struct PYI_CONTEXT *pyi_ctx)
 {
     char *env_suppress_splash;
     bool suppressed = false;
@@ -602,7 +602,7 @@ cleanup:
  *                  Onedir or onefile child codepath                  *
 \**********************************************************************/
 static int
-_pyi_main_onedir_or_onefile_child(PYI_CONTEXT *pyi_ctx)
+_pyi_main_onedir_or_onefile_child(struct PYI_CONTEXT *pyi_ctx)
 {
     int ret;
 
@@ -694,7 +694,7 @@ _pyi_main_onedir_or_onefile_child(PYI_CONTEXT *pyi_ctx)
  *                      Onefile parent codepath                       *
 \**********************************************************************/
 static int
-_pyi_main_onefile_parent(PYI_CONTEXT *pyi_ctx)
+_pyi_main_onefile_parent(struct PYI_CONTEXT *pyi_ctx)
 {
     int cleanup_status;
     int ret;
@@ -977,7 +977,7 @@ _pyi_is_ld_linux_so(const char *filename)
 static bool
 _pyi_find_progam_in_search_path(const char *name, char *result_path)
 {
-    char *search_paths = pyi_getenv("PATH"); // returns a copy
+    char *search_paths = pyi_getenv("PATH"); /* returns a copy */
     char *search_path;
 
     if (search_paths == NULL) {
@@ -1074,7 +1074,7 @@ _pyi_resolve_executable_posix(const char *argv0, char *executable_filename)
 
 
 static int
-_pyi_main_resolve_executable(PYI_CONTEXT *pyi_ctx)
+_pyi_main_resolve_executable(struct PYI_CONTEXT *pyi_ctx)
 {
     /* Resolve using OS-specific implementation */
 #ifdef _WIN32
@@ -1121,7 +1121,7 @@ _pyi_allow_pkg_sideload(const char *executable)
 }
 
 static int
-_pyi_main_resolve_pkg_archive(PYI_CONTEXT *pyi_ctx)
+_pyi_main_resolve_pkg_archive(struct PYI_CONTEXT *pyi_ctx)
 {
     int status;
 
@@ -1189,7 +1189,7 @@ _pyi_main_resolve_pkg_archive(PYI_CONTEXT *pyi_ctx)
  * environment variable to keep track of whether the process has already
  * been restarted or not. */
 static int
-_pyi_main_handle_posix_onedir(PYI_CONTEXT *pyi_ctx)
+_pyi_main_handle_posix_onedir(struct PYI_CONTEXT *pyi_ctx)
 {
     /* Check if we need to restart */
     if (pyi_ctx->process_level > PYI_PROCESS_LEVEL_PARENT) {

--- a/bootloader/src/pyi_main.h
+++ b/bootloader/src/pyi_main.h
@@ -21,11 +21,11 @@
 #endif
 
 
-typedef struct _archive ARCHIVE;
-typedef struct _splash_context SPLASH_CONTEXT;
+struct ARCHIVE;
+struct SPLASH_CONTEXT;
 
 #if defined(__APPLE__) && defined(WINDOWED)
-typedef struct _apple_event_handler_context APPLE_EVENT_HANDLER_CONTEXT;
+struct APPLE_EVENT_HANDLER_CONTEXT;
 #endif
 
 
@@ -68,11 +68,11 @@ enum PYI_PROCESS_LEVEL
     /* A sub-process spawned from the main application process using the
      * same executable (e.g., spawned using sys.executable; for example,
      * a multiprocessing worker process). */
-    PYI_PROCESS_LEVEL_SUBPROCESS = 2,
+    PYI_PROCESS_LEVEL_SUBPROCESS = 2
 };
 
 
-typedef struct _pyi_context
+struct PYI_CONTEXT
 {
     /* Command line arguments passed to the application.
      *
@@ -125,10 +125,10 @@ typedef struct _pyi_context
     char archive_filename[PYI_PATH_MAX];
 
     /* Main PKG archive */
-    ARCHIVE *archive;
+    struct ARCHIVE *archive;
 
     /* Splash screen context structure */
-    SPLASH_CONTEXT *splash;
+    struct SPLASH_CONTEXT *splash;
 
     /* Flag indicating whether the application's main PKG archive has
      * onefile semantics or not (i.e., needs to extract files to
@@ -249,14 +249,14 @@ typedef struct _pyi_context
      * Apple Events handling in macOS .app bundles
      */
 #if defined(__APPLE__) && defined(WINDOWED)
-    APPLE_EVENT_HANDLER_CONTEXT *ae_ctx;
+    struct APPLE_EVENT_HANDLER_CONTEXT *ae_ctx;
 #endif
-} PYI_CONTEXT;
+};
 
-extern PYI_CONTEXT *global_pyi_ctx;
+extern struct PYI_CONTEXT *global_pyi_ctx;
 
 
-int pyi_main(PYI_CONTEXT *pyi_ctx);
+int pyi_main(struct PYI_CONTEXT *pyi_ctx);
 
 
 #endif /* PYI_MAIN_H */

--- a/bootloader/src/pyi_multipkg.c
+++ b/bootloader/src/pyi_multipkg.c
@@ -79,10 +79,10 @@ pyi_multipkg_split_dependency_string(char *path, char *filename, const char *dep
  * returned; otherwise, the archive is opened and added to the pool,
  * and then returned. If an error occurs, returns NULL.
  */
-static ARCHIVE *
-_get_archive(PYI_CONTEXT *pyi_ctx, ARCHIVE **archive_pool, const char *archive_filename)
+static struct ARCHIVE *
+_get_archive(struct PYI_CONTEXT *pyi_ctx, struct ARCHIVE **archive_pool, const char *archive_filename)
 {
-    ARCHIVE *archive = NULL;
+    struct ARCHIVE *archive = NULL;
     int index = 0;
 
     PYI_DEBUG("LOADER: retrieving archive for path %s.\n", archive_filename);
@@ -117,8 +117,8 @@ _get_archive(PYI_CONTEXT *pyi_ctx, ARCHIVE **archive_pool, const char *archive_f
  * and extract it using the appropriate helpers. */
 int
 pyi_multipkg_extract_dependency(
-    PYI_CONTEXT *pyi_ctx,
-    ARCHIVE **archive_pool,
+    struct PYI_CONTEXT *pyi_ctx,
+    struct ARCHIVE **archive_pool,
     const char *other_executable,
     const char *dependency_name,
     const char *output_filename
@@ -189,9 +189,9 @@ pyi_multipkg_extract_dependency(
             return -1;
         }
     } else {
-        ARCHIVE *other_archive = NULL;
+        struct ARCHIVE *other_archive = NULL;
         char other_archive_path[PYI_PATH_MAX];
-        const TOC_ENTRY *toc_entry;
+        const struct TOC_ENTRY *toc_entry;
 
         PYI_DEBUG("LOADER: file %s not found on filesystem, assuming onefile reference.\n", dependency_name);
 

--- a/bootloader/src/pyi_multipkg.h
+++ b/bootloader/src/pyi_multipkg.h
@@ -17,14 +17,14 @@
 #ifndef PYI_MULTIPKG_H
 #define PYI_MULTIPKG_H
 
-typedef struct _pyi_context PYI_CONTEXT;
-typedef struct _archive ARCHIVE;
+struct PYI_CONTEXT;
+struct ARCHIVE;
 
 /* Maximum number of allowed archives in multi-package archive pool. */
 #define PYI_MULTIPKG_ARCHIVE_POOL_SIZE 20
 
 int pyi_multipkg_split_dependency_string(char *path, char *filename, const char *dependency_string);
-int pyi_multipkg_extract_dependency(PYI_CONTEXT *pyi_ctx, ARCHIVE **archive_pool, const char *other_executable, const char *dependency_name, const char *output_filename);
+int pyi_multipkg_extract_dependency(struct PYI_CONTEXT *pyi_ctx, struct ARCHIVE **archive_pool, const char *other_executable, const char *dependency_name, const char *output_filename);
 
 #endif /* PYI_MULTIPKG_H */
 

--- a/bootloader/src/pyi_pyconfig.c
+++ b/bootloader/src/pyi_pyconfig.c
@@ -30,7 +30,7 @@
  * pyi_config_parse_runtime_options(). No-op if passed a NULL pointer.
  */
 void
-pyi_runtime_options_free(PyiRuntimeOptions *options)
+pyi_runtime_options_free(struct PyiRuntimeOptions *options)
 {
     int i;
 
@@ -137,18 +137,18 @@ _pyi_match_and_parse_xflag(const char *flag, const char *name, int *dest_var)
  * Allocate the PyiRuntimeOptions structure and populate it based on
  * options found in the PKG archive.
  */
-PyiRuntimeOptions *
-pyi_runtime_options_read(const PYI_CONTEXT *pyi_ctx)
+struct PyiRuntimeOptions *
+pyi_runtime_options_read(const struct PYI_CONTEXT *pyi_ctx)
 {
-    PyiRuntimeOptions *options;
-    const ARCHIVE *archive = pyi_ctx->archive;
-    const TOC_ENTRY *toc_entry;
+    struct PyiRuntimeOptions *options;
+    const struct ARCHIVE *archive = pyi_ctx->archive;
+    const struct TOC_ENTRY *toc_entry;
     int num_wflags = 0;
     int num_xflags = 0;
     int failed = 0;
 
     /* Allocate the structure */
-    options = calloc(1, sizeof(PyiRuntimeOptions));
+    options = calloc(1, sizeof(struct PyiRuntimeOptions));
     if (options == NULL) {
         return options;
     }
@@ -333,7 +333,7 @@ pyi_pyconfig_free(PyConfig *config)
  * Set program name. Used to set sys.executable, and in early error messages.
  */
 int
-pyi_pyconfig_set_program_name(PyConfig *config, const PYI_CONTEXT *pyi_ctx)
+pyi_pyconfig_set_program_name(PyConfig *config, const struct PYI_CONTEXT *pyi_ctx)
 {
     /* Macro to avoid manual code repetition. */
     #define _IMPL_CASE(PY_VERSION, PYCONFIG_IMPL) \
@@ -366,7 +366,7 @@ pyi_pyconfig_set_program_name(PyConfig *config, const PYI_CONTEXT *pyi_ctx)
  * Set python home directory. Used to set sys.prefix.
  */
 int
-pyi_pyconfig_set_python_home(PyConfig *config, const PYI_CONTEXT *pyi_ctx)
+pyi_pyconfig_set_python_home(PyConfig *config, const struct PYI_CONTEXT *pyi_ctx)
 {
     /* Macro to avoid manual code repetition. */
     #define _IMPL_CASE(PY_VERSION, PYCONFIG_IMPL) \
@@ -432,7 +432,7 @@ _pyi_pyconfig_set_module_search_paths(PyConfig *config, int python_version, int 
 }
 
 int
-pyi_pyconfig_set_module_search_paths(PyConfig *config, const PYI_CONTEXT *pyi_ctx)
+pyi_pyconfig_set_module_search_paths(PyConfig *config, const struct PYI_CONTEXT *pyi_ctx)
 {
     /* TODO: instead of stitching together char strings and converting
      * them, we could probably stitch together wide-char strings directly,
@@ -537,7 +537,7 @@ _pyi_pyconfig_set_argv(PyConfig *config, int python_version, int argc, wchar_t *
  * of wide-char strings, we can directly pass it into Python's
  * configuration structure. */
 int
-pyi_pyconfig_set_argv(PyConfig *config, const PYI_CONTEXT *pyi_ctx)
+pyi_pyconfig_set_argv(PyConfig *config, const struct PYI_CONTEXT *pyi_ctx)
 {
     return _pyi_pyconfig_set_argv(
         config,
@@ -555,7 +555,7 @@ pyi_pyconfig_set_argv(PyConfig *config, const PYI_CONTEXT *pyi_ctx)
  * function, which accounts for the locale/encoding that was set up
  * during pre-initialization of Python interpreter. */
 int
-pyi_pyconfig_set_argv(PyConfig *config, const PYI_CONTEXT *pyi_ctx)
+pyi_pyconfig_set_argv(PyConfig *config, const struct PYI_CONTEXT *pyi_ctx)
 {
     char *const *argv;
     wchar_t **argv_w;
@@ -617,7 +617,7 @@ end:
  * Set run-time options.
  */
 int
-pyi_pyconfig_set_runtime_options(PyConfig *config, int python_version, const PyiRuntimeOptions *runtime_options)
+pyi_pyconfig_set_runtime_options(PyConfig *config, int python_version, const struct PyiRuntimeOptions *runtime_options)
 {
     /* Macro to avoid manual code repetition. */
     #define _IMPL_CASE(PY_VERSION, PYCONFIG_IMPL) \
@@ -687,9 +687,10 @@ pyi_pyconfig_set_runtime_options(PyConfig *config, int python_version, const Pyi
  * Pre-initialize python interpreter.
  */
 int
-pyi_pyconfig_preinit_python(const PyiRuntimeOptions *runtime_options)
+pyi_pyconfig_preinit_python(const struct PyiRuntimeOptions *runtime_options)
 {
     PyPreConfig_Common config;
+    PyStatus status;
 
     PI_PyPreConfig_InitIsolatedConfig((PyPreConfig *)&config);
 
@@ -700,6 +701,6 @@ pyi_pyconfig_preinit_python(const PyiRuntimeOptions *runtime_options)
     config.configure_locale = 1;
 
     /* Pre-initialize */
-    PyStatus status = PI_Py_PreInitialize((const PyPreConfig *)&config);
+    status = PI_Py_PreInitialize((const PyPreConfig *)&config);
     return PI_PyStatus_Exception(status) ? -1 : 0;
 }

--- a/bootloader/src/pyi_pyconfig.h
+++ b/bootloader/src/pyi_pyconfig.h
@@ -23,11 +23,11 @@
 
 #include "pyi_python.h"
 
-typedef struct _pyi_context PYI_CONTEXT;
+struct PYI_CONTEXT;
 
 
 /* Collect run-time options from PKG */
-typedef struct
+struct PyiRuntimeOptions
 {
     int verbose;
     int unbuffered;
@@ -44,21 +44,21 @@ typedef struct
 
     int num_xflags;
     wchar_t **xflags;
-}  PyiRuntimeOptions;
+};
 
-PyiRuntimeOptions *pyi_runtime_options_read(const PYI_CONTEXT *pyi_ctx);
-void pyi_runtime_options_free(PyiRuntimeOptions *options);
+struct PyiRuntimeOptions *pyi_runtime_options_read(const struct PYI_CONTEXT *pyi_ctx);
+void pyi_runtime_options_free(struct PyiRuntimeOptions *options);
 
 /* PEP 587 helpers */
 PyConfig *pyi_pyconfig_create(int python_version);
 void pyi_pyconfig_free(PyConfig *config);
 
-int pyi_pyconfig_set_program_name(PyConfig *config, const PYI_CONTEXT *pyi_ctx);
-int pyi_pyconfig_set_python_home(PyConfig *config, const PYI_CONTEXT *pyi_ctx);
-int pyi_pyconfig_set_module_search_paths(PyConfig *config, const PYI_CONTEXT *pyi_ctx);
-int pyi_pyconfig_set_argv(PyConfig *config, const PYI_CONTEXT *pyi_ctx);
-int pyi_pyconfig_set_runtime_options(PyConfig *config, int python_version, const PyiRuntimeOptions *runtime_options);
+int pyi_pyconfig_set_program_name(PyConfig *config, const struct PYI_CONTEXT *pyi_ctx);
+int pyi_pyconfig_set_python_home(PyConfig *config, const struct PYI_CONTEXT *pyi_ctx);
+int pyi_pyconfig_set_module_search_paths(PyConfig *config, const struct PYI_CONTEXT *pyi_ctx);
+int pyi_pyconfig_set_argv(PyConfig *config, const struct PYI_CONTEXT *pyi_ctx);
+int pyi_pyconfig_set_runtime_options(PyConfig *config, int python_version, const struct PyiRuntimeOptions *runtime_options);
 
-int pyi_pyconfig_preinit_python(const PyiRuntimeOptions *runtime_options);
+int pyi_pyconfig_preinit_python(const struct PyiRuntimeOptions *runtime_options);
 
 #endif /* PYI_PYCONFIG_H */

--- a/bootloader/src/pyi_python.c
+++ b/bootloader/src/pyi_python.c
@@ -24,64 +24,64 @@
 
 
 /* Python functions to bind */
-PYI_DECLPROC(Py_DecRef);
-PYI_DECLPROC(Py_DecodeLocale);
-PYI_DECLPROC(Py_ExitStatusException);
-PYI_DECLPROC(Py_Finalize);
-PYI_DECLPROC(Py_InitializeFromConfig);
-PYI_DECLPROC(Py_IsInitialized);
-PYI_DECLPROC(Py_PreInitialize);
+PYI_DECLPROC(Py_DecRef)
+PYI_DECLPROC(Py_DecodeLocale)
+PYI_DECLPROC(Py_ExitStatusException)
+PYI_DECLPROC(Py_Finalize)
+PYI_DECLPROC(Py_InitializeFromConfig)
+PYI_DECLPROC(Py_IsInitialized)
+PYI_DECLPROC(Py_PreInitialize)
 
-PYI_DECLPROC(PyConfig_Clear);
-PYI_DECLPROC(PyConfig_InitIsolatedConfig);
-PYI_DECLPROC(PyConfig_Read);
-PYI_DECLPROC(PyConfig_SetBytesString);
-PYI_DECLPROC(PyConfig_SetString);
-PYI_DECLPROC(PyConfig_SetWideStringList);
+PYI_DECLPROC(PyConfig_Clear)
+PYI_DECLPROC(PyConfig_InitIsolatedConfig)
+PYI_DECLPROC(PyConfig_Read)
+PYI_DECLPROC(PyConfig_SetBytesString)
+PYI_DECLPROC(PyConfig_SetString)
+PYI_DECLPROC(PyConfig_SetWideStringList)
 
-PYI_DECLPROC(PyErr_Clear);
-PYI_DECLPROC(PyErr_Fetch);
-PYI_DECLPROC(PyErr_NormalizeException);
-PYI_DECLPROC(PyErr_Occurred);
-PYI_DECLPROC(PyErr_Print);
-PYI_DECLPROC(PyErr_Restore);
+PYI_DECLPROC(PyErr_Clear)
+PYI_DECLPROC(PyErr_Fetch)
+PYI_DECLPROC(PyErr_NormalizeException)
+PYI_DECLPROC(PyErr_Occurred)
+PYI_DECLPROC(PyErr_Print)
+PYI_DECLPROC(PyErr_Restore)
 
-PYI_DECLPROC(PyEval_EvalCode);
+PYI_DECLPROC(PyEval_EvalCode)
 
-PYI_DECLPROC(PyImport_AddModule);
-PYI_DECLPROC(PyImport_ExecCodeModule);
-PYI_DECLPROC(PyImport_ImportModule);
+PYI_DECLPROC(PyImport_AddModule)
+PYI_DECLPROC(PyImport_ExecCodeModule)
+PYI_DECLPROC(PyImport_ImportModule)
 
-PYI_DECLPROC(PyList_Append);
+PYI_DECLPROC(PyList_Append)
 
-PYI_DECLPROC(PyMarshal_ReadObjectFromString);
+PYI_DECLPROC(PyMarshal_ReadObjectFromString)
 
-PYI_DECLPROC(PyMem_RawFree);
+PYI_DECLPROC(PyMem_RawFree)
 
-PYI_DECLPROC(PyModule_GetDict);
+PYI_DECLPROC(PyModule_GetDict)
 
-PYI_DECLPROC(PyObject_CallFunction);
-PYI_DECLPROC(PyObject_CallFunctionObjArgs);
-PYI_DECLPROC(PyObject_GetAttrString);
-PYI_DECLPROC(PyObject_SetAttrString);
-PYI_DECLPROC(PyObject_Str);
+PYI_DECLPROC(PyObject_CallFunction)
+PYI_DECLPROC(PyObject_CallFunctionObjArgs)
+PYI_DECLPROC(PyObject_GetAttrString)
+PYI_DECLPROC(PyObject_SetAttrString)
+PYI_DECLPROC(PyObject_Str)
 
-PYI_DECLPROC(PyPreConfig_InitIsolatedConfig);
+PYI_DECLPROC(PyPreConfig_InitIsolatedConfig)
 
-PYI_DECLPROC(PyRun_SimpleStringFlags);
+PYI_DECLPROC(PyRun_SimpleStringFlags)
 
-PYI_DECLPROC(PyStatus_Exception);
+PYI_DECLPROC(PyStatus_Exception)
 
-PYI_DECLPROC(PySys_GetObject);
-PYI_DECLPROC(PySys_SetObject);
+PYI_DECLPROC(PySys_GetObject)
+PYI_DECLPROC(PySys_SetObject)
 
-PYI_DECLPROC(PyUnicode_AsUTF8);
-PYI_DECLPROC(PyUnicode_Decode);
-PYI_DECLPROC(PyUnicode_DecodeFSDefault);
-PYI_DECLPROC(PyUnicode_FromFormat);
-PYI_DECLPROC(PyUnicode_FromString);
-PYI_DECLPROC(PyUnicode_Join);
-PYI_DECLPROC(PyUnicode_Replace);
+PYI_DECLPROC(PyUnicode_AsUTF8)
+PYI_DECLPROC(PyUnicode_Decode)
+PYI_DECLPROC(PyUnicode_DecodeFSDefault)
+PYI_DECLPROC(PyUnicode_FromFormat)
+PYI_DECLPROC(PyUnicode_FromString)
+PYI_DECLPROC(PyUnicode_Join)
+PYI_DECLPROC(PyUnicode_Replace)
 
 
 /*
@@ -90,64 +90,64 @@ PYI_DECLPROC(PyUnicode_Replace);
 int
 pyi_python_bind_functions(pyi_dylib_t dll, int python_version)
 {
-    PYI_GETPROC(dll, Py_DecRef);
-    PYI_GETPROC(dll, Py_DecodeLocale);
-    PYI_GETPROC(dll, Py_ExitStatusException);
-    PYI_GETPROC(dll, Py_Finalize);
-    PYI_GETPROC(dll, Py_InitializeFromConfig);
-    PYI_GETPROC(dll, Py_IsInitialized);
-    PYI_GETPROC(dll, Py_PreInitialize);
+    PYI_GETPROC(dll, Py_DecRef)
+    PYI_GETPROC(dll, Py_DecodeLocale)
+    PYI_GETPROC(dll, Py_ExitStatusException)
+    PYI_GETPROC(dll, Py_Finalize)
+    PYI_GETPROC(dll, Py_InitializeFromConfig)
+    PYI_GETPROC(dll, Py_IsInitialized)
+    PYI_GETPROC(dll, Py_PreInitialize)
 
-    PYI_GETPROC(dll, PyConfig_Clear);
-    PYI_GETPROC(dll, PyConfig_InitIsolatedConfig);
-    PYI_GETPROC(dll, PyConfig_Read);
-    PYI_GETPROC(dll, PyConfig_SetBytesString);
-    PYI_GETPROC(dll, PyConfig_SetString);
-    PYI_GETPROC(dll, PyConfig_SetWideStringList);
+    PYI_GETPROC(dll, PyConfig_Clear)
+    PYI_GETPROC(dll, PyConfig_InitIsolatedConfig)
+    PYI_GETPROC(dll, PyConfig_Read)
+    PYI_GETPROC(dll, PyConfig_SetBytesString)
+    PYI_GETPROC(dll, PyConfig_SetString)
+    PYI_GETPROC(dll, PyConfig_SetWideStringList)
 
-    PYI_GETPROC(dll, PyErr_Clear);
-    PYI_GETPROC(dll, PyErr_Fetch);
-    PYI_GETPROC(dll, PyErr_NormalizeException);
-    PYI_GETPROC(dll, PyErr_Occurred);
-    PYI_GETPROC(dll, PyErr_Print);
-    PYI_GETPROC(dll, PyErr_Restore);
+    PYI_GETPROC(dll, PyErr_Clear)
+    PYI_GETPROC(dll, PyErr_Fetch)
+    PYI_GETPROC(dll, PyErr_NormalizeException)
+    PYI_GETPROC(dll, PyErr_Occurred)
+    PYI_GETPROC(dll, PyErr_Print)
+    PYI_GETPROC(dll, PyErr_Restore)
 
-    PYI_GETPROC(dll, PyEval_EvalCode);
+    PYI_GETPROC(dll, PyEval_EvalCode)
 
-    PYI_GETPROC(dll, PyImport_AddModule);
-    PYI_GETPROC(dll, PyImport_ExecCodeModule);
-    PYI_GETPROC(dll, PyImport_ImportModule);
+    PYI_GETPROC(dll, PyImport_AddModule)
+    PYI_GETPROC(dll, PyImport_ExecCodeModule)
+    PYI_GETPROC(dll, PyImport_ImportModule)
 
-    PYI_GETPROC(dll, PyList_Append);
+    PYI_GETPROC(dll, PyList_Append)
 
-    PYI_GETPROC(dll, PyMarshal_ReadObjectFromString);
+    PYI_GETPROC(dll, PyMarshal_ReadObjectFromString)
 
-    PYI_GETPROC(dll, PyMem_RawFree);
+    PYI_GETPROC(dll, PyMem_RawFree)
 
-    PYI_GETPROC(dll, PyModule_GetDict);
+    PYI_GETPROC(dll, PyModule_GetDict)
 
-    PYI_GETPROC(dll, PyObject_CallFunction);
-    PYI_GETPROC(dll, PyObject_CallFunctionObjArgs);
-    PYI_GETPROC(dll, PyObject_GetAttrString);
-    PYI_GETPROC(dll, PyObject_SetAttrString);
-    PYI_GETPROC(dll, PyObject_Str);
+    PYI_GETPROC(dll, PyObject_CallFunction)
+    PYI_GETPROC(dll, PyObject_CallFunctionObjArgs)
+    PYI_GETPROC(dll, PyObject_GetAttrString)
+    PYI_GETPROC(dll, PyObject_SetAttrString)
+    PYI_GETPROC(dll, PyObject_Str)
 
-    PYI_GETPROC(dll, PyPreConfig_InitIsolatedConfig);
+    PYI_GETPROC(dll, PyPreConfig_InitIsolatedConfig)
 
-    PYI_GETPROC(dll, PyRun_SimpleStringFlags);
+    PYI_GETPROC(dll, PyRun_SimpleStringFlags)
 
-    PYI_GETPROC(dll, PyStatus_Exception);
+    PYI_GETPROC(dll, PyStatus_Exception)
 
-    PYI_GETPROC(dll, PySys_GetObject);
-    PYI_GETPROC(dll, PySys_SetObject);
+    PYI_GETPROC(dll, PySys_GetObject)
+    PYI_GETPROC(dll, PySys_SetObject)
 
-    PYI_GETPROC(dll, PyUnicode_AsUTF8);
-    PYI_GETPROC(dll, PyUnicode_Decode);
-    PYI_GETPROC(dll, PyUnicode_DecodeFSDefault);
-    PYI_GETPROC(dll, PyUnicode_FromFormat);
-    PYI_GETPROC(dll, PyUnicode_FromString);
-    PYI_GETPROC(dll, PyUnicode_Join);
-    PYI_GETPROC(dll, PyUnicode_Replace);
+    PYI_GETPROC(dll, PyUnicode_AsUTF8)
+    PYI_GETPROC(dll, PyUnicode_Decode)
+    PYI_GETPROC(dll, PyUnicode_DecodeFSDefault)
+    PYI_GETPROC(dll, PyUnicode_FromFormat)
+    PYI_GETPROC(dll, PyUnicode_FromString)
+    PYI_GETPROC(dll, PyUnicode_Join)
+    PYI_GETPROC(dll, PyUnicode_Replace)
 
     PYI_DEBUG("LOADER: loaded functions from Python shared library.\n");
 

--- a/bootloader/src/pyi_python.h
+++ b/bootloader/src/pyi_python.h
@@ -152,78 +152,78 @@ typedef struct _PyConfig PyConfig;
 
 
 /* Py_ */
-PYI_EXTDECLPROC(void, Py_DecRef, (PyObject *));
-PYI_EXTDECLPROC(wchar_t *, Py_DecodeLocale, (const char *, size_t *));
-PYI_EXTDECLPROC(void, Py_ExitStatusException, (PyStatus));
-PYI_EXTDECLPROC(int, Py_Finalize, (void));
-PYI_EXTDECLPROC(PyStatus, Py_InitializeFromConfig, (PyConfig *));
-PYI_EXTDECLPROC(int, Py_IsInitialized, (void));
-PYI_EXTDECLPROC(PyStatus, Py_PreInitialize, (const PyPreConfig *));
+PYI_EXTDECLPROC(void, Py_DecRef, (PyObject *))
+PYI_EXTDECLPROC(wchar_t *, Py_DecodeLocale, (const char *, size_t *))
+PYI_EXTDECLPROC(void, Py_ExitStatusException, (PyStatus))
+PYI_EXTDECLPROC(int, Py_Finalize, (void))
+PYI_EXTDECLPROC(PyStatus, Py_InitializeFromConfig, (PyConfig *))
+PYI_EXTDECLPROC(int, Py_IsInitialized, (void))
+PYI_EXTDECLPROC(PyStatus, Py_PreInitialize, (const PyPreConfig *))
 
 /* PyConfig_ */
-PYI_EXTDECLPROC(void, PyConfig_Clear, (PyConfig *));
-PYI_EXTDECLPROC(void, PyConfig_InitIsolatedConfig, (PyConfig *));
-PYI_EXTDECLPROC(PyStatus, PyConfig_Read, (PyConfig *));
-PYI_EXTDECLPROC(PyStatus, PyConfig_SetBytesString, (PyConfig *, wchar_t **, const char *));
-PYI_EXTDECLPROC(PyStatus, PyConfig_SetString, (PyConfig *, wchar_t **, const wchar_t *));
-PYI_EXTDECLPROC(PyStatus, PyConfig_SetWideStringList, (PyConfig *, PyWideStringList *, Py_ssize_t, wchar_t **));
+PYI_EXTDECLPROC(void, PyConfig_Clear, (PyConfig *))
+PYI_EXTDECLPROC(void, PyConfig_InitIsolatedConfig, (PyConfig *))
+PYI_EXTDECLPROC(PyStatus, PyConfig_Read, (PyConfig *))
+PYI_EXTDECLPROC(PyStatus, PyConfig_SetBytesString, (PyConfig *, wchar_t **, const char *))
+PYI_EXTDECLPROC(PyStatus, PyConfig_SetString, (PyConfig *, wchar_t **, const wchar_t *))
+PYI_EXTDECLPROC(PyStatus, PyConfig_SetWideStringList, (PyConfig *, PyWideStringList *, Py_ssize_t, wchar_t **))
 
 /* PyErr_ */
-PYI_EXTDECLPROC(void, PyErr_Clear, (void) );
-PYI_EXTDECLPROC(void, PyErr_Fetch, (PyObject **, PyObject **, PyObject **));
-PYI_EXTDECLPROC(void, PyErr_NormalizeException, (PyObject **, PyObject **, PyObject **));
-PYI_EXTDECLPROC(PyObject *, PyErr_Occurred, (void) );
-PYI_EXTDECLPROC(void, PyErr_Print, (void) );
-PYI_EXTDECLPROC(void, PyErr_Restore, (PyObject *, PyObject *, PyObject *));
+PYI_EXTDECLPROC(void, PyErr_Clear, (void) )
+PYI_EXTDECLPROC(void, PyErr_Fetch, (PyObject **, PyObject **, PyObject **))
+PYI_EXTDECLPROC(void, PyErr_NormalizeException, (PyObject **, PyObject **, PyObject **))
+PYI_EXTDECLPROC(PyObject *, PyErr_Occurred, (void) )
+PYI_EXTDECLPROC(void, PyErr_Print, (void) )
+PYI_EXTDECLPROC(void, PyErr_Restore, (PyObject *, PyObject *, PyObject *))
 
 /* PyEval */
-PYI_EXTDECLPROC(PyObject *, PyEval_EvalCode, (PyObject *, PyObject *, PyObject *));
+PYI_EXTDECLPROC(PyObject *, PyEval_EvalCode, (PyObject *, PyObject *, PyObject *))
 
 /* PyImport_ */
-PYI_EXTDECLPROC(PyObject *, PyImport_AddModule, (const char *));
-PYI_EXTDECLPROC(PyObject *, PyImport_ExecCodeModule, (const char *, PyObject *));
-PYI_EXTDECLPROC(PyObject *, PyImport_ImportModule, (const char *));
+PYI_EXTDECLPROC(PyObject *, PyImport_AddModule, (const char *))
+PYI_EXTDECLPROC(PyObject *, PyImport_ExecCodeModule, (const char *, PyObject *))
+PYI_EXTDECLPROC(PyObject *, PyImport_ImportModule, (const char *))
 
 /* PyList_ */
-PYI_EXTDECLPROC(int, PyList_Append, (PyObject *, PyObject *));
+PYI_EXTDECLPROC(int, PyList_Append, (PyObject *, PyObject *))
 
 /* PyMarshal_ */
-PYI_EXTDECLPROC(PyObject *, PyMarshal_ReadObjectFromString, (const char *, Py_ssize_t));
+PYI_EXTDECLPROC(PyObject *, PyMarshal_ReadObjectFromString, (const char *, Py_ssize_t))
 
 /* PyMem_ */
-PYI_EXTDECLPROC(void, PyMem_RawFree, (void *));
+PYI_EXTDECLPROC(void, PyMem_RawFree, (void *))
 
 /* PyModule_ */
-PYI_EXTDECLPROC(PyObject *, PyModule_GetDict, (PyObject *));
+PYI_EXTDECLPROC(PyObject *, PyModule_GetDict, (PyObject *))
 
 /* PyObject_ */
-PYI_EXTDECLPROC(PyObject *, PyObject_CallFunction, (PyObject *, char *, ...));
-PYI_EXTDECLPROC(PyObject *, PyObject_CallFunctionObjArgs, (PyObject *, ...));
-PYI_EXTDECLPROC(PyObject *, PyObject_GetAttrString, (PyObject *, const char *));
-PYI_EXTDECLPROC(int, PyObject_SetAttrString, (PyObject *, char *, PyObject *));
-PYI_EXTDECLPROC(PyObject *, PyObject_Str, (PyObject *));
+PYI_EXTDECLPROC(PyObject *, PyObject_CallFunction, (PyObject *, char *, ...))
+PYI_EXTDECLPROC(PyObject *, PyObject_CallFunctionObjArgs, (PyObject *, ...))
+PYI_EXTDECLPROC(PyObject *, PyObject_GetAttrString, (PyObject *, const char *))
+PYI_EXTDECLPROC(int, PyObject_SetAttrString, (PyObject *, char *, PyObject *))
+PYI_EXTDECLPROC(PyObject *, PyObject_Str, (PyObject *))
 
 /* PyPreConfig_ */
-PYI_EXTDECLPROC(void, PyPreConfig_InitIsolatedConfig, (PyPreConfig *));
+PYI_EXTDECLPROC(void, PyPreConfig_InitIsolatedConfig, (PyPreConfig *))
 
 /* PyRun_ */
-PYI_EXTDECLPROC(int, PyRun_SimpleStringFlags, (const char *, PyCompilerFlags *));
+PYI_EXTDECLPROC(int, PyRun_SimpleStringFlags, (const char *, PyCompilerFlags *))
 
 /* PyStatus_ */
-PYI_EXTDECLPROC(int, PyStatus_Exception, (PyStatus));
+PYI_EXTDECLPROC(int, PyStatus_Exception, (PyStatus))
 
 /* PySys_ */
-PYI_EXTDECLPROC(PyObject *, PySys_GetObject, (const char *));
-PYI_EXTDECLPROC(int, PySys_SetObject, (char *, PyObject *));
+PYI_EXTDECLPROC(PyObject *, PySys_GetObject, (const char *))
+PYI_EXTDECLPROC(int, PySys_SetObject, (char *, PyObject *))
 
 /* PyUnicode_ */
-PYI_EXTDECLPROC(const char *, PyUnicode_AsUTF8, (PyObject *));
-PYI_EXTDECLPROC(PyObject *, PyUnicode_Decode, (const char *, Py_ssize_t, const char *, const char *));
-PYI_EXTDECLPROC(PyObject *, PyUnicode_DecodeFSDefault, (const char *));
-PYI_EXTDECLPROC(PyObject *, PyUnicode_FromFormat, (const char *, ...));
-PYI_EXTDECLPROC(PyObject *, PyUnicode_FromString, (const char *));
-PYI_EXTDECLPROC(PyObject *, PyUnicode_Join, (PyObject *, PyObject *));
-PYI_EXTDECLPROC(PyObject *, PyUnicode_Replace, (PyObject *, PyObject *, PyObject *, Py_ssize_t));
+PYI_EXTDECLPROC(const char *, PyUnicode_AsUTF8, (PyObject *))
+PYI_EXTDECLPROC(PyObject *, PyUnicode_Decode, (const char *, Py_ssize_t, const char *, const char *))
+PYI_EXTDECLPROC(PyObject *, PyUnicode_DecodeFSDefault, (const char *))
+PYI_EXTDECLPROC(PyObject *, PyUnicode_FromFormat, (const char *, ...))
+PYI_EXTDECLPROC(PyObject *, PyUnicode_FromString, (const char *))
+PYI_EXTDECLPROC(PyObject *, PyUnicode_Join, (PyObject *, PyObject *))
+PYI_EXTDECLPROC(PyObject *, PyUnicode_Replace, (PyObject *, PyObject *, PyObject *, Py_ssize_t))
 
 
 #endif /* PYI_PYTHON_H */

--- a/bootloader/src/pyi_pythonlib.c
+++ b/bootloader/src/pyi_pythonlib.c
@@ -41,9 +41,9 @@
  * Load the Python shared library, and bind all required symbols from it.
  */
 int
-pyi_pylib_load(PYI_CONTEXT *pyi_ctx)
+pyi_pylib_load(struct PYI_CONTEXT *pyi_ctx)
 {
-    const ARCHIVE *archive = pyi_ctx->archive;
+    const struct ARCHIVE *archive = pyi_ctx->archive;
     char dll_name[MAX_DLL_NAME_LEN];
     size_t dll_name_len;
     char dll_fullpath[PYI_PATH_MAX];
@@ -139,9 +139,9 @@ pyi_pylib_load(PYI_CONTEXT *pyi_ctx)
  * Initialize and start python interpreter.
  */
 int
-pyi_pylib_start_python(const PYI_CONTEXT *pyi_ctx)
+pyi_pylib_start_python(const struct PYI_CONTEXT *pyi_ctx)
 {
-    PyiRuntimeOptions *runtime_options = NULL;
+    struct PyiRuntimeOptions *runtime_options = NULL;
     PyConfig *config = NULL;
     PyStatus status;
     int ret = -1;
@@ -259,10 +259,10 @@ end:
  * Import (bootstrap) modules embedded in the PKG archive.
  */
 int
-pyi_pylib_import_modules(const PYI_CONTEXT *pyi_ctx)
+pyi_pylib_import_modules(const struct PYI_CONTEXT *pyi_ctx)
 {
-    const ARCHIVE *archive = pyi_ctx->archive;
-    const TOC_ENTRY *toc_entry;
+    const struct ARCHIVE *archive = pyi_ctx->archive;
+    const struct TOC_ENTRY *toc_entry;
     unsigned char *data;
     PyObject *co;
     PyObject *mod;
@@ -338,7 +338,7 @@ pyi_pylib_import_modules(const PYI_CONTEXT *pyi_ctx)
  * NB: This entry is removed from sys.path by the Python-side bootstrap scripts.
  */
 int
-_pyi_pylib_install_pyz_entry(const PYI_CONTEXT *pyi_ctx, const TOC_ENTRY *toc_entry)
+_pyi_pylib_install_pyz_entry(const struct PYI_CONTEXT *pyi_ctx, const struct TOC_ENTRY *toc_entry)
 {
     unsigned long long zlib_offset;
     PyObject *sys_path;
@@ -382,10 +382,10 @@ _pyi_pylib_install_pyz_entry(const PYI_CONTEXT *pyi_ctx, const TOC_ENTRY *toc_en
  * Return non zero on failure.
  */
 int
-pyi_pylib_install_pyz(const PYI_CONTEXT *pyi_ctx)
+pyi_pylib_install_pyz(const struct PYI_CONTEXT *pyi_ctx)
 {
-    const ARCHIVE *archive = pyi_ctx->archive;
-    const TOC_ENTRY *toc_entry;
+    const struct ARCHIVE *archive = pyi_ctx->archive;
+    const struct TOC_ENTRY *toc_entry;
 
     PYI_DEBUG("LOADER: installing PYZ archive with Python modules.\n");
 
@@ -405,7 +405,7 @@ pyi_pylib_install_pyz(const PYI_CONTEXT *pyi_ctx)
 }
 
 void
-pyi_pylib_finalize(const PYI_CONTEXT *pyi_ctx)
+pyi_pylib_finalize(const struct PYI_CONTEXT *pyi_ctx)
 {
     /* Ensure python library was loaded; otherwise PI_* function pointers
      * are invalid, and we have nothing to do here. */

--- a/bootloader/src/pyi_pythonlib.h
+++ b/bootloader/src/pyi_pythonlib.h
@@ -18,14 +18,14 @@
 #ifndef PYI_PYTHONLIB_H
 #define PYI_PYTHONLIB_H
 
-typedef struct _pyi_context PYI_CONTEXT;
+struct PYI_CONTEXT;
 
-int pyi_pylib_load(PYI_CONTEXT *pyi_ctx);
-int pyi_pylib_start_python(const PYI_CONTEXT *pyi_ctx);
-int pyi_pylib_import_modules(const PYI_CONTEXT *pyi_ctx);
-int pyi_pylib_install_pyz(const PYI_CONTEXT *pyi_ctx);
-int pyi_pylib_run_scripts(const PYI_CONTEXT *pyi_ctx);
+int pyi_pylib_load(struct PYI_CONTEXT *pyi_ctx);
+int pyi_pylib_start_python(const struct PYI_CONTEXT *pyi_ctx);
+int pyi_pylib_import_modules(const struct PYI_CONTEXT *pyi_ctx);
+int pyi_pylib_install_pyz(const struct PYI_CONTEXT *pyi_ctx);
+int pyi_pylib_run_scripts(const struct PYI_CONTEXT *pyi_ctx);
 
-void pyi_pylib_finalize(const PYI_CONTEXT *pyi_ctx);
+void pyi_pylib_finalize(const struct PYI_CONTEXT *pyi_ctx);
 
 #endif /* PYI_PYTHONLIB_H */

--- a/bootloader/src/pyi_splash.h
+++ b/bootloader/src/pyi_splash.h
@@ -21,7 +21,7 @@
 
 /* Archive item header for splash data
  * This struct is a header describing the rest of this archive item */
-typedef struct _splash_data_header
+struct SPLASH_DATA_HEADER
 {
     /* Filename of the Tcl shared library, e.g., tcl86t.dll */
     char tcl_libname[16];
@@ -52,10 +52,10 @@ typedef struct _splash_data_header
      * Followed by a chunk of data, including the splash screen
      * script, the image, and the required files array.
      */
-} SPLASH_DATA_HEADER;
+};
 
 /* Runtime context for the splash screen */
-typedef struct _splash_context
+struct SPLASH_CONTEXT
 {
     /* Mutexes used for thread-safe access to context and its variables. */
     Tcl_Mutex context_mutex;
@@ -124,36 +124,36 @@ typedef struct _splash_context
      * during finalization. */
     pyi_dylib_t dll_tcl;
     pyi_dylib_t dll_tk;
-} SPLASH_CONTEXT;
+};
 
-typedef int (pyi_splash_event_proc)(SPLASH_CONTEXT *, const void *);
+typedef int (pyi_splash_event_proc)(struct SPLASH_CONTEXT *, const void *);
 
-typedef struct _pyi_context PYI_CONTEXT;
+struct PYI_CONTEXT;
 
 
 /**
  * Public API functions for pyi_splash
  */
-int pyi_splash_setup(SPLASH_CONTEXT *splash, const PYI_CONTEXT *pyi_ctx);
+int pyi_splash_setup(struct SPLASH_CONTEXT *splash, const struct PYI_CONTEXT *pyi_ctx);
 
-int pyi_splash_load_shared_libaries(SPLASH_CONTEXT *splash);
-int pyi_splash_finalize(SPLASH_CONTEXT *splash);
-int pyi_splash_start(SPLASH_CONTEXT *splash, const char *executable);
+int pyi_splash_load_shared_libaries(struct SPLASH_CONTEXT *splash);
+int pyi_splash_finalize(struct SPLASH_CONTEXT *splash);
+int pyi_splash_start(struct SPLASH_CONTEXT *splash, const char *executable);
 
 /* Archive helper functions */
-int pyi_splash_extract(SPLASH_CONTEXT *splash, const PYI_CONTEXT *pyi_ctx);
-int pyi_splash_is_splash_requirement(SPLASH_CONTEXT *splash, const char *name);
+int pyi_splash_extract(struct SPLASH_CONTEXT *splash, const struct PYI_CONTEXT *pyi_ctx);
+int pyi_splash_is_splash_requirement(struct SPLASH_CONTEXT *splash, const char *name);
 
 int pyi_splash_send(
-    SPLASH_CONTEXT *splash,
+    struct SPLASH_CONTEXT *splash,
     bool async,
     const void *user_data,
     pyi_splash_event_proc proc
 );
-int pyi_splash_update_text(SPLASH_CONTEXT *splash, const char *toc_entry_name);
+int pyi_splash_update_text(struct SPLASH_CONTEXT *splash, const char *toc_entry_name);
 
 /* Memory allocation functions */
-SPLASH_CONTEXT *pyi_splash_context_new();
-void pyi_splash_context_free(SPLASH_CONTEXT **splash_ref);
+struct SPLASH_CONTEXT *pyi_splash_context_new();
+void pyi_splash_context_free(struct SPLASH_CONTEXT **splash_ref);
 
 #endif /*PYI_SPLASH_H */

--- a/bootloader/src/pyi_splashlib.c
+++ b/bootloader/src/pyi_splashlib.c
@@ -27,47 +27,47 @@
 #include "pyi_splashlib.h"
 
 /* Tcl Initialization/Destruction */
-PYI_DECLPROC(Tcl_Init);
-PYI_DECLPROC(Tcl_CreateInterp);
-PYI_DECLPROC(Tcl_FindExecutable);
-PYI_DECLPROC(Tcl_DoOneEvent);
-PYI_DECLPROC(Tcl_Finalize);
-PYI_DECLPROC(Tcl_FinalizeThread);
-PYI_DECLPROC(Tcl_DeleteInterp);
+PYI_DECLPROC(Tcl_Init)
+PYI_DECLPROC(Tcl_CreateInterp)
+PYI_DECLPROC(Tcl_FindExecutable)
+PYI_DECLPROC(Tcl_DoOneEvent)
+PYI_DECLPROC(Tcl_Finalize)
+PYI_DECLPROC(Tcl_FinalizeThread)
+PYI_DECLPROC(Tcl_DeleteInterp)
 
 /* Threading */
-PYI_DECLPROC(Tcl_CreateThread);
-PYI_DECLPROC(Tcl_GetCurrentThread);
-PYI_DECLPROC(Tcl_JoinThread);
-PYI_DECLPROC(Tcl_MutexLock);
-PYI_DECLPROC(Tcl_MutexUnlock);
-PYI_DECLPROC(Tcl_MutexFinalize);
-PYI_DECLPROC(Tcl_ConditionFinalize);
-PYI_DECLPROC(Tcl_ConditionNotify);
-PYI_DECLPROC(Tcl_ConditionWait);
-PYI_DECLPROC(Tcl_ThreadQueueEvent);
-PYI_DECLPROC(Tcl_ThreadAlert);
+PYI_DECLPROC(Tcl_CreateThread)
+PYI_DECLPROC(Tcl_GetCurrentThread)
+PYI_DECLPROC(Tcl_JoinThread)
+PYI_DECLPROC(Tcl_MutexLock)
+PYI_DECLPROC(Tcl_MutexUnlock)
+PYI_DECLPROC(Tcl_MutexFinalize)
+PYI_DECLPROC(Tcl_ConditionFinalize)
+PYI_DECLPROC(Tcl_ConditionNotify)
+PYI_DECLPROC(Tcl_ConditionWait)
+PYI_DECLPROC(Tcl_ThreadQueueEvent)
+PYI_DECLPROC(Tcl_ThreadAlert)
 
 /* Tcl interpreter manipulation */
-PYI_DECLPROC(Tcl_GetVar2);
-PYI_DECLPROC(Tcl_SetVar2);
-PYI_DECLPROC(Tcl_CreateObjCommand);
-PYI_DECLPROC(Tcl_GetString);
-PYI_DECLPROC(Tcl_NewStringObj);
-PYI_DECLPROC(Tcl_NewByteArrayObj);
-PYI_DECLPROC(Tcl_SetVar2Ex);
-PYI_DECLPROC(Tcl_GetObjResult);
+PYI_DECLPROC(Tcl_GetVar2)
+PYI_DECLPROC(Tcl_SetVar2)
+PYI_DECLPROC(Tcl_CreateObjCommand)
+PYI_DECLPROC(Tcl_GetString)
+PYI_DECLPROC(Tcl_NewStringObj)
+PYI_DECLPROC(Tcl_NewByteArrayObj)
+PYI_DECLPROC(Tcl_SetVar2Ex)
+PYI_DECLPROC(Tcl_GetObjResult)
 
 /* Evaluating scripts and memory functions */
-PYI_DECLPROC(Tcl_EvalFile);
-PYI_DECLPROC(Tcl_EvalEx);
-PYI_DECLPROC(Tcl_EvalObjv);
-PYI_DECLPROC(Tcl_Alloc);
-PYI_DECLPROC(Tcl_Free);
+PYI_DECLPROC(Tcl_EvalFile)
+PYI_DECLPROC(Tcl_EvalEx)
+PYI_DECLPROC(Tcl_EvalObjv)
+PYI_DECLPROC(Tcl_Alloc)
+PYI_DECLPROC(Tcl_Free)
 
 /* Tk */
-PYI_DECLPROC(Tk_Init);
-PYI_DECLPROC(Tk_GetNumMainWindows);
+PYI_DECLPROC(Tk_Init)
+PYI_DECLPROC(Tk_GetNumMainWindows)
 
 
 /*
@@ -77,47 +77,47 @@ int
 pyi_splashlib_bind_functions(pyi_dylib_t dll_tcl, pyi_dylib_t dll_tk)
 {
     /* Tcl Initialization/Destruction */
-    PYI_GETPROC(dll_tcl, Tcl_Init);
-    PYI_GETPROC(dll_tcl, Tcl_CreateInterp);
-    PYI_GETPROC(dll_tcl, Tcl_FindExecutable);
-    PYI_GETPROC(dll_tcl, Tcl_DoOneEvent);
-    PYI_GETPROC(dll_tcl, Tcl_Finalize);
-    PYI_GETPROC(dll_tcl, Tcl_FinalizeThread);
-    PYI_GETPROC(dll_tcl, Tcl_DeleteInterp);
+    PYI_GETPROC(dll_tcl, Tcl_Init)
+    PYI_GETPROC(dll_tcl, Tcl_CreateInterp)
+    PYI_GETPROC(dll_tcl, Tcl_FindExecutable)
+    PYI_GETPROC(dll_tcl, Tcl_DoOneEvent)
+    PYI_GETPROC(dll_tcl, Tcl_Finalize)
+    PYI_GETPROC(dll_tcl, Tcl_FinalizeThread)
+    PYI_GETPROC(dll_tcl, Tcl_DeleteInterp)
 
     /* Threading */
-    PYI_GETPROC(dll_tcl, Tcl_CreateThread);
-    PYI_GETPROC(dll_tcl, Tcl_GetCurrentThread);
-    PYI_GETPROC(dll_tcl, Tcl_JoinThread);
-    PYI_GETPROC(dll_tcl, Tcl_MutexLock);
-    PYI_GETPROC(dll_tcl, Tcl_MutexUnlock);
-    PYI_GETPROC(dll_tcl, Tcl_MutexFinalize);
-    PYI_GETPROC(dll_tcl, Tcl_ConditionFinalize);
-    PYI_GETPROC(dll_tcl, Tcl_ConditionNotify);
-    PYI_GETPROC(dll_tcl, Tcl_ConditionWait);
-    PYI_GETPROC(dll_tcl, Tcl_ThreadQueueEvent);
-    PYI_GETPROC(dll_tcl, Tcl_ThreadAlert);
+    PYI_GETPROC(dll_tcl, Tcl_CreateThread)
+    PYI_GETPROC(dll_tcl, Tcl_GetCurrentThread)
+    PYI_GETPROC(dll_tcl, Tcl_JoinThread)
+    PYI_GETPROC(dll_tcl, Tcl_MutexLock)
+    PYI_GETPROC(dll_tcl, Tcl_MutexUnlock)
+    PYI_GETPROC(dll_tcl, Tcl_MutexFinalize)
+    PYI_GETPROC(dll_tcl, Tcl_ConditionFinalize)
+    PYI_GETPROC(dll_tcl, Tcl_ConditionNotify)
+    PYI_GETPROC(dll_tcl, Tcl_ConditionWait)
+    PYI_GETPROC(dll_tcl, Tcl_ThreadQueueEvent)
+    PYI_GETPROC(dll_tcl, Tcl_ThreadAlert)
 
     /* Tcl interpreter manipulation */
-    PYI_GETPROC(dll_tcl, Tcl_GetVar2);
-    PYI_GETPROC(dll_tcl, Tcl_SetVar2);
-    PYI_GETPROC(dll_tcl, Tcl_CreateObjCommand);
-    PYI_GETPROC(dll_tcl, Tcl_GetString);
-    PYI_GETPROC(dll_tcl, Tcl_NewStringObj);
-    PYI_GETPROC(dll_tcl, Tcl_NewByteArrayObj);
-    PYI_GETPROC(dll_tcl, Tcl_SetVar2Ex);
-    PYI_GETPROC(dll_tcl, Tcl_GetObjResult);
+    PYI_GETPROC(dll_tcl, Tcl_GetVar2)
+    PYI_GETPROC(dll_tcl, Tcl_SetVar2)
+    PYI_GETPROC(dll_tcl, Tcl_CreateObjCommand)
+    PYI_GETPROC(dll_tcl, Tcl_GetString)
+    PYI_GETPROC(dll_tcl, Tcl_NewStringObj)
+    PYI_GETPROC(dll_tcl, Tcl_NewByteArrayObj)
+    PYI_GETPROC(dll_tcl, Tcl_SetVar2Ex)
+    PYI_GETPROC(dll_tcl, Tcl_GetObjResult)
 
     /* Evaluating scripts and memory functions */
-    PYI_GETPROC(dll_tcl, Tcl_EvalFile);
-    PYI_GETPROC(dll_tcl, Tcl_EvalEx);
-    PYI_GETPROC(dll_tcl, Tcl_EvalObjv);
-    PYI_GETPROC(dll_tcl, Tcl_Alloc);
-    PYI_GETPROC(dll_tcl, Tcl_Free);
+    PYI_GETPROC(dll_tcl, Tcl_EvalFile)
+    PYI_GETPROC(dll_tcl, Tcl_EvalEx)
+    PYI_GETPROC(dll_tcl, Tcl_EvalObjv)
+    PYI_GETPROC(dll_tcl, Tcl_Alloc)
+    PYI_GETPROC(dll_tcl, Tcl_Free)
 
     /* Tk */
-    PYI_GETPROC(dll_tk, Tk_Init);
-    PYI_GETPROC(dll_tk, Tk_GetNumMainWindows);
+    PYI_GETPROC(dll_tk, Tk_Init)
+    PYI_GETPROC(dll_tk, Tk_GetNumMainWindows)
 
     PYI_DEBUG("LOADER: loaded functions from Tcl/Tk shared libraries.\n");
     return 0;

--- a/bootloader/src/pyi_splashlib.h
+++ b/bootloader/src/pyi_splashlib.h
@@ -79,47 +79,47 @@ typedef enum
  * Bound functions from Tcl/Tk
  */
 /* Tcl Initialization/Destruction */
-PYI_EXTDECLPROC(int, Tcl_Init, (Tcl_Interp *));
-PYI_EXTDECLPROC(Tcl_Interp*, Tcl_CreateInterp, (void));
-PYI_EXTDECLPROC(void, Tcl_FindExecutable, (const char *));
-PYI_EXTDECLPROC(int, Tcl_DoOneEvent, (int));
-PYI_EXTDECLPROC(void, Tcl_Finalize, (void));
-PYI_EXTDECLPROC(void, Tcl_FinalizeThread, (void));
-PYI_EXTDECLPROC(void, Tcl_DeleteInterp, (Tcl_Interp *));
+PYI_EXTDECLPROC(int, Tcl_Init, (Tcl_Interp *))
+PYI_EXTDECLPROC(Tcl_Interp*, Tcl_CreateInterp, (void))
+PYI_EXTDECLPROC(void, Tcl_FindExecutable, (const char *))
+PYI_EXTDECLPROC(int, Tcl_DoOneEvent, (int))
+PYI_EXTDECLPROC(void, Tcl_Finalize, (void))
+PYI_EXTDECLPROC(void, Tcl_FinalizeThread, (void))
+PYI_EXTDECLPROC(void, Tcl_DeleteInterp, (Tcl_Interp *))
 
 /* Threading */
-PYI_EXTDECLPROC(int, Tcl_CreateThread, (Tcl_ThreadId *, Tcl_ThreadCreateProc *, ClientData, int, int));
-PYI_EXTDECLPROC(Tcl_ThreadId, Tcl_GetCurrentThread, (void));
-PYI_EXTDECLPROC(int, Tcl_JoinThread, (Tcl_ThreadId, int *));
-PYI_EXTDECLPROC(void, Tcl_MutexLock, (Tcl_Mutex *));
-PYI_EXTDECLPROC(void, Tcl_MutexUnlock, (Tcl_Mutex *));
-PYI_EXTDECLPROC(void, Tcl_MutexFinalize, (Tcl_Mutex *));
-PYI_EXTDECLPROC(void, Tcl_ConditionFinalize, (Tcl_Condition *));
-PYI_EXTDECLPROC(void, Tcl_ConditionNotify, (Tcl_Condition *));
-PYI_EXTDECLPROC(void, Tcl_ConditionWait, (Tcl_Condition *, Tcl_Mutex *, const Tcl_Time *));
-PYI_EXTDECLPROC(void, Tcl_ThreadQueueEvent, (Tcl_ThreadId, Tcl_Event *, Tcl_QueuePosition));
-PYI_EXTDECLPROC(void, Tcl_ThreadAlert, (Tcl_ThreadId threadId));
+PYI_EXTDECLPROC(int, Tcl_CreateThread, (Tcl_ThreadId *, Tcl_ThreadCreateProc *, ClientData, int, int))
+PYI_EXTDECLPROC(Tcl_ThreadId, Tcl_GetCurrentThread, (void))
+PYI_EXTDECLPROC(int, Tcl_JoinThread, (Tcl_ThreadId, int *))
+PYI_EXTDECLPROC(void, Tcl_MutexLock, (Tcl_Mutex *))
+PYI_EXTDECLPROC(void, Tcl_MutexUnlock, (Tcl_Mutex *))
+PYI_EXTDECLPROC(void, Tcl_MutexFinalize, (Tcl_Mutex *))
+PYI_EXTDECLPROC(void, Tcl_ConditionFinalize, (Tcl_Condition *))
+PYI_EXTDECLPROC(void, Tcl_ConditionNotify, (Tcl_Condition *))
+PYI_EXTDECLPROC(void, Tcl_ConditionWait, (Tcl_Condition *, Tcl_Mutex *, const Tcl_Time *))
+PYI_EXTDECLPROC(void, Tcl_ThreadQueueEvent, (Tcl_ThreadId, Tcl_Event *, Tcl_QueuePosition))
+PYI_EXTDECLPROC(void, Tcl_ThreadAlert, (Tcl_ThreadId threadId))
 
 /* Tcl interpreter manipulation */
-PYI_EXTDECLPROC(const char*, Tcl_GetVar2, (Tcl_Interp *, const char *, const char *, int));
-PYI_EXTDECLPROC(const char*, Tcl_SetVar2, (Tcl_Interp *, const char *, const char *, const char *, int));
-PYI_EXTDECLPROC(Tcl_Command, Tcl_CreateObjCommand, (Tcl_Interp *, const char *, Tcl_ObjCmdProc *, ClientData, Tcl_CmdDeleteProc *));
-PYI_EXTDECLPROC(char *, Tcl_GetString, (Tcl_Obj *));
-PYI_EXTDECLPROC(Tcl_Obj *, Tcl_NewStringObj, (const char *, int));
-PYI_EXTDECLPROC(Tcl_Obj *, Tcl_NewByteArrayObj, (const unsigned char *, int));
-PYI_EXTDECLPROC(Tcl_Obj *, Tcl_SetVar2Ex, (Tcl_Interp *, const char *, const char *, Tcl_Obj *, int));
-PYI_EXTDECLPROC(Tcl_Obj *, Tcl_GetObjResult, (Tcl_Interp *));
+PYI_EXTDECLPROC(const char*, Tcl_GetVar2, (Tcl_Interp *, const char *, const char *, int))
+PYI_EXTDECLPROC(const char*, Tcl_SetVar2, (Tcl_Interp *, const char *, const char *, const char *, int))
+PYI_EXTDECLPROC(Tcl_Command, Tcl_CreateObjCommand, (Tcl_Interp *, const char *, Tcl_ObjCmdProc *, ClientData, Tcl_CmdDeleteProc *))
+PYI_EXTDECLPROC(char *, Tcl_GetString, (Tcl_Obj *))
+PYI_EXTDECLPROC(Tcl_Obj *, Tcl_NewStringObj, (const char *, int))
+PYI_EXTDECLPROC(Tcl_Obj *, Tcl_NewByteArrayObj, (const unsigned char *, int))
+PYI_EXTDECLPROC(Tcl_Obj *, Tcl_SetVar2Ex, (Tcl_Interp *, const char *, const char *, Tcl_Obj *, int))
+PYI_EXTDECLPROC(Tcl_Obj *, Tcl_GetObjResult, (Tcl_Interp *))
 
 /* Evaluating scripts and memory functions */
-PYI_EXTDECLPROC(int, Tcl_EvalFile, (Tcl_Interp *, const char *));
-PYI_EXTDECLPROC(int, Tcl_EvalEx, (Tcl_Interp *, const char *, int, int));
-PYI_EXTDECLPROC(int, Tcl_EvalObjv, (Tcl_Interp *, int, Tcl_Obj * const[], int));
-PYI_EXTDECLPROC(char *, Tcl_Alloc, (unsigned int));
-PYI_EXTDECLPROC(void, Tcl_Free, (char *));
+PYI_EXTDECLPROC(int, Tcl_EvalFile, (Tcl_Interp *, const char *))
+PYI_EXTDECLPROC(int, Tcl_EvalEx, (Tcl_Interp *, const char *, int, int))
+PYI_EXTDECLPROC(int, Tcl_EvalObjv, (Tcl_Interp *, int, Tcl_Obj * const[], int))
+PYI_EXTDECLPROC(char *, Tcl_Alloc, (unsigned int))
+PYI_EXTDECLPROC(void, Tcl_Free, (char *))
 
 /* Tk */
-PYI_EXTDECLPROC(int, Tk_Init, (Tcl_Interp *));
-PYI_EXTDECLPROC(int, Tk_GetNumMainWindows, (void));
+PYI_EXTDECLPROC(int, Tk_Init, (Tcl_Interp *))
+PYI_EXTDECLPROC(int, Tk_GetNumMainWindows, (void))
 
 /* Bind all required functions from Tcl and Tk shared libraries */
 int pyi_splashlib_bind_functions(pyi_dylib_t dll_tcl, pyi_dylib_t dll_tk);

--- a/bootloader/src/pyi_utils.c
+++ b/bootloader/src/pyi_utils.c
@@ -46,7 +46,7 @@
  * Returns 0 on success, -1 on failure.
  */
 int
-pyi_create_parent_directory_tree(const PYI_CONTEXT *pyi_ctx, const char *prefix_path, const char *filename)
+pyi_create_parent_directory_tree(const struct PYI_CONTEXT *pyi_ctx, const char *prefix_path, const char *filename)
 {
     char path[PYI_PATH_MAX];
     char *subpath_cursor;

--- a/bootloader/src/pyi_utils.h
+++ b/bootloader/src/pyi_utils.h
@@ -23,7 +23,7 @@
 
 #include "pyi_global.h" /* dylib_t */
 
-typedef struct _pyi_context PYI_CONTEXT;
+struct PYI_CONTEXT;
 
 /* Environment variables. */
 char *pyi_getenv(const char *variable);
@@ -31,13 +31,13 @@ int pyi_setenv(const char *variable, const char *value);
 int pyi_unsetenv(const char *variable);
 
 /* Temporary top-level application directory (onefile). */
-int pyi_create_temporary_application_directory(PYI_CONTEXT *pyi_ctx);
+int pyi_create_temporary_application_directory(struct PYI_CONTEXT *pyi_ctx);
 
 /* Recursive directory deletion. */
 int pyi_recursive_rmdir(const char *dir);
 
 /* Misc. file/directory manipulation. */
-int pyi_create_parent_directory_tree(const PYI_CONTEXT *pyi_ctx, const char *prefix_path, const char *filename);
+int pyi_create_parent_directory_tree(const struct PYI_CONTEXT *pyi_ctx, const char *prefix_path, const char *filename);
 int pyi_copy_file(const char *src_filename, const char *dest_filename);
 
 /* Shared library loading. */
@@ -45,7 +45,7 @@ pyi_dylib_t pyi_utils_dlopen(const char *filename);
 int pyi_utils_dlclose(pyi_dylib_t handle);
 
 /* Child process */
-int pyi_utils_create_child(PYI_CONTEXT *pyi_ctx);
+int pyi_utils_create_child(struct PYI_CONTEXT *pyi_ctx);
 
 #if !defined(_WIN32) && !defined(__APPLE__)
 int pyi_utils_set_library_search_path(const char *path);
@@ -53,9 +53,9 @@ int pyi_utils_set_library_search_path(const char *path);
 
 /* Argument handling (POSIX only) */
 #if !defined(_WIN32)
-int pyi_utils_initialize_args(PYI_CONTEXT *pyi_ctx, const int argc, char *const argv[]);
-int pyi_utils_append_to_args(PYI_CONTEXT *pyi_ctx, const char *arg);
-void pyi_utils_free_args(PYI_CONTEXT *pyi_ctx);
+int pyi_utils_initialize_args(struct PYI_CONTEXT *pyi_ctx, const int argc, char *const argv[]);
+int pyi_utils_append_to_args(struct PYI_CONTEXT *pyi_ctx, const char *arg);
+void pyi_utils_free_args(struct PYI_CONTEXT *pyi_ctx);
 #endif
 
 /* Magic pattern matching */
@@ -76,7 +76,7 @@ void pyi_win32_minimize_console();
 
 /* Force-unload of bundled DLLs from onefile parent process (Windows only) */
 #if defined(_WIN32)
-void pyi_win32_force_unload_bundled_dlls(PYI_CONTEXT *pyi_ctx);
+void pyi_win32_force_unload_bundled_dlls(struct PYI_CONTEXT *pyi_ctx);
 #endif
 
 /* Windows low-level helpers */

--- a/bootloader/src/pyi_utils_posix.c
+++ b/bootloader/src/pyi_utils_posix.c
@@ -16,8 +16,11 @@
  * to POSIX platforms.
  */
 
-#ifndef _WIN32
+/* Having a header included outside of the ifdef block prevents the compilation
+ * unit from becoming empty, which is disallowed by pedantic ISO C. */
+#include "pyi_global.h"
 
+#ifndef _WIN32
 
 #include <stdio.h>  /* FILE */
 #include <stdlib.h>
@@ -57,8 +60,6 @@
 
 /* PyInstaller headers. */
 #include "pyi_utils.h"
-
-#include "pyi_global.h"
 #include "pyi_path.h"
 #include "pyi_main.h"
 #include "pyi_apple_events.h"
@@ -213,7 +214,7 @@ _pyi_format_and_create_tmpdir(char *tmpdir_path)
 }
 
 int
-pyi_create_temporary_application_directory(PYI_CONTEXT *pyi_ctx)
+pyi_create_temporary_application_directory(struct PYI_CONTEXT *pyi_ctx)
 {
     static const char *candidate_env_vars[] = {
         "TMPDIR",
@@ -500,7 +501,7 @@ _signal_handler(int signum)
 /* Start frozen application in a subprocess. The frozen application runs
  * in a subprocess. */
 int
-pyi_utils_create_child(PYI_CONTEXT *pyi_ctx)
+pyi_utils_create_child(struct PYI_CONTEXT *pyi_ctx)
 {
     pid_t pid = 0;
     int rc = 0;
@@ -673,7 +674,7 @@ cleanup:
  * passed to executable when .app bundle is launched from Finder:
  * https://stackoverflow.com/questions/10242115/os-x-strange-psn-command-line-parameter-when-launched-from-finder
  */
-int pyi_utils_initialize_args(PYI_CONTEXT *pyi_ctx, const int argc, char *const argv[])
+int pyi_utils_initialize_args(struct PYI_CONTEXT *pyi_ctx, const int argc, char *const argv[])
 {
     int i;
 
@@ -717,7 +718,7 @@ int pyi_utils_initialize_args(PYI_CONTEXT *pyi_ctx, const int argc, char *const 
  * Returns 0 on success, -1 on failure (due to failed array reallocation).
  * On failure, pyi_argv and pyi_argc remain unchanged.
  */
-int pyi_utils_append_to_args(PYI_CONTEXT *pyi_ctx, const char *arg)
+int pyi_utils_append_to_args(struct PYI_CONTEXT *pyi_ctx, const char *arg)
 {
     char **new_pyi_argv;
     char *arg_copy;
@@ -747,7 +748,7 @@ int pyi_utils_append_to_args(PYI_CONTEXT *pyi_ctx, const char *arg)
 /*
  * Free/clean-up the private arguments (pyi_argv).
  */
-void pyi_utils_free_args(PYI_CONTEXT *pyi_ctx)
+void pyi_utils_free_args(struct PYI_CONTEXT *pyi_ctx)
 {
     /* Free each entry */
     int i;

--- a/bootloader/src/pyi_utils_win32.c
+++ b/bootloader/src/pyi_utils_win32.c
@@ -16,8 +16,11 @@
  * to Windows.
  */
 
-#ifdef _WIN32
+/* Having a header included outside of the ifdef block prevents the compilation
+ * unit from becoming empty, which is disallowed by pedantic ISO C. */
+#include "pyi_global.h"
 
+#ifdef _WIN32
 
 #include <windows.h>
 #include <io.h> /* _get_osfhandle */
@@ -30,8 +33,6 @@
 
 /* PyInstaller headers. */
 #include "pyi_utils.h"
-
-#include "pyi_global.h"
 #include "pyi_path.h"
 #include "pyi_main.h"
 
@@ -226,7 +227,7 @@ _pyi_create_runtime_tmpdir(const char *runtime_tmpdir)
 }
 
 int
-pyi_create_temporary_application_directory(PYI_CONTEXT *pyi_ctx)
+pyi_create_temporary_application_directory(struct PYI_CONTEXT *pyi_ctx)
 {
     char *original_tmp_value = NULL;
     wchar_t prefix[16];
@@ -455,13 +456,13 @@ _pyi_win32_console_ctrl(DWORD dwCtrlType)
 #if defined(LAUNCH_DEBUG)
     /* https://docs.microsoft.com/en-us/windows/console/handlerroutine */
     static const wchar_t *name_map[] = {
-        L"CTRL_C_EVENT", // 0
-        L"CTRL_BREAK_EVENT", // 1
-        L"CTRL_CLOSE_EVENT", // 2
+        L"CTRL_C_EVENT", /* 0 */
+        L"CTRL_BREAK_EVENT", /* 1 */
+        L"CTRL_CLOSE_EVENT", /* 2 */
         NULL,
         NULL,
-        L"CTRL_LOGOFF_EVENT", // 5
-        L"CTRL_SHUTDOWN_EVENT" // 6
+        L"CTRL_LOGOFF_EVENT", /* 5 */
+        L"CTRL_SHUTDOWN_EVENT" /* 6 */
     };
     const wchar_t *name = (dwCtrlType >= 0 && dwCtrlType <= 6) ? name_map[dwCtrlType] : NULL;
 
@@ -519,7 +520,7 @@ _pyi_get_stream_handle(FILE *stream)
 }
 
 int
-pyi_utils_create_child(PYI_CONTEXT *pyi_ctx)
+pyi_utils_create_child(struct PYI_CONTEXT *pyi_ctx)
 {
     SECURITY_ATTRIBUTES security_attributes;
     STARTUPINFOW startup_info;
@@ -647,7 +648,7 @@ _pyi_win32_get_sid(TOKEN_INFORMATION_CLASS token_information_class)
         }
     }
 
-    // Cleanup
+    /* Cleanup */
 cleanup:
     free(token_info);
     if (process_token != INVALID_HANDLE_VALUE) {
@@ -791,7 +792,7 @@ void pyi_win32_minimize_console()
 /* Our last resort in ensuring that onefile application can clean up
  * its temporary directory... */
 void
-pyi_win32_force_unload_bundled_dlls(PYI_CONTEXT *pyi_ctx)
+pyi_win32_force_unload_bundled_dlls(struct PYI_CONTEXT *pyi_ctx)
 {
     HANDLE process_handle;
     HMODULE *loaded_dlls = NULL;

--- a/bootloader/src/pyi_utils_win32_low_level.c
+++ b/bootloader/src/pyi_utils_win32_low_level.c
@@ -16,11 +16,13 @@
  * to Windows.
  */
 
+/* Having a header included outside of the ifdef block prevents the compilation
+ * unit from becoming empty, which is disallowed by pedantic ISO C. */
+#include "pyi_global.h"
+
 #ifdef _WIN32
 
-
 /* PyInstaller headers. */
-#include "pyi_global.h"  /* PYI_PATH_MAX */
 #include "pyi_utils.h"
 
 #ifndef IO_REPARSE_TAG_SYMLINK

--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -282,6 +282,8 @@ def set_arch_flags(ctx):
 
         # Enable 64-bit porting warnings and other warnings.
         ctx.env.append_value('CFLAGS', '/W3')
+        # Treat compiler warnings as errors.
+        ctx.env.append_value('CFLAGS', '/WX')
         # Disable warnings about unrecognized pragmas.
         ctx.env.append_value('CFLAGS', '/wd4068')
         # Disable warnings about deprecated POSIX function names.
@@ -292,6 +294,8 @@ def set_arch_flags(ctx):
         ctx.env.append_value('CFLAGS', '/EHa')
         # Set the PE checksum on resulting binary.
         ctx.env.append_value('LINKFLAGS', '/RELEASE')
+        # Treat linker warnings as errors
+        ctx.env.append_value('LINKFLAGS', '/WX')
 
     # Ensure proper architecture flags on Mac OS.
     elif ctx.env.DEST_OS == 'darwin':

--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -508,6 +508,17 @@ def configure(ctx):
         # -Wno-error=unused-but-set-variable is not available on old gcc versions (e.g., 4.4.3)
         if ctx.check_cc(cflags='-Wno-error=unused-but-set-variable', execute=False, mandatory=False):
             ctx.env.append_value('CFLAGS', ['-Wno-error=unused-but-set-variable'])
+    elif ctx.env.CC_NAME == 'clang':
+        # For clang, also enable extra warnings and treat them as errors. Similarly to gcc, do not treat warnings about
+        # unused variables and unused functions as errors.
+        ctx.env.append_value(
+            'CFLAGS', [
+                '-Wall',
+                '-Werror',
+                '-Wno-error=unused-variable',
+                '-Wno-error=unused-function',
+            ]
+        )
 
     # ** Defines, includes **
 
@@ -713,7 +724,7 @@ def configure(ctx):
     # On linux link only with needed libraries.
     # On some platforms (Mac OS, Solaris, AIX), -Wl,--as-needed is detected as supported during configuration,
     # but fails during build. So use it only with linux.
-    if ctx.env.DEST_OS == 'linux' and ctx.check_cc(cflags='-Wl,--as-needed'):
+    if ctx.env.DEST_OS == 'linux' and ctx.check_cc(linkflags='-Wl,--as-needed', mandatory=False):
         ctx.env.append_value('LINKFLAGS', '-Wl,--as-needed')
 
     if not is_msvc_target(ctx):


### PR DESCRIPTION
Clean up the bootloader code so that it compiles with `gcc -std=c99 -pedantic`. It almost compiles with `gcc -std=gnu90 -pedantic`, if it were not for variadic macros (which I added to debug macros the other day) and a use of `unsigned long long` (which I am reluctant to touch).

Enable extra warnings when building with `clang` and with MSVC, and treat warnings as errors. (So that stupid mistakes that result in compilation warnings are caught when bootloader is compiled, rather than at run-time in form of crashes).