### PR TITLE
loader: fix PyiFrozenResourceReader.files() for (sub)modules

### DIFF
--- a/PyInstaller/loader/pyimod02_importers.py
+++ b/PyInstaller/loader/pyimod02_importers.py
@@ -460,7 +460,11 @@ class PyiFrozenResourceReader:
         # Local import to avoid including `pathlib` and its dependencies in `base_library.zip`
         from pathlib import Path
         self.importer = importer
-        self.path = Path(sys._MEIPASS).joinpath(*name.split('.'))
+        if self.importer.is_package(name):  # covers both normal packages and PEP-420 namespace packages
+            self.path = Path(sys._MEIPASS).joinpath(*name.split('.'))
+        else:
+            # For modules, we should return the path to their parent (package) directory.
+            self.path = Path(sys._MEIPASS).joinpath(*name.split('.')[:-1])
 
     def open_resource(self, resource):
         return self.files().joinpath(resource).open('rb')

--- a/news/8659.bugfix.rst
+++ b/news/8659.bugfix.rst
@@ -1,0 +1,3 @@
+Fix the implementation of ``PyiFrozenResourceReader.files()``; when called
+with (sub)module name, it should return the path to the module's parent
+(package) directory, instead of a sub-directory with module's name.

--- a/tests/functional/scripts/pyi_importlib_resources.py
+++ b/tests/functional/scripts/pyi_importlib_resources.py
@@ -350,5 +350,15 @@ assert data.splitlines() == expected_data.splitlines()
 
 # Test that for submodules, files() returns the path to their parent package.
 # See https://github.com/pyinstaller/pyinstaller/issues/8659
-assert importlib_resources.files('pyi_pkgres_testpkg.a') == pkg_path
-assert importlib_resources.files('pyi_pkgres_testpkg.subpkg1.c') == subpkg1_path
+#
+# NOTE: passing a module name to files() seems to be supported only under python >= 3.12 (stdlib) or equivalent
+# importlib_resources >= 5.12. Under earlier versions, it raises `TypeError: '<name>' is not a package`.
+try:
+    assert importlib_resources.files('pyi_pkgres_testpkg.a') == pkg_path
+except TypeError:
+    pass
+
+try:
+    assert importlib_resources.files('pyi_pkgres_testpkg.subpkg1.c') == subpkg1_path
+except TypeError:
+    pass

--- a/tests/functional/scripts/pyi_importlib_resources.py
+++ b/tests/functional/scripts/pyi_importlib_resources.py
@@ -347,3 +347,8 @@ with importlib_resources.as_file(data_path) as file_path:
     with open(file_path, 'rb') as fp:
         data = fp.read()
 assert data.splitlines() == expected_data.splitlines()
+
+# Test that for submodules, files() returns the path to their parent package.
+# See https://github.com/pyinstaller/pyinstaller/issues/8659
+assert importlib_resources.files('pyi_pkgres_testpkg.a') == pkg_path
+assert importlib_resources.files('pyi_pkgres_testpkg.subpkg1.c') == subpkg1_path


### PR DESCRIPTION
When called with (sub)module name, the `files()` method should return path to the module's parent (package) directory.

For example, `importlib.resources.files('package.module')` should in frozen application return `sys._MEIPASS/package`  instead of `sys._MEIPASS/package/module`. Fixes #8659.