### PR TITLE
Fixes for running PyInstaller as SYSTEM Windows user

### DIFF
--- a/PyInstaller/depend/utils.py
+++ b/PyInstaller/depend/utils.py
@@ -296,6 +296,11 @@ def _resolveCtypesImports(cbinaries):
             # 'W: library kernel32.dll required via ctypes not found'
             if not include_library(cbin):
                 continue
+            # On non-Windows, automatically ignore all ctypes-based referenes to DLL files. This complements the above
+            # check, which might not match potential case variations (e.g., `KERNEL32.dll`, instead of `kernel32.dll`)
+            # due to case-sensitivity of the matching that is in effect on non-Windows platforms.
+            if not compat.is_win and cbin.lower().endswith('.dll'):
+                continue
             logger.warning("Library %s required via ctypes not found", cbin)
         else:
             if not include_library(cpath):

--- a/news/8810.bugfix.rst
+++ b/news/8810.bugfix.rst
@@ -1,0 +1,3 @@
+(Windows) Fix binary dependency analysis for files found under
+SYSTEM user's home directory (``%WINDIR%\system32\config\systemprofile``)
+when running PyInstaller as SYSTEM user.

--- a/news/8816.bugfix.rst
+++ b/news/8816.bugfix.rst
@@ -1,0 +1,5 @@
+(Windows) Allow PyInstaller to be launched from SYSTEM user's home
+directory (``%WINDIR%\system32\config\systemprofile``) and its
+sub-directories, as an exception to general prohibition of running
+from Windows directory and its sub-directories (which was introduced
+in :issue:`8570`).


### PR DESCRIPTION
The first two commits in this PR are Windows-specific, and are motivated by #8810. While I generally question the wisdom of running PyInstaller under SYSTEM Windows user, as the OP put it, "sometimes things are out of your control" and there is little practical benefit of us blocking such scenario.

The first commit relaxes the prohibition of running PyInstaller from Windows directory to exempt the cases when running from user's home directory (or its sub-directories) that happens to be rooted under Windows directory (as is the case with SYSTEM user's `%WINDIR%\system32\config\systemprofile`). Also, replace the hard-coded `C:\Windows` with actual Windows directory (for example, if Windows happens to be installed on different drive).

Similarly, the second commit fixes binary dependency analysis for DLLs that are located in SYSTEM user's home directory; originally, we would ignore them due to being located in the Windows directory, but the user's home directory (and its sub-directories) should be exempt from that. Closes #8810.

The third commit cleans up the associated bindepend codebase a bit; in particular, it consolidates regex-list-matching classes (`ExcludeList`, `IncludeList`, and `MissingLibWarningSuppressionList`) into a single `MatchList`  class that receives the entries list via constructor argument instead of accessing global variable. Furthermore, have `MacExcludeList` and `WinExcludeList` classes inherit from `MatchList` instead of encapsulating it.

Lastly, explicitly ignore unresolved `ctypes`-based references to DLLs on non-Windows platforms; i.e., check if unresolved library name ends with `.dll` and automatically suppress the missing-ctypes-reference warning. This silences warnings about `KERNEL32.DLL` not being found (due to matching via include-list rules being case sensitive on non-Windows, this existing approach matched only `kernel32.dll`), but also about other DLLs that are valid in Windows context but not in non-Windows one (e.g., when freezing `torch`-based application on linux, there are also complaints about `vcruntime140.dll`, `vcruntime140_1.dll`, and `msvcp140.dll` `ctypes`-based references not being found.