### PR TITLE
hooks: update gi hook and helper code for compatibility with PyGObject >= 3.52

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
-        os: ['windows-latest', 'ubuntu-22.04', 'macos-13', 'macos-14']
+        os: ['windows-latest', 'ubuntu-24.04', 'macos-13', 'macos-14']
         # Split macOS workflows between macos-13 (x86_64) and macos-14 (arm64)
         # runners to cover both architectures without running all combinations.
         exclude:
@@ -78,7 +78,8 @@ jobs:
             libopengl0 libegl1 \
             libpulse0 libpulse-mainloop-glib0 \
             gstreamer1.0-plugins-base libgstreamer-gl1.0-0 \
-            gir1.2-gtk-3.0 libgirepository1.0-dev \
+            gir1.2-gtk-3.0 libgirepository1.0-dev libgirepository-2.0-dev \
+            libcairo2-dev \
             libfuse2
 
       # The following locales are required by test_basic::test_user_preferred_locale

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,8 +78,8 @@ jobs:
             libopengl0 libegl1 \
             libpulse0 libpulse-mainloop-glib0 \
             gstreamer1.0-plugins-base libgstreamer-gl1.0-0 \
-            gir1.2-gtk-3.0 libgirepository1.0-dev libgirepository-2.0-dev \
-            libcairo2-dev \
+            libgirepository1.0-dev libgirepository-2.0-dev libcairo2-dev \
+            gir1.2-girepository-2.0 gir1.2-girepository-3.0 gir1.2-gtk-3.0 \
             libfuse2
 
       # The following locales are required by test_basic::test_user_preferred_locale

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -394,6 +394,7 @@ jobs:
             mingw-w64-${{matrix.env}}-python-pytest-timeout
             mingw-w64-${{matrix.env}}-python-pywin32
             mingw-w64-${{matrix.env}}-python-pillow
+            mingw-w64-${{matrix.env}}-python-gobject
 
       # Some msys2 python packages are not available for i686 anymore:
       #  - numpy

--- a/PyInstaller/hooks/hook-gi.py
+++ b/PyInstaller/hooks/hook-gi.py
@@ -9,4 +9,18 @@
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
 
+from PyInstaller import compat
+from packaging.version import Version
+
+pygobject_version = Version(compat.importlib_metadata.version("pygobject")).release
+
 hiddenimports = ['gi._error', 'gi._option']
+
+# PyGObject 3.50.0 added support for `asyncio`, and attempts to import inside the `_gi` extension.
+if pygobject_version >= (3, 50, 0):
+    hiddenimports += ['asyncio']
+
+# PyGobject 3.52.0 added `gi._enum`, which needs to be added to hiddenimports due to being imported from the
+# `_gi` extension.
+if pygobject_version >= (3, 52, 0):
+    hiddenimports += ['gi._enum']

--- a/PyInstaller/utils/hooks/gi.py
+++ b/PyInstaller/utils/hooks/gi.py
@@ -45,16 +45,38 @@ class GiModuleInfo:
         @isolated.decorate
         def _get_module_info(module, version):
             import gi
-            gi.require_version("GIRepository", "2.0")
+
+            # Ideally, we would use gi.Repository, which provides common abstraction for some of the functions we use in
+            # this codepath (e.g., `require`, `get_typelib_path`, `get_immediate_dependencies`). However, it lacks the
+            # `get_shared_library` function, which is why we are using "full" bindings via `gi.repository.GIRepository`.
+            #
+            # PyGObject 3.52.0 switched from girepository-1.0 to girepository-2.0, which means that GIRepository version
+            # has changed from 2.0 to 3.0 and some of the API has changed.
+            try:
+                gi.require_version("GIRepository", "3.0")
+                new_api = True
+            except ValueError:
+                gi.require_version("GIRepository", "2.0")
+                new_api = False
+
             from gi.repository import GIRepository
 
-            repo = GIRepository.Repository.get_default()
-            repo.require(module, version, GIRepository.RepositoryLoadFlags.IREPOSITORY_LOAD_FLAG_LAZY)
+            # The old API had `get_default` method to obtain global singleton object; it was removed in the new API,
+            # which requires creation of separate GIRepository instances.
+            if new_api:
+                repo = GIRepository.Repository()
+                repo.require(module, version, GIRepository.RepositoryLoadFlags.LAZY)
 
-            # Shared library/libraries
-            # Comma-separated list of paths to shared libraries, or None if none are associated. Convert to list.
-            sharedlibs = repo.get_shared_library(module)
-            sharedlibs = [lib.strip() for lib in sharedlibs.split(",")] if sharedlibs else []
+                # The new API returns the list of shared libraries.
+                sharedlibs = repo.get_shared_libraries(module)
+            else:
+                repo = GIRepository.Repository.get_default()
+                repo.require(module, version, GIRepository.RepositoryLoadFlags.IREPOSITORY_LOAD_FLAG_LAZY)
+
+                # Shared library/libraries
+                # Comma-separated list of paths to shared libraries, or None if none are associated. Convert to list.
+                sharedlibs = repo.get_shared_library(module)
+                sharedlibs = [lib.strip() for lib in sharedlibs.split(",")] if sharedlibs else []
 
             # Path to .typelib file
             typelib = repo.get_typelib_path(module)

