### PR TITLE
Improve Cygwin support and add a Cygwin-based CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -476,6 +476,10 @@ jobs:
           echo "DISPLAY=:99" >> $GITHUB_ENV
 
       - name: Run tests
+        # Keep the number of pytest workers below the number of available
+        # CPU cores to avoid CPU contention scenarios, which seem to trigger
+        # a race condition in Cygwin `tkinter` (seemingly in both unfrozen
+        # and frozen programs).
         run: >
             python -m pytest
-            -n 5 --maxfail 3 --durations 10 tests/unit tests/functional
+            -n 3 --maxfail 3 --durations 10 tests/unit tests/functional

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -425,17 +425,15 @@ jobs:
           # NOTE: some of the provided packages (python39-wheel,
           # python39-setuptools, python39-packaging, python39-pytest) are
           # out-of-date, and we instead install PyPI wheels.
-          #
-          # NOTE: tkinter could be installed via python39-tkinter, but
-          # is unusable ("no display name and no $DISPLAY environment
-          # variable" error).
           packages: >-
             gcc-core
             zlib
             zlib-devel
+            xorg-server-extra
             python39
             python39-devel
             python39-pip
+            python39-tkinter
 
       - name: Disable CRLF line endings in git checkout
         run: git config --global core.autocrlf input
@@ -463,6 +461,11 @@ jobs:
 
           # Make sure the help options print.
           python -m PyInstaller -h
+
+      - name: Start display server
+        run: |
+          Xvfb :99 &
+          echo "DISPLAY=:99" >> $GITHUB_ENV
 
       - name: Run tests
         run: >

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -425,6 +425,10 @@ jobs:
           # NOTE: some of the provided packages (python39-wheel,
           # python39-setuptools, python39-packaging, python39-pytest) are
           # out-of-date, and we instead install PyPI wheels.
+          #
+          # Installing python39 seems to install python39-sphinx, but
+          # without sphinxcontrib packages that we need in our test.
+          # So make sure they are all installed.
           packages: >-
             gcc-core
             zlib
@@ -434,6 +438,12 @@ jobs:
             python39-devel
             python39-pip
             python39-tkinter
+            python39-sphinx
+            python39-alabaster
+            python39-sphinxcontrib-applehelp
+            python39-sphinxcontrib-devhelp
+            python39-sphinxcontrib-htmlhelp
+            python39-sphinxcontrib-qthelp
 
       - name: Disable CRLF line endings in git checkout
         run: git config --global core.autocrlf input

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -426,9 +426,12 @@ jobs:
           # python39-setuptools, python39-packaging, python39-pytest) are
           # out-of-date, and we instead install PyPI wheels.
           #
-          # Installing python39 seems to install python39-sphinx, but
-          # without sphinxcontrib packages that we need in our test.
-          # So make sure they are all installed.
+          # NOTE: for some reason, python39-pip depends on python39-sphinx,
+          # which is an old sphinx v4.4.0 package. This version contains
+          # an issue caused by open() without specified encoding, which
+          # was fixed in sphinx >= v5.0. Therefore, we install an up-to-date
+          # version of sphinx from PyPI in the "Update pip and base test tools"
+          # step.
           packages: >-
             gcc-core
             zlib
@@ -438,12 +441,7 @@ jobs:
             python39-devel
             python39-pip
             python39-tkinter
-            python39-sphinx
-            python39-alabaster
-            python39-sphinxcontrib-applehelp
-            python39-sphinxcontrib-devhelp
-            python39-sphinxcontrib-htmlhelp
-            python39-sphinxcontrib-qthelp
+
 
       - name: Disable CRLF line endings in git checkout
         run: git config --global core.autocrlf input
@@ -457,7 +455,7 @@ jobs:
           python --version
 
       - name: Update pip and base test tools
-        run: python -m pip install --progress-bar=off --upgrade pip setuptools wheel build --requirement tests/requirements-base.txt
+        run: python -m pip install --progress-bar=off --upgrade pip setuptools wheel build --requirement tests/requirements-base.txt sphinx
 
       - name: Install PyInstaller
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -411,3 +411,60 @@ jobs:
         run: >
             pytest
             -n 5 --maxfail 3 --durations 10 tests/unit tests/functional
