### PR TITLE
hooks: add hooks for PyQt6.QtGraphs and PyQt6.QtGraphsWidgets

### DIFF
--- a/PyInstaller/hooks/hook-PyQt6.QtGraphs.py
+++ b/PyInstaller/hooks/hook-PyQt6.QtGraphs.py
@@ -1,0 +1,17 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2024, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks.qt import add_qt6_dependencies
+
+hiddenimports, binaries, datas = add_qt6_dependencies(__file__)
+
+# These dependencies cannot seem to be inferred from linked libraries.
+hiddenimports += ['PyQt6.QtNetwork', 'PyQt6.QtQml']

--- a/PyInstaller/hooks/hook-PyQt6.QtGraphsWidgets.py
+++ b/PyInstaller/hooks/hook-PyQt6.QtGraphsWidgets.py
@@ -1,0 +1,17 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2024, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks.qt import add_qt6_dependencies
+
+hiddenimports, binaries, datas = add_qt6_dependencies(__file__)
+
+# These dependencies cannot seem to be inferred from linked libraries.
+hiddenimports += ['PyQt6.QtGraphs', 'PyQt6.QtQuickWidgets']

--- a/news/8924.hooks.rst
+++ b/news/8924.hooks.rst
@@ -1,0 +1,2 @@
+Add hooks for ``PyQt6.QtGraphs`` and ``PyQt6.QtGraphsWidgets`` that
+were introduced in ``PyQt6`` v6.8.1 (via ``PyQt6-Graphs`` add-on package).

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -60,6 +60,8 @@ PyQt6-Charts==6.8.0; python_version >= '3.9'
 PyQt6-Charts-Qt6==6.8.1; python_version >= '3.9'
 PyQt6-DataVisualization==6.8.0; python_version >= '3.9'
 PyQt6-DataVisualization-Qt6==6.8.1; python_version >= '3.9'
+PyQt6-Graphs==6.8.0; python_version >= '3.9'
+PyQt6-Graphs-Qt6==6.8.1; python_version >= '3.9'
 PyQt6-NetworkAuth==6.8.0; python_version >= '3.9'
 PyQt6-NetworkAuth-Qt6==6.8.1; python_version >= '3.9'
 PyQt6-QScintilla==2.14.1; python_version >= '3.9'  # Does not have a corresponding -Qt6 package


### PR DESCRIPTION
Add hooks for `PyQt6.QtGraphs` and `PyQt6.QtGraphsWidgets` that were introduced in `PyQt6` v6.8.1 (via `PyQt6-Graphs add-on package).