### PR TITLE
hooks: update PyInstaller's copy of numpy hook and raise its priority

### DIFF
--- a/PyInstaller/hooks/hook-numpy.py
+++ b/PyInstaller/hooks/hook-numpy.py
@@ -1,44 +1,88 @@
-#!/usr/bin/env python3
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013-2024, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader. Additional
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
 
 # --- Copyright Disclaimer ---
 #
-# In order to support PyInstaller with numpy<1.20.0 this file will be duplicated for a short period inside
-# PyInstaller's repository [1]. However this file is the intellectual property of the NumPy team and is
-# under the terms and conditions outlined their repository [2].
+# An earlier copy of this hook has been submitted to the NumPy project, where it was integrated in v1.23.0rc1
+# (https://github.com/numpy/numpy/pull/20745), under terms and conditions outlined in their repository [1].
+#
+# A special provision is hereby granted to the NumPy project that allows the NumPy copy of the hook to incorporate the
+# changes made to this (PyInstaller's) copy of the hook, subject to their licensing terms as opposed to PyInstaller's
+# (stricter) licensing terms.
 #
 # .. refs:
 #
-#   [1] PyInstaller: https://github.com/pyinstaller/pyinstaller/
-#   [2] NumPy's license: https://github.com/numpy/numpy/blob/master/LICENSE.txt
-#
-"""
-This hook should collect all binary files and any hidden modules that numpy needs.
+#   [1] NumPy's license: https://github.com/numpy/numpy/blob/master/LICENSE.txt
 
-Our (some-what inadequate) docs for writing PyInstaller hooks are kept here:
-https://pyinstaller.readthedocs.io/en/stable/hooks.html
+# NOTE: when comparing the contents of this hook and the NumPy version of the hook (for example, to port changes), keep
+# in mind that this copy is PyInstaller-centric - it caters to the version of PyInstaller it is bundled with, but needs
+# to account for different behavior of different NumPy versions. In contrast, the NumPy copy of the hook caters to the
+# version of NumPy it is bundled with, but should account for behavior differences in different PyInstaller versions.
 
-PyInstaller has a lot of NumPy users so we consider maintaining this hook a high priority.
-Feel free to @mention either bwoodsend or Legorooj on Github for help keeping it working.
-"""
+# Override the default hook priority so that our copy of hook is used instead of NumPy's one (which has priority 0,
+# the default for upstream hooks).
+# $PyInstaller-Hook-Priority: 1
 
-from PyInstaller.compat import is_conda, is_pure_conda
-from PyInstaller.utils.hooks import collect_dynamic_libs, check_requirement
+from PyInstaller import compat
+from PyInstaller.utils.hooks import (
+    get_installer,
+    collect_dynamic_libs,
+)
 
-# Collect all DLLs inside numpy's installation folder, dump them into built app's root.
-binaries = collect_dynamic_libs("numpy", ".")
+from packaging.version import Version
 
-# If using Conda without any non-conda virtual environment manager:
-if is_pure_conda:
-    # Assume running the NumPy from Conda-forge and collect it's DLLs from the communal Conda bin directory. DLLs from
-    # NumPy's dependencies must also be collected to capture MKL, OpenBlas, OpenMP, etc.
+numpy_version = Version(compat.importlib_metadata.version("numpy")).release
+numpy_installer = get_installer('numpy')
+
+hiddenimports = []
+datas = []
+binaries = []
+
+# Collect shared libraries that are bundled inside the numpy's package directory. With PyInstaller 6.x, the directory
+# layout of collected shared libraries should be preserved (to match behavior of the binary dependency analysis). In
+# earlier versions of PyInstaller, it was necessary to collect the shared libraries into application's top-level
+# directory (because that was also what binary dependency analysis in PyInstaller < 6.0 did).
+binaries += collect_dynamic_libs("numpy")
+
+# Check if we are using Anaconda-packaged numpy
+if numpy_installer == 'conda':
+    # Collect DLLs for NumPy and its dependencies (MKL, OpenBlas, OpenMP, etc.) from the communal Conda bin directory.
     from PyInstaller.utils.hooks import conda_support