+
+  test-cygwin:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: bash -o igncr -eo pipefail '{0}'
+    steps:
+      - name: Setup Cygwin
+        uses: cygwin/cygwin-install-action@master
+        with:
+          platform: x86_64
+          # NOTE: some of the provided packages (python39-wheel,
+          # python39-setuptools, python39-packaging, python39-pytest) are
+          # out-of-date, and we instead install PyPI wheels.
+          #
+          # NOTE: tkinter could be installed via python39-tkinter, but
+          # is unusable ("no display name and no $DISPLAY environment
+          # variable" error).
+          packages: >-
+            gcc-core
+            zlib
+            zlib-devel
+            python39
+            python39-devel
+            python39-pip
+
+      - name: Disable CRLF line endings in git checkout
+        run: git config --global core.autocrlf input
+
+      - name: Checkout PyInstaller code
+        uses: actions/checkout@v4
+
+      - name: Show system and python information
+        run: |
+          uname -a
+          python --version
+
+      - name: Update pip and base test tools
+        run: python -m pip install --progress-bar=off --upgrade pip setuptools wheel build --requirement tests/requirements-base.txt
+
+      - name: Install PyInstaller
+        run: |
+          # Compile bootloader
+          cd bootloader
+          python waf --gcc --tests all
+          cd ..
+
+          # Install PyInstaller.
+          python -m pip install --progress-bar=off .[completion]
+
+          # Make sure the help options print.
+          python -m PyInstaller -h
+
+      - name: Run tests
+        run: >
+            python -m pytest
+            -n 5 --maxfail 3 --durations 10 tests/unit tests/functional

--- a/PyInstaller/depend/dylib.py
+++ b/PyInstaller/depend/dylib.py
@@ -237,9 +237,15 @@ _aix_excludes = {
     r'libz\.a',
 }
 
+_cygwin_excludes = {
+    r'cygwin1\.dll',
+}
+
 if compat.is_win:
     _includes |= _win_includes
     _excludes |= _win_excludes
+elif compat.is_cygwin:
+    _excludes |= _cygwin_excludes
 elif compat.is_aix:
     # The exclude list for AIX differs from other *nix platforms.
     _excludes |= _aix_excludes

--- a/PyInstaller/depend/utils.py
+++ b/PyInstaller/depend/utils.py
@@ -271,7 +271,7 @@ def _resolveCtypesImports(cbinaries):
         except FileNotFoundError:
             # In these cases, find_library() should return None.
             cpath = None
-        if compat.is_unix:
+        if compat.is_unix or compat.is_cygwin:
             # CAVEAT: find_library() is not the correct function. ctype's documentation says that it is meant to resolve
             # only the filename (as a *compiler* does) not the full path. Anyway, it works well enough on Windows and
             # macOS. On Linux, we need to implement more code to find out the full path.
@@ -298,7 +298,7 @@ def _resolveCtypesImports(cbinaries):
             # On non-Windows, automatically ignore all ctypes-based referenes to DLL files. This complements the above
             # check, which might not match potential case variations (e.g., `KERNEL32.dll`, instead of `kernel32.dll`)
             # due to case-sensitivity of the matching that is in effect on non-Windows platforms.
-            if not compat.is_win and cbin.lower().endswith('.dll'):
+            if (not compat.is_win and not compat.is_cygwin) and cbin.lower().endswith('.dll'):
                 continue
             logger.warning("Library %s required via ctypes not found", cbin)
         else:
@@ -320,6 +320,11 @@ def load_ldconfig_cache():
     global LDCONFIG_CACHE
 
     if LDCONFIG_CACHE is not None:
+        return
+
+    if compat.is_cygwin:
+        # Not available under Cygwin; but we might be re-using general POSIX codepaths, and end up here. So exit early.
+        LDCONFIG_CACHE = {}
         return
 
     if compat.is_musl:

