### PR TITLE
bootloader: fix calloc() result check to account for AIX behavior

### DIFF
--- a/bootloader/src/pyi_pyconfig.c
+++ b/bootloader/src/pyi_pyconfig.c
@@ -209,11 +209,14 @@ pyi_runtime_options_read(const struct PYI_CONTEXT *pyi_ctx)
 
     /* Collect Wflags and Xflags for pass-through */
 
-    /* Allocate - calloc should be safe to call with num = 0 (and returns
-     * a non-NULL address that should be safe to free) */
+    /* Allocate - calloc should be safe to call with num = 0.
+     * On most platforms, when called with num = 0, calloc returns a
+     * non-NULL address that should be safe to free. On AIX, though,
+     * it returns NULL (unless _LINUX_SOURCE_COMPAT is defined, but we
+     * cannot have that defined together with _ALL_SOURCE). */
     options->wflags = calloc(num_wflags, sizeof(wchar_t *));
     options->xflags = calloc(num_xflags, sizeof(wchar_t *));
-    if (options->wflags == NULL || options->xflags == NULL) {
+    if ((num_wflags && options->wflags == NULL) || (num_xflags && options->xflags == NULL)) {
         failed = 1;
         goto end;
     }

--- a/news/9006.bugfix.rst
+++ b/news/9006.bugfix.rst
@@ -1,0 +1,3 @@
+(AIX) Fix spurious run-time error in bootloader when no Wflags and/or no
+Xflags are specified via bootloader's run-time options (i.e., most of the
+time).


### PR DESCRIPTION
On AIX, when `calloc` is called with number of elements set to 0, it returns a NULL pointer (unless `_LINUX_SOURCE_COMPAT` is defined, but this is negated by having `_ALL_SOURCE` defined, which we do). This differs from behavior on other platforms, where a non-NULL address is returned in such cases, and NULL is returned only on allocation failure.

Therefore, perform a NULL check on returned pointer to detect allocation failure only when we call `calloc` with non-zero number of elements.

This fixes spurious run-time error on AIX when no Wflags and/or no Xflags are specified via bootloader's run-time options.

Fixes #9006.