### PR TITLE
bootloader: fix error when compiling bootloader under cygwin

### DIFF
--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -419,8 +419,7 @@ pyi_main(struct PYI_CONTEXT *pyi_ctx)
 
 #if defined(__CYGWIN__)
         /* Cygwin */
-        ret = cygwin_conv_path(CCP_POSIX_TO_WIN_W | CCP_RELATIVE, pyi_ctx->application_home_dir, dllpath_w, PYI_PATH_MAX);
-        if (ret != 0) {
+        if (cygwin_conv_path(CCP_POSIX_TO_WIN_W | CCP_RELATIVE, pyi_ctx->application_home_dir, dllpath_w, PYI_PATH_MAX) != 0) {
             PYI_PERROR("cygwin_conv_path", "Failed to convert DLL search path!\n");
             return -1;
         }

--- a/news/8814.bootloader.rst
+++ b/news/8814.bootloader.rst
@@ -1,0 +1,2 @@
+(Cygwin) Fix missing-variable-error when compiling bootloader under
+Cygwin (regression introduced in PyInstaller v6.8).


### PR DESCRIPTION
Fix error when compiling bootloader under cygwin, caused by missing variable (regression introduced during code refactor in PyInstaller v6.8 development cycle).

Fixes #8814.