### PR TITLE
Implement mechanism for overriding priority of analysis hooks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,12 +231,25 @@ jobs:
       - name: Install hooksample
         run: pip install "https://github.com/pyinstaller/hooksample/archive/v4.0rc1.zip"
 
-      - name: Inject bogus hook
+      # Augment _pyinstaller_hooks_contrib with bogus hooks that conflict with the hooks provided by hooksample.
+      # Due to (implicit) hook priority, the 3rd-party hooks should be chosen over _pyinstaller_hooks_contrib
+      # ones, and so the bogus hooks should never be ran. This applies to standard module hooks, as well as
+      # the pre-find-module-path and pre-safe-import-module hooks.
+      - name: Inject bogus hooks
         shell: python
         run: |
-          from _pyinstaller_hooks_contrib.stdhooks import __path__ as path
-          with open(path[0] + "/hook-pyi_hooksample.py", "w") as f:
-              f.write('assert 0, "Wrong hook! Use the pyi_hooksample copy instead!"\n')
+          import os
+          from _pyinstaller_hooks_contrib import (
+              stdhooks,
+              pre_safe_import_module,
+              pre_find_module_path,
+          )
+          with open(os.path.join(stdhooks.__path__[0], "hook-pyi_hooksample.py"), "w") as f:
+              f.write('raise Exception("Wrong hook! Use the pyi_hooksample copy instead!")\n')
+          with open(os.path.join(pre_safe_import_module.__path__[0], "hook-pyi_hooksample.py"), "w") as f:
+              f.write('raise Exception("Wrong hook! Use the pyi_hooksample copy instead!")\n')
+          with open(os.path.join(pre_find_module_path.__path__[0], "hook-pyi_hooksample.py"), "w") as f:
+              f.write('raise Exception("Wrong hook! Use the pyi_hooksample copy instead!")\n')
 
       - name: Run hooksample tests
         run: |

--- a/PyInstaller/building/build_main.py
+++ b/PyInstaller/building/build_main.py
@@ -37,7 +37,7 @@ from PyInstaller.building.utils import (
 )
 from PyInstaller.compat import is_win, is_conda, is_darwin, is_linux
 from PyInstaller.depend import bindepend
-from PyInstaller.depend.analysis import initialize_modgraph
+from PyInstaller.depend.analysis import initialize_modgraph, HookPriority
 from PyInstaller.depend.utils import create_py3_base_library, scan_code_for_ctypes
 from PyInstaller import isolated
 from PyInstaller.utils.misc import absnormpath, get_path_to_toplevel_modules, mtime
@@ -94,6 +94,7 @@ def discover_hook_directories():
     from traceback import format_exception_only
     from PyInstaller.log import logger
     from PyInstaller.compat import importlib_metadata
+    from PyInstaller.depend.analysis import HookPriority
 
     # The “selectable” entry points (via group and name keyword args) were introduced in importlib_metadata 4.6 and
     # Python 3.10. The compat module ensures we are using a compatible version.
@@ -106,15 +107,29 @@ def discover_hook_directories():
 
     hook_directories = []
     for entry_point in entry_points:
+        # Query hook directory location(s) from entry point
         try:
-            hook_directories.extend(entry_point.load()())
+            hook_directory_entries = entry_point.load()()
         except Exception as e:
             msg = "".join(format_exception_only(type(e), e)).strip()
             logger.warning("discover_hook_directories: Failed to process hook entry point '%s': %s", entry_point, msg)
+            continue
+
+        # Determine location-based priority: upstream hooks vs. hooks from contributed hooks package.
+        location_priority = (
+            HookPriority.CONTRIBUTED_HOOKS
+            if entry_point.module.startswith("_pyinstaller_hooks_contrib") else HookPriority.UPSTREAM_HOOKS
+        )
+
+        # Append entries
+        hook_directories.extend([(hook_directory_entry, location_priority)
+                                 for hook_directory_entry in hook_directory_entries])
 
     logger.debug("discover_hook_directories: Hook directories: %s", hook_directories)
 
-    return hook_directories
+    # Unfortunately, HookEntry enum values cannot be marshalled, so we need to convert them to integer values. Do so
+    # after dumping them in the above debug message, so that their symbolic names are displayed.
+    return [(path, int(priority)) for path, priority in hook_directories]
 
 
 def find_binary_dependencies(binaries, import_packages):
@@ -503,10 +518,11 @@ class Analysis(Target):
         # shell when using ˙--additional-hooks-dir=~/path/abc` instead of ˙--additional-hooks-dir ~/path/abc` (or when
         # the path argument is quoted).
         if hookspath:
-            self.hookspath.extend([os.path.expanduser(path) for path in hookspath])
+            self.hookspath.extend([(os.path.expanduser(path), HookPriority.USER_HOOKS) for path in hookspath])
 
