### PR TITLE
bootloader: fix errors when compiling bootloader on AIX

### DIFF
--- a/bootloader/src/pyi_pythonlib.c
+++ b/bootloader/src/pyi_pythonlib.c
@@ -68,8 +68,8 @@ pyi_pylib_load(struct PYI_CONTEXT *pyi_ctx)
         pyver_minor = archive->python_version % 100;
 
         dll_name_len = snprintf(
-            dllname,
-            DLLNAME_LEN,
+            dll_name,
+            MAX_DLL_NAME_LEN,
             "libpython%d.%d.a(libpython%d.%d.so)",
             pyver_major,
             pyver_minor,

--- a/news/8819.bootloader.rst
+++ b/news/8819.bootloader.rst
@@ -1,0 +1,2 @@
+(AIX) Fix errors when compiling bootloader under AIX (regression
+introduced in PyInstaller v6.8).


### PR DESCRIPTION
Fix the variable names inside the `#ifdef AIX` block to match the new names used since bootloader code refactor in PyInstaller v6.8. Closes #8819.