### PR TITLE
Couple of debugging-related improvements

### DIFF
--- a/PyInstaller/utils/conftest.py
+++ b/PyInstaller/utils/conftest.py
@@ -353,7 +353,6 @@ class AppBuilder:
         # Run the executable
         self._display_message('RUN-EXE', f'Running {exe_path!r}, args: {args!r}')
         process = popen_implementation(args, executable=exe_path, env=prog_env, cwd=prog_cwd)
-        self._display_message('RUN-EXE', f'Process ID: {process.pid}')
 
         # Wait for the process to finish. If no run-time (= timeout) is specified, we expect the process to exit on
         # its own, and use global _EXE_TIMEOUT. If run-time is specified, we expect the application to be running

--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -80,6 +80,10 @@ struct PYI_CONTEXT *const global_pyi_ctx = &_pyi_ctx;
  * keep their definitions below that of `pyi_main`, in an attempt to
  * keep code organized in top-down fashion. Hence, we need forward
  * declarations here */
+#if defined(LAUNCH_DEBUG)
+static void _pyi_main_dump_command_line_arguments(const struct PYI_CONTEXT *pyi_ctx);
+#endif
+
 static void _pyi_main_read_runtime_options(struct PYI_CONTEXT *pyi_ctx);
 
 static void _pyi_main_setup_splash_screen(struct PYI_CONTEXT *pyi_ctx);
@@ -110,6 +114,11 @@ pyi_main(struct PYI_CONTEXT *pyi_ctx)
 #endif  /* _WIN32 */
 
     PYI_DEBUG("PyInstaller Bootloader 6.x\n");
+
+    /* In debug builds, dump the command-line arguments. */
+#if defined(LAUNCH_DEBUG)
+    _pyi_main_dump_command_line_arguments(pyi_ctx);
+#endif
 
     /* Fully resolve the executable name. */
     if (_pyi_main_resolve_executable(pyi_ctx) < 0) {
@@ -456,6 +465,23 @@ pyi_main(struct PYI_CONTEXT *pyi_ctx)
         return _pyi_main_onedir_or_onefile_child(pyi_ctx);
     }
 }
+
+#if defined(LAUNCH_DEBUG)
+
+static void
+_pyi_main_dump_command_line_arguments(const struct PYI_CONTEXT *pyi_ctx)
+{
+    int i;
+    for (i = 0; i < pyi_ctx->argc; i++) {
+#if defined(_WIN32)
+        PYI_DEBUG_W(L"LOADER: argv[%d]: %ls\n", i, pyi_ctx->argv_w[i]);
+#else
+        PYI_DEBUG("LOADER: argv[%d]: %s\n", i, pyi_ctx->argv[i]);
+#endif
+    }
+}
+
+#endif /* defined(LAUNCH_DEBUG) */
 
 static void
 _pyi_main_read_runtime_options(struct PYI_CONTEXT *pyi_ctx)


### PR DESCRIPTION
A short follow-up to #8957.

Remove `self._display_message('RUN-EXE', f'Process ID: {process.pid}')` in `AppBuilder._run_executable`; avoid printing any messages between the point where the test program process is started and until it finishes or needs to be killed due to time-out. As we stopped redirecting stdout/stderr to pipes (f5d670162d13cbbd9fc217a9be3a2aa2c1647650), such messages might end up interleaved with program's output, and cause sporadic test failures in tests that expect specific output - see https://github.com/pyinstaller/pyinstaller/actions/runs/12539058334/job/34964835513

Have the debug-enabled instance of bootloader print its command-line arguments at the start of the process. This should make it easier to identify processes in multiprocessing-like scenarios (i.e., without having to instrument the entry-point script to dump `sys.argv`).
