### PR TITLE
hookutils: have Tcl/Tk helper gracefully handle built-in _tkinter module

### DIFF
--- a/PyInstaller/building/splash.py
+++ b/PyInstaller/building/splash.py
@@ -140,6 +140,7 @@ class Splash(Target):
             )
 
         # Check if the Tcl/Tk version is supported.
+        logger.info("Verifying Tcl/Tk compatibility with splash screen requirements")
         self._check_tcl_tk_compatibility()
 
         # Make image path relative to .spec file
@@ -396,6 +397,17 @@ class Splash(Target):
                 "The installed Tcl version is not threaded. PyInstaller only supports the splash screen "
                 "using threaded Tcl."
             )
+
+        # Ensure that Tcl and Tk shared libraries are available
+        if tcltk_info.tcl_shared_library is None or tcltk_info.tk_shared_library is None:
+            message = \
+                "Could not determine the path to Tcl and/or Tk shared library, which are required for splash screen."
+            if not tcltk_info.tkinter_extension_file:
+                message += (
+                    " The _tkinter module appears to be a built-in, which likely means that python was built with "
+                    "statically-linked Tcl/Tk libraries and is incompatible with splash screen."
+                )
+            raise SystemExit(message)
 
     def generate_script(self):
         """

--- a/news/9012.bugfix.rst
+++ b/news/9012.bugfix.rst
@@ -1,0 +1,9 @@
+Gracefully handle cases when ``_tkinter`` is a built-in instead of an
+extension module, and thus does not have a ``__file__`` attribute.
+Most notable example of this are `indygreg's python-build-standalone
+CPython builds <https://github.com/astral-sh/python-build-standalone>`_
+for macOS and Linux. This fixes collection of ``tkinter`` and associated
+Tcl/Tk resources when using such python builds. When trying to enable
+splash screen, a descriptive error is now raised, because splash screen
+requires shared Tcl/Tk libraries, while a built-in ``_tkinter`` seems to
+indicate that python was statically linked against Tcl/Tk libraries.


### PR DESCRIPTION
Have our `TclTkInfo` hook utility class gracefully handle cases when `_tkinter` is a built-in instead of an extension module, and thus does not have a `__file__` attribute.

Most notable example of this are `indygreg`'s `python-build-standalone` CPython builds for macOS and Linux, where python seems to be statically linked against Tcl and Tk (and other) libraries.

Therefore, if we fail to obtain `__file__` attribute of the `_tkinter` module, skip attempts at determining the location of Tcl and Tk shared libraries, as those are likely not applicable. This allows us to initialize other member variables of `TclTkInfo` structure, and properly collect `tkinter` and its associated Tcl/Tk resources even when `_tkinter` module is a built-in.

In the splash screen building codepath, add a check for valid Tcl and Tk shared library paths, as those are hard requirements for the splash screen functionality. Raise a descriptive error if either of the libraries could not be resolved. In cases when path to `_tkinter` extension module is also unavailable (due to it being a built-in), extend the error message with the note that shared Tcl/Tk libraries are required, while the python build was likely statically linked against Tcl/Tk, and is thus inherently incompatible with splash screen.

Closes #9012.