### PR TITLE
bindepend: macOS: avoid using dyld_find in _resolve_using_loader_path

### DIFF
--- a/news/8962.bugfix.rst
+++ b/news/8962.bugfix.rst
@@ -1,0 +1,7 @@
+(macOS) Prevent binary dependency analysis from spuriously resolving
+shared library instance in a standard library path (for example,
+Homebrew-installed library in ``/usr/local/lib``) when trying to
+resolve ``@rpath``-based reference with multiple candidate run paths
+that are anchored to ``@loader_path`` or ``@executable_path`` prefix
+that resolves to a completely different path prefix (for example, an
+Anaconda python environment).


### PR DESCRIPTION
Avoid using macholib's `dyld_find` in the `_resolve_using_loader_path` helper of the `_get_imports_macholib` function.

`dyld_find` uses fall-back search locations, and might therefore end up resolving wrong instance of the library when the candidate library path does not exist. For example, if our `bin_path` and `python_bin_path` are anchored in an Anaconda python environment and the candidate library path does not exit (because we are calling this function when trying to resolve `@rpath` with multiple candidate run paths), we do not want to fall back to eponymous library that happens to be present in the Homebrew python environment...

Instead of calling `dyld_find`, we now manually substitute the `@loader_path`/`@executable_path` prefix with the given `bin_path` or `python_bin_path`, and try resolving the obtained absolute path using the `_resolve_using_path` helper.