### PR TITLE
bootloader: support execution by direct dynamic loader invocation in onedir mode

### DIFF
--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -1054,7 +1054,7 @@ _pyi_find_progam_in_search_path(const char *name, char *result_path)
 }
 
 static int
-_pyi_resolve_executable_posix(const char *argv0, char *executable_filename, char *linker_filename)
+_pyi_resolve_executable_posix(const char *argv0, char *executable_filename, char *loader_filename)
 {
     /* On Linux, Cygwin, FreeBSD, and Solaris, we try /proc entry first.
      * The entry points at "true" file location, i.e., fully canonicalized
@@ -1079,8 +1079,8 @@ _pyi_resolve_executable_posix(const char *argv0, char *executable_filename, char
      * to ignore it. */
 #if defined(__linux__)
     if (_pyi_is_ld_linux_so(executable_filename) == true) {
-        PYI_DEBUG("LOADER: resolved executable file %s is ld.so dynamic loader - ignoring it! (but storing the information)\n", executable_filename);
-        strncpy(linker_filename, executable_filename, PYI_PATH_MAX);
+        PYI_DEBUG("LOADER: resolved executable file %s is ld.so dynamic linker/loader - storing its name.\n", executable_filename);
+        strncpy(loader_filename, executable_filename, PYI_PATH_MAX); /* both buffers are guaranteed to be PYI_PATH_MAX-sized */
         name_len = -1;
     }
 #endif
@@ -1139,7 +1139,7 @@ _pyi_main_resolve_executable(struct PYI_CONTEXT *pyi_ctx)
 #elif __APPLE__
     return _pyi_resolve_executable_macos(pyi_ctx->executable_filename);
 #else
-    return _pyi_resolve_executable_posix(pyi_ctx->argv[0], pyi_ctx->executable_filename, pyi_ctx->linker_filename);
+    return _pyi_resolve_executable_posix(pyi_ctx->argv[0], pyi_ctx->executable_filename, pyi_ctx->dynamic_loader_filename);
 #endif
 }
 
@@ -1267,19 +1267,25 @@ _pyi_main_handle_posix_onedir(struct PYI_CONTEXT *pyi_ctx)
     /* NOTE: the codepath that ended up here does not perform any
      * argument modification, so we always use pyi_ctx->argv (as
      * pyi_ctx->pyi_argv is unavailable). */
