### PR TITLE
bootloader: fix VCRUNTIME140.dll leak/regression in splash-enabled onefile builds

### DIFF
--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -390,6 +390,14 @@ pyi_main(struct PYI_CONTEXT *pyi_ctx)
 #if defined(_WIN32)
     if (pyi_ctx->archive->toc_splash && pyi_ctx->is_onefile && pyi_ctx->process_level == PYI_PROCESS_LEVEL_PARENT) {
         const wchar_t *dll_name = L"VCRUNTIME140.dll";
+
+        /* Avoid accidentally picking up VCRUNTIME140.dll from another
+         * (instance of) frozen application that might have launched
+         * this instance. I.e., call SetDllDirectoryW(NULL) to reset
+         * the search path modification that happens in the code block
+         * that follows this one (and is inherited by child processes). */
+        SetDllDirectoryW(NULL);
+
         PYI_DEBUG_W(L"LOADER: attempting to pre-load system copy of %ls...\n", dll_name);
         if (LoadLibraryExW(dll_name, NULL, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS)) {
             PYI_DEBUG_W(L"LOADER: successfully loaded system copy of %ls.\n", dll_name);

--- a/news/8701.bugfix.rst
+++ b/news/8701.bugfix.rst
@@ -1,0 +1,3 @@
+(Windows) Fix the leak of ``VCRUNTIME140.dll`` in ``onefile`` applications
+with splash screen enabled, this time in scenarios with full application
+restart (regression introduced by :issue:`8650`).


### PR DESCRIPTION
When trying to pre-load system copy of `VCRUNTIME140.dll` to avoid issues with temporary directory cleanup in splash-enabled one-file builds, make sure to reset DLL search path via `SetDllDirectoryW(NULL)`, in case a parent frozen application (instance) set it to its (temporary) top-level application directory. Otherwise, we will load `VCRUNTIME140.dll` from there, and cause the very issue we are trying to prevent.