### PR TITLE
loader: split PyiFrozenImporter into PyiFrozenFinder and PyiFrozenLoader

### DIFF
--- a/PyInstaller/hooks/rthooks/pyi_rth_pkgres.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_pkgres.py
@@ -9,11 +9,11 @@
 # SPDX-License-Identifier: Apache-2.0
 #-----------------------------------------------------------------------------
 
-# To make pkg_resources work with frozen modules we need to set the 'Provider' class for PyiFrozenImporter.
+# To make pkg_resources work with frozen modules, we need to set the 'Provider' class for PyiFrozenLoader.
 # This class decides where to look for resources and other stuff.
 #
-# 'pkg_resources.NullProvider' is dedicated to PEP302 import hooks like PyiFileImporter is. It uses method
-# __loader__.get_data() in methods pkg_resources.resource_string() and pkg_resources.resource_stream()
+# 'pkg_resources.NullProvider' is dedicated to abitrary PEP302 loaders, such as our PyiFrozenLoader. It uses method
+# __loader__.get_data() in methods pkg_resources.resource_string() and pkg_resources.resource_stream().
 #
 # We provide PyiFrozenProvider, which subclasses the NullProvider and implements _has(), _isdir(), and _listdir()
 # methods, which are needed for pkg_resources.resource_exists(), resource_isdir(), and resource_listdir() to work. We
@@ -24,7 +24,7 @@
 # results are typically combined for both types of resources (e.g., when listing a directory or checking whether a
 # resource exists). When the order of precedence matters, the PYZ-embedded resources take precedence over the
 # on-filesystem ones, to keep the behavior consistent with the actual file content retrieval via _get() method (which in
-# turn uses PyiFrozenImporter's get_data() method). For example, when checking whether a resource is a directory via
+# turn uses PyiFrozenLoader's get_data() method). For example, when checking whether a resource is a directory via
 # _isdir(), a PYZ-embedded file will take precedence over a potential on-filesystem directory. Also, in contrast to
 # unfrozen packages, the frozen ones do not contain source .py files, which are therefore absent from content listings.
 
@@ -77,7 +77,7 @@ def _pyi_rthook():
 
     class PyiFrozenProvider(pkg_resources.NullProvider):
         """
-        Custom pkg_resources provider for PyiFrozenImporter.
+        Custom pkg_resources provider for PyiFrozenLoader.
         """
         def __init__(self, module):
             super().__init__(module)
@@ -90,7 +90,7 @@ def _pyi_rthook():
             #
             # NOTE: the path is NOT resolved for symbolic links, as neither are paths that are passed by `pkg_resources`
             # to `_has`, `_isdir`, `_listdir` (they are all anchored to `module_path`, which in turn is just
-            # `os.path.dirname(module.__file__)`. As `__file__` returned by `PyiFrozenImporter` is always anchored to
+            # `os.path.dirname(module.__file__)`. As `__file__` returned by `PyiFrozenLoader` is always anchored to
             # `sys._MEIPASS`, we do not have to worry about cross-linked directories in macOS .app bundles, where the
             # resolved `__file__` could be either in the `Contents/Frameworks` directory (the "true" `sys._MEIPASS`), or
             # in the `Contents/Resources` directory due to cross-linking.
@@ -154,11 +154,11 @@ def _pyi_rthook():
                 content = list(set(content + os.listdir(path)))
             return content
 
-    pkg_resources.register_loader_type(pyimod02_importers.PyiFrozenImporter, PyiFrozenProvider)
+    pkg_resources.register_loader_type(pyimod02_importers.PyiFrozenLoader, PyiFrozenProvider)
 
-    # With our PyiFrozenImporter now being a path entry finder, it effectively replaces python's FileFinder. So we need
+    # With our PyiFrozenFinder now being a path entry finder, it effectively replaces python's FileFinder. So we need
     # to register it with `pkg_resources.find_on_path` to allow metadata to be found on filesystem.
-    pkg_resources.register_finder(pyimod02_importers.PyiFrozenImporter, pkg_resources.find_on_path)
+    pkg_resources.register_finder(pyimod02_importers.PyiFrozenFinder, pkg_resources.find_on_path)
 
     # For the above change to fully take effect, we need to re-initialize pkg_resources's master working set (since the
     # original one was built with assumption that sys.path entries are handled by python's FileFinder).

--- a/PyInstaller/hooks/rthooks/pyi_rth_pkgutil.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_pkgutil.py
@@ -9,19 +9,19 @@
 # SPDX-License-Identifier: Apache-2.0
 #-----------------------------------------------------------------------------
 #
-# The run-time hook provides a custom module iteration function for our PyiFrozenImporter, which allows
+# The run-time hook provides a custom module iteration function for our PyiFrozenFinder, which allows
 # `pkgutil.iter_modules()` to return entries for modules that are embedded in the PYZ archive. The non-embedded modules
 # (binary extensions, modules collected as only source .py files, etc.) are enumerated using the `fallback_finder`
-# provided by `PyiFrozenImporter` (which typically would be the python's `FileFinder`).
+# provided by `PyiFrozenFinder` (which typically would be the python's `FileFinder`).
 def _pyi_rthook():
     import pkgutil
 
     import pyimod02_importers  # PyInstaller's bootstrap module
 
-    # This could, in fact, be implemented as `iter_modules()` method of the `PyiFrozenImporter`. However, we want to
+    # This could, in fact, be implemented as `iter_modules()` method of the `PyiFrozenFinder`. However, we want to
     # avoid importing `pkgutil` in that bootstrap module (i.e., for the `pkgutil.iter_importer_modules()` call on the
     # fallback finder).
-    def _iter_pyi_frozen_file_finder_modules(finder, prefix=''):
+    def _iter_pyi_frozen_finder_modules(finder, prefix=''):
         # Fetch PYZ TOC tree from pyimod02_importers
         pyz_toc_tree = pyimod02_importers.get_pyz_toc_tree()
 
@@ -55,8 +55,8 @@ def _pyi_rthook():
             yield from pkgutil.iter_importer_modules(finder.fallback_finder, prefix)
 
     pkgutil.iter_importer_modules.register(
-        pyimod02_importers.PyiFrozenImporter,
-        _iter_pyi_frozen_file_finder_modules,
+        pyimod02_importers.PyiFrozenFinder,
+        _iter_pyi_frozen_finder_modules,
     )
 
 

--- a/news/8934.moduleloader.rst
+++ b/news/8934.moduleloader.rst
@@ -1,0 +1,7 @@
+Split the ``PyiFrozenImporter`` (fused `path based finder
+<https://docs.python.org/3/glossary.html#term-path-based-finder>`_
+and `loader <https://docs.python.org/3/glossary.html#term-loader>`_)
+into separate finder (``PyiFrozenFinder``) and loader (``PyiFrozenLoader``).
+This better matches the separation between python's built-in finders and
+loaders, and thus accommodates 3rd-party code that naively expects to
+encounter only python's built-in finders and loaders.

--- a/tests/functional/test_import.py
+++ b/tests/functional/test_import.py
@@ -156,7 +156,7 @@ def test_module_with_coding_utf8(pyi_builder):
     pyi_builder.test_source("import module_with_coding_utf8")
 
 
-# Test that our PyiFrozenImporter's get_source() method can load source files with utf-8 emoji characters.
+# Test that our PyiFrozenLoader's get_source() method can load source files with utf-8 emoji characters.
 # See issue #6143.
 def test_source_utf8_emoji(pyi_builder):
     # Collect the module's source as data file

--- a/tests/functional/test_importlib_resources.py
+++ b/tests/functional/test_importlib_resources.py
@@ -15,7 +15,7 @@
 #
 # Running the unfrozen test script allows us to verify the behavior of importlib.resources (or its importlib_resources
 # back-port for python 3.8 and earlier) and thereby also validate the test script itself. Running the frozen test
-# validates the behavior of the resource reader implemented by PyInstaller's PyiFrozenImporter.
+# validates the behavior of the resource reader provided by PyInstaller's PyiFrozenLoader.
 #
 # For details on the structure of the test and the contents of the test package, see the top comment in the test script
 # itself.
@@ -80,7 +80,7 @@ def test_importlib_resources_frozen(pyi_builder, tmpdir, script_dir):
 #    the same as in unfrozen python - python's built-in import machinery takes care of the namespace package and the
 #    associated resource reader.
 #  - if the namespace package is collected into PYZ (in addition to resources being collected as data files), the
-#    namespace package ends up being handled by PyInstaller's `PyiFrozenImporter`, which requires extra care to ensure
+#    namespace package ends up being handled by PyInstaller's `PyiFrozenFinder`, which requires extra care to ensure
 #    compatibility with `importlib` resource reader.
 # The test covers both scenarios via `as_package` parameter.
 @pytest.mark.parametrize('as_package', [True, False])


### PR DESCRIPTION
As per https://github.com/pyinstaller/pyinstaller/issues/8928#issuecomment-2550972159, split the `PyiFrozenImporter` (importer = finder + loader) into separate finder (`PyiFrozenFinder`) and loader (`PyiFrozenLoader`). The better matches the organization of finders/loaders in unfrozen python, which are also separate; the finder is typically `FileFinder`, while the loader is one of `SourceFileLoader`, `SourceLessFileLoader`, or `ExtensionFileLoader`. Having a similar split between finder and loader allows us to accommodate 3rd-party code that naively assumes to be always dealing with python's built-in finders/loaders. (Specifically, w.r.t. #8928, the `PyiFrozenLoader` now has public `name` and `path` attributes that are otherwise available on afore-mentioned loaders that inherit from `importlib.abc.FileLoader`).

Since `PyiFrozenLoader` instances are now tied to specific modules (similarly to python's file loaders), we can simplify the method implementations; for example, we do not have to look up the PYZ entry in each method anymore - instead, the PYZ entry name and typecode can be passed to loader's constructor from finder. The filename can also be constructed only once, and then re-used everywhere. And since construction of loader instance happens only if our finder manages to look up the entry in the PYZ, the loader itself requires no checks w.r.t. the existence of the entry in the PYZ.