### PR TITLE
Improve behavior of tests under CPU contention scenarios

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,7 @@ jobs:
         id: run-tests
         run: >
             pytest
-            -n 3 --maxfail 3 --durations 10 tests/unit tests/functional
+            -n 5 --maxfail 3 --durations 10 tests/unit tests/functional
 
       # On all platforms, create a tarball to ensure that symlinks are preserved. Avoid using compression here,
       # as the tarball will end up collected into artifact zip archive.
@@ -287,7 +287,7 @@ jobs:
           docker run
           foo
           pytest
-          -n 3 --maxfail 3 --durations 10 tests/unit tests/functional
+          -n 5 --maxfail 3 --durations 10 tests/unit tests/functional
 
       # Verify that installing from sdist works. This is mostly just a verification that the MANIFEST.in contains
       # all the extras needed to compile the bootloader.
@@ -363,4 +363,4 @@ jobs:
       - name: Run tests
         run: >
             pytest
-            -n 3 --maxfail 3 --durations 10 tests/unit tests/functional
+            -n 5 --maxfail 3 --durations 10 tests/unit tests/functional

--- a/bootloader/src/pyi_utils.h
+++ b/bootloader/src/pyi_utils.h
@@ -75,9 +75,9 @@ void pyi_win32_hide_console();
 void pyi_win32_minimize_console();
 #endif
 
-/* Force-unload of bundled DLLs from onefile parent process (Windows only) */
+/* Attempt to mitigate locked files in temporary directory that prevent its removal. */
 #if defined(_WIN32)
-void pyi_win32_force_unload_bundled_dlls(struct PYI_CONTEXT *pyi_ctx);
+int pyi_win32_mitigate_locked_temporary_directory(const struct PYI_CONTEXT *pyi_ctx);
 #endif
 
 /* Windows low-level helpers */

--- a/news/8870.bugfix.rst
+++ b/news/8870.bugfix.rst
@@ -1,0 +1,4 @@
+(Windows) Add a retry loop to ``onefile`` temporary directory cleanup
+as an attempt to mitigate situations when bundled DLLs and python
+extension modules remain locked by the OS and/or anti-virus program
+for a short while after the application process exits.

--- a/tests/functional/scripts/pyi_multiprocessing_nested_process.py
+++ b/tests/functional/scripts/pyi_multiprocessing_nested_process.py
@@ -46,8 +46,14 @@ def main(start_method):
     while not queue.empty():
         results.append(queue.get())
 
+    # NOTE: as per [1]: "If multiple processes are enqueuing objects, it is possible for the objects to be received at
+    # the other end out-of-order. However, objects enqueued by the same process will always be in the expected order
+    # with respect to each other."
+    # [1] https://docs.python.org/3/library/multiprocessing.html#pipes-and-queues
+    #
+    # Therefore, accept either order of results as a valid one.
     print(f"Results: {results}")
-    assert results == [1, 2]
+    assert results == [1, 2] or results == [2, 1]
 
 
 if __name__ == '__main__':

--- a/tests/functional/test_signals.py
+++ b/tests/functional/test_signals.py
@@ -33,13 +33,16 @@ def test_onefile_signal_handling(pyi_builder, forward_signals):
 
         # Quietly exit if no signal number is given on command-line. This accommodates the fact that
         # `pyi_builder.test_source()` always runs the program after building it.
-        if len(sys.argv) < 2:
-            print(f"Usage: {sys.argv[0]} <signal-number>", file=sys.stderr)
+        if len(sys.argv) < 3:
+            print(f"Usage: {sys.argv[0]} <signal-number> <timeout>", file=sys.stderr)
             sys.exit(0)
 
-        # Signal number is passed as first command-line argument
+        # Signal number is passed as the first command-line argument
         signal_number = int(sys.argv[1])
         signal_name = signal.Signals(signal_number).name  # This implicitly validates signal number
+
+        # Timeout is passed as the second command-line argument
+        timeout = float(sys.argv[2])
 
         # Return code: received signal number, or zero if signal was not received.
         return_code = 0
@@ -60,14 +63,16 @@ def test_onefile_signal_handling(pyi_builder, forward_signals):
         )
         os.kill(parent_pid, signal_number)
 