-    datas = conda_support.collect_dynamic_libs("numpy", dependencies=True)
+    datas += conda_support.collect_dynamic_libs("numpy", dependencies=True)
+
+# NumPy 1.26 started using `delvewheel` for its Windows PyPI wheels. While contemporary PyInstaller versions
+# automatically pick up DLLs from external `numpy.libs` directory, this does not work on Anaconda python 3.8 and 3.9
+# due to defunct `os.add_dll_directory`, which forces `delvewheel` to use the old load-order file approach. So we need
+# to explicitly ensure that load-order file as well as DLLs are collected.
+if compat.is_win and numpy_version >= (1, 26) and numpy_installer == 'pip':
+    from PyInstaller.utils.hooks import collect_delvewheel_libs_directory
+    datas, binaries = collect_delvewheel_libs_directory("numpy", datas=datas, binaries=binaries)
 
 # Submodules PyInstaller cannot detect (probably because they are only imported by extension modules, which PyInstaller
 # cannot read).
-hiddenimports = ['numpy.core._dtype_ctypes']
-if is_conda:
-    hiddenimports.append("six")
+if numpy_version >= (2, 0):
+    # In v2.0.0, `numpy.core` was renamed to `numpy._core`.
+    # See https://github.com/numpy/numpy/commit/47b70cbffd672849a5d3b9b6fa6e515700460fd0
+    hiddenimports += ['numpy._core._dtype_ctypes', 'numpy._core._multiarray_tests']
+else:
+    hiddenimports += ['numpy.core._dtype_ctypes']
+
+    # See https://github.com/numpy/numpy/commit/99104bd2d0557078d7ea9a590129c87dd63df623
+    if numpy_version >= (1, 25):
+        hiddenimports += ['numpy.core._multiarray_tests']
+
+# This hidden import was removed from NumPy hook in v1.25.0 (https://github.com/numpy/numpy/pull/22666). According to
+# comment in the linked PR, it should have been unnecessary since v1.19.
+if compat.is_conda and numpy_version < (1, 19):
+    hiddenimports += ["six"]
 
 # Remove testing and building code and packages that are referenced throughout NumPy but are not really dependencies.
 excludedimports = [
@@ -47,13 +91,22 @@ excludedimports = [
     "nose",
     "f2py",
     "setuptools",
-    "numpy.f2py",
 ]
 
-# As of version 1.22, numpy.testing (imported for example by some scipy modules) requires numpy.distutils and distutils.
+# As of v1.22, numpy.testing (imported for example by some scipy modules) requires numpy.distutils and distutils.
 # So exclude them only for earlier versions.
-if check_requirement("numpy < 1.22"):
+if numpy_version < (1, 22):
     excludedimports += [
         "distutils",
         "numpy.distutils",
+    ]
+
+# In numpy v2.0.0, numpy.f2py submodule has been added to numpy's `__all__` attribute. Therefore, using
+# `from numpy import *` leads to an error if `numpy.f2py` is excluded (seen in scipy 1.14). The exclusion in earlier
+# releases was not reported to cause any issues, so keep it around. Although it should be noted that it does break an
+# explicit import (i.e., ˙import numpy.f2py`) from user's code as well, because it prevents collection of other
+# submodules from `numpy.f2py`.
+if numpy_version < (2, 0):
+    excludedimports += [
+        "numpy.f2py",
     ]

--- a/PyInstaller/hooks/hook-numpy.py
+++ b/PyInstaller/hooks/hook-numpy.py
@@ -93,9 +93,13 @@ excludedimports = [
     "setuptools",
 ]
 
-# As of v1.22, numpy.testing (imported for example by some scipy modules) requires numpy.distutils and distutils.
-# So exclude them only for earlier versions.
-if numpy_version < (1, 22):
+# As of v1.22.0, numpy.testing (imported for example by some scipy modules) requires numpy.distutils and distutils.
+# This was due to numpy.testing adding import of numpy.testing._private.extbuild, which in turn imported numpy.distutils
+# and distutils. These imports were moved into functions that require them in v1.22.2 and v.1.23.0.
+# See: https://github.com/numpy/numpy/pull/20831 and https://github.com/numpy/numpy/pull/20906
+# So we can exclude them for all numpy versions except for v1.22.0 and v1.22.1 - the main motivation is to avoid pulling
+# in `setuptools` (which nowadays provides its vendored version of `distutils`).
+if numpy_version < (1, 22, 0) or numpy_version > (1, 22, 1):
     excludedimports += [
         "distutils",
         "numpy.distutils",

--- a/news/8736.bugfix.rst
+++ b/news/8736.bugfix.rst
@@ -1,0 +1,3 @@
+(Windows) Fix regression with PyInstaller 6.x and ``numpy`` < 1.26
+that resulted in duplicated shared libraries bundled with ``numpy``
+PyPI wheels.

--- a/news/8799.hooks.rst
+++ b/news/8799.hooks.rst
@@ -1,0 +1,19 @@
+Update and modernize PyInstaller's copy of ``numpy`` hook for compatibility
+with ``numpy`` 1.24.x, 1.25.x, 1.26x, and 2.x. Set the priority of
+PyInstaller's copy of ``numpy`` hook to 1 (using the new hook priority
+mechanism from :issue:`8740`), so that it overrides the upstream hook, in
+attempt to address the following issues:
+
+- fix duplication of shared libraries bundled with ``numpy`` < 1.26
+  PyPI wheels on Windows, which is caused by changed behavior of
+  PyInstaller's binary dependency analysis in PyInstaller 6.x (both the
+  old version of PyInstaller's numpy hook and its upstream counterpart
+  were written for behavior of v5 and earlier).
+
+- avoid triggering a warning about ``numpy`` base dist not being
+  found when using ``pip``-installed ``numpy`` with Anaconda python.
+
+- with ``numpy`` >= 1.26 on Windows, collect the load-order file from
+  ``numpy.libs`` directory (if available) along with the shared libraries.
+  This should minimize potential issues when using ``pip``-installed
+  ``numpy`` >= 1.26 with Anaconda python 3.8 and 3.9.


