### PR TITLE
Update readthedocs integration

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -273,6 +273,13 @@ html_static_path = ['_static']
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'PyInstallerdoc'
 
+# Define the canonical URL if you are using a custom domain on Read the Docs
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
+
+# Tell Jinja2 templates the build is running on Read the Docs
+if os.environ.get("READTHEDOCS", "") == "True":
+    html_context = {"READTHEDOCS": True}
+
 # -- Options for LaTeX output ---------------------------------------------
 
 latex_elements = {


### PR DESCRIPTION
To minimise the differences between local vs readthedocs builds, readthedocs will cease to monkey patch sphinx configurations before building. This requires us to add some of the information forwarding that these patches used to do.

See https://about.readthedocs.com/blog/2024/07/addons-by-default/

These changes re-enable the version selector/downloads box at the bottom of the sidebar and some absolute pyinstaller.org URLs (although I don't really understand why those exist).