### PR TITLE
misc: adjust for changes in _pyinstaller_hooks_contrib layout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,7 +234,7 @@ jobs:
       - name: Inject bogus hook
         shell: python
         run: |
-          from _pyinstaller_hooks_contrib.hooks.stdhooks import __path__ as path
+          from _pyinstaller_hooks_contrib.stdhooks import __path__ as path
           with open(path[0] + "/hook-pyi_hooksample.py", "w") as f:
               f.write('assert 0, "Wrong hook! Use the pyi_hooksample copy instead!"\n')
 

--- a/PyInstaller/building/build_main.py
+++ b/PyInstaller/building/build_main.py
@@ -100,7 +100,9 @@ def discover_hook_directories():
     entry_points = importlib_metadata.entry_points(group='pyinstaller40', name='hook-dirs')
 
     # Ensure that pyinstaller_hooks_contrib comes last so that hooks from packages providing their own take priority.
-    entry_points = sorted(entry_points, key=lambda x: x.module == "_pyinstaller_hooks_contrib.hooks")
+    # In pyinstaller-hooks-contrib >= 2024.8, the entry-point module is `_pyinstaller_hooks_contrib`; in earlier
+    # versions, it was `_pyinstaller_hooks_contrib.hooks`.
+    entry_points = sorted(entry_points, key=lambda x: x.module.startswith("_pyinstaller_hooks_contrib"))
 
     hook_directories = []
     for entry_point in entry_points:

--- a/doc/hooks.rst
+++ b/doc/hooks.rst
@@ -46,7 +46,7 @@ Additional hooks are provided by the ``pyinstaller-hooks-contrib``
 package, which is typically installed as part of PyInstaller dependencies.
 See `here <https://github.com/pyinstaller/pyinstaller/tree/develop/PyInstaller/hooks>`__
 to browse PyInstaller-provided hooks in the online repository,
-and `here <https://github.com/pyinstaller/pyinstaller-hooks-contrib/tree/master/src/_pyinstaller_hooks_contrib/hooks/stdhooks>`__
+and `here <https://github.com/pyinstaller/pyinstaller-hooks-contrib/tree/master/_pyinstaller_hooks_contrib/stdhooks>`__
 for hooks provided by the ``pyinstaller-hooks-contrib``.
 
 Many hooks consist of only one statement, an assignment to ``hiddenimports``.


### PR DESCRIPTION
`pyinstaller-hooks-contrib` 2024.8 changed the layout of its `_pyinstaller_hooks_contrib` package. There are couple of places in main repository that need to be adjusted accordingly:

* sorting of entry-points in `discover_hook_directories`

* the "Inject bogus hook" step in the ci.yml

* URL to contributed hooks repository in "Understanding PyInstaller Hooks" documentation section.