### PR TITLE
hookutils: get_installer: fix error handling in macOS-specific checks

### DIFF
--- a/PyInstaller/utils/hooks/__init__.py
+++ b/PyInstaller/utils/hooks/__init__.py
@@ -25,7 +25,6 @@ import packaging.requirements
 from PyInstaller import HOMEPATH, compat
 from PyInstaller import log as logging
 from PyInstaller.depend.imphookapi import PostGraphAPI
-from PyInstaller.exceptions import ExecCommandFailed
 from PyInstaller import isolated
 from PyInstaller.compat import importlib_metadata
 
@@ -1089,7 +1088,7 @@ def get_installer(module: str):
                                     encoding='utf-8').stdout
             if 'is provided by' in output:
                 return 'macports'
-        except ExecCommandFailed:
+        except Exception:
             pass
 
         # Check if the file is located in homebrew's Cellar directory


### PR DESCRIPTION
Fix error handling in macOS-specific checks in `get_installer` hook utility function; when trying to run `port` command via `subprocess`, catch and ignore all instances of `Exception`, instead of `ExecCommandFailed` (which is a left-over from times when `exec_command_stdout` was used).

This fixes uncaught `FileNotFoundError: [Errno 2] No such file or directory: 'port'` error when this part of the code happens to be reached.