### PR DESCRIPTION
Update and modernize PyInstaller's copy of `numpy` hook:

- update for compatibility with `numpy` 1.24.x, 1.25.x, 1.26x, and 2.x, based on changes made in the upstream version of the hook (the original version of the hook was upstreamed in `numpy` 1.23.0 and updated there, while PyInstaller's copy was left unchanged).

- set the priority value of our copy of the hook to 1 (using the new hook priority mechanism from #8740), so that it overrides the upstream hook of all existing `numpy` releases.

- ensure dynamic libs from `numpy` package are collected into `numpy` directory, instead of top-level application directory. In PyInstaller 5.x and 4.x, collection into top-level application directory was necessary to prevent duplication with copies collected by binary dependency analysis; in 6.x, binary dependency analysis preserves the directory of discovered shared libraries, so explicit collection also needs to do the same to avoid duplication. Closes #8736.

- try collecting `numpy` libraries via `conda` helper functions only if installer metadata suggests that the `numpy` package was installed via Anaconda. This fixes warning about `numpy` base dist not being found when using `pip`-installed `numpy` with Anaconda python.

- if using `pip`-installed numpy >= 1.26 on Windows, explicitly collect `delvewheel`-created `numpy.libs` directory, including the load-order file, if available. This should minimize the chances of issues when using `pip`-installed `numpy` with Anaconda python 3.8 and 3.9.