### PR TITLE
Fix .icns files being omitted from macOS wheels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,21 +145,24 @@ jobs:
             python waf --tests --target-arch=64bit-arm all
             ls ../PyInstaller/bootloader/Windows-64bit-arm
 
+      - name: Update pip
+        run: python -m pip install --upgrade pip setuptools wheel build
+
+      - name: Compile bootloader
+        run: cd bootloader && python waf --tests all
+
+      - name: Download dependencies
+        run: pip download --dest=dist .[completion] && rm -f dist/pyinstaller-*.whl
+        shell: bash
+
+      - name: Build wheels
+        run: sh release/build-wheels
+
       - name: Install PyInstaller
-        run: |
-          # Update pip.
-          python -m pip install --upgrade pip setuptools wheel
+        run: pip install --no-index --find-links=dist pyinstaller[completion]
 
-          # Compile bootloader
-          cd bootloader
-          python waf --tests all
-          cd ..
-
-          # Install PyInstaller.
-          pip install --progress-bar=off .[completion]
-
-          # Make sure the help options print.
-          python -m PyInstaller -h
+      - name: Check pyinstaller --help
+        run: python -m PyInstaller -h
 
       - name: Install test dependencies (base tools)
         run: |

--- a/news/8855.bugfix.rst
+++ b/news/8855.bugfix.rst
@@ -1,0 +1,2 @@
+Fix macOS's default icons being missing from wheels (regression introduced in
+v6.11.0)

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ class Wheel(bdist_wheel):
 
         if self.pyi_platform:
             if "Darwin" in self.pyi_platform:
-                icons = ["incs"]
+                icons = ["icns"]
             elif "Windows" in self.pyi_platform:
                 icons = ["ico"]
             else:

--- a/tests/unit/test_normalize_icon_type.py
+++ b/tests/unit/test_normalize_icon_type.py
@@ -16,7 +16,6 @@ from pathlib import Path
 
 import pytest
 
-import PyInstaller
 from PyInstaller.building.icon import normalize_icon_type
 
 
@@ -32,7 +31,7 @@ def test_normalize_icon(monkeypatch, tmp_path):
 
     # Native image - file path is passed through unchanged
 
-    icon = str(Path(PyInstaller.__file__).with_name("bootloader") / "images" / 'icon-console.ico')
+    icon = str(Path(__file__, "../../functional/data/set_icon/pyi_icon.ico").resolve())
     ret = normalize_icon_type(icon, ("ico",), "ico", workpath)
     if ret != icon:
         pytest.fail("icon validation changed path even though the format was correct already", False)


### PR DESCRIPTION
Also switch CI to install from "realistic" wheels (built with the platform specific contents filtering enabled) in an attempt to minimise this happening again.

Fixes #8855