### PR TITLE
docs: slightly extend the docs about macOS multi-arch support [skip ci]

### DIFF
--- a/PyInstaller/utils/osx.py
+++ b/PyInstaller/utils/osx.py
@@ -290,7 +290,9 @@ class IncompatibleBinaryArchError(Exception):
     """
     Exception raised by `binary_to_target_arch` when the passed binary fails the strict architecture check.
     """
-    pass
+    def __init__(self, message):
+        url = "https://pyinstaller.org/en/stable/feature-notes.html#macos-multi-arch-support"
+        super().__init__(f"{message} For details about this error message, see: {url}")
 
 
 def get_binary_architectures(filename):

--- a/doc/feature-notes.rst
+++ b/doc/feature-notes.rst
@@ -297,15 +297,27 @@ Architecture validation during binary collection
 
 To prevent run-time issues caused by missing or mismatched architecture slices
 in binaries, the binary collection process performs strict architecture validation.
-It checks whether collected binary files contain required arch slice(s), and if
-not, the build process is aborted with an error message about the problematic
-binary.
+It checks whether collected binary files contain required arch slice(s) -- if
+not, the build process is aborted with exception of type
+``PyInstaller.utils.osx.IncompatibleBinaryArchError`` that contains a
+detailed error message about the problematic binary.
+
+The error message will typically be either ``"{name} does not contain
+slice for {target_arch}!"`` (when trying to build a ``universal2`` program
+and the collected binary is a thin single-arch file) or ``"{name} is
+incompatible with target arch {target_arch} (has arch: ...)!"`` (when
+trying to build program for foreign architecture in a partial ``universal2``
+environment and the collected binary is a thin single-arch file for the
+non-target architecture).
 
 In such cases, creating frozen application for the selected target
 architecture will not be possible unless the problem of missing arch slices
-is manually addressed (for example, by downloading the wheel corresponding to
+is manually addressed; for example, by downloading the wheel corresponding to
 the missing architecture, and stiching the offending binary files together
-using the ``lipo`` utility).
+using the ``lipo`` utility. You can also use 3rd party utilities, such as
+``delocate-merge`` from the `delocate <https://pypi.org/project/delocate>`_
+project, to merge two single-arch wheels for a package into a ``universal2``
+wheel, and then install the merged wheel into your build environment.
 
 .. versionchanged:: 4.10
    In earlier PyInstaller versions, the architecture validation was performed


### PR DESCRIPTION
In the documentation section about macOS multi-arch support, mention the `IncompatibleBinaryArchError` exception by name - to increase the chances of the text being returned by ~search engines~ chatbots. Also mention the two most likely error messages, for the same reason.

Mention `delocate-merge` from the `delocate` project as a viable alternative to manually stitching binaries using `lipo`. This one has been kind of on my TODO list ever since someone mentioned it in our issue tracker, but I never really got around to adding it.