### PR TITLE
makespec: disable UPX by default

### DIFF
--- a/PyInstaller/building/makespec.py
+++ b/PyInstaller/building/makespec.py
@@ -468,10 +468,19 @@ def __add_options(parser):
         help="Apply a symbol-table strip to the executable and shared libs (not recommended for Windows)",
     )
     g.add_argument(
-        "--noupx",
+        "--upx",
         action="store_true",
+        dest="upx",
         default=False,
-        help="Do not use UPX even if it is available (works differently between Windows and *nix)",
+        help="Use UPX (if available) to compress collected binaries.",
+    )
+    g.add_argument(
+        "--noupx",
+        action="store_false",
+        dest="upx",
+        default=False,
+        help="Do not use UPX even if it is available. This option is kept for backward compatibility; UPX is now "
+        "disabled by default, and must be enabled using --upx option.",
     )
     g.add_argument(
         "--upx-exclude",
@@ -664,7 +673,7 @@ def main(
     debug=[],
     python_options=[],
     strip=False,
-    noupx=False,
+    upx=False,
     upx_exclude=None,
     runtime_tmpdir=None,
     contents_directory=None,
@@ -846,7 +855,7 @@ def main(
         'debug_bootloader': 'bootloader' in debug,
         'bootloader_ignore_signals': bootloader_ignore_signals,
         'strip': strip,
-        'upx': not noupx,
+        'upx': upx,
         'upx_exclude': upx_exclude,
         'runtime_tmpdir': runtime_tmpdir,
         'exe_options': exe_options,

--- a/news/8653.breaking.rst
+++ b/news/8653.breaking.rst
@@ -1,0 +1,6 @@
+UPX is not enabled by default anymore (even if available and supported
+on the target OS, i.e., Windows). Instead of opting out of its use with
+:option:`noupx`, it must now be explicitly opted in using :option:`upx`,
+or by setting ``upx=True`` in the spec file. The change applies only to
+newly-generated spec files (including spec files that are generated
+on-the-fly).


### PR DESCRIPTION
Disable UPX by default, even if its executable is available and use of UPX is supported on the target OS (i.e., Windows).

Interested users must now explicitly enable use of UPX via new `--upx` command-line option, or by setting `upx=True` in the .spec file (and live with potential fallout).

This applies only to newly-generated spec files (including spec files that are generated on the fly). The `--noupx` option is kept for backward compatibility, although it is now effectively a no-op.