### PR TITLE
ci: fix issue with `psutil` not being available in msys2/mingw32 anymore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -392,14 +392,24 @@ jobs:
             mingw-w64-${{matrix.env}}-python-pytest
             mingw-w64-${{matrix.env}}-python-pytest-xdist
             mingw-w64-${{matrix.env}}-python-pytest-timeout
-            mingw-w64-${{matrix.env}}-python-psutil
             mingw-w64-${{matrix.env}}-python-pywin32
             mingw-w64-${{matrix.env}}-python-pillow
 
-      - name: Install extra msys2 packages
+      # Some msys2 python packages are not available for i686 anymore:
+      #  - numpy
+      #  - pefile
+      #  - psutil (removed with update to psutil 6.1.1; see https://github.com/msys2/MINGW-packages/commit/7f1c75b33a5aebb89899f99f5fa656c623eeb9ed)
+      # If running in 64-bit environment, install the said packages here.
+      # Otherwise, we will run tests without these packages (note that
+      # if not installed here, `pefile` will end up installed via `pip`
+      # as part of PyInstaller's dependencies).
+      - name: Install extra msys2 packages (64-bit only)
         if: matrix.env != 'i686'
-        # numpy and pefile are unavailable for i686. Ignore numpy and install pefile via pip
-        run: pacman -S --noconfirm mingw-w64-${{matrix.env}}-python-numpy mingw-w64-${{matrix.env}}-python-pefile
+        run: >
+          pacman -S --noconfirm
+          mingw-w64-${{matrix.env}}-python-numpy
+          mingw-w64-${{matrix.env}}-python-pefile
+          mingw-w64-${{matrix.env}}-python-psutil
 
       - name: Checkout PyInstaller code
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,26 +197,26 @@ jobs:
         run: cd bootloader && python waf --tests all
 
       - name: Download dependencies
-        run: pip download --dest=dist .[completion] && rm -f dist/pyinstaller-*.whl
         shell: bash
+        run: python -m pip download --dest=dist .[completion] && rm -f dist/pyinstaller-*.whl
 
       - name: Build wheels
         run: sh release/build-wheels
 
       - name: Install PyInstaller
-        run: pip install --no-index --find-links=dist pyinstaller[completion]
+        run: python -m pip install --no-index --find-links=dist pyinstaller[completion]
 
       - name: Check pyinstaller --help
         run: python -m PyInstaller -h
 
       - name: Install test dependencies (base tools)
         run: |
-          pip install --progress-bar=off --upgrade --requirement tests/requirements-base.txt
+          python -m pip install --progress-bar=off --upgrade --requirement tests/requirements-base.txt
 
       - name: Install test dependencies (tools and libraries)
         if: ${{ !endsWith(matrix.python-version, '-dev') }}
         run: |
-          pip install --progress-bar=off --upgrade --requirement tests/requirements-libraries.txt
+          python -m pip install --progress-bar=off --upgrade --requirement tests/requirements-libraries.txt
 
       - name: Set up extra environment variables (non-Windows)
         if: ${{ !startsWith(matrix.os, 'windows') }}
@@ -292,7 +292,7 @@ jobs:
       # Install and test PyInstaller Hook Sample, to ensure that tests declared in
       # entry-points are discovered.
       - name: Install hooksample
-        run: pip install "https://github.com/pyinstaller/hooksample/archive/v4.0rc1.zip"
+        run: python -m pip install "https://github.com/pyinstaller/hooksample/archive/v4.0rc1.zip"
 
       # Augment _pyinstaller_hooks_contrib with bogus hooks that conflict with the hooks provided by hooksample.
       # Due to (implicit) hook priority, the 3rd-party hooks should be chosen over _pyinstaller_hooks_contrib
@@ -349,7 +349,7 @@ jobs:
       - name: Create sdist
         run: |
           git clean -xfdq .
-          pip install build
+          python -m pip install build
           python -m build --sdist --outdir dist
           docker build --target=wheel-factory -t bar -f alpine.dockerfile .
 
@@ -357,7 +357,7 @@ jobs:
         run: |
           sdist="$(ls dist)"
           docker run -v "$PWD/dist:/io" bar ash -c "
-            pip install /io/$sdist
+            python -m pip install /io/$sdist
             echo 'print(1 + 1)' > test.py
             pyinstaller test.py
             ./dist/test/test
@@ -417,7 +417,7 @@ jobs:
           cd ..
 
           # Install PyInstaller.
-          pip install --progress-bar=off .[completion]
+          python -m pip install --progress-bar=off .[completion]
 
           # Make sure the help options print.
           python -m PyInstaller -h

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,8 @@ jobs:
             os: 'macos-13'
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout PyInstaller code
+        uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
@@ -325,12 +326,14 @@ jobs:
   test-alpine:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: 3.x
-      - run: docker build -f alpine.dockerfile -t foo .
-      - run: >
+      - name: Checkout PyInstaller code
+        uses: actions/checkout@v4
+
+      - name: Build container
+        run: docker build -f alpine.dockerfile -t foo .
+
+      - name: Run tests in container
+        run: >
           docker run
           foo
           pytest
@@ -338,12 +341,20 @@ jobs:
 
       # Verify that installing from sdist works. This is mostly just a verification that the MANIFEST.in contains
       # all the extras needed to compile the bootloader.
-      - run: |
+      - name: Setup Python for creating sdist
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+
+      - name: Create sdist
+        run: |
           git clean -xfdq .
           pip install build
           python -m build --sdist --outdir dist
           docker build --target=wheel-factory -t bar -f alpine.dockerfile .
-      - run: |
+
+      - name: Install and test PyInstaller installed from sdist
+        run: |
           sdist="$(ls dist)"
           docker run -v "$PWD/dist:/io" bar ash -c "
             pip install /io/$sdist
@@ -365,7 +376,8 @@ jobs:
       run:
         shell: msys2 {0}
     steps:
-      - uses: msys2/setup-msys2@v2
+      - name: Setup msys2 environment
+        uses: msys2/setup-msys2@v2
         with:
           update: true
           msystem: ${{matrix.sys}}
@@ -384,13 +396,16 @@ jobs:
             mingw-w64-${{matrix.env}}-python-pywin32
             mingw-w64-${{matrix.env}}-python-pillow
 
-      - if: matrix.env != 'i686'
+      - name: Install extra msys2 packages
+        if: matrix.env != 'i686'
         # numpy and pefile are unavailable for i686. Ignore numpy and install pefile via pip
         run: pacman -S --noconfirm mingw-w64-${{matrix.env}}-python-numpy mingw-w64-${{matrix.env}}-python-pefile
 
-      - uses: actions/checkout@v4
+      - name: Checkout PyInstaller code
+        uses: actions/checkout@v4
 
-      - run: |
+      - name: Show system and python information
+        run: |
           uname -a
           python --version
 


### PR DESCRIPTION
With update to `psutil` 6.1.1, `msys2` stopped providing this package for their mingw32/i686 environments; see https://github.com/msys2/MINGW-packages/commit/7f1c75b33a5aebb89899f99f5fa656c623eeb9ed)

Move the installation of `mingw-w64-${{matrix.env}}-python-psutil` into the "Install extra msys2 packages (64-bit only)" step. On i686, we now run the test suite without `psutil`.

The first two commits contain additional CI workflow cleanup:
- ensure that all steps are named
- ensure that `pip` is consistently invoked as `python -m pip`