### PR TITLE
isolated: implicitly disallow nesting of isolated subprocesses

### DIFF
--- a/PyInstaller/isolated/_child.py
+++ b/PyInstaller/isolated/_child.py
@@ -86,6 +86,10 @@ def run_next_command(read_fh, write_fh):
 
 
 if __name__ == '__main__':
+    # Mark this process as PyInstaller's isolated subprocess; this makes attempts at spawning further isolated
+    # subprocesses via `PyInstaller.isolated` from this process no-op.
+    sys._pyi_isolated_subprocess = True
+
     read_from_parent, write_to_parent = map(int, sys.argv[1:])
 
     with _open(read_from_parent, "rb") as read_fh:


### PR DESCRIPTION
When trying to use `PyInstaller.isolated` from a process that is already a PyInstaller-isolated subprocess, make the `isolated` framework no-op and execute the code directly in that process.

This means that the maximum depth of PyInstaller-isolated subprocess tree is one, and that nesting of isolated subprocesses is implicitly disallowed now.

This behavior enables transparent use of hook utility functions within isolated subprocess, without having to worry whether their implementation makes use of `isolated` framework or not. For example, we can now import an expensive package once, and then run several hook utility functions that perform their tasks in the same process, instead of each spawning their own subprocess and importing the package in it.