### PR TITLE
bootloader: work around another source of VCRUNTIME140.dll leak

### DIFF
--- a/bootloader/src/pyi_archive.c
+++ b/bootloader/src/pyi_archive.c
@@ -483,6 +483,11 @@ pyi_archive_open(const char *filename)
         /* Check if entry is extractable */
         archive->contains_extractable_entries |= _pyi_archive_is_extractable(toc_entry->typecode);
 
+        /* Check if this is SPLASH entry */
+        if (toc_entry->typecode == ARCHIVE_ITEM_SPLASH) {
+            archive->toc_splash = toc_entry;
+        }
+
         /* Jump to next entry; with the current entry fixed up, we can
          * use non-const equivalent of pyi_archive_next_toc_entry() */
         toc_entry = (struct TOC_ENTRY *)((const char *)toc_entry + toc_entry->entry_length);

--- a/bootloader/src/pyi_archive.h
+++ b/bootloader/src/pyi_archive.h
@@ -73,6 +73,9 @@ struct ARCHIVE
      * and thus has onefile semantics */
     bool contains_extractable_entries;
 
+    /* Pointer to SPLASH TOC entry, if available */
+    const struct TOC_ENTRY *toc_splash;
+
     /* Python version: major * 100 + minor, e.g., 310 for python 3.10 */
     int python_version;
 

--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -515,6 +515,13 @@ _pyi_main_setup_splash_screen(struct PYI_CONTEXT *pyi_ctx)
     bool suppressed = false;
     bool is_eligible = false;
 
+    /* Check if splash screen is available at all, i.e., if PKG/CArchive
+     * contains SPLASH entry. */
+    if (!pyi_ctx->archive->toc_splash) {
+        PYI_DEBUG("LOADER: splash screen is unavailable.\n");
+        return;
+    }
+
     /* Check if user requested splash screen to be suppressed by setting
      * the PYINSTALLER_SUPPRESS_SPLASH_SCREEN environment variable to 1 */
     env_suppress_splash = pyi_getenv("PYINSTALLER_SUPPRESS_SPLASH_SCREEN");
@@ -550,18 +557,15 @@ _pyi_main_setup_splash_screen(struct PYI_CONTEXT *pyi_ctx)
         return;
     }
 
-    /* Check if splash screen resources are available. TODO: it would
-     * be nice if we did this at the start of this function, but without
-     * fully loading the resources... */
-    PYI_DEBUG("LOADER: looking for splash screen resources...\n");
+    /* Load splash screen resources. */
+    PYI_DEBUG("LOADER: loading splash screen resources...\n");
     pyi_ctx->splash = pyi_splash_context_new();
     if (pyi_splash_setup(pyi_ctx->splash, pyi_ctx) != 0) {
-        /* Splash screen resources not found */
-        PYI_DEBUG("LOADER: splash screen resources not found.\n");
+        PYI_WARNING("Failed to load splash screen resources!\n");
         goto cleanup;
     }
 
-    /* Splash screen resources found; setup up splash screen */
+    /* Splash screen resources loaded; setup up splash screen */
     PYI_DEBUG("LOADER: setting up splash screen...\n");
 
     /* In onefile mode, we need to extract dependencies (shared

--- a/news/7106.bugfix.rst
+++ b/news/7106.bugfix.rst
@@ -1,0 +1,4 @@
+(Windows) Attempt to work around the leak of ``VCRUNTIME140.dll`` in
+``onefile`` applications with splash screen enabled in scenarios where
+the OS and/or anti-virus program injects additional DLLs into the process
+that also depend on ``VCRUNTIME140.dll``.

--- a/news/8650.bootloader.rst
+++ b/news/8650.bootloader.rst
@@ -1,0 +1,11 @@
+(Windows) The parent process of a ``onefile`` application with enabled
+splash screen now attempts to pre-load a system-wide copy of
+``VCRUNTIME140.dll``, preferring it over the bundled copy (which would
+be loaded as dependency of Tcl/Tk DLLs during splash screen setup).
+If a system-wide copy is available, the OS and/or anti-virus
+programs might inject other 3rd party DLLs into the process that
+also depend on ``VCRUNTIME140.dll`` (for example, Trend Micro's User Mode
+Hooking component has been observed to do that). Such externally loaded
+DLLs prevent the bootloader from unloading the ``VCRUNTIME140.dll``
+during the clean-up phase, and if the bundled copy was loaded, it would
+also prevent its removal from the application's temporary directory.


### PR DESCRIPTION
Have the parent process of a splash-screen-enabled onefile application prefer the system-wide copy of `VCRUNTIME140.dll` (if available), by trying to preemptively load it before splash screen is set up.

Contemporary Tcl/Tk DLLs are known to depend on `VCRUNTIME140.dll`, so when we load them during splash screen initialization, they cause `VCRUNTIME140.dll` to be loaded as well. This happens after the frozen application's top-level directory is pushed into the search path; therefore, the bundled copy of the DLL is loaded, which is intended to accommodate systems that do not have system-wide copy of the DLL available.

However, the OS and/or anti-virus programs might inject additional DLLs into the process that also depend on `VCRUNTIME140.dll` (see the follow-up discussion under https://github.com/pyinstaller/pyinstaller/issues/7106); such externally loaded DLLs might prevent us from unloading the bundled copy of `VCRUNTIME140.dll` during the cleanup phase, and thus interfere with removal of application's temporary directory.