### PR TITLE
building: ensure macOS executables have unique Mach-O image UUIDs

### DIFF
--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -835,6 +835,14 @@ class EXE(Target):
             logger.info("Removing signature(s) from EXE")
             osxutils.remove_signature_from_binary(build_name)
 
+            # Fix Mach-O image UUID(s) in executable to ensure uniqueness across different builds.
+            # NOTE: even if PKG is side-loaded, use the hash of its contents to generate the new UUID.
+            # NOTE: this step is performed *before* PKG is appended and sizes are fixed in the executable's headers;
+            # this ensures that we are operating only on original header size instead of enlarged one (which could
+            # be significantly larger in large onefile builds).
+            logger.info("Modifying Mach-O image UUID(s) in EXE")
+            osxutils.update_exe_identifier(build_name, self.pkg.name)
+
             # Append the data
             logger.info("Appending %s to EXE", append_type)
             self._append_data_to_exe(build_name, append_file)

--- a/PyInstaller/utils/osx.py
+++ b/PyInstaller/utils/osx.py
@@ -31,6 +31,7 @@ from macholib.mach_o import (
     LC_RPATH,
     LC_SEGMENT_64,
     LC_SYMTAB,
+    LC_UUID,
     LC_VERSION_MIN_MACOSX,
 )
 from macholib.MachO import MachO
@@ -277,6 +278,48 @@ def _get_arch_string(header):
     elif cputype == 7:
         return 'i386'  # 32-bit intel
     assert False, 'Unhandled architecture!'
+
+
+def update_exe_identifier(filename, pkg_filename):
+    """
+    Modifies the Mach-O image UUID stored in the LC_UUID command (if present) in order to ensure that different
+    frozen applications have different identifiers. See TN3178 for details on why this is required:
+    https://developer.apple.com/documentation/technotes/tn3178-checking-for-and-resolving-build-uuid-problems
+    """
+
+    # Compute hash of the PKG
+    import hashlib
+    pkg_hash = hashlib.sha1()
+    with open(pkg_filename, 'rb') as fp:
+        for chunk in iter(lambda: fp.read(8192), b""):
+            pkg_hash.update(chunk)
+
+    # Modify UUID in all arch slices of the executable.
+    executable = MachO(filename)
+    for header in executable.headers:
+        # Find LC_UUID command
+        uuid_cmd = [cmd for cmd in header.commands if cmd[0].cmd == LC_UUID]
+        if not uuid_cmd:
+            continue
+        uuid_cmd = uuid_cmd[0]
+
+        # Read the existing UUID (which is based on bootloader executable itself).
+        original_uuid = uuid_cmd[1].uuid
+
+        # Add original UUID to the hash; this is similar to what UUID v3/v5 do with namespace + name, except
+        # that in our case, the prefix UUID (namespace) is added at the end, so that PKG hash needs to be
+        # (pre)computed only once.
+        combined_hash = pkg_hash.copy()
+        combined_hash.update(original_uuid)
+
+        new_uuid = combined_hash.digest()[:16]  # Same as uuid.uuid3() / uuid.uuid5().
+        assert len(new_uuid) == 16
+
+        uuid_cmd[1].uuid = new_uuid
+
+    # Write changes
+    with open(filename, 'rb+') as fp:
+        executable.write(fp)
 
 
 class InvalidBinaryError(Exception):

--- a/news/9056.feature.rst
+++ b/news/9056.feature.rst
@@ -1,0 +1,8 @@
+(macOS) When assembling the executable, PyInstaller now modifies the
+Mach-O image UUID of all architecture slices in the executable, and
+sets them to a value derived from the hash of the embedded PKG archive
+and the original (bootloader's) UUID. This should ensure that different
+application executables have unique identifiers, as per
+`TN3178 <https://developer.apple.com/documentation/technotes/tn3178-checking-for-and-resolving-build-uuid-problems>`_,
+which might be required by newer macOS features, such as
+`local network privacy <https://developer.apple.com/documentation/technotes/tn3179-understanding-local-network-privacy#Build-time-considerations>`_.


### PR DESCRIPTION
When assembling the executable for macOS, overwrite the UUIDs stored in LC_UUID commands in all architecture slices with custom values that are derived from the original (bootloader executable's) UIID and the hash of the embedded PKG archive.

This ensures that the Mach-O image UUIDs are unique for different application executables, as per Apple's [TN3178](https://developer.apple.com/documentation/technotes/tn3178-checking-for-and-resolving-build-uuid-problems), while also keeping them reproducible (as long as bootloader executable and the PKG archive contents remain unchanged).

Valid and unique UUIDs seem to be mandated by certain features on contemporary macOS versions, for example, local network privacy that was introduced in macOS 15 (see [TN3179](https://developer.apple.com/documentation/technotes/tn3179-understanding-local-network-privacy#Build-time-considerations)).

Closes #9056.