### PR TITLE
analysis: do not associate standard and run-time hooks with AliasNode

### DIFF
--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -639,7 +639,9 @@ PURE_PYTHON_MODULE_TYPES = {
 # Object types of special Python modules (built-in, run-time, namespace package) in modulegraph dependency graph that do
 # not have code object.
 SPECIAL_MODULE_TYPES = {
-    'AliasNode',
+    # Omit AliasNode from here (and consequently from VALID_MODULE_TYPES), in order to prevent PyiModuleGraph from
+    # running standard hooks for aliased modules.
+    #'AliasNode',
     'BuiltinModule',
     'RuntimeModule',
     'RuntimePackage',

--- a/PyInstaller/depend/analysis.py
+++ b/PyInstaller/depend/analysis.py
@@ -301,7 +301,7 @@ class PyiModuleGraph(ModuleGraph):
         # 2. All cached hooks whose hook() functions were called are removed from this cache. If this cache is empty, no
         #    hook() functions will be called by the next iteration and this loop will be terminated.
         # 3. If no hook() functions were called, this loop is terminated.
-        logger.info('Processing module hooks...')
+        logger.info('Processing module hooks (post-graph stage)...')
         while True:
             # Set of the names of all imported modules whose post-graph hooks are run by this iteration, preventing the
             # next iteration from re- running these hooks. If still empty at the end of this iteration, no post-graph
@@ -473,7 +473,8 @@ class PyiModuleGraph(ModuleGraph):
             # For the absolute path of each such hook...
             for hook in self._hooks_pre_safe_import_module[module_name]:
                 # Dynamically import this hook as a fabricated module.
-                logger.info('Processing pre-safe import module hook %s from %r.', module_name, hook.hook_filename)
+                hook_path, hook_basename = os.path.split(hook.hook_filename)
+                logger.info('Processing pre-safe-import-module hook %r from %r', hook_basename, hook_path)
                 hook_module_name = 'PyInstaller_hooks_pre_safe_import_module_' + module_name.replace('.', '_')
                 hook_module = importlib_load_source(hook_module_name, hook.hook_filename)
 
@@ -516,7 +517,8 @@ class PyiModuleGraph(ModuleGraph):
             # For the absolute path of each such hook...
             for hook in self._hooks_pre_find_module_path[fullname]:
                 # Dynamically import this hook as a fabricated module.
-                logger.info('Processing pre-find module path hook %s from %r.', fullname, hook.hook_filename)
+                hook_path, hook_basename = os.path.split(hook.hook_filename)
+                logger.info('Processing pre-find-module-path hook %r from %r', hook_basename, hook_path)
                 hook_fullname = 'PyInstaller_hooks_pre_find_module_path_' + fullname.replace('.', '_')
                 hook_module = importlib_load_source(hook_fullname, hook.hook_filename)
 
@@ -721,7 +723,8 @@ class PyiModuleGraph(ModuleGraph):
             if mod_name in self._available_rthooks:
                 # There could be several run-time hooks for a module.
                 for abs_path in self._available_rthooks[mod_name]:
-                    logger.info("Including run-time hook %r", abs_path)
+                    hook_path, hook_basename = os.path.split(abs_path)
+                    logger.info("Including run-time hook %r from %r", hook_basename, hook_path)
                     rthooks_nodes.append(self.add_script(abs_path))
 
         return rthooks_nodes

--- a/PyInstaller/depend/imphook.py
+++ b/PyInstaller/depend/imphook.py
@@ -377,8 +377,8 @@ class ModuleHook:
 
         # Load and execute the hook script. Even if mechanisms from the import machinery are used, this does not import
         # the hook as the module.
-        head, tail = os.path.split(self.hook_filename)
-        logger.info('Loading module hook %r from %r...', tail, head)
+        hook_path, hook_basename = os.path.split(self.hook_filename)
+        logger.info('Processing standard module hook %r from %r', hook_basename, hook_path)
         try:
             self._hook_module = importlib_load_source(self.hook_module_name, self.hook_filename)
         except ImportError:


### PR DESCRIPTION
Remove the `AliasNode` from `PyInstaller.compat.VALID_MODULE_TYPES` set, in order to prevent the standard hook for aliased module name from being run. If such module needs to be hooked, the hook should be added for its "true" name in order to properly accommodate the situation that led to aliasing.

For example, if we end up adding alias that maps `mydependency` to `mypackage._vendor.mydependency`, we should not run the hook for `mydependency`, which would attempt to collect data files and binaries for the "top-level" package (into corresponding "top-level" directory). The collection of extra files for the vendored package should be handled by the hook for vendored package, or hook for parent package that does the vendoring.

In practice, things already kind of work this way, although it is hard to say whether by design or due to an oversight. Although hook for `mydependency` would run and register its `datas` and `binaries` lists with `AdditionalFilesCache` under `mydependency` name, when the time comes to gather these lists in `PyiModuleGraph.make_hook_binaries_toc` and `make_hook_datas_toc`, [the module name is taken as `node.identifier`](https://github.com/pyinstaller/pyinstaller/blob/v6.9.0/PyInstaller/depend/analysis.py#L877), which in `AliasNode` contains the name of referred module. So this ends up trying to access binaries/datas for `mypackage._vendor.mydependency`, twice.

So we are primarily aiming to formalize the behavior, but also to reduce the noise during the build, and to avoid potential issues/discrepancies with `hiddenimports`, especially if we have both "stand-alone" and "vendored" hook available.

The situation with run-time hooks is quite similar to the above; the `PyiModuleGraph.analyze_runtime_hooks` [creates the list of modules based on `VALID_MODULE_TYPES`](https://github.com/pyinstaller/pyinstaller/blob/v6.9.0/PyInstaller/depend/analysis.py#L718), but [`_make_toc`](https://github.com/pyinstaller/pyinstaller/blob/v6.9.0/PyInstaller/depend/analysis.py#L586-L588) and its underlying `_node_to_toc` again [rely on `node.identifier` for the module name](https://github.com/pyinstaller/pyinstaller/blob/v6.9.0/PyInstaller/depend/analysis.py#L636-L638). So in practice, run-time hook for `mydependency` (if available) is ignored, and the
run-time hook for `mypackage._vendor.mydependency` (if available) is added twice, as evident by two "Including run-time hook..." messages in the build log. However, the actual duplication is prevented by TOC de-duplication mechanism that we have in place. So again, we are primarily aiming to reduce noise and confusion.