### PR TITLE
tests: install setuptools & wheel the Alpine Linux docker image

### DIFF
--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -33,6 +33,10 @@ COPY tests/requirements-base.txt tests/
 COPY tests/requirements-tools.txt tests/
 RUN pip wheel -r tests/requirements-tools.txt -w wheels
 
+# Recent versions of python docker image do not provide setuptools and wheel with python (>= 3.12) by default.
+# See: https://github.com/docker-library/python/issues/952
+RUN pip install --upgrade setuptools wheel
+
 # Build a wheel for PyInstaller. Do this last and use as few files as possible to maximize cache-ability.
 COPY COPYING.txt .
 COPY setup.* ./


### PR DESCRIPTION
Latest version of python docker image does not provide `setuptools` and `wheel` with python (>= 3.12) by default anymore, so we need to install them ourselves.