### PR TITLE
replace non-ascii characters in comment with ascii characters

### DIFF
--- a/bootloader/src/pyi_pythonlib.c
+++ b/bootloader/src/pyi_pythonlib.c
@@ -52,7 +52,7 @@ pyi_pylib_load(struct PYI_CONTEXT *pyi_ctx)
      * the 'ar' archives can be used for both static and shared objects.
      * A shared library can be loaded from such an archive like this:
      *   dlopen("libpythonX.Y.a(libpythonX.Y.so)", RTLD_MEMBER)
-     * This means that if python library name ends with ˙.a˙ suffix, we
+     * This means that if python library name ends with '.a' suffix, we
      * need to change it into:
      *   libpython3.6.a(libpython3.6.so)
      * Shared libraries whose names end with .so may be used as-is. */


### PR DESCRIPTION
This PR fixes https://github.com/pyinstaller/pyinstaller/issues/8949

I searched for **/*.c files and **/*.h files for `˙`, and these are the only lines with the letter.