### PR TITLE
hooks: babel: collect all submodules required to unpickle locale data

### DIFF
--- a/PyInstaller/hooks/hook-babel.py
+++ b/PyInstaller/hooks/hook-babel.py
@@ -11,6 +11,14 @@
 
 from PyInstaller.utils.hooks import collect_data_files
 
-hiddenimports = ["babel.dates"]
-
+# Ensure that .dat files from locale-data sub-directory are collected.
 datas = collect_data_files('babel')
+
+# Unpickling of locale-data/root.dat currently (babel v2.16.0) requires classes from following modules, so ensure that
+# they are always collected:
+hiddenimports = [
+    "babel.dates",
+    "babel.localedata",
+    "babel.plural",
+    "babel.numbers",
+]

--- a/news/8750.hooks.rst
+++ b/news/8750.hooks.rst
@@ -1,0 +1,2 @@
+Update ``babel`` hook to collect all submodules that are needed to
+unpickle the bundled locale data files.

--- a/tests/functional/test_libraries.py
+++ b/tests/functional/test_libraries.py
@@ -492,3 +492,18 @@ def test_setuptools(pyi_builder):
     pyi_builder.test_source("""
         import setuptools
         """)
+
+
+@importorskip('babel')
+def test_babel(pyi_builder):
+    # Try to format a date/time in order to ensure that data files from babel's locale-data directory (especially
+    # root.dat) can be unpickled.
+    pyi_builder.test_source(
+        """
+        import datetime
+        from babel.dates import format_datetime
+
+        datetime_obj = datetime.datetime(2007, 4, 1, 15, 30)
+        print(format_datetime(datetime_obj, 'full', locale='fr_FR'))
+        """
+    )


### PR DESCRIPTION
Update `hiddenimports` list in the `babel` hook to include all `babel` submodules that are needed to unpickle the bundled locale data files.

Fixes #8750.