--- a/PyInstaller/utils/hooks/gi.py
+++ b/PyInstaller/utils/hooks/gi.py
@@ -65,13 +65,19 @@ class GiModuleInfo:
             # which requires creation of separate GIRepository instances.
             if new_api:
                 repo = GIRepository.Repository()
-                repo.require(module, version, GIRepository.RepositoryLoadFlags.LAZY)
+                try:
+                    repo.require(module, version, GIRepository.RepositoryLoadFlags.LAZY)
+                except ValueError:
+                    return None  # Module not available
 
                 # The new API returns the list of shared libraries.
                 sharedlibs = repo.get_shared_libraries(module)
             else:
                 repo = GIRepository.Repository.get_default()
-                repo.require(module, version, GIRepository.RepositoryLoadFlags.IREPOSITORY_LOAD_FLAG_LAZY)
+                try:
+                    repo.require(module, version, GIRepository.RepositoryLoadFlags.IREPOSITORY_LOAD_FLAG_LAZY)
+                except ValueError:
+                    return None  # Module not available
 
                 # Shared library/libraries
                 # Comma-separated list of paths to shared libraries, or None if none are associated. Convert to list.
@@ -97,13 +103,16 @@ class GiModuleInfo:
         # Try to query information; if this fails, mark module as unavailable.
         try:
             info = _get_module_info(module, self.version)
-            self.sharedlibs = info['sharedlibs']
-            self.typelib = info['typelib']
-            self.dependencies = info['dependencies']
-            self.available = True
+            if info is None:
+                logger.debug("GI module info %s %s not found.", module, self.version)
+            else:
+                logger.debug("GI module info %s %s found.", module, self.version)
+                self.sharedlibs = info['sharedlibs']
+                self.typelib = info['typelib']
+                self.dependencies = info['dependencies']
+                self.available = True
         except Exception as e:
-            logger.debug("Failed to query GI module %s %s: %s", module, self.version, e)
-            self.available = False
+            logger.warning("Failed to query GI module %s %s: %s", module, self.version, e)
 
     def get_libdir(self):
         """

--- a/news/9055.hooks.rst
+++ b/news/9055.hooks.rst
@@ -1,0 +1,3 @@
+Update hook for ``PyGObject`` (``gi``) and associated helper code to
+support changes made in ``PyGObject`` v3.52 (switch from ``girepository-1.0``
+to ``girepository-2.0``).

--- a/tests/functional/test_gi.py
+++ b/tests/functional/test_gi.py
@@ -49,9 +49,25 @@ def test_gi_repository(pyi_builder, repository_name, version):
     # Test the importability of this subpackage.
     pyi_builder.test_source(
         f"""
+        import sys
+        import pathlib
+
         import gi
+
+        # Check that package/namespace can be imported
         gi.require_version('{repository_name}', '{version}')
         from gi.repository import {repository_name}
         print({repository_name})
+
+        # Check that the typelib is, in fact, loaded from the frozen application (instead of falling back to the copy
+        # that is installed on the system).
+        repo = gi.Repository.get_default()
+        typelib_path = repo.get_typelib_path('{repository_name}')
+        print("typelib path: ", typelib_path)
+
+        typelib_path = pathlib.Path(typelib_path).resolve()
+        application_path = pathlib.Path(sys._MEIPASS).resolve()
+        if application_path not in typelib_path.parents:
+            raise ValueError(f"Typelib {{str(typelib_path)!r}} is not loaded from frozen application's directory!")
         """
     )

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -22,7 +22,7 @@ matplotlib==3.10.0; python_version >= '3.10'
 numpy==2.2.3; python_version >= '3.10'
 pandas==2.2.3; python_version >= '3.9'
 pygments==2.19.1
-PyGObject==3.50.0; sys_platform == 'linux' and python_version >= '3.9'
+PyGObject==3.52.1; sys_platform == 'linux' and python_version >= '3.9'
 # Official PySide2 wheels do not support python 3.11 or newer. Nor are they available for arm64 on macOS.
 PySide2==5.15.2.1; python_version < '3.11' and (sys_platform != 'darwin' or platform_machine != 'arm64')
 # PySide6 is a metapackage that depends on PySide6-Essentials and PySide6-Addons. Their versions are


### PR DESCRIPTION
Update hook for `PyGObject` (`gi`) and associated helper code to support changes made in `PyGObject` v3.52 (switch from `girepository-1.0` to `girepository-2.0`).

Closes #9052.