### PR TITLE
bindepend: allow hooks to suppress creation of shared library symlinks

### DIFF
--- a/PyInstaller/depend/analysis.py
+++ b/PyInstaller/depend/analysis.py
@@ -94,6 +94,9 @@ class PyiModuleGraph(ModuleGraph):
         Cache of all external dependencies (e.g., binaries, datas) listed in hook scripts for imported modules.
     _module_collection_mode : dict
         A dictionary of module/package collection mode settings set by hook scripts for their modules.
+    _bindepend_symlink_suppression : set
+        A set of paths or path patterns corresponding to shared libraries for which binary dependency analysis should
+        not create symbolic links into top-level application directory.
     _base_modules: list
         Dependencies for `base_library.zip` (which remain the same for every executable).
     """
@@ -120,6 +123,7 @@ class PyiModuleGraph(ModuleGraph):
         self._top_script_node = None
         self._additional_files_cache = AdditionalFilesCache()
         self._module_collection_mode = dict()
+        self._bindepend_symlink_suppression = set()
         # Hook sources: user-supplied (command-line / spec file), entry-point (upstream hooks, contributed hooks), and
         # built-in hooks. The order does not really matter anymore, because each entry is now a (location, priority)
         # tuple, and order is determined from assigned priority (which may also be overridden by hooks themselves).
@@ -344,6 +348,9 @@ class PyiModuleGraph(ModuleGraph):
 
                 # Update package collection mode settings.
                 self._module_collection_mode.update(module_hook.module_collection_mode)
+
+                # Update symbolic link suppression patterns for binary dependency analysis.
+                self._bindepend_symlink_suppression.update(module_hook.bindepend_symlink_suppression)
 
                 # Prevent this module's hooks from being run again.
                 hooked_module_names.add(module_name)

--- a/PyInstaller/depend/imphookapi.py
+++ b/PyInstaller/depend/imphookapi.py
@@ -306,6 +306,9 @@ class PostGraphAPI:
     _module_collection_mode : dict
         Dictionary of package/module names and their corresponding collection mode strings. This is equivalent to the
         global `module_collection_mode` hook attribute.
+    _bindepend_symlink_suppression : set
+        A set of paths or path patterns corresponding to shared libraries for which binary dependency analysis should
+        not generate symbolic links into top-level application directory.
     """
     def __init__(self, module_name, module_graph, analysis):
         # Mutable attributes.
@@ -332,6 +335,7 @@ class PostGraphAPI:
         self._added_imports = []
         self._deleted_imports = []
         self._module_collection_mode = {}
+        self._bindepend_symlink_suppression = set()
 
     # Immutable properties. No corresponding setters are defined.
     @property
@@ -473,3 +477,10 @@ class PostGraphAPI:
             self._module_collection_mode.pop(name)
         else:
             self._module_collection_mode[name] = mode
+
+    def add_bindepend_symlink_suppression_pattern(self, pattern):
+        """
+        Add the given path or path pattern to the set of patterns that prevent binary dependency analysis from creating
+        a symbolic link to the top-level application directory.
+        """
+        self._bindepend_symlink_suppression.add(pattern)

--- a/doc/hooks.rst
+++ b/doc/hooks.rst
@@ -351,6 +351,54 @@ applies them to the bundle being created.
    can be modified using the `set_module_collection_mode method`_ from
    the ``hook_api`` object instead of setting the global hook variable.
 
+.. _bindepend symlink suppression:
+
+``bindepend_symlink_suppression``
+   An option for hooks to prevent the PyInstaller's binary dependency
+   analysis process from creating a symbolic link to top-level application
+   directory for specific shared library. Has effect only on platforms
+   where such symbolic links are created.
+
+   The value can be either a string (single path or pattern), a list of
+   strings, or a set of strings. During binary dependency analysis,
+   the discovered shared library's source path is matched against all
+   patterns that have been set by hooks to determine whether the symbolic
+   link should be created or not.
+
+   This mechanism is intended to be used in specific cases to work around
+   issues caused by symbolic links created by binary dependency analysis;
+   for example, when such a library tries to look up its location, but
+   does not fully resolve the obtained path.
+
+   Example::
+
+      # hook-mypackage.py
+
+      import os
+      from PyInstaller import compat
+      from PyInstaller.utils.hooks import get_module_file_attribute
+
+      # On linux, suppress creation of symbolic links to top-level application
+      # directory for all shared libraries collected from the package's directory.
+      if compat.is_linux:
+         package_dir = os.path.dirname(get_module_file_attribute('mypackage'))
+         bindepend_symlink_suppression = os.path.join(package_dir, "*.so*")
+
+   Example::
+
+      # hook-mypackage.py
+
+      from PyInstaller import compat
+
+      # On linux, suppress creation of symbolic links to top-level application
+      # directory for shared libraries bundled with this package in its two
+      # library subdirectories.
+      if compat.is_linux:
+         bindepend_symlink_suppression = [
+            "**/mypackage/lib_dir1/*.so*",
+            "**/mypackage/lib_dir2/*.so*",
+         ]
+
 
 Useful Items in ``PyInstaller.compat``
 ----------------------------------------
@@ -553,6 +601,12 @@ The ``hook_api`` object also offers the following methods:
    current hook's context! The collection mode may be set for the hooked
    package, its sub-module or sub-package, or for other packages. If ``name``
    is ``None``, it is substituted with the hooked package/module name.
+
+``add_bindepend_symlink_suppression_pattern( pattern )``:
+   Add the given path or path pattern to the set of patterns that prevent
+   binary dependency analysis from creating a symbolic link to the top-level
+   application directory. The same can be achieved by setting the
+   :ref:`bindepend_symlink_suppression hook global variable <bindepend symlink suppression>`.
 
 The ``hook()`` function can add, remove or change included files using the
 above methods of ``hook_api``.

--- a/news/8761.feature.rst
+++ b/news/8761.feature.rst
@@ -1,0 +1,7 @@
+Implement a mechanism that allows hooks to inform PyInstaller's binary
+dependency analysis that it should not create symbolic links to top-level
+application directory for certain shared libraries (applicable to platforms
+where such symbolic links are created in the first place). This mechanism
+is intended as a work around for corner cases when such symbolic links
+disrupt run-time discovery of other shared libraries that are stored in
+the linked library's true location.


### PR DESCRIPTION
Implement a mechanism that allows hooks to inform PyInstaller's binary dependency analysis that it should not create symbolic links to top-level application directory for certain shared libraries (applicable to platforms where such symbolic links are created in the first place).

This is done by registering paths or path patterns via `bindepend_symlink_suppression` global hook variable. During binary dependency analysis, the source path of each discovered shared library is matched against the registered paths/patterns to decide whether symbolic link should be created into top-level application directory or not.

This mechanism is intended as a work around for corner cases when such symbolic links disrupt run-time discovery of other shared libraries that are stored in the linked library's true location.