### PR TITLE
ci: pin setuptools < 71.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
       - name: Install PyInstaller
         run: |
           # Update pip.
-          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install --upgrade pip "setuptools<71.0.0" wheel
 
           # Compile bootloader
           cd bootloader


### PR DESCRIPTION
Prevent the fallout of the new vendoring system in `setuptools` 71 from affecting regular CI operation, until we sort out compatibility issues.