### PR TITLE
hookutils: reorganize Tcl/Tk utility functions & fix tkinter/Tcl/Tk + python 3.13 + macOS

### DIFF
--- a/PyInstaller/hooks/hook-_tkinter.py
+++ b/PyInstaller/hooks/hook-_tkinter.py
@@ -9,21 +9,14 @@
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
 
-import sys
-
-from PyInstaller import compat
-from PyInstaller.utils.hooks import logger
-from PyInstaller.utils.hooks.tcl_tk import collect_tcl_tk_files
+from PyInstaller.utils.hooks.tcl_tk import tcltk_info
 
 
 def hook(hook_api):
-    # Use a hook-function to get the module's attr:`__file__` easily.
-    """
-    Freeze all external Tcl/Tk data files if this is a supported platform *or* log a non-fatal error otherwise.
-    """
-    if compat.is_win or compat.is_darwin or compat.is_unix:
-        # collect_tcl_tk_files() returns a Tree, so we need to store it into `hook_api.datas` in order to prevent
-        # `building.imphook.format_binaries_and_datas` from crashing with "too many values to unpack".
-        hook_api.add_datas(collect_tcl_tk_files(hook_api.__file__))
-    else:
-        logger.error("... skipping Tcl/Tk handling on unsupported platform %s", sys.platform)
+    # Add all Tcl/Tk data files, based on the `TclTkInfo.data_files`. If Tcl/Tk is unavailable, the list is empty.
+    #
+    # NOTE: the list contains 3-element TOC tuples with full destination filenames (because other parts of code,
+    # specifically splash-screen writer, currently require this format). Therefore, we need to use
+    # `PostGraphAPI.add_datas` (which supports 3-element TOC tuples); if this was 2-element "hook-style" TOC list,
+    #  we could just assign `datas` global hook variable, without implementing the post-graph `hook()` function.
+    hook_api.add_datas(tcltk_info.data_files)

--- a/PyInstaller/hooks/rthooks/pyi_rth__tkinter.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth__tkinter.py
@@ -14,8 +14,9 @@ def _pyi_rthook():
     import os
     import sys
 
-    tcldir = os.path.join(sys._MEIPASS, 'tcl')
-    tkdir = os.path.join(sys._MEIPASS, 'tk')
+    # The directory names must match TCL_ROOTNAME and TK_ROOTNAME constants defined in `PyInstaller.utils.hooks.tcl_tk`.
+    tcldir = os.path.join(sys._MEIPASS, '_tcl_data')
+    tkdir = os.path.join(sys._MEIPASS, '_tk_data')
 
     # Notify "tkinter" of data directories. On macOS, we do not collect data directories if system Tcl/Tk framework is
     # used. On other OSes, we always collect them, so their absence is considered an error.

--- a/PyInstaller/utils/hooks/setuptools.py
+++ b/PyInstaller/utils/hooks/setuptools.py
@@ -162,11 +162,11 @@ class SetuptoolsInfo:
 
     # Delay initialization of setuptools information until until the corresponding attributes are first requested.
     def __getattr__(self, name):
-        if 'version' in self.__dict__:
+        if 'available' in self.__dict__:
             # Initialization was already done, but requested attribute is not available.
             raise AttributeError(name)
 
-        # Load Qt library info...
+        # Load setuptools info...
         self._load_setuptools_info()
         # ... and return the requested attribute
         return getattr(self, name)
@@ -192,7 +192,7 @@ class SetuptoolsInfo:
 
         # If package could not be imported, `_retrieve_setuptools_info` returns None. In such cases, emit a debug
         # message instead of a warning, because this initialization might be triggered by a helper function that is
-        # trying to determine availability of `setuptools` by inspecting the `version` attribute.
+        # trying to determine availability of `setuptools` by inspecting the `available` attribute.
         if setuptools_info is None:
             logger.debug("%s: failed to obtain setuptools info: setuptools could not be imported.", self)
             return

--- a/tests/functional/scripts/pyi_lib_tkinter.py
+++ b/tests/functional/scripts/pyi_lib_tkinter.py
@@ -44,13 +44,13 @@ def compare(test_name, expect, frozen):
 # Tcl scripts directory
 tcl_dir = os.environ.get('TCL_LIBRARY')
 if tcl_dir:
-    compare('Tcl', os.path.join(sys.prefix, 'tcl'), tcl_dir)
+    compare('Tcl', os.path.join(sys.prefix, '_tcl_data'), tcl_dir)
 elif sys.platform != 'darwin':
     raise SystemExit("TCL_LIBRARY environment variable is not set!")
 
 # Tk scripts directory
 tk_dir = os.environ.get('TK_LIBRARY')
 if tk_dir:
-    compare('Tk', os.path.join(sys.prefix, 'tk'), tk_dir)
+    compare('Tk', os.path.join(sys.prefix, '_tk_data'), tk_dir)
 elif sys.platform != 'darwin':
     raise SystemExit("TK_LIBRARY environment variable is not set!")


