### PR TITLE
building: MERGE: use (src_name, dest_name) as key for dependency bookkeeping

### DIFF
--- a/news/8687.bugfix.rst
+++ b/news/8687.bugfix.rst
@@ -1,0 +1,5 @@
+The ``MERGE`` dependency processing code now uses both source and
+destination path as bookkeeping key (instead of just source path). This
+should fix issues when using ``MERGE`` with application TOCs that contain
+entries for a file that is collected more than once, with different
+destination names.


### PR DESCRIPTION
Have `MERGE` processing use `(src_name, dest_name)` tuple as key for dependency bookkeeping.

Previously, just the `src_name` string was used, which leads to problems when we have the same file collected multiple times, with different destination names; because corresponding entries would have the same `src_name`, the processing code would discard all but one of them as duplicates.

Fixes #8687.