### PR TITLE
ci: Increase pytest-xdist forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,7 @@ jobs:
         id: run-tests
         run: >
             pytest
-            -n 3 --maxfail 3 --durations 10 tests/unit tests/functional
+            -n 5 --maxfail 3 --durations 10 tests/unit tests/functional
 
       # On all platforms, create a tarball to ensure that symlinks are preserved. Avoid using compression here,
       # as the tarball will end up collected into artifact zip archive.
@@ -287,7 +287,7 @@ jobs:
           docker run
           foo
           pytest
-          -n 3 --maxfail 3 --durations 10 tests/unit tests/functional
+          -n 5 --maxfail 3 --durations 10 tests/unit tests/functional
 
       # Verify that installing from sdist works. This is mostly just a verification that the MANIFEST.in contains
       # all the extras needed to compile the bootloader.
@@ -363,4 +363,4 @@ jobs:
       - name: Run tests
         run: >
             pytest
-            -n 3 --maxfail 3 --durations 10 tests/unit tests/functional
+            -n 5 --maxfail 3 --durations 10 tests/unit tests/functional


### PR DESCRIPTION
At some point, the standard GitHub Actions runners switched from having two CPU cores each to (usually) four. Take advantage of them.