### PR TITLE
_pyi_rth_utils: fix path matching in prepend_path_to_environment_variable

### DIFF
--- a/PyInstaller/fake-modules/_pyi_rth_utils/__init__.py
+++ b/PyInstaller/fake-modules/_pyi_rth_utils/__init__.py
@@ -24,8 +24,10 @@ def prepend_path_to_environment_variable(path, variable_name):
     """
     stored_paths = os.environ.get(variable_name)
     if stored_paths:
-        # If path is already included, make this a no-op.
-        if path in stored_paths:
+        # If path is already included, make this a no-op. NOTE: we need to split the string and search in the list of
+        # substrings to find an exact match; searching in the original string might erroneously match a prefix of a
+        # longer (i.e., sub-directory) path when such entry already happens to be in PATH (see #8857).
+        if path in stored_paths.split(os.pathsep):
             return
         # Otherwise, prepend the path
         stored_paths = path + os.pathsep + stored_paths

--- a/news/8857.bugfix.rst
+++ b/news/8857.bugfix.rst
@@ -1,0 +1,7 @@
+(Windows) Fix Qt run-time hooks failing to add the top-level application
+directory to ``PATH`` when the latter already contains a sub-directory
+of the top-level application directory (for example, ``pywin32_system32``
+sub-directory added to ``PATH`` by ``pywin32`` run-time hook). This
+failure prevented QtNetwork from discovering bundled OpenSSL DLLs, and 
+caused it to (attempt to) load them from other locations that happened
+to be in ``PATH``.


### PR DESCRIPTION
Fix path matching in `_pyi_rth_utils.prepend_path_to_environment_variable` when trying to determine if the given path is already stored in the target environment variable. Instead of checking for occurrence of the given path within the environment variable's value, we need to split the value on `os.pathsep` and search the resulting list of paths. This ensures that we match only the exact (full) path, instead of erroneously matching a prefix of a longer path (i.e., to a sub-directory of the given path) that already happens to be among the stored paths.

This fixes the problem with Qt run-time hooks failing to add the top-level application directory to `PATH` (necessary for `QtNetwork` to discover the bundled OpenSSL DLLs) when the `pywin32` run-time hook alreayd added the path to bundled `pywin32_system32` directory to `PATH`.

Fixes #8857.