-        # Wait up to a second for signal to be delivered.
-        for i in range(10):
+        # Wait for signal to be delivered or the specified timeout interval to pass.
+        start_time = time.time()
+        while True:
+            if time.time() - start_time >= timeout:
+                print(f"Signal not received within {timeout} seconds!", file=sys.stderr)
+                break
             if return_code != 0:
                 print("Signal received!", file=sys.stderr)
                 break
-            time.sleep(0.1)
-        else:
-            print("Signal not received!", file=sys.stderr)
+            time.sleep(0.1)  # 100 ms steps
 
         sys.exit(return_code)
         """,
@@ -100,9 +105,19 @@ def test_onefile_signal_handling(pyi_builder, forward_signals):
         # Expected return code: signal number in signal-forwarding mode, zero otherwise.
         expected_code = signal_number if forward_signals else 0
 
+        # Timeout interval when waiting for signal to be delivered (or not): in signal-forwarding mode, wait up to 5
+        # seconds, to be on the safe side and avoid sporadic test failures. The initial 1-second interval is sometimes
+        # too short when running tests under CPU contention scenario (number of pytest runners matching or exceeding
+        # number of CPU cores). Since the test program exits as soon as signal is received, we expect to never hit this
+        # 5-seconds limit. In contrast, when in signal-ignoring mode, we need to wait for the whole interval to see that
+        # the signal is not delivered. In this case, we stick with original 1-second timeout to avoid unnecessarily
+        # slowing down the test; as mentioned earlier, we expect signals to be delivered within 1 second for most of the
+        # time, so if ignore mode was broken, at least some tests would fail.
+        timeout = 5 if forward_signals else 1  # seconds
+
         # Run
         print(f"=== running test with {signal_name} ===", file=sys.stderr)
-        status = subprocess.run([program_exe, str(signal_number)])
+        status = subprocess.run([program_exe, str(signal_number), str(timeout)])
         ret_code = status.returncode
 
         print(f"=== program returned code {ret_code} (expected {expected_code}) ===", file=sys.stderr)


### PR DESCRIPTION
This PR resurrects #8829; not for the speed-up gains, but to introduce CPU contention scenario. This in turn flushes out some undesired behavior (both in the test suite and in the frozen application/bootloader - see https://github.com/pyinstaller/pyinstaller/pull/8829#issuecomment-2411758489), which we aim to fix here.

- `test_multiprocessing_nested_process` should not assume the order of results in the pipe, as it is [not guaranteed when multiple processes are enqueuing objects](https://docs.python.org/3/library/multiprocessing.html#pipes-and-queues). This test failure is not really tied to CPU contention and could be seen on the CI every now and then (e.g., [here](https://github.com/pyinstaller/pyinstaller/actions/runs/11759270035/job/32758556572)).

- in onefile POSIX codepath, install signal handler before forking the child process. This fixes a race condition that is probably specific to `test_onefile_signal_handling` (where we signal the onefile parent from the child). In addition, increase the wait time in signal-forwarding variant of `test_onefile_signal_handling` from 1s to 5s in an attempt to ensure that we always wait for signal to be delivered (in signal-blocking variant it is left at 1s because there we need to wait for the whole period, and we do not want to slow down the test).

- rework and extend the Windows-specific mitigation when onefile temporary directory cannot be removed. First, if no DLLs were force-unloaded from the parent process, do not attempt to repeat the removal again (at that step of mitigation), since it is very unlikely it will succeed. Improve debug messages of this decision process to make the run-time log easier to follow. Add a retry loop, where we try to remove the temporary directory multiple times with 1-second delays in between. On our CI, this mitigates issues with `QtWebEngineProcess.exe` helper of QtWebEngine-based frozen tests being slow to shut down in CPU contention scenario, and still locking its files after application process exits and the parent process enters cleanup. A similar issue was reported when running x64 applications under arm64 Windows (#8837) - I've reproduced this one and can confirm that retry loop fixes the problem. It should also close #8866, which appears to be the same kind of issue (although the context is not fully clear, and I have not been able to reproduce it locally).

