### PR TITLE
Update CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,23 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.8, 3.9, '3.10', '3.11', '3.12', '3.13']
-        os: ['windows-latest', 'ubuntu-22.04', 'macos-14']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        os: ['windows-latest', 'ubuntu-22.04', 'macos-13', 'macos-14']
+        # Split macOS workflows between macos-13 (x86_64) and macos-14 (arm64)
+        # runners to cover both architectures without running all combinations.
+        exclude:
+          - python-version: '3.8'
+            os: 'macos-14'
+          - python-version: '3.10'
+            os: 'macos-14'
+          - python-version: '3.12'
+            os: 'macos-14'
+          - python-version: '3.9'
+            os: 'macos-13'
+          - python-version: '3.11'
+            os: 'macos-13'
+          - python-version: '3.13'
+            os: 'macos-13'
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.8, 3.9, '3.10', '3.11', '3.12', '3.13-dev']
+        python-version: [3.8, 3.9, '3.10', '3.11', '3.12', '3.13']
         os: ['windows-latest', 'ubuntu-22.04', 'macos-12']
       fail-fast: false
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.8, 3.9, '3.10', '3.11', '3.12', '3.13']
-        os: ['windows-latest', 'ubuntu-22.04', 'macos-12']
+        os: ['windows-latest', 'ubuntu-22.04', 'macos-14']
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/tests/functional/scripts/pyi_osx_aevent_logger_carbon.py
+++ b/tests/functional/scripts/pyi_osx_aevent_logger_carbon.py
@@ -36,7 +36,7 @@ class EventTypeSpec(ctypes.Structure):
 
 
 def _ctypes_setup():
-    carbon = ctypes.CDLL("/System/Library/Carbon.framework/Carbon")
+    carbon = ctypes.CDLL("/System/Library/Frameworks/Carbon.framework/Carbon")
 
     ae_callback = ctypes.CFUNCTYPE(ctypes.c_int, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p)
     carbon.AEInstallEventHandler.argtypes = [

--- a/tests/functional/test_apple_events.py
+++ b/tests/functional/test_apple_events.py
@@ -75,9 +75,9 @@ def _test_apple_events_handling(appname, tmpdir, pyi_builder_spec, monkeypatch, 
             time.sleep(polltime)
 
     # Generate unique URL scheme & file ext to avoid collisions.
-    unique_key = int(time.time())
-    custom_url_scheme = "pyi-test-%i" % unique_key
-    custom_file_ext = 'pyi_test_%i' % unique_key
+    unique_key = uuid.uuid4()
+    custom_url_scheme = f"pyi-test-{unique_key}"
+    custom_file_ext = f"pyi_test_{unique_key}"
     monkeypatch.setenv("PYI_CUSTOM_URL_SCHEME", custom_url_scheme)
     monkeypatch.setenv("PYI_CUSTOM_FILE_EXT", custom_file_ext)
     monkeypatch.setenv("PYI_BUILD_MODE", build_mode)
@@ -105,7 +105,7 @@ def _test_apple_events_handling(appname, tmpdir, pyi_builder_spec, monkeypatch, 
     # re-using the same path (even though the preceding test's contents were removed) may cause issues with app bundle
     # registration...
     old_dist = os.path.join(tmpdir, 'dist')
-    new_dist = os.path.join(tmpdir, f'dist-{uuid.uuid4()}')
+    new_dist = os.path.join(tmpdir, f'dist-{unique_key}')
 
     os.rename(old_dist, new_dist)
 

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -28,8 +28,8 @@ numpy==2.1.2; python_version >= '3.10'
 pandas==2.2.3; python_version >= '3.9'
 pygments==2.18.0
 PyGObject==3.50.0; sys_platform == 'linux' and python_version >= '3.9'
-# Official PySide2 wheels do not support python 3.11 or newer
-PySide2==5.15.2.1; python_version < '3.11'
+# Official PySide2 wheels do not support python 3.11 or newer. Nor are they available for arm64 on macOS.
+PySide2==5.15.2.1; python_version < '3.11' and (sys_platform != 'darwin' or platform_machine != 'arm64')
 # PySide6 is a metapackage that depends on PySide6-Essentials and PySide6-Addons. Their versions are
 # usually kept in sync.
 PySide6==6.7.3; python_version >= '3.9' and python_version < '3.13'

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -32,9 +32,9 @@ PyGObject==3.50.0; sys_platform == 'linux' and python_version >= '3.9'
 PySide2==5.15.2.1; python_version < '3.11'
 # PySide6 is a metapackage that depends on PySide6-Essentials and PySide6-Addons. Their versions are
 # usually kept in sync.
-PySide6==6.7.3; python_version >= '3.9'
-PySide6-Addons==6.7.3; python_version >= '3.9'
-PySide6-Essentials==6.7.3; python_version >= '3.9'
+PySide6==6.7.3; python_version >= '3.9' and python_version < '3.13'
+PySide6-Addons==6.7.3; python_version >= '3.9' and python_version < '3.13'
+PySide6-Essentials==6.7.3; python_version >= '3.9' and python_version < '3.13'
 # PyQt5 and add-on packages
 # We do not pin *-Qt5 packages (which contain Qt shared libraries), as Qt5 is not actively developed
 # anymore, and thus 5.15.x has a stable ABI. Plus, it seems that *-Qt5 5.15.2 wheels are available for

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -20,9 +20,7 @@ Django==5.1.1; python_version >= '3.10'
 future==1.0.0
 gevent==24.2.1; python_version < '3.13'
 ipython==8.28.0; python_version >= '3.10'
-# keyring >= 23.1 requires python >= 3.8.7 on macOS 11 and later (with dyld shared cache support)
-keyring==23.0.1; sys_platform == 'darwin' and python_version < '3.8.7'  # pyup: ignore
-keyring==25.4.1; sys_platform != 'darwin' or python_version >= '3.8.7'
+keyring==25.4.1
 matplotlib==3.9.2; python_version >= '3.9'
 numpy==2.1.2; python_version >= '3.10'
 pandas==2.2.3; python_version >= '3.9'

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -18,7 +18,7 @@ importlib_resources==6.4.5; python_version < '3.9'
 babel==2.16.0
 Django==5.1.1; python_version >= '3.10'
 future==1.0.0
-gevent==24.2.1
+gevent==24.2.1; python_version < '3.13'
 ipython==8.28.0; python_version >= '3.10'
 # keyring >= 23.1 requires python >= 3.8.7 on macOS 11 and later (with dyld shared cache support)
 keyring==23.0.1; sys_platform == 'darwin' and python_version < '3.8.7'  # pyup: ignore


### PR DESCRIPTION
Make python 3.13 first-class citizen of our `tests` CI workflow; i.e., upgrade from `3.13-dev` to `3.13` to run with all libraries. Well, except `gevent` and `PySide6`, which do not support python 3.13 yet.

`macos-12` runner is being phased out, so switch to a newer one. `macos-14` is arm64 and is *significantly* faster than x86_64-based `macos-12` or `macos-13`. 

However, it might be a good idea to retain at least some tests with x86_64 - in that case, we will need to also add at least some `macos-13` runners. Perhaps run python <= 3.10 with macos-13 and python > 3.10 with macos-14, or something along those lines, to avoid running all versions on both (which is slow again - see [here](https://github.com/rokm/pyinstaller/actions/runs/11278858588)). As a side note, trying to run x86_64 python through rosetta2 on macos-14 has no speed benefit over macos-13 (see [here](https://github.com/rokm/pyinstaller/actions/runs/11274181176)), and it brings additional problems (the test failures are presumably due to lack of Homebrew-provided x86_64 OpenSSL library).