### PR TITLE
Assorted cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,11 +244,11 @@ jobs:
               pre_safe_import_module,
               pre_find_module_path,
           )
-          with open(os.path.join(stdhooks.__path__[0], "hook-pyi_hooksample.py"), "w") as f:
+          with open(os.path.join(stdhooks.__path__[0], "hook-pyi_hooksample.py"), "w", encoding="utf-8") as f:
               f.write('raise Exception("Wrong hook! Use the pyi_hooksample copy instead!")\n')
-          with open(os.path.join(pre_safe_import_module.__path__[0], "hook-pyi_hooksample.py"), "w") as f:
+          with open(os.path.join(pre_safe_import_module.__path__[0], "hook-pyi_hooksample.py"), "w", encoding="utf-8") as f:
               f.write('raise Exception("Wrong hook! Use the pyi_hooksample copy instead!")\n')
-          with open(os.path.join(pre_find_module_path.__path__[0], "hook-pyi_hooksample.py"), "w") as f:
+          with open(os.path.join(pre_find_module_path.__path__[0], "hook-pyi_hooksample.py"), "w", encoding="utf-8") as f:
               f.write('raise Exception("Wrong hook! Use the pyi_hooksample copy instead!")\n')
 
       - name: Run hooksample tests

--- a/PyInstaller/depend/bindepend.py
+++ b/PyInstaller/depend/bindepend.py
@@ -199,7 +199,7 @@ def binary_dependency_analysis(binaries, search_paths=None, symlink_suppression_
                 pass
             elif any(dep_src_path.match(pattern) for pattern in symlink_suppression_patterns):
                 # Honor symlink suppression patterns specified by hooks.
-                logger.warning(
+                logger.debug(
                     "Skipping symbolic link from %r to top-level application directory due to source path matching one "
                     "of symlink suppression path patterns.", str(dep_dest_path)
                 )

--- a/PyInstaller/depend/imphook.py
+++ b/PyInstaller/depend/imphook.py
@@ -379,7 +379,7 @@ class ModuleHook:
         # Priority override pattern: `# $PyInstaller-Hook-Priority: <value>`
         priority_pattern = re.compile(r"^\s*#\s*\$PyInstaller-Hook-Priority:\s*(?P<value>[\S]+)")
 
-        with open(self.hook_filename, "r") as f:
+        with open(self.hook_filename, "r", encoding="utf-8") as f:
             for line in f:
                 # Attempt to match and parse hook priority directive
                 m = priority_pattern.match(line)

--- a/PyInstaller/depend/utils.py
+++ b/PyInstaller/depend/utils.py
@@ -17,6 +17,7 @@ import ctypes.util
 import io
 import os
 import re
+import shutil
 import struct
 import zipfile
 from types import CodeType
@@ -323,12 +324,11 @@ def load_ldconfig_cache():
         LDCONFIG_CACHE = {}
         return
 
-    from distutils.spawn import find_executable
-    ldconfig = find_executable('ldconfig')
+    ldconfig = shutil.which('ldconfig')
     if ldconfig is None:
         # If `ldconfig` is not found in $PATH, search for it in some fixed directories. Simply use a second call instead
         # of fiddling around with checks for empty env-vars and string-concat.
-        ldconfig = find_executable('ldconfig', '/usr/sbin:/sbin:/usr/bin:/usr/sbin')
+        ldconfig = shutil.which('ldconfig', path='/usr/sbin:/sbin:/usr/bin:/bin')
 
         # If we still could not find the 'ldconfig' command...
         if ldconfig is None:

--- a/PyInstaller/utils/hooks/qt/__init__.py
+++ b/PyInstaller/utils/hooks/qt/__init__.py
@@ -985,7 +985,7 @@ class QtLibraryInfo:
         plugin_binaries = set()
 
         # Read the `qmldir` file to determine the names of plugin binaries, if any.
-        contents = qmldir_file.read_text()
+        contents = qmldir_file.read_text(encoding="utf-8")
         for line in contents.splitlines():
             m = self._qml_plugin_def.match(line)
             if m is None:

--- a/tests/functional/test_misc.py
+++ b/tests/functional/test_misc.py
@@ -429,7 +429,7 @@ def _test_optimization(pyi_builder, level, tmpdir, pyi_args):
 
     pyi_builder.test_script("pyi_optimization.py", pyi_args=pyi_args, app_args=[results_filename])
 
-    with open(results_filename, "r") as fp:
+    with open(results_filename, "r", encoding="utf-8") as fp:
         results = json.load(fp)
 
     # Check that sys.flags.optimize matches the specified level


### PR DESCRIPTION
Assorted cleanup, based on warnings emitted by our CI pipelines:

- replace `distutils.spawn.find_exectuable('ldconfig')` with `shutil.which('ldconfig')`
- add missing `encoding='utf-8'` argument to several places where we open files
- downgrade a message about suppressed symbolic link from `warning` to `debug` (was supposed to be temporarily elevated for local testing, but then ended up slipping into #8761).