### PR TITLE
hooks: add hook for PySide6.QtGraphWidget

### DIFF
--- a/PyInstaller/hooks/hook-PySide6.QtGraphsWidgets.py
+++ b/PyInstaller/hooks/hook-PySide6.QtGraphsWidgets.py
@@ -1,0 +1,17 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2024, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks.qt import add_qt6_dependencies
+
+hiddenimports, binaries, datas = add_qt6_dependencies(__file__)
+
+# These dependencies cannot seem to be inferred from linked libraries.
+hiddenimports += ['PySide6.QtQuickWidgets', 'PySide6.QtGraphs']

--- a/news/8828.hooks.rst
+++ b/news/8828.hooks.rst
@@ -1,0 +1,2 @@
+Add hook for ``PySide6.QtGraphsWidgets``, which was introduced with
+``PySide6`` v6.8.0.

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -30,9 +30,9 @@ PyGObject==3.50.0; sys_platform == 'linux' and python_version >= '3.9'
 PySide2==5.15.2.1; python_version < '3.11' and (sys_platform != 'darwin' or platform_machine != 'arm64')
 # PySide6 is a metapackage that depends on PySide6-Essentials and PySide6-Addons. Their versions are
 # usually kept in sync.
-PySide6==6.7.3; python_version >= '3.9' and python_version < '3.13'
-PySide6-Addons==6.7.3; python_version >= '3.9' and python_version < '3.13'
-PySide6-Essentials==6.7.3; python_version >= '3.9' and python_version < '3.13'
+PySide6==6.8.0; python_version >= '3.9' and python_version < '3.13'
+PySide6-Addons==6.8.0; python_version >= '3.9' and python_version < '3.13'
+PySide6-Essentials==6.8.0; python_version >= '3.9' and python_version < '3.13'
 # PyQt5 and add-on packages
 # We do not pin *-Qt5 packages (which contain Qt shared libraries), as Qt5 is not actively developed
 # anymore, and thus 5.15.x has a stable ABI. Plus, it seems that *-Qt5 5.15.2 wheels are available for


### PR DESCRIPTION
Add hook for `PySide6.QtGraphWidget`, which was added in PySide6 v6.8.0 and has a hidden dependency on `PySide6.QtQuickWidgets`.