### PR TITLE
bootloader: fix race condition responsible for test_onefile_signal_handling failures

### DIFF
--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -73,7 +73,7 @@ static struct PYI_CONTEXT _pyi_ctx;
 
 /* Pointer to global PYI_CONTEXT structure. Intended for use in signal
  * handlers that have no user data / context */
-struct PYI_CONTEXT *global_pyi_ctx = &_pyi_ctx;
+struct PYI_CONTEXT *const global_pyi_ctx = &_pyi_ctx;
 
 
 /* Large parts of `pyi_main` are implemented as helper functions. We

--- a/bootloader/src/pyi_main.h
+++ b/bootloader/src/pyi_main.h
@@ -221,6 +221,19 @@ struct PYI_CONTEXT
      * once the temporary directory has been cleaned up. */
     int child_signalled;
     int child_signal;
+
+#if defined(LAUNCH_DEBUG)
+    /* Basic statistics for forwarding signal handler:
+     *  - number of received signals (number of times the handler was called)
+     *  - number of successfully forwarded signals
+     *  - number of errors during forwarding (number of failed kill() calls)
+     *  - number of no-op handler calls (with invalid child_pid).
+     * All members are volatile due to being modified in signal handler. */
+    volatile unsigned int signal_forward_all;
+    volatile unsigned int signal_forward_ok;
+    volatile unsigned int signal_forward_error;
+    volatile unsigned int signal_forward_noop;
+#endif /* defined(LAUNCH_DEBUG) */
 #endif
 
     /**

--- a/bootloader/src/pyi_main.h
+++ b/bootloader/src/pyi_main.h
@@ -286,7 +286,7 @@ struct PYI_CONTEXT
 #endif
 };
 
-extern struct PYI_CONTEXT *global_pyi_ctx;
+extern struct PYI_CONTEXT *const global_pyi_ctx;
 
 
 int pyi_main(struct PYI_CONTEXT *pyi_ctx);

--- a/bootloader/src/pyi_main.h
+++ b/bootloader/src/pyi_main.h
@@ -203,14 +203,18 @@ struct PYI_CONTEXT
 
     /* CTRL_CLOSE_EVENT, CTRL_SHUTDOWN_EVENT, or CTRL_LOGOFF_EVENT
      * received via installed console handler. */
-    unsigned char console_shutdown;
+    /* NOTE: marked as volatile because it is set in installed console
+     * handler, and read in the main codepath. */
+    volatile unsigned char console_shutdown;
 
     /* WM_QUERYENDSESSION received via hidden window. */
     unsigned char session_shutdown;
 #else
     /* Process ID of the child process (onefile mode). Keeping track of
      * the child PID allows us to forward signals to the child. */
-    pid_t child_pid;
+    /* NOTE: marked as volatile because it is read in the POSIX signal
+     * handler. */
+    volatile pid_t child_pid;
 
     /* Remember whether child has received a signal and what signal it was.
      * In onefile mode, this allows us to re-raise the signal in the parent

--- a/bootloader/src/pyi_utils_posix.c
+++ b/bootloader/src/pyi_utils_posix.c
@@ -491,6 +491,7 @@ _ignoring_signal_handler(int signum)
 static void
 _signal_handler(int signum)
 {
+    int original_errno = errno; /* Store original errno */
     pid_t child_pid = global_pyi_ctx->child_pid; /* Read from volatile global variable */
 
     /* Forward signal to the child. Avoid generating debug messages, as
@@ -503,6 +504,8 @@ _signal_handler(int signum)
         return;
     }
     kill(child_pid, signum);
+
+    errno = original_errno; /* Restore original errno */
 }
 
 /* Start frozen application in a subprocess. The frozen application runs

--- a/tests/functional/test_signals.py
+++ b/tests/functional/test_signals.py
@@ -66,11 +66,12 @@ def test_onefile_signal_handling(pyi_builder, forward_signals):
         # Wait for signal to be delivered or the specified timeout interval to pass.
         start_time = time.time()
         while True:
-            if time.time() - start_time >= timeout:
+            elapsed_time = time.time() - start_time
+            if elapsed_time >= timeout:
                 print(f"Signal not received within {timeout} seconds!", file=sys.stderr)
                 break
             if return_code != 0:
-                print("Signal received!", file=sys.stderr)
+                print(f"Signal received! Elapsed time: {elapsed_time:.2f} seconds.", file=sys.stderr)
                 break
             time.sleep(0.1)  # 100 ms steps
 


### PR DESCRIPTION
This PR aims to properly fix the sporadic failures of `test_onefile_signal_handling` when running under CPU contention scenario (which I deliberately introduced via d0d767b4ca0df9ef39ccd11958b8fecea4df2356 in #8870).

This was previously attempted in 235f6b97368d0ae58c4bf65953c391b0522fee36 by moving signal handler setup before the `fork()`. But even so, the signal handlers still need to be "activated" by having the child process PID available in `pyi_ctx->child_pid` variable. It might just so happen that the parent process is stalled after `fork()` creates the child process, but before it returns, or before its return value is recorded. If that stall is sufficiently long, the child might go ahead and execute the test code while signal handlers are (albeit installed) still inactive.

The series of initial commits adds additional diagnostic messages to both the test and bootloader that allows us to debug the issue. We also ensure that variables used in signal handler and in Windows console handler are marked as volatile, just to ensure that the issue is not caused by compiler getting in our way (especially if building bootloader at higher optimization levels than we do by default).

These allow us to [confirm](https://github.com/rokm/pyinstaller/actions/runs/11996456754/job/33440919581#step:25:4922) that the issue is indeed caused by still-inactive signal handlers.

The solution is to create a semaphore shared between the parent and the child process:
- the child waits on it immediately after the `fork()`
- the parent sets up the signal handlers and activates them (by storing child PID), and signals the semaphore
This way, the test python code should never run before the signal handlers in the process are fully ready. The use of explicit sync also allows us to move signal handler setup after the `fork()` call again. This saves us from having to explain why it was done before the `fork` (although we now instead need a comment explaining the existence of the semaphore...).
