### PR TITLE
Pin pefile != 2024.8.26

### DIFF
--- a/news/8762.core.rst
+++ b/news/8762.core.rst
@@ -1,0 +1,3 @@
+(Windows) Pin ``pefile != 2024.8.26`` due to performance regression in
+``pefile`` 2024.8.26 that heavily impacts PyInstaller's binary dependency
+analysis and binary-vs-data classification.

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,11 +59,11 @@ packages = find:
 zip_safe = False
 include_package_data = False
 python_requires = >=3.8, <3.14
-## IMPORTANT: Keep aligned with requirements.txt
 install_requires =
     setuptools >= 42.0.0
     altgraph
-    pefile >= 2022.5.30 ; sys_platform == 'win32'
+    # pefile 2024.8.26 contains performance regression that heavily impacts our binary dependency analysis
+    pefile >= 2022.5.30, != 2024.8.26; sys_platform == 'win32'
     pywin32-ctypes >= 0.2.1 ; sys_platform == 'win32'
     macholib >= 1.8 ; sys_platform == 'darwin'
     pyinstaller-hooks-contrib >= 2024.8


### PR DESCRIPTION
Pin `pefile < 2024.8.26` due to performance regression in `pefile` 2024.8.26 that heavily impacts PyInstaller's binary dependency  analysis and binary-vs-data classification.

Improve the Windows implementation of `bindepend._classify_binary_vs_data`:
- check first two bytes for `MZ` signature to avoid using `pefile`-based check on every data file
- use context manager with `pefile` check to avoid leaking resources; this would not do us any favors with `pefile` 2024.8.26, but API wise, it is probably the right thing to do.
- classify file as DATA only on `pefile.PEFormatError`; on other types of exceptions, return `None` to signal that we cannot classify the file