### PR TITLE
bootloader: fixes for onefile cleanup

### DIFF
--- a/bootloader/src/pyi_main.h
+++ b/bootloader/src/pyi_main.h
@@ -193,6 +193,15 @@ struct PYI_CONTEXT
     int child_signal;
 #endif
 
+    /* Flags used on Windows to signal various circumstances under which
+     * the application should shut itself down (i.e., in onefile mode,
+     * it should terminate the child process and perform the cleanup) */
+#if defined(_WIN32)
+    /* CTRL_CLOSE_EVENT, CTRL_SHUTDOWN_EVENT, or CTRL_LOGOFF_EVENT
+     * received via installed console handler. */
+    unsigned char console_shutdown;
+#endif
+
     /**
      * Runtime options
      */

--- a/bootloader/src/pyi_main.h
+++ b/bootloader/src/pyi_main.h
@@ -180,8 +180,26 @@ struct PYI_CONTEXT
     SECURITY_ATTRIBUTES *security_attr;
 #endif
 
-    /* Child process (onefile mode) variables. Used only in POSIX codepath. */
-#if !defined(_WIN32)
+    /* Child process (onefile mode) variables. */
+#if defined(_WIN32)
+    /* Child process information. */
+    PROCESS_INFORMATION child_process;
+
+    /* Hidden window used to receive session shutdown events
+     * (WM_QUERYENDSESSION and WM_ENDSESSION messages). */
+    HWND hidden_window;
+
+    /* Flags used on Windows to signal various circumstances under which
+     * the application should shut itself down (i.e., in onefile mode,
+     * it should terminate the child process and perform the cleanup) */
+
+    /* CTRL_CLOSE_EVENT, CTRL_SHUTDOWN_EVENT, or CTRL_LOGOFF_EVENT
+     * received via installed console handler. */
+    unsigned char console_shutdown;
+
+    /* WM_QUERYENDSESSION received via hidden window. */
+    unsigned char session_shutdown;
+#else
     /* Process ID of the child process (onefile mode). Keeping track of
      * the child PID allows us to forward signals to the child. */
     pid_t child_pid;
@@ -191,15 +209,6 @@ struct PYI_CONTEXT
      * once the temporary directory has been cleaned up. */
     int child_signalled;
     int child_signal;
-#endif
-
-    /* Flags used on Windows to signal various circumstances under which
-     * the application should shut itself down (i.e., in onefile mode,
-     * it should terminate the child process and perform the cleanup) */
-#if defined(_WIN32)
-    /* CTRL_CLOSE_EVENT, CTRL_SHUTDOWN_EVENT, or CTRL_LOGOFF_EVENT
-     * received via installed console handler. */
-    unsigned char console_shutdown;
 #endif
 
     /**
@@ -266,6 +275,9 @@ extern struct PYI_CONTEXT *global_pyi_ctx;
 
 
 int pyi_main(struct PYI_CONTEXT *pyi_ctx);
+
+/* Used in both pyi_main.c and pyi_utils_win32.c */
+int pyi_main_onefile_parent_cleanup(struct PYI_CONTEXT *pyi_ctx);
 
 
 #endif /* PYI_MAIN_H */

--- a/news/8640.bugfix.rst
+++ b/news/8640.bugfix.rst
@@ -1,0 +1,11 @@
+(Windows) Improve handling of ``CTRL_CLOSE_EVENT`` console event in
+``onefile`` builds for compatibility with Windows Terminal in order to
+avoid leaking temporary files when user closes the terminal window
+(or tab). Upon receiving the event, the parent process now gives the child
+process a 500-millisecond grace period to exit, after which it terminates
+the child process and proceeds with the cleanup (previously, the parent
+process indefinitely waited for the child to exit, under assumption that
+the ``CTRL_CLOSE_EVENT`` will also cause the child to exit at the same
+time - which was the case with ``conhost.exe``, but is not the case with
+Windows Terminal, where the child appears to receive event only after
+OS already terminated the parent process).

--- a/news/8648.bootloader.rst
+++ b/news/8648.bootloader.rst
@@ -1,0 +1,7 @@
+(Windows) The ``onefile`` parent process now sets up invisible window
+to receive and handle ``WM_QUERYENDSESSION`` and ``WM_ENDSESSION``
+event messages, which allows it properly clean up temporary files during
+session shutdown (i.e., user logging off, or initiating system shutdown
+or restart). Cleanup during session shutdown should now work in both
+console-enabled and windowed/noconsole builds, and regardless of whether
+splash screen is used or not.