--- a/PyInstaller/utils/conftest.py
+++ b/PyInstaller/utils/conftest.py
@@ -35,7 +35,7 @@ import pytest  # noqa: E402
 
 from PyInstaller import __main__ as pyi_main  # noqa: E402
 from PyInstaller import configure  # noqa: E402
-from PyInstaller.compat import is_darwin, is_win  # noqa: E402
+from PyInstaller.compat import is_cygwin, is_darwin, is_win  # noqa: E402
 from PyInstaller.depend.analysis import initialize_modgraph  # noqa: E402
 from PyInstaller.archive.readers import pkg_archive_contents  # noqa: E402
 from PyInstaller.utils.tests import gen_sourcefile  # noqa: E402
@@ -320,6 +320,9 @@ class AppBuilder:
         if is_win:
             # Minimum Windows PATH is in most cases:   C:\Windows\system32;C:\Windows
             prog_env['PATH'] = os.pathsep.join(winutils.get_system_path())
+        # Same for Cygwin - if /usr/bin is not in PATH, cygwin1.dll cannot be discovered.
+        if is_cygwin:
+            prog_env['PATH'] = os.pathsep.join(['/usr/local/bin', '/usr/bin'])
         # On macOS, we similarly set up minimal PATH with system directories, in case utilities from there are used by
         # tested python code (for example, matplotlib >= 3.9.0 uses `system_profiler` that is found in /usr/sbin).
         if is_darwin:

--- a/doc/common-issues-and-pitfalls.rst
+++ b/doc/common-issues-and-pitfalls.rst
@@ -122,7 +122,7 @@ sub-sections.
 Linux and Unix-like OSes
 ------------------------------
 
-On POSIX systems (with exception of macOS - see its dedicated sub-section),
+On POSIX systems (with exception of macOS and Cygwin - see their dedicated sub-sections),
 the library search path is modified via the ``LD_LIBRARY_PATH`` environment
 variable (``LIBPATH`` on AIX).
 
@@ -195,6 +195,21 @@ the external program.
     locations that are typically in ``PATH`` when running a Terminal
     session (e.g., ``/usr/local/bin``, ``/opt/homebrew/bin``) will not
     be visible to the app, unless referenced by their full path.
+
+Cygwin
+------
+
+Under Cygwin, the ``LD_LIBRARY_PATH`` environment variable is used by
+``dlopen()`` when trying to resolve a library that was given only by a
+basename (without path), while the linked dependencies of binaries and
+loaded DLLs are resolved by Windows loader, whose search path is controlled
+by the `SetDllDirectoryW <https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-setdlldirectoryw>`_
+Win32 API function.
+
+The PyInstaller's bootloader sets the library search path to the top-level
+application directory (i.e., the path that is also available in ``sys._MEIPASS``)
+using *both mechanisms*; therefore, both Linux-specific and Windows-specific
+considerations from earlier sub-sections apply.
 
 
 .. _multiprocessing:

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -764,6 +764,63 @@ When working with a 64-bit Python executable proceed as follows::
     $ pyinstaller <your arguments>
 
 
