### PR TITLE
bootloader: specify missing header for _NSGetExecutablePath

### DIFF
--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -41,6 +41,10 @@
     #include <Carbon/Carbon.h>  /* TransformProcessType */
 #endif
 
+#if defined(__APPLE__)
+    #include <mach-o/dyld.h>  /* _NSGetExecutablePath() */
+#endif
+
 /* PyInstaller headers. */
 #include "pyi_main.h"
 #include "pyi_global.h"  /* PYI_PATH_MAX */


### PR DESCRIPTION
On using a custom build of Clang, build on macOS fails with:
```
 ../../src/pyi_main.c:997:9: error: call to undeclared function '_NSGetExecutablePath';
    if (_NSGetExecutablePath(program_path, &name_length) != 0) {
        ^
1 error generated.
```

The missing include was lost in the refactor at: https://github.com/pyinstaller/pyinstaller/commit/c3167147