### PR TITLE
hooks: attempt at improving handling of setuptools >= 71.0

### DIFF
--- a/PyInstaller/hooks/hook-setuptools._vendor.importlib_metadata.py
+++ b/PyInstaller/hooks/hook-setuptools._vendor.importlib_metadata.py
@@ -1,0 +1,21 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2024, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+import fnmatch
+from PyInstaller.utils.hooks.setuptools import setuptools_info
+
+# Collect metadata for setuptools-vendored copy of importlib-metadata, to match the behavior of hook for
+# stand-alone version of the package (i.e., `hook-importlib_metadata.py`).
+
+# Use cached data files list from setuptools_info, and extract relevant bits (to avoid having to call another
+# `collect_data_files` and import `setuptools` in isolated process).
+datas = [(src_name, dest_name) for src_name, dest_name in setuptools_info.vendored_data
+         if fnmatch.fnmatch(src_name, "**/setuptools/_vendor/importlib_metadata-*.dist-info/*")]

--- a/PyInstaller/hooks/hook-setuptools._vendor.jaraco.text.py
+++ b/PyInstaller/hooks/hook-setuptools._vendor.jaraco.text.py
@@ -1,0 +1,18 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2024, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+import fnmatch
+from PyInstaller.utils.hooks.setuptools import setuptools_info
+
+# Use cached data files list from setuptools_info, and extract relevant bits (to avoid having to call another
+# `collect_data_files` and import `setuptools` in isolated process).
+datas = [(src_name, dest_name) for src_name, dest_name in setuptools_info.vendored_data
+         if fnmatch.fnmatch(src_name, "**/setuptools/_vendor/jaraco/text/*")]

--- a/PyInstaller/hooks/hook-setuptools.py
+++ b/PyInstaller/hooks/hook-setuptools.py
@@ -28,7 +28,6 @@ if compat.is_unix or compat.is_darwin:
 # its vendored dependencies).
 excludedimports = [
     'pytest',
-    'unittest',
     'numpy',  # originally from hook-setuptools.msvc
     'docutils',  # originally from hool-setuptools._distutils.command.check
 ]

--- a/PyInstaller/utils/hooks/__init__.py
+++ b/PyInstaller/utils/hooks/__init__.py
@@ -1031,6 +1031,11 @@ def copy_metadata(package_name: str, recursive: bool = False):
                 f"Distribution metadata path {src_path!r} for {package_name} is neither file nor directory!"
             )
 
+        # Hack for metadata from packages vendored by setuptools >= 71. If source path is rooted in setuptools/_vendor,
+        # prepend the same to the destination path and avoid collecting into top-level directory.
+        if src_path.parent.name == '_vendor' and src_path.parent.parent.name == 'setuptools':
+            dest_path = os.path.join('setuptools', '_vendor', dest_path)
+
         out.append((str(src_path), str(dest_path)))
 
         if not recursive:

--- a/news/8737.hooks.rst
+++ b/news/8737.hooks.rst
@@ -1,0 +1,4 @@
+Tweak the ``setuptools`` hook to minimize collection of vendored
+packages/modules and their (meta)data when using ``setuptools`` >= 71.0;
+the aim is to have the run-time behavior of collected vendored package
+closely match the behavior of its non-vendored counterpart.


### PR DESCRIPTION
Attempt at improving the recently-added setuptools >= 71.0, based on feedback from https://github.com/pyinstaller/pyinstaller/issues/8728.

1. We need to make metadata-handling hook utility functions aware of setuptools-vendored packages, so that a `importlib_metadata.version('some-package')` avoids triggering collection of metadata for `some-package` into top-level application directory when `some-package` happens to be vendored and exposed by `setuptools`; instead, the metadata should be collected into `setuptools/_vendor` directory.

2. with aliases being set up for vendored modules in setuptools >= 71.0, I *think* we can avoid explicitly collecting all those vendored submodules via `hiddenimports`; the aliases should ensure that only the referenced bits are collected, same as they would be for non-vendored/stand-alone package variant.

3. turns out we should not be collecting all vendored packages' metadata automatically, because that might cause a mix-up when stand-alone package is also present and collected. In that case, if we are not also collecting the stand-alone package's metadata, the frozen application will end up with modules of stand-alone package in top-level directory, and metadata from vendored package in `setuptools/_vendor` directory, and the two might not necessarily match. So now, we only collect metadata for vendored `importlib_metadata` and data file for vendored `jaraco.text`. This is done via separate `hook-setuptools._vendor.importlib_metadata.py` and `hook-setuptools._vendor.jaraco.text.py`, which are ran only if the corresponding modules are collected (which, with other changes outlined above, should now happen only if stand-alone variant of corresponding packages is not available).

Closes https://github.com/pyinstaller/pyinstaller/issues/8728.