### PR TITLE
bindepend: Handle binaries linked using $ORIGIN

### DIFF
--- a/PyInstaller/hooks/hook-matplotlib.backend_bases.py
+++ b/PyInstaller/hooks/hook-matplotlib.backend_bases.py
@@ -1,0 +1,12 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2024, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+excludedimports = ['IPython']

--- a/PyInstaller/hooks/hook-matplotlib.pyplot.py
+++ b/PyInstaller/hooks/hook-matplotlib.pyplot.py
@@ -1,0 +1,12 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2024, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+excludedimports = ['IPython', "IPython.core.pylabtools"]

--- a/PyInstaller/hooks/pre_find_module_path/hook-tkinter.py
+++ b/PyInstaller/hooks/pre_find_module_path/hook-tkinter.py
@@ -1,0 +1,21 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2024, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+from PyInstaller import log as logging
+from PyInstaller.utils.hooks import tcl_tk
+
+logger = logging.getLogger(__name__)
+
+
+def pre_find_module_path(hook_api):
+    if not tcl_tk.tcltk_info.available:
+        logger.warning("tkinter installation is broken. It will be excluded from the application")
+        hook_api.search_dirs = []

--- a/news/8868.bugfix.1.rst
+++ b/news/8868.bugfix.1.rst
@@ -1,0 +1,1 @@
+(Linux/musl) Prevent ``ld-musl-x86_64.so.1`` from being collected.

--- a/news/8868.bugfix.2.rst
+++ b/news/8868.bugfix.2.rst
@@ -1,0 +1,1 @@
+Prevent :mod:`tkinter` from being collected if it is unusable.

--- a/news/8868.bugfix.rst
+++ b/news/8868.bugfix.rst
@@ -1,0 +1,1 @@
+(GNU/Linux) Fix resolving binary dependencies linked using ``$ORIGIN``.

--- a/news/8868.hooks.rst
+++ b/news/8868.hooks.rst
@@ -1,0 +1,2 @@
+Prevent ``IPython`` from being packaged redundantly if ``matplotlib`` is
+imported.


### PR DESCRIPTION
Following on from https://github.com/pyinstaller/pyinstaller/pull/8850#pullrequestreview-2397500788 and #8848