+.. _Platform-specific Notes - Cygwin:
+
+Cygwin
+------
+
+Cygwin-based Frozen Applications and ``cygwin1.dll``
+====================================================
+
+Under Cygwin, the PyInstaller's bootloader executable (and therefore the
+frozen application's executable) ends up being dynamically linked against
+the ``cygwin1.dll``. As noted under `Q 6.14 of the Cygwin's FAQ
+<https://www.cygwin.com/faq.html#faq.programming.static-linking>`_,
+the Cygwin library cannot be statically linked into an executable in
+order to obtain an independent, self-contained executable.
+
+This means that at run-time, the ``cygwin1.dll`` needs to be available
+to the frozen application's executable for it to be able to launch.
+Depending on the deployment scenario, this means that it needs to be
+either available in the environment (i.e., the environment's search path)
+or a copy of the DLL needs to be available *next to the executable*.
+
+On the other hand, Cygwin does not permit more than one copy of
+``cygwin1.dll``; or rather, it requires multiple copies of the DLL
+to be strictly separated, as each instance constitutes its own Cygwin
+installation/environment (see `Q 4.20 of the Cygwin FAQ
+<https://www.cygwin.com/faq.html#faq.using.multiple-copies>`_).
+Trying to run an executable with an adjacent copy of the DLL from an
+existing Cygwin environment will likely result in the application crashing.
+
+In practice, this means that if you want to create a frozen application
+that will run in an existing Cygwin environment, the application
+should not bundle a copy of ``cygwin1.dll``. On the other hand, if you
+want to create a frozen application that will run outside of a Cygwin
+environment (i.e., a "stand-alone" application that runs directly under
+Windows), the application will require a copy of ``cygwin1.dll`` -- and
+that copy needs to be placed *next to the program's executable*, regardless
+of whether ``onedir`` or ``onefile`` build mode is used.
+
+As PyInstaller cannot guess the deployment mode that you are pursuing,
+it makes no attempt to collect ``cygwin1.dll``. So if you want your
+application to run outside of an externally-provided Cygwin environment,
+you need to place a copy of ``cygwin1.dll`` next to the program's
+executable and distribute them together.
+
+.. note::
+    If you plan to create a "stand-alone" Cygwin-based frozen application
+    (i.e., distribute ``cygwin1.dll`` along with the executable), you will
+    likely want to build the bootloader with statically linked ``zlib``
+    library, in order to avoid a run-time dependency on ``cygz.dll``.
+
+    You can do so by passing ``--static-zlib`` option to ``waf`` when
+    manually building the bootloader before installing PyInstaller
+    from source, or by adding the option to ``PYINSTALLER_BOOTLOADER_WAF_ARGS``
+    environment variable if installing directly via ``pip install``.
+    For details, see :ref:`building the bootloader`.
+
+
 .. include:: _common_definitions.txt
 
 .. Emacs config:

--- a/news/8972.breaking.rst
+++ b/news/8972.breaking.rst
@@ -1,4 +1,5 @@
 (Cygwin) PyInstaller does not attempt to collect ``cygwin1.dll`` anymore.
 If you want to create "stand-alone" Cygwin-based frozen application, you
 need to place a copy of the DLL next to the frozen application's
-executable, and distribute them together.
+executable, and distribute them together. See :ref:`Cygwin-specific section
+of Platform-specific Notes <Platform-specific Notes - Cygwin>` for details.

--- a/news/8972.breaking.rst
+++ b/news/8972.breaking.rst
@@ -1,0 +1,4 @@
+(Cygwin) PyInstaller does not attempt to collect ``cygwin1.dll`` anymore.
+If you want to create "stand-alone" Cygwin-based frozen application, you
+need to place a copy of the DLL next to the frozen application's
+executable, and distribute them together.

--- a/news/8972.doc.rst
+++ b/news/8972.doc.rst
@@ -1,0 +1,2 @@
+Add notes about Cygwin and ``cygwin1.dll`` under new :ref:`Cygwin-specific
+section of Platform-specific Notes <Platform-specific Notes - Cygwin>`.

--- a/news/8972.feature.rst
+++ b/news/8972.feature.rst
@@ -1,0 +1,2 @@
+(Cygwin) Improve Cygwin support to the extent that we can run a
+Cygwin-based CI pipeline with basic part of PyInstaller's test suite.

--- a/tests/functional/test_basic.py
+++ b/tests/functional/test_basic.py
@@ -19,7 +19,7 @@ import re
 
 import pytest
 
-from PyInstaller.compat import is_darwin, is_win
+from PyInstaller.compat import is_cygwin, is_darwin, is_win
 from PyInstaller.utils.tests import importorskip, skipif, xfail, onedir_only, onefile_only
 
 
@@ -709,7 +709,7 @@ def test_sys_executable(pyi_builder, append_pkg, monkeypatch):
 
     # Expected executable basename
     exe_basename = 'test_source'
-    if is_win:
+    if is_win or is_cygwin:
         exe_basename += '.exe'
 
     pyi_builder.test_source(

--- a/tests/functional/test_multiprocessing.py
+++ b/tests/functional/test_multiprocessing.py
@@ -15,9 +15,17 @@ import subprocess
 
 import pytest
 
-from PyInstaller.compat import is_win
+from PyInstaller.compat import is_win, is_cygwin
 
-START_METHODS = ['spawn'] if is_win else ['spawn', 'fork', 'forkserver']
+if is_win:
+    # On Windows, only spawn method is supported.
+    START_METHODS = ['spawn']
+elif is_cygwin:
+    # Under Cygwin, forkserver does not seem to work even in unfrozen python.
+    START_METHODS = ['spawn', 'fork']
+else:
+    # On POSIX systems (including macOS), all methods are supported.
+    START_METHODS = ['spawn', 'fork', 'forkserver']
 
 
 @pytest.mark.timeout(timeout=60)

--- a/tests/requirements-base.txt
+++ b/tests/requirements-base.txt
@@ -23,5 +23,6 @@ pytest-drop-dup-tests
 # Rerun flaky (apple event related) tests
 pytest-rerunfailures
 
-# Better subprocess alternative with implemented timeout.
-psutil
+# Better subprocess alternative with process tree support.
+# Not available on cygwin.
+psutil; sys_platform != 'cygwin'

--- a/tests/unit/test_modulegraph/test_modulegraph.py
+++ b/tests/unit/test_modulegraph/test_modulegraph.py
@@ -5,8 +5,8 @@ import sys
 import shutil
 import warnings
 from altgraph import Graph
-from PyInstaller.compat import is_win
-from PyInstaller.utils.tests import importorskip
+from PyInstaller.compat import is_win, is_cygwin
+from PyInstaller.utils.tests import importorskip, skipif
 import textwrap
 import pickle
 from io import StringIO
@@ -72,6 +72,12 @@ class TestFunctions (unittest.TestCase):
         def assertIsInstance(self, obj, types):
             self.assertTrue(isinstance(obj, types), '%r is not instance of %r'%(obj, types))
 
+    # The test package (and its .zip and .egg variants) do not contain dummy extension file with .dll suffix, which
+    # would be required for the test under Cygwin.
+    @skipif(
+        is_cygwin,
+        reason="Does not account for the .dll suffix used for extension modules under Cygwin.",
+    )
     def test_find_module(self):
         for path in ('syspath', 'syspath.zip', 'syspath.egg'):
             path = os.path.join(os.path.dirname(TESTDATA), path)
@@ -163,8 +169,10 @@ class TestFunctions (unittest.TestCase):
 
                 if sys.platform == 'win32':
                     ext = '.pyd'
+                elif sys.platform == 'cygwin':
+                    ext = '.dll'
                 else:
-                    # This is a ly, but is good enough for now
+                    # This is a lie, but is good enough for now
                     ext = '.so'
 
                 self.assertEqual(filename, os.path.join(path, 'myext' + ext))


### PR DESCRIPTION
Set up a Cygwin-based CI pipeline (using official [cygwin-install-action](https://github.com/cygwin/cygwin-install-action)), and attempt to improve our Cygwin support to the point where we can successfully run the basic part of our test suite.

The biggest change is that we now refrain from collecting `cygwin1.dll`. Since bootloader is dynamically linked against this DLL, running a Cygwin-based frozen application outside of an existing Cygwin environment requires the DLL to be in the search path or bundled with the application; however, if bundled, it must be *next to the executable*, which is not the case in either `onedir` or `onefile` builds (with v5, it was the case with `onedir` but not with `onefile`). On the other hand, if we want to run the application inside an existing Cygwin environment (as is the case with the CI), the executable must not load a duplicate/bundled copy of `cywin1.dll`, otherwise it crashes. So avoid collecting the DLL altogether, and add a documentation section that describes the situation. Just in case, also add a breaking-change news fragment.

Cygwin-based onedir builds do not need to restart themselves (because in contrast to Linux and other POSIX systems, we can modify the search path without process restart), so avoid doing so.

Fix the `ctypes`-based shared library collection so that our `ctypes`-based tests pass under Cygwin.

Skip bunch of hookutils and modulegraph tests that make strong assumptions about python extension suffices, as properly fixing them would be messy (under Cygwin, python extensions have .dll suffix, which clashes with shared libraries suffix for Windows), and too much hassle for little gain.