-        # Add hook directories from PyInstaller entry points.
-        self.hookspath += discover_hook_directories()
+        # Add hook directories from PyInstaller entry points. Convert integer priority values back into their enum
+        # counterpaths
+        self.hookspath += [(path, HookPriority(priority)) for path, priority in discover_hook_directories()]
 
         self.hooksconfig = {}
         if hooksconfig:

--- a/PyInstaller/depend/analysis.py
+++ b/PyInstaller/depend/analysis.py
@@ -59,10 +59,10 @@ from PyInstaller.utils.hooks import collect_submodules, is_package
 logger = logging.getLogger(__name__)
 
 # Location-based hook priority constants
-HOOK_PRIORITY_BUILTIN_HOOKS = 0  # Built-in hooks. Lowest priority.
-HOOK_PRIORITY_CONTRIBUTED_HOOKS = 1000  # Hooks from pyinstaller-hooks-contrib package.
-HOOK_PRIORITY_UPSTREAM_HOOKS = 2000  # Hooks provided by packages themselves, via entry-points.
-HOOK_PRIORITY_USER_HOOKS = 3000  # User-supplied hooks (command-line / spec file). Highest priority.
+HOOK_PRIORITY_BUILTIN_HOOKS = -2000  # Built-in hooks. Lowest priority.
+HOOK_PRIORITY_CONTRIBUTED_HOOKS = -1000  # Hooks from pyinstaller-hooks-contrib package.
+HOOK_PRIORITY_UPSTREAM_HOOKS = 0  # Hooks provided by packages themselves, via entry-points.
+HOOK_PRIORITY_USER_HOOKS = 1000  # User-supplied hooks (command-line / spec file). Highest priority.
 
 
 class PyiModuleGraph(ModuleGraph):

--- a/PyInstaller/depend/analysis.py
+++ b/PyInstaller/depend/analysis.py
@@ -40,7 +40,6 @@ import sys
 import traceback
 from collections import defaultdict
 from copy import deepcopy
-import enum
 
 from PyInstaller import HOMEPATH, PACKAGEPATH
 from PyInstaller import log as logging
@@ -59,12 +58,11 @@ from PyInstaller.utils.hooks import collect_submodules, is_package
 
 logger = logging.getLogger(__name__)
 
-
-class HookPriority(enum.IntEnum):
-    BUILTIN_HOOKS = 0  # Built-in hooks. Lowest priority.
-    CONTRIBUTED_HOOKS = 1000  # Hooks from pyinstaller-hooks-contrib package.
-    UPSTREAM_HOOKS = 2000  # Hooks provided by packages themselves, via entry-points.
-    USER_HOOKS = 3000  # User-supplied hooks (command-line / spec file). Highest priority.
+# Location-based hook priority constants
+HOOK_PRIORITY_BUILTIN_HOOKS = 0  # Built-in hooks. Lowest priority.
+HOOK_PRIORITY_CONTRIBUTED_HOOKS = 1000  # Hooks from pyinstaller-hooks-contrib package.
+HOOK_PRIORITY_UPSTREAM_HOOKS = 2000  # Hooks provided by packages themselves, via entry-points.
+HOOK_PRIORITY_USER_HOOKS = 3000  # User-supplied hooks (command-line / spec file). Highest priority.
 
 
 class PyiModuleGraph(ModuleGraph):
@@ -127,7 +125,7 @@ class PyiModuleGraph(ModuleGraph):
         # tuple, and order is determined from assigned priority (which may also be overridden by hooks themselves).
         self._user_hook_dirs = [
             *user_hook_dirs,
-            (os.path.join(PACKAGEPATH, 'hooks'), HookPriority.BUILTIN_HOOKS),
+            (os.path.join(PACKAGEPATH, 'hooks'), HOOK_PRIORITY_BUILTIN_HOOKS),
         ]
         # Hook-specific lookup tables. These need to reset when reusing cached PyiModuleGraph to avoid hooks to refer to
         # files or data from another test-case.

--- a/PyInstaller/depend/imphook.py
+++ b/PyInstaller/depend/imphook.py
@@ -16,6 +16,7 @@ import glob
 import os.path
 import sys
 import weakref
+import re
 
 from PyInstaller import log as logging
 from PyInstaller.building.utils import format_binaries_and_datas
@@ -287,6 +288,7 @@ class ModuleHook:
         self.module_name = module_name
         self.hook_filename = hook_filename
 
+        # Default priority; used as fall-back for dynamic `hook_priority` attribute.
         self._default_priority = default_priority
 
         # Name of the in-memory module fabricated to refer to this hook script.
