### PR TITLE
loader: raise error when given path points to a file

### DIFF
--- a/PyInstaller/loader/pyimod02_importers.py
+++ b/PyInstaller/loader/pyimod02_importers.py
@@ -154,6 +154,12 @@ class PyiFrozenImporter:
             else:
                 raise
 
+        # Ensure that path does not point to a file on filesystem. Strictly speaking, we should be checking that the
+        # given path is a valid directory, but that would need to check both PYZ and filesystem. So for now, limit the
+        # check to catch paths pointing to file, because that breaks `runpy.run_path()`, as per #8767.
+        if os.path.isfile(path):
+            raise ImportError("only directories are supported")
+
         if relative_path == '.':
             self._pyz_entry_prefix = ''
         else:

--- a/news/8767.bugfix.rst
+++ b/news/8767.bugfix.rst
@@ -1,0 +1,2 @@
+Fix a regression when trying to use ``runpy.run_path`` to run a python
+script bundled with the frozen application.

--- a/tests/functional/test_misc.py
+++ b/tests/functional/test_misc.py
@@ -469,3 +469,22 @@ def test_optimization_via_python_option(pyi_builder, level, tmpdir):
 def test_optimization_via_optimize_option(pyi_builder, level, tmpdir):
     pyi_args = ["--optimize", str(level)]
     _test_optimization(pyi_builder, level, tmpdir, pyi_args)
+
+
+# Test that runpy.run_path() in frozen application can run a bundled python script file. See #8767.
+def test_runpy_run_from_location(tmpdir, pyi_builder):
+    script_file = tmpdir / "script.py"
+    with open(script_file, "w", encoding="utf8") as fp:
+        fp.write("""print("Hello world!")\n""")
+
+    pyi_builder.test_source(
+        """
+        import os
+        import sys
+        import runpy
+
+        script_file = os.path.join(sys._MEIPASS, 'script.py')
+        runpy.run_path(script_file, run_name="__main__")
+        """,
+        pyi_args=['--add-data', f"{script_file}:."],
+    )


### PR DESCRIPTION
Refuse to instantiate `PyiFrozenImporter` on paths that correspond to files, to match the behavior of python's own `FileFinder`.

Failing to do so results in `ImportError: can't find '__main__' module in '{_MEIPASS}/script.py'` when frozen application tries to run bundled `script.py` file via `runpy.run_path()`.

Fixes #8767.