### PR TITLE
bootloader/waf: Relax check for libdl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,6 +264,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
       - run: docker build -f alpine.dockerfile -t foo .
       - run: >
           docker run
@@ -276,7 +279,7 @@ jobs:
       - run: |
           git clean -xfdq .
           pip install build
-          python -m build --sdist --no-isolation --outdir dist
+          python -m build --sdist --outdir dist
           docker build --target=wheel-factory -t bar -f alpine.dockerfile .
       - run: |
           sdist="$(ls dist)"

--- a/.github/workflows/validate-new-news.yml
+++ b/.github/workflows/validate-new-news.yml
@@ -12,6 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
 
       - name: Validate new news items
         run: python scripts/verify-news-fragments.py

--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -611,12 +611,13 @@ def configure(ctx):
             ctx.check_cc(lib='advapi32', mandatory=True)
             ctx.check_cc(lib='gdi32', mandatory=True)
     else:
-        # Mac OS X and FreeBSD do not need libdl.
-        # https://stackoverflow.com/questions/20169660/where-is-libdl-so-on-mac-os-x
-        if ctx.env.DEST_OS not in ('darwin', 'freebsd', 'openbsd'):
-            ctx.check_cc(lib='dl', mandatory=True)
-            # libdl to be thread-safe requires libpthread!
-            ctx.check_cc(lib='pthread', mandatory=True)
+        # On most platforms, the libdl symbols are moved to libc. The POSIX
+        # standard states that libdl should always be linkable against, even if
+        # it's empty, but not all provide appropriate libdl.a stub archives.
+        # Treat it as optional.
+        ctx.check_cc(lib='dl', mandatory=False)
+        # libdl to be thread-safe requires libpthread! Assume it must be available if libdl is available.
+        ctx.check_cc(lib='pthread', mandatory=bool(ctx.env.LIB_DL))
         if ctx.env.DEST_OS == 'freebsd' and sysconfig.get_config_var('HAVE_PTHREAD_H'):
             # On FreeBSD if python has threads: libthr needs to be loaded in the main process, so the bootloader needs
             # to be link to thr.

--- a/news/7552.build.rst
+++ b/news/7552.build.rst
@@ -1,0 +1,4 @@
+Relax the check for ``libdl`` to accommodate platforms which put the ``libdl``
+symbols in ``libc`` but don't provide the placeholders needed to adhere to the
+POSIX requirement that ``-ldl`` should always be available, most notably
+OpenWRT.


### PR DESCRIPTION
OpenWRT joins macOS and FreeBSD in list of platforms that don't adhere to POSIX's requirement that libdl should always be linkable against. See #7552