### PR DESCRIPTION
So initially, the idea here was to reorganize the Tcl/Tk utility functions into utility class similar to what we now have for setuptools (which in turn is modeled after what we already had for Qt bindings packages).

That's because while trying out the free-threading python builds that now come with official installers, it turned out that on Windows, I could not run PyInstaller at all - because `PyInstaller.build.build_main` imports `PyInstaller.building.splash`, which imports `PyInstaller.utils.hooks.tcl_tk`, and that attempts to obtain Tcl/Tk information during import. While isolated sub-process is used for that, we don't guard against `isolated.SubprocessDiedError`, and as the luck would have it, importing tkinter in free-threading version of python on Windows crashes the interpreter.

So the idea was to properly guard against this sort of exceptions, but also to delay retrieval of information until it was really required (i.e., when `hook-_tkinter.py` or `Splash` target tries to access the corresponding attributes. At the same time, we can clean up the code a bit, and reorganize it to be a bit more compact and easier to follow.

The `PyInstaller.utils.hooks.can_iumport_module` should also be able to gracefully handle interpreter crash, so wrap its implementation in another try/except block and return False if `isolated.SubprocessDiedError` is thrown, as for our intents and purposes, this means that module cannot be imported. (I thought this would take care of issues with `pytest`, but it turned out that `pytest` crashes under free-threaded Windows python interpreter on its own, without PyInstaller or its tests being involved).

The refactoring of Tcl/Tk utils introduced [a failure on `macos-12 + python 3.13` runner in `tkinter`-related tests](https://github.com/rokm/pyinstaller/actions/runs/10317838082/job/28562933089).

In onefile builds,

``` 
[PYI-25989:DEBUG] LOADER: extracting files to temporary directory...
[PYI-25989:ERROR] Failed to extract tcl/auto.tcl: failed to open target file!
fopen: Not a directory
[PYI-25989:ERROR] Failed to extract entry: tcl/auto.tcl.
```

at *run time*; and in onedir builds,

```
NotADirectoryError: [Errno 20] Not a directory: '/Users/runner/work/_temp/pytest-of-runner/pytest-0/popen-gw1/test_idlelib_onedir_0/dist/test_source/_internal/tcl/encoding'
```

at *build time* during COLLECT stage.

Looking at the build artifacts made from the failed tests, it turned out that the `_internal` directory contains `Tcl` and `Tk` files, which are preventing creation of eponymous directories. Which means that python 3.13 builds resurrected our old nemesis - Tcl/Tk framework builds. Except this time, those are not system-provided (outdated Tcl/Tk 8.5), but rather private framework bundles, shipped in `/Library/Frameworks/Python.framework/Versions/3.13/Frameworks/{Tcl,Tk}.framework`. This applies both to GHA setup-python build, and python.org macOS installer.

But why did those tests start failing only after the re-factor? Because original implementation [has all-or-nothing strategy](https://github.com/pyinstaller/pyinstaller/blob/80724ff94bc51fcb9115c28696b134a51a516097/PyInstaller/utils/hooks/tcl_tk.py#L253-L259) for collecting Tcl and Tk library directory ("library" as in "script collection", not "dynamic library"), and (as it would later turn out) we incorrectly compute Tk library directory in the case of framework bundles. In the refactored version, I went with collecting whatever is available - which in this case was Tcl library/data directory (but not Tk one, due to oversight from original implementation being ported over), so that end up clashing with `Tcl` shared library file.

But how could we fail to collect Tcl/Tk library/data directory without tests failing? *As it turns out, our test suite has no test that would actually try to create a tkinter-based UI.*

The newly added test (initially on top of [develop, for sanity check](https://github.com/rokm/pyinstaller/actions/runs/10319834946)) predictably failed on `macos-12 + python 3.13`, but for good measure, also on `macos-12 + python 3.8`, `3.9`, and `3.10`. Turns out that those python builds have broken tkinter, which seems to have been build against Tcl/Tk 8.5, but is now trying to use 8.6 from Homebrew.

At least I now have the solace of understanding the bizarre ` ERROR    PyInstaller.utils.hooks.tcl_tk:tcl_tk.py:257 Tk data directory "/usr/local/Cellar/tcl-tk/8.6.14/lib/tk8.5" not found.` messages that I kept seeing in (unrelated) failed tests on python 3.8-3.10 + macOS runners while working on setuptools 71 branch...

So the newly added `tkinter` test needs to be guarded by isolated check that tries to instantiate `tkinter.Tk()` itself, instead of just a `can_import_module('tkinter')` check.

Afterwards, we need to change the target directory for collected Tcl/Tk data directory to avoid potential clashes with framework-bundle Tcl and Tk files (`tcl` -> `_tcl_data`, `tk`-> `_tk_data`). Perhaps later on, I will check if we can preserve those .framework bundle layouts, and maybe then we can collect those data directories into `.framework/Version/8.x/Resources/Scripts` and avoid potential name clash altogether.

And we need to fix the assumed path for Tk data directory in case of Tk.framework bundle, because `$tcl_root/../tkX.Y` does not apply.