### PR TITLE
ci: create an artifact out of failed tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,15 +171,60 @@ jobs:
       # Required on macOS >= 11 by tests that register custom URL schema. This could also be achieved by passing
       # --basetemp to pytest, but using environment variable allows us to have a unified "Run test" step for
       # all OSes.
+      #
+      # We now relocate the temporary directory to a fixed location on all OSes, in order to be able to generate
+      # artifacts out of failed tests.
       - name: Relocate temporary dir
-        if: startsWith(matrix.os, 'macos')
+        shell: bash
         run: |
           echo "PYTEST_DEBUG_TEMPROOT=$RUNNER_TEMP" >> $GITHUB_ENV
 
       - name: Run tests
+        id: run-tests
         run: >
             pytest
             -n 3 --maxfail 3 --durations 10 tests/unit tests/functional
+
+      # On all platforms, create a tarball to ensure that symlinks are preserved. Avoid using compression here,
+      # as the tarball will end up collected into artifact zip archive.
+      # To simplify this across platform, run this step in python and use python's tarfile module.
+      - name: Archive failed tests
+        if: ${{ failure() && steps.run-tests.outcome == 'failure' }}
+        shell: python
+        run: |
+          import os
+          import sys
+          import tarfile
+
+          try:
+            import getpass
+            user = getpass.getuser() or "unknown"
+          except Exception:
+            user = "unknown"
+
+          temproot = os.environ['PYTEST_DEBUG_TEMPROOT']
+
+          pytest_name = f'pytest-of-{user}'
+          pytest_fullpath = os.path.join(temproot, pytest_name)
+          print(f"Input directory: {pytest_fullpath}!", file=sys.stderr)
+
+          output_file = os.path.join(temproot, 'archived-failed-tests.tar')
+          print(f"Output file: {output_file}!", file=sys.stderr)
+
+          assert os.path.isdir(pytest_fullpath)
+          assert not os.path.exists(output_file)
+
+          with tarfile.open(output_file, "w") as tf:
+            tf.add(pytest_fullpath, arcname=pytest_name, recursive=True)
+
+          print(f"Created {output_file}!", file=sys.stderr)
+
+      - name: Create artifact out of archived failed tests
+        if: ${{ failure() && steps.run-tests.outcome == 'failure' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: failed-tests-${{ matrix.os }}-python-${{ matrix.python-version }}
+          path: '${{ env.PYTEST_DEBUG_TEMPROOT }}/archived-failed-tests.tar'
 
       # Install and test PyInstaller Hook Sample, to ensure that tests declared in
       # entry-points are discovered.

--- a/PyInstaller/utils/conftest.py
+++ b/PyInstaller/utils/conftest.py
@@ -518,7 +518,12 @@ def pyi_builder_spec(tmpdir, request, monkeypatch, pyi_modgraph):
     # as the original value.
     monkeypatch.setattr('PyInstaller.config.CONF', {'pathex': []})
 
-    return AppBuilder(tmpdir, request, None)
+    yield AppBuilder(tmpdir, request, None)
+
+    # Clean up the temporary directory of a successful test
+    if _PYI_BUILDER_CLEANUP and request.node.rep_setup.passed and request.node.rep_call.passed:
+        if tmpdir.exists():
+            tmpdir.remove(rec=1, ignore_errors=True)
 
 
 # Define a fixture which compiles the data/load_dll_using_ctypes/ctypes_dylib.c program in the tmpdir, returning the


### PR DESCRIPTION
Create an artifact out of failed tests, which allows us to inspect them (the frozen application itself and the build directory with .toc files and xref.html for debugging import chains).

Example: https://github.com/rokm/pyinstaller/actions/runs/10012000357

This could be refined further; e.g., to exclude empty `test_` directories  (or perhaps include only the ones that contain `build` and `dist` directories, which correspond to tests with `pyi_builder` and `pyi_builder_spec` fixtures). Also, I suspect that xfail-ed tests do not clean after themselves - but we should perhaps reconsider what to do about those anyway (e.g., not run them in the first place).

If storage becomes concern, we could try tying this to the "Enable debug logging" option when restarting the failed workflow, so the artifacts are created only on demand.