--- a/news/8648.bugfix.1.rst
+++ b/news/8648.bugfix.1.rst
@@ -1,0 +1,3 @@
+(Windows) The windowed/noconsole ``onefile`` builds should now clean up
+their temporary directories during session shutdown (i.e., when user logs
+off or initiates system shutdown or restart).

--- a/news/8648.bugfix.rst
+++ b/news/8648.bugfix.rst
@@ -1,0 +1,12 @@
+(Windows) Fix regression in PyInstaller 6.x that caused console-enabled
+onefile applications fail to clean up their temporary directory during
+system session shutdown (i.e., when user logs off or initiates system
+shutdown or restart). For console-enabled onefile applications, this
+used to work up until PyInstaller 6.0 by means of installed console
+handler; however, due to contemporary bootloader executables being linked
+against ``user32.dll``, the console handler does not receive ``CTRL_LOGOFF_EVENT``
+and ``CTRL_SHUTDOWN_EVENT`` console events anymore (for the same reason,
+this did not work for builds with splash screen, even between v5.3 and
+6.0). Instead, session shutdown needs to be handled by means of hidden
+window and handling of ``WM_QUERYENDSESSION`` and ``WM_ENDSESSION`` event
+messages.


### PR DESCRIPTION
Attempt to fix the issues with onefile cleanup that were brought up recently (#8571, #8640).

When Windows Terminal is used and user closes the terminal window (or tab), the child process in console-enabled onefile application does not seem to receive `CTRL_CLOSE_EVENT` at the same time as the parent process; in fact, that does not seem to happen until after the OS terminates the parent. Therefore, we cannot have the parent process just delay the return from the console event handler (while assuming that the main thread will notice that the child has exited, and thus perform the cleanup and exit the process). Instead, we now have the console event handler set a flag in PYI_CONTEXT, which causes the main thread go into console shutdown mode - the child is given a grace period of 500 ms to exit (or be terminated by the OS), and then we terminate the child in order to be able to proceed with cleanup. This fixes #8640.

As noted in https://github.com/pyinstaller/pyinstaller/issues/8571#issuecomment-2143424118, we also fail to clean up temporary directories when frozen application is running in the background, and the OS session is shut down - either because user logged off, or because they initiated system shutdown or restart. For console-enabled builds, this is a regression in v6 - it used to work since v5.3 introduced console event handler, which handled `CTRL_LOGOFF_EVENT` and `CTRL_SHUTDOWN_EVENT`. However, contemporary bootloaders are linked against `user32.dll`, which causes the console event handler to not receive those events anymore. Instead, session shutdown needs to be handled by means of a hidden window and handling `WM_QUERYENDSESSION` / `WM_ENDSESSION`, as mentioned by [Microsoft docs](https://learn.microsoft.com/en-us/windows/console/setconsolectrlhandler). This sort of cleanup therefore didn't work for console-enabled onefile builds that also used splash screen (because that also loaded `user32.dll` in the process), nor for noconsole/windowed onefile builds (which do not have console, so console event handler is not applicable at all).

Therefore, the parent process of onefile application now sets up a hidden window to process afore-mentioned  `WM_QUERYENDSESSION` and `WM_ENDSESSION` messages. This allows us to perform cleanup in both console-enabled and noconsole/windowed builds, and regardless of whether splash screen is used or not. In `WM_ENDSESSION` handler, we give the child process a grace period of 1 second to exit (if it has not exited already); but in practice, the child might be terminated by the OS (due to user's code not processing those messages) even before the parent receives `WM_QUERYENDSESSION`. Therefore, when we break the waiting loop due to child having stopped, we now wait for 250 ms to see if we receive `WM_QUERYENDSESSION` - this is to ensure that on the off chance that session shutdown is indeed imminent, we go into `WM_QUERYENDSESSION`/`WM_ENDSESSION` based shutdown (to have the OS wait for us to perform the shutdown before terminating the process) instead of going through "regular" shutdown (which might be interrupted by OS terminating the process). This means that "normal" application shutdowns now take 250 ms longer.