### PR TITLE
modulegraph: reorder creation of nodes when creating AliasNode

### DIFF
--- a/PyInstaller/lib/modulegraph/modulegraph.py
+++ b/PyInstaller/lib/modulegraph/modulegraph.py
@@ -513,10 +513,6 @@ class Node:
         return '%s%r' % (type(self).__name__, self.infoTuple())
 
 
-# TODO: This indirection is, frankly, unnecessary. The
-# ModuleGraph.alias_module() should directly add the desired AliasNode instance
-# to the graph rather than indirectly adding an Alias instance to the
-# "lazynodes" dictionary.
 class Alias(str):
     """
     Placeholder aliasing an existing source module to a non-existent target


### PR DESCRIPTION
When `AliasNode` is being created by `find_node` method, we should first create the `AliasNode` and add it to the graph, before trying to resolve the referred node.

Otherwise, the recursive resolution/analysis of the referred node might happen upon a reference to the module/package we are trying to alias, and will end up adding a real node (`PackageNode` or `SourceModule` node) to the graph, which then turns the attempt into adding an `AliasNode` into a no-op. This makes it impossible to use the modulegraph's alias mechanism to avoid duplications of modules that are aliased due to `sys.path` manipulation (e.g., `setuptools._vendor.platformdirs` being collected both under its true name, and as "top-level" `platformdirs` due to `_vendor` directory being added to `sys.path).