@@ -296,10 +298,6 @@ class ModuleHook:
         self._loaded = False
         self._has_hook_function = False
         self._hook_module = None
-
-    @property
-    def priority(self):
-        return self._default_priority
 
     def __getattr__(self, attr_name):
         """
@@ -319,13 +317,16 @@ class ModuleHook:
         Class docstring for supported magic attributes.
         """
 
-        # If this is a magic attribute, initialize this attribute by lazy loading this hook script and then return
-        # this attribute.
+        if attr_name == 'priority':
+            # If attribute is part of hook metadata, read metadata from hook script and return the attribute value.
+            self._load_hook_metadata()
+            return getattr(self, attr_name)
         if attr_name in _MAGIC_MODULE_HOOK_ATTRS and not self._loaded:
+            # If attribute is hook's magic attribute, load and run the hook script, and return the attribute value.
             self._load_hook_module()
             return getattr(self, attr_name)
-        # Else, this is an undefined attribute. Raise an exception.
         else:
+            # This is an undefined attribute. Raise an exception.
             raise AttributeError(attr_name)
 
     def __setattr__(self, attr_name, attr_value):
@@ -351,6 +352,29 @@ class ModuleHook:
         return super().__setattr__(attr_name, attr_value)
 
     #-- Loading --
+
+    def _load_hook_metadata(self):
+        """
+        Load hook metadata from its source file.
+        """
+        self.priority = self._default_priority
+
+        # Priority override pattern: `# $PyInstaller-Hook-Priority: <value>`
+        priority_pattern = re.compile(r"^\s*#\s*\$PyInstaller-Hook-Priority:\s*(?P<value>[\S]+)")
+
+        with open(self.hook_filename, "r") as f:
+            for line in f:
+                # Attempt to match and parse hook priority directive
+                m = priority_pattern.match(line)
+                if m is not None:
+                    try:
+                        self.priority = int(m.group('value'))
+                    except Exception:
+                        logger.warning(
+                            "Failed to parse hook priority value string: %r!", m.group('value'), exc_info=True
+                        )
+                    # Currently, this is our only line of interest, so we can stop the search here.
+                    return
 
     def _load_hook_module(self, keep_module_ref=False):
         """

--- a/tests/unit/test_pyimodulegraph.py
+++ b/tests/unit/test_pyimodulegraph.py
@@ -175,7 +175,12 @@ def _gen_pseudo_rthooks(name, rthook_dat, tmpdir, gen_files=True):
 def test_collect_rthooks_1(tmpdir, monkeypatch):
     rh1 = {"test_pyimodulegraph_mymod1": ["m1.py"]}
     hd1 = _gen_pseudo_rthooks("h1", rh1, tmpdir)
-    mg = FakePyiModuleGraph(HOMEPATH, user_hook_dirs=[str(hd1)])
+    mg = FakePyiModuleGraph(
+        HOMEPATH,
+        user_hook_dirs=[
+            (str(hd1), analysis.HookPriority.BUILTIN_HOOKS),
+        ],
+    )
     assert len(mg._available_rthooks["test_pyimodulegraph_mymod1"]) == 1
 
 
@@ -184,7 +189,13 @@ def test_collect_rthooks_2(tmpdir, monkeypatch):
     rh2 = {"test_pyimodulegraph_mymod2": ["rth1.py", "rth1.py"]}
     hd1 = _gen_pseudo_rthooks("h1", rh1, tmpdir)
     hd2 = _gen_pseudo_rthooks("h2", rh2, tmpdir)
-    mg = FakePyiModuleGraph(HOMEPATH, user_hook_dirs=[str(hd1), str(hd2)])
+    mg = FakePyiModuleGraph(
+        HOMEPATH,
+        user_hook_dirs=[
+            (str(hd1), analysis.HookPriority.BUILTIN_HOOKS),
+            (str(hd2), analysis.HookPriority.BUILTIN_HOOKS),
+        ],
+    )
     assert len(mg._available_rthooks["test_pyimodulegraph_mymod1"]) == 1
     assert len(mg._available_rthooks["test_pyimodulegraph_mymod2"]) == 2
 
@@ -194,7 +205,13 @@ def test_collect_rthooks_3(tmpdir, monkeypatch):
     rh2 = {"test_pyimodulegraph_mymod1": ["rth1.py", "rth1.py"]}
     hd1 = _gen_pseudo_rthooks("h1", rh1, tmpdir)
     hd2 = _gen_pseudo_rthooks("h2", rh2, tmpdir)
-    mg = FakePyiModuleGraph(HOMEPATH, user_hook_dirs=[str(hd1), str(hd2)])
+    mg = FakePyiModuleGraph(
+        HOMEPATH,
+        user_hook_dirs=[
+            (str(hd1), analysis.HookPriority.BUILTIN_HOOKS),
+            (str(hd2), analysis.HookPriority.BUILTIN_HOOKS),
+        ],
+    )
     assert len(mg._available_rthooks["test_pyimodulegraph_mymod1"]) == 1
 
 
@@ -202,7 +219,12 @@ def test_collect_rthooks_fail_1(tmpdir, monkeypatch):
     rh1 = {"test_pyimodulegraph_mymod1": ["m1.py"]}
     hd1 = _gen_pseudo_rthooks("h1", rh1, tmpdir, False)
     with pytest.raises(AssertionError):
-        FakePyiModuleGraph(HOMEPATH, user_hook_dirs=[str(hd1)])
+        FakePyiModuleGraph(
+            HOMEPATH,
+            user_hook_dirs=[
+                (str(hd1), analysis.HookPriority.BUILTIN_HOOKS),
+            ],
+        )
 
 
 class FakeGraph(analysis.PyiModuleGraph):

--- a/tests/unit/test_pyimodulegraph.py
+++ b/tests/unit/test_pyimodulegraph.py
@@ -178,7 +178,7 @@ def test_collect_rthooks_1(tmpdir, monkeypatch):
     mg = FakePyiModuleGraph(
         HOMEPATH,
         user_hook_dirs=[
-            (str(hd1), analysis.HookPriority.BUILTIN_HOOKS),
+            (str(hd1), analysis.HOOK_PRIORITY_BUILTIN_HOOKS),
         ],
     )
     assert len(mg._available_rthooks["test_pyimodulegraph_mymod1"]) == 1
@@ -192,8 +192,8 @@ def test_collect_rthooks_2(tmpdir, monkeypatch):
     mg = FakePyiModuleGraph(
         HOMEPATH,
         user_hook_dirs=[
-            (str(hd1), analysis.HookPriority.BUILTIN_HOOKS),
-            (str(hd2), analysis.HookPriority.BUILTIN_HOOKS),
+            (str(hd1), analysis.HOOK_PRIORITY_BUILTIN_HOOKS),
+            (str(hd2), analysis.HOOK_PRIORITY_BUILTIN_HOOKS),
         ],
     )
     assert len(mg._available_rthooks["test_pyimodulegraph_mymod1"]) == 1
@@ -208,8 +208,8 @@ def test_collect_rthooks_3(tmpdir, monkeypatch):
     mg = FakePyiModuleGraph(
         HOMEPATH,
         user_hook_dirs=[
-            (str(hd1), analysis.HookPriority.BUILTIN_HOOKS),
-            (str(hd2), analysis.HookPriority.BUILTIN_HOOKS),
+            (str(hd1), analysis.HOOK_PRIORITY_BUILTIN_HOOKS),
+            (str(hd2), analysis.HOOK_PRIORITY_BUILTIN_HOOKS),
         ],
     )
     assert len(mg._available_rthooks["test_pyimodulegraph_mymod1"]) == 1
@@ -222,7 +222,7 @@ def test_collect_rthooks_fail_1(tmpdir, monkeypatch):
         FakePyiModuleGraph(
             HOMEPATH,
             user_hook_dirs=[
-                (str(hd1), analysis.HookPriority.BUILTIN_HOOKS),
+                (str(hd1), analysis.HOOK_PRIORITY_BUILTIN_HOOKS),
             ],
         )
 


### PR DESCRIPTION
Transform the implicit analysis hook priority system into explicit one. Each hook source location/type is now assigned a numeric value:
- built-in hooks: 0
- pyinstaller-hooks-contrib: 1000
- upstream hooks provided by packages: 2000
- hooks supplied by user via command-line/spec: 3000
When multiple hooks are defined for a module, use the one that has the highest priority value. 

Allow the default location-based priority value to be overridden via `# $PyInstaller-Hook-Priority: <value>` comment found in the hook. (We scan hook source files for these in cases when multiple hooks are defined for a module).

This gives us ability to override a 3rd party hook with our own, either from main repository or from `pyinstaller-hooks-contrib`. For example, with upstream hooks having default priority of 2000, our copy with added `# $PyInstaller-Hook-Priority: 2001` would be used instead (unless user overrides it).

This way, the override can be kept permanent (assuming upstream does not add their own override), but it could also be temporary - i.e., assuming we have higher release cadence than upstream, we can push a release with updated/fixed hook that overrides the upstream one, and when upstream is ready to release their fixed hook, they can increase the priority value override in their hook (to surpass ours).

The default priority value scheme is up to debate; an alternative to presented one could be for example
- built-in hooks: -2
- pyinstaller-hooks-contrib: -1
- upstream hooks provided by packages: 0
- hooks supplied by user via command-line/spec: 10000