### PR TITLE
Add additional search path for lib dependencies on MacOS

### DIFF
--- a/PyInstaller/depend/bindepend.py
+++ b/PyInstaller/depend/bindepend.py
@@ -528,8 +528,7 @@ def _get_imports_macholib(filename, search_paths):
     # keep it around in case of unforeseen corner cases.
     run_paths.append(os.path.join(compat.base_prefix, 'lib'))
 
-    # De-duplicate run_paths while preserving the order of the list. This is better than using a set for run paths
-    # because the set can do arbriary re-ording and we want to keep the priority in the order we found the paths above.
+    # De-duplicate run_paths while preserving their order.
     run_paths = list(dict.fromkeys(run_paths))
 
     def _resolve_using_loader_path(lib, bin_path, python_bin_path):

--- a/PyInstaller/depend/bindepend.py
+++ b/PyInstaller/depend/bindepend.py
@@ -13,6 +13,7 @@ Find external dependencies of binary libraries.
 """
 
 import ctypes.util
+import functools
 import os
 import pathlib
 import re
@@ -457,40 +458,62 @@ def _get_imports_macholib(filename, search_paths):
         _dyld_shared_cache_contains_path = None
 
     output = set()
-    referenced_libs = set()  # Libraries referenced in Mach-O headers.
 
     # Parent directory of the input binary and parent directory of python executable, used to substitute @loader_path
     # and @executable_path. The MacOS dylib loader (dyld) fully resolves the symbolic links when using @loader_path
     # and @executable_path references, so we need to do the same using `os.path.realpath`.
     bin_path = os.path.dirname(os.path.realpath(filename))
-    python_bin_path = os.path.dirname(os.path.realpath(sys.executable))
+    python_bin = os.path.realpath(sys.executable)
+    python_bin_path = os.path.dirname(python_bin)
 
-    # Walk through Mach-O headers, and collect all referenced libraries.
-    m = MachO(filename)
-    for header in m.headers:
-        for idx, name, lib in header.walkRelocatables():
-            referenced_libs.add(lib)
+    def _get_referenced_libs(m):
+        # collect referenced libraries from MachO object
+        referenced_libs = set()
+        for header in m.headers:
+            for idx, name, lib in header.walkRelocatables():
+                referenced_libs.add(lib)
+        return referenced_libs
 
-    # Find LC_RPATH commands to collect rpaths. macholib does not handle @rpath, so we need to handle run paths
-    # ourselves.
-    run_paths = set()
-    for header in m.headers:
-        for command in header.commands:
-            # A command is a tuple like:
-            #   (<macholib.mach_o.load_command object at 0x>,
-            #    <macholib.mach_o.rpath_command object at 0x>,
-            #    '../lib\x00\x00')
-            cmd_type = command[0].cmd
-            if cmd_type == LC_RPATH:
-                rpath = command[2].decode('utf-8')
-                # Remove trailing '\x00' characters. E.g., '../lib\x00\x00'
-                rpath = rpath.rstrip('\x00')
-                # If run path starts with @, ensure it starts with either @loader_path or @executable_path. We cannot
-                # process anything else.
-                if rpath.startswith("@") and not rpath.startswith(("@executable_path", "@loader_path")):
-                    logger.warning("Unsupported rpath format %r found in binary %r - ignoring...", rpath, filename)
-                    continue
-                run_paths.add(rpath)
+    def _get_run_paths(m):
+        # Find LC_RPATH commands to collect rpaths from MachO object.
+        # macholib does not handle @rpath, so we need to handle run paths ourselves.
+        run_paths = set()
+        for header in m.headers:
+            for command in header.commands:
+                # A command is a tuple like:
+                #   (<macholib.mach_o.load_command object at 0x>,
+                #    <macholib.mach_o.rpath_command object at 0x>,
+                #    '../lib\x00\x00')
+                cmd_type = command[0].cmd
+                if cmd_type == LC_RPATH:
+                    rpath = command[2].decode('utf-8')
+                    # Remove trailing '\x00' characters. E.g., '../lib\x00\x00'
+                    rpath = rpath.rstrip('\x00')
+                    # If run path starts with @, ensure it starts with either @loader_path or @executable_path.
+                    # We cannot process anything else.
+                    if rpath.startswith("@") and not rpath.startswith(("@executable_path", "@loader_path")):
+                        logger.warning("Unsupported rpath format %r found in binary %r - ignoring...", rpath, filename)
+                        continue
+                    run_paths.add(rpath)
+        return run_paths
+
+    @functools.lru_cache
+    def get_run_paths_and_referenced_libs(filename):
+        # Walk through Mach-O headers, and collect all referenced libraries and run paths
+        m = MachO(filename)
+        return _get_referenced_libs(m), _get_run_paths(m)
+
+    @functools.lru_cache
+    def get_run_paths(filename):
+        # Walk through Mach-O headers, and collect only run_paths
+        return _get_run_paths(MachO(filename))
+
+    referenced_libs, run_paths = get_run_paths_and_referenced_libs(filename)
+
+    # Also add any rpaths that are set by sys.executable for the case where a library has rpath-based dependencies with
+    # additional path components (e.g. @rpath/some/path/somelib.dylib) but rpath isn't set in the library itself
+    # We cache the result of this using functools.lru_cache so that we aren't calling it for every file
+    run_paths = run_paths.union(get_run_paths(python_bin))
 
     # For distributions like Anaconda, all of the dylibs are stored in the lib directory of the Python distribution, not
     # alongside of the .so's in each module's subdirectory. Usually, libraries using @rpath to reference their

--- a/news/8951.bugfix.rst
+++ b/news/8951.bugfix.rst
@@ -1,0 +1,5 @@
+(macOS) Have binary dependency analysis obtain the actual lists of
+run paths set on the python executable (``sys.executable``), instead of
+assuming that it is effectively set to ``@loader_path/../lib``. This
+enables discovery of shared libraries bundled with python builds that
+use different origin for their run paths and ``@rpath``-based references.


### PR DESCRIPTION
Problem:
I am using pywebview + pyinstaller to create a standalone app on MacOS. There's a shared object file that specifies dependencies to libcrypto and libssl but it has relative paths in the so file and no rpath set. So the relative paths get added on to the calculated run path and duplicate sections of path.

Solution:
Search basenames of found libs in the run path as well as specified search paths as a last-ditch effort to find them.

Testing:
My app now correctly packages libcrypto and libssl.