### PR TITLE
building: main: display path to dist directory at end of the build

### DIFF
--- a/PyInstaller/building/build_main.py
+++ b/PyInstaller/building/build_main.py
@@ -1207,6 +1207,8 @@ def build(spec, distpath, workpath, clean_build):
         raise SystemExit(f'Spec file "{spec}" not found!')
     exec(code, spec_namespace)
 
+    logger.info("Build complete! The results are available in: %s", CONF['distpath'])
+
 
 def __add_options(parser):
     parser.add_argument(


### PR DESCRIPTION
At the end of the build process, display a "build complete" message, along with the path to the `dist` directory (or rather, the path in `CONF['distpath']`), in an attempt to dissuade users from trying to run the intermediate build results in the `build` directory (i.e., `CONF['workpath']`).

Closes #8933.