### PR TITLE
actions: schedule the lock-threads workflow to run an hour later

### DIFF
--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -2,7 +2,7 @@ name: Lock Closed Threads
 
 on:
   schedule:
-    - cron: '0 12 * * *'
+    - cron: '0 13 * * *'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Schedule the `lock-threads` workflow to run an hour later (at 13h UTC) to avoid running at same time as `viruscheck` work flow; hopefully, this will take care of sporadic `You have exceeded a secondary rate limit. Please wait a few minutes before you try again.` error.