-    if (strncmp(pyi_ctx->linker_filename, "", 1) != 0) {
-        char **new_argv = prepend_string_array(pyi_ctx->argv, pyi_ctx->argc, pyi_ctx->linker_filename);
-        PYI_DEBUG("LOADER: restarting process via execvp by calling dynamic linker: %s\n", pyi_ctx->linker_filename);
-        if (execvp(pyi_ctx->linker_filename, new_argv) < 0) {
-            PYI_ERROR("LOADER: failed to restart process via execvp by calling dynamic linker: %s\n", strerror(errno));
+    if (pyi_ctx->dynamic_loader_filename[0] != 0) {
+        char *const *exec_argv;
+
+        PYI_DEBUG("LOADER: restarting process via execvp and dynamic linker/loader: %s\n", pyi_ctx->dynamic_loader_filename);
+        exec_argv = pyi_prepend_dynamic_loader_to_argv(pyi_ctx->argc, pyi_ctx->argv, pyi_ctx->dynamic_loader_filename);
+        if (exec_argv == NULL) {
+            PYI_ERROR("LOADER: failed to allocate argv array for execvp!\n");
+            return -1;
+        }
+        if (execvp(pyi_ctx->dynamic_loader_filename, exec_argv) < 0) {
+            PYI_ERROR("LOADER: failed to restart process: %s\n", strerror(errno));
             return -1;
         }
     } else {
-      if (execvp(pyi_ctx->executable_filename, pyi_ctx->argv) < 0) {
-        PYI_ERROR("LOADER: failed to restart process via execvp: %s\n",
-                  strerror(errno));
-        return -1;
-      }
+        PYI_DEBUG("LOADER: restarting process via execvp\n");
+        if (execvp(pyi_ctx->executable_filename, pyi_ctx->argv) < 0) {
+            PYI_ERROR("LOADER: failed to restart process: %s\n", strerror(errno));
+            return -1;
+        }
     }
 
     /* Unreachable */

--- a/bootloader/src/pyi_main.h
+++ b/bootloader/src/pyi_main.h
@@ -168,12 +168,13 @@ struct PYI_CONTEXT
      * PyInstaller's CI. */
     unsigned char strict_unpack_mode;
 
-#if !defined(_WIN32) && !defined(__APPLE__)
-    /* Path to the linker executable. If started in onedir mode and
-     * directly via dynamic loader on POSIX platform, store the path
-     * to the linker executable for follow-up execvp() call. */
-    char linker_filename[PYI_PATH_MAX];
-#endif /* !_WIN32 and !__APPLE */
+#if !defined(_WIN32)
+    /* Path to the dynamic linker/loader; if executable is launched
+     * via explicitly specified dynamic linker/loader (for example,
+     * /lib64/ld-linux-x86-64.so.2 /path/to/executable), we need to
+     * propagate its name into execvp() call. */
+    char dynamic_loader_filename[PYI_PATH_MAX];
+#endif /* !defined(_WIN32) */
 
 #if defined(_WIN32)
     /* Security attributes structure with security descriptor that limits

--- a/bootloader/src/pyi_main.h
+++ b/bootloader/src/pyi_main.h
@@ -168,6 +168,13 @@ struct PYI_CONTEXT
      * PyInstaller's CI. */
     unsigned char strict_unpack_mode;
 
+#if !defined(_WIN32) && !defined(__APPLE__)
+    /* Path to the linker executable. If started in onedir mode and
+     * directly via dynamic loader on POSIX platform, store the path
+     * to the linker executable for follow-up execvp() call. */
+    char linker_filename[PYI_PATH_MAX];
+#endif /* !_WIN32 and !__APPLE */
+
 #if defined(_WIN32)
     /* Security attributes structure with security descriptor that limits
      * the access to created directory to the user. Used in onefile mode

--- a/bootloader/src/pyi_utils.h
+++ b/bootloader/src/pyi_utils.h
@@ -56,7 +56,7 @@ int pyi_utils_set_library_search_path(const char *path);
 int pyi_utils_initialize_args(struct PYI_CONTEXT *pyi_ctx, const int argc, char *const argv[]);
 int pyi_utils_append_to_args(struct PYI_CONTEXT *pyi_ctx, const char *arg);
 void pyi_utils_free_args(struct PYI_CONTEXT *pyi_ctx);
-char **prepend_string_array(char *argv[], int argc, char *prepend);
+char *const *pyi_prepend_dynamic_loader_to_argv(const int argc, char *const argv[], char *const loader_filename);
 #endif
 
 /* Magic pattern matching */

--- a/bootloader/src/pyi_utils.h
+++ b/bootloader/src/pyi_utils.h
@@ -56,6 +56,7 @@ int pyi_utils_set_library_search_path(const char *path);
 int pyi_utils_initialize_args(struct PYI_CONTEXT *pyi_ctx, const int argc, char *const argv[]);
 int pyi_utils_append_to_args(struct PYI_CONTEXT *pyi_ctx, const char *arg);
 void pyi_utils_free_args(struct PYI_CONTEXT *pyi_ctx);
+char **prepend_string_array(char *argv[], int argc, char *prepend);
 #endif
 
 /* Magic pattern matching */

--- a/bootloader/src/pyi_utils_posix.c
+++ b/bootloader/src/pyi_utils_posix.c
@@ -765,4 +765,30 @@ void pyi_utils_free_args(struct PYI_CONTEXT *pyi_ctx)
 }
 
 
+/*
+ * Create a new array of strings with a prepended string.
+ *
+ * Exec is making own copy of the argv array, so we can use original
+ * array strings.
+ */
+char **prepend_string_array(char *argv[], int argc, char *prepend) {
+    // Allocate memory for the new array of strings
+    char **new_argv = (char **)calloc((argc + 1), sizeof(char *));
+    if (new_argv == NULL) {
+        fprintf(stderr, "Memory allocation failed\n");
+        return NULL;
+    }
+
+    // Set the first element to the prepend string
+    new_argv[0] = prepend;
+
+    // Copy the rest of the elements from the original array together
+    // with null terminator
+    int i;
+    for (i = 0; i < argc + 1; i++) {
+        new_argv[i + 1] = argv[i];
+    }
+
+    return new_argv;
+}
 #endif /* ifndef _WIN32 */

--- a/news/8662.bootloader.rst
+++ b/news/8662.bootloader.rst
@@ -1,0 +1,7 @@
+(Linux) When frozen executable is launched via dynamic linker/loader
+invocation (e.g., ``/lib64/ld-linux-x86-64.so.2 /path/to/executable``),
+the loader executable's name is now captured and passed on to ``execvp``
+call when restarting the process (``onedir`` mode) or starting the
+child process (``onefile`` mode). This ensures that the restarted/spawned
+process also uses the specified dynamic loader instead of the one
+encoded in executable's ELF headers.


### PR DESCRIPTION
Onedir mode on POSIX platform performs additional exec to correctly set environment for itself. When binary is invoked as `ld-linux binary.py` and the exec is not relying on provided dynamic loader but relies instead on the one written in ELF header. We already detect this way of invocation but we didn't kept this information for the exec. This patch changes that.
