### PR TITLE
loader: have PyiFrozenImporter.find_spec ignore non-string path entries

### DIFF
--- a/PyInstaller/loader/pyimod02_importers.py
+++ b/PyInstaller/loader/pyimod02_importers.py
@@ -272,6 +272,8 @@ class PyiFrozenImporter:
             modname = fullname.rsplit('.')[-1]
 
             for p in path:
+                if not isinstance(p, str):
+                    continue
                 if not p.startswith(SYS_PREFIX):
                     continue
                 p = p[SYS_PREFIXLEN:]


### PR DESCRIPTION
In `PyiFrozenImporter.find_spec`, skip entries of `path` that are not instances of `str`. This matches behavior of [built-in finders](https://github.com/python/cpython/blob/v3.11.7/Lib/importlib/_bootstrap_external.py#L1470-L1472), which perform similar entry filtering. In our case, skipping non-string entries (either `None` or some other type) avoids raising an `AttributeError` when trying to compare path prefix via `startswith` method.