### PR TITLE
Deprecate -m shorthand for --manifest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,7 +290,6 @@ jobs:
         with:
           update: true
           msystem: ${{matrix.sys}}
-          # mingw-w64-${{matrix.env}}-python-pefile seems unavailable for i686, so omit it here and install it via pip. Same as altgraph, which does not seem to be packaged.
           install: >-
             mingw-w64-${{matrix.env}}-gcc
             mingw-w64-${{matrix.env}}-python
@@ -304,8 +303,11 @@ jobs:
             mingw-w64-${{matrix.env}}-python-pytest-timeout
             mingw-w64-${{matrix.env}}-python-psutil
             mingw-w64-${{matrix.env}}-python-pywin32
-            mingw-w64-${{matrix.env}}-python-numpy
             mingw-w64-${{matrix.env}}-python-pillow
+
+      - if: matrix.env != 'i686'
+        # numpy and pefile are unavailable for i686. Ignore numpy and install pefile via pip
+        run: pacman -S --noconfirm mingw-w64-${{matrix.env}}-python-numpy mingw-w64-${{matrix.env}}-python-pefile
 
       - uses: actions/checkout@v4
 

--- a/PyInstaller/building/makespec.py
+++ b/PyInstaller/building/makespec.py
@@ -542,10 +542,15 @@ def __add_options(parser):
         help="Add a version resource from FILE to the exe.",
     )
     g.add_argument(
-        "-m",
         "--manifest",
         metavar="<FILE or XML>",
         help="Add manifest FILE or XML to the exe.",
+    )
+    g.add_argument(
+        "-m",
+        dest="shorthand_manifest",
+        metavar="<FILE or XML>",
+        help="Deprecated shorthand for --manifest.",
     )
     g.add_argument(
         "--no-embed-manifest",
@@ -756,6 +761,12 @@ def main(
         # We need to encapsulate it into apostrofes.
         bundle_identifier = "'%s'" % bundle_identifier
 
+    if _kwargs["shorthand_manifest"]:
+        manifest = _kwargs["shorthand_manifest"]
+        logger.log(
+            logging.DEPRECATION, "PyInstaller v7 will remove the -m shorthand flag. Please use --manifest=%s instead",
+            manifest
+        )
     if manifest:
         if "<" in manifest:
             # Assume XML string

--- a/news/2560.deprecation.rst
+++ b/news/2560.deprecation.rst
@@ -1,0 +1,1 @@
+The ``-m`` shorthand for :option:`--manifest` will be removed in v7.0.


### PR DESCRIPTION
If we're ever to deal with the issue of relative imports in the entry point script (#2560) then we'll need to support Python's -m option and therefore remove the current interpretation of PyInstaller's -m option.