### PR TITLE
building: rework the localpycs cache in building/<name>

### DIFF
--- a/news/8909.bugfix.rst
+++ b/news/8909.bugfix.rst
@@ -1,0 +1,7 @@
+Rework the ``localpycs`` cache in the ``build`` directory to avoid relying
+on the source .py file timestamps. Some package managers (e.g., Anaconda)
+(re)set the file creation/modification time of installed files to the
+time of packaging rather than having them reflect the time of installation;
+therefore, the PyInstaller bootstrap script and modules would fail to be
+properly recompiled when switching between different versions of
+PyInstaller packaged by Anaconda.


### PR DESCRIPTION
Rework the caching of .pyc files in the `building/<name>/localpycs` cache; do not rely on the source .py file timestamp, because some package managers end up (re)setting those to the time of packaging instead of time of installation.

Instead, we now *always* obtain the latest version of the code object (in whatever way is applicable - from code object cache, by compiling the source .py file, or by reading the source .pyc file for source-less modules) and construct the .pyc module contents in memory.

However, if the .pyc file already exists in the `localpycs` cache, we also read its contents, compare it to our current in-memory .pyc module, and (over)write it only if it is different (either due to different python interpreter version, or due to different marshalled code object). This way, we still avoid unnecessary file (re)writes, and by extension, avoid invalidating the cached build targets that make use of these .pyc files (e.g., `PKG` and `COLLECT`) when the contents of the files remains unhcanged.

Closes #8909.