### PR TITLE
loader: PyiFrozenFinder: robustify relative path computation

### DIFF
--- a/news/8994.bugfix.rst
+++ b/news/8994.bugfix.rst
@@ -1,0 +1,7 @@
+When constructing ``PyiFrozenFinder`` for the given path and trying
+to compute the path that is relative to the top-level application
+directory, do not fully resolve the given path. Instead, try computing
+relative path using both the original and the fully resolved top-level
+application directory path. This change prevents us from potentially
+resolving symbolic links in parts of the given path that do not belong
+to the top-level application directory.


### PR DESCRIPTION
When constructing `PyiFrozenFinder` for the given path and trying to compute the path that is relative to the top-level application directory, do not fully resolve the given path. Instead, try computing relative path using both the original and the fully resolved top-level application directory path.

This change prevents us from potentially resolving symbolic links in parts of the given path that do not belong to the top-level application directory; whereas we only want to ensure that we are always able to match the top-level application directory (original or fully resolved) and compute the relative path.

Fixes #8994.