### PR TITLE
bindepend: reorder fall-back options in python shared library search

### DIFF
--- a/news/8850.bugfix.rst
+++ b/news/8850.bugfix.rst
@@ -1,0 +1,3 @@
+(Linux) Fix discovery and collection of Python shared library when using
+``uv``-installed or ``rye``-installed Python that happens to be of same
+version as the system-installed Python.


### PR DESCRIPTION
Reorder fall-back options in `get_python_library_path` when we fail to discover python shared library via dependency analysis on python interpreter executable.

In  particular, make sure that we search standard library search paths only after all other options are exhausted (specifically, after looking in `sys.base_prefix` and the `lib` directory under `sys.base_prefix`).

This prevents us from incorrectly picking up shared library from system-installed python that happens to be of same version as the used `uv`-installed or `rye`-installed python.

This should close #8802 and #8848 even without extending bindepend to handle full path of the `NEEDED` entry in ELF header (see https://github.com/pyinstaller/pyinstaller/issues/8802#issuecomment-2370754076).