### PR TITLE
tests: add basic build reproducibility tests

### DIFF
--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -343,8 +343,14 @@ class PKG(Target):
             elif typecode in {'PYSOURCE', 'PYSOURCE-1', 'PYSOURCE-2', 'PYMODULE', 'PYMODULE-1', 'PYMODULE-2'}:
                 # Collect python script and modules in a TOC that will not be sorted.
                 bootstrap_toc.append((dest_name, src_name, self.cdict.get(typecode, False), self.xformdict[typecode]))
+            elif typecode == 'PYZ':
+                # Override PYZ name in the PKG archive into PYZ.pyz, regardless of what the original name was. The
+                # bootloader looks for PYZ via the typecode and implicitly expects a single entry, so the name does
+                # not matter. However, having a fixed name matters if we want reproducibility in scenarios where
+                # multiple builds are performed within the same process (for example, on our CI).
+                archive_toc.append(('PYZ.pyz', src_name, self.cdict.get(typecode, False), self.xformdict[typecode]))
             else:
-                # PYZ, PKG, DEPENDENCY, SPLASH, SYMLINK
+                # PKG, DEPENDENCY, SPLASH, SYMLINK
                 archive_toc.append((dest_name, src_name, self.cdict.get(typecode, False), self.xformdict[typecode]))
 
         # Sort content alphabetically by type and name to enable reproducible builds.

--- a/tests/functional/scripts/pyi_helloworld2.py
+++ b/tests/functional/scripts/pyi_helloworld2.py
@@ -1,0 +1,12 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2015-2023, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+# ----------------------------------------------------------------------------
+
+print('Hello Python #2!')

--- a/tests/functional/specs/pyi_macos_executable_uuid.spec
+++ b/tests/functional/specs/pyi_macos_executable_uuid.spec
@@ -1,0 +1,116 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+# First program script built as a POSIX onedir application.
+program_script = os.path.join(os.path.dirname(SPECPATH), 'scripts', 'pyi_helloworld.py')
+
+a = Analysis([program_script])
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    name='program1_onedir',
+    exclude_binaries=True,  # onedir
+    console=True,  # console-enabled bootloader
+)
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.datas,
+    name='program1_onedir',
+)
+
+# First program script built as a POSIX onefile application.
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    exclude_binaries=False,  # onefile
+    name='program1_onefile',
+    console=True,  # console-enabled bootloader
+)
+
+# First program script built as an .app bundle.
+exe = EXE(
+    pyz,
+    a.scripts,
+    name='program1_onedir_w',
+    exclude_binaries=True,  # onedir
+    console=False,  # windowed
+)
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.datas,
+    name='program1_onedir_w',
+)
+app = BUNDLE(
+    coll,
+    name='program1_onedir_w.app'
+)
+
+
+# Second program script built as a POSIX onedir application.
+# NOTE: second program script is identical to the first one (same file - so the script name matches as well)!
+program_script = os.path.join(os.path.dirname(SPECPATH), 'scripts', 'pyi_helloworld.py')
+
+a = Analysis([program_script])
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    name='program2_onedir',
+    exclude_binaries=True,  # onedir
+    console=True,  # console-enabled bootloader
+)
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.datas,
+    name='program2_onedir',
+)
+
+# Second program script built as a POSIX onefile application.
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    exclude_binaries=False,  # onefile
+    name='program2_onefile',
+    console=True,  # console-enabled bootloader
+)
+
+
+# Third program script built as a POSIX onedir application.
+program_script = os.path.join(os.path.dirname(SPECPATH), 'scripts', 'pyi_helloworld2.py')
+
+a = Analysis([program_script])
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    name='program3_onedir',
+    exclude_binaries=True,  # onedir
+    console=True,  # console-enabled bootloader
+)
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.datas,
+    name='program3_onedir',
+)
+
+# Third program script built as a POSIX onefile application.
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    exclude_binaries=False,  # onefile
+    name='program3_onefile',
+    console=True,  # console-enabled bootloader
+)

--- a/tests/functional/test_reproducibility.py
+++ b/tests/functional/test_reproducibility.py
@@ -9,8 +9,11 @@
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
 
+import dataclasses
 import filecmp
 import time
+
+import pytest
 
 from PyInstaller.compat import is_win
 
@@ -70,3 +73,119 @@ def test_reproducible_subsequent_builds(pyi_builder, tmp_path, monkeypatch):
 
     # Compare whole executables
     assert filecmp.cmp(executable1, executable2, shallow=False)
+
+
+# Test that in macOS executables, Mach-O image UUIDs are modified during the build process, based on the contents (hash)
+# of the PKG archive.
+@pytest.mark.darwin
+def test_macos_executable_uuid(pyi_builder_spec, tmp_path):
+    # Helper for reading Mach-O image UUIDs from executable.
+    def _read_uuids(filename):
+        import uuid
+
+        from macholib.mach_o import LC_UUID
+        from macholib.MachO import MachO
+
+        uuids = []
+
+        executable = MachO(filename)
+        for header in executable.headers:
+            # Find LC_UUID command
+            uuid_cmd = [cmd for cmd in header.commands if cmd[0].cmd == LC_UUID]
+            if not uuid_cmd:
+                continue
+            uuid_cmd = uuid_cmd[0]
+
+            # Copy UUID
+            uuids.append(uuid.UUID(bytes=uuid_cmd[1].uuid))
+
+        return uuids
+
+    # Helper structure for organizing the results of build runs.
+    @dataclasses.dataclass
+    class Result:
+        # For each resulting executable, we store  the list of UUIDs extracted from all available arch slices.
+        program1_onedir: list
+        program1_onefile: list
+        program1_onedir_w: list
+        program1_onedir_w_app: list
+
+        program2_onedir: list
+        program2_onefile: list
+
+        program3_onedir: list
+        program3_onefile: list
+
+        @staticmethod
+        def create_result(dist_path):
+            return Result(
+                # First program
+                program1_onedir=_read_uuids(dist_path / "program1_onedir/program1_onedir"),
+                program1_onefile=_read_uuids(dist_path / "program1_onefile"),
+                program1_onedir_w=_read_uuids(dist_path / "program1_onedir_w/program1_onedir_w"),
+                program1_onedir_w_app=_read_uuids(dist_path / "program1_onedir_w.app/Contents/MacOS/program1_onedir_w"),
+                # Second program
+                program2_onedir=_read_uuids(dist_path / "program2_onedir/program2_onedir"),
+                program2_onefile=_read_uuids(dist_path / "program2_onefile"),
+                # Third program
+                program3_onedir=_read_uuids(dist_path / "program3_onedir/program3_onedir"),
+                program3_onefile=_read_uuids(dist_path / "program3_onefile"),
+            )
+
+        def display_result(self, build_name):
+            print(f"{build_name}")
+
+            print("* program1_onedir:", self.program1_onedir)
+            print("* program1_onefile:", self.program1_onefile)
+            print("* program1_onedir_w:", self.program1_onedir_w)
+            print("* program1_onedir_w_app:", self.program1_onedir_w_app)
+
+            print("* program2_onedir:", self.program2_onedir)
+            print("* program2_onedfile:", self.program2_onefile)
+
+            print("* program3_onedir:", self.program3_onedir)
+            print("* program3_onefile:", self.program3_onefile)
+
+    # Build the test programs - first run.
+    pyi_builder_spec._dist_dir = tmp_path / 'dist-1'
+    pyi_builder_spec._build_dir = tmp_path / 'build-1'
+    pyi_builder_spec.test_spec(
+        'pyi_macos_executable_uuid.spec',
+        # Provide name of one application to appease the find/run-executable phase.
+        app_name='program1_onedir',
+    )
+
+    result1 = Result.create_result(pyi_builder_spec._dist_dir)
+    result1.display_result("First build")
+
+    # onefile and onedir have different contents of PKG archive.
+    assert result1.program1_onedir != result1.program1_onefile
+
+    # windowed mode uses different bootloader executable.
+    assert result1.program1_onedir != result1.program1_onedir_w
+
+    # In windowed mode, regular onedir build uses same executable as the .app bundle. So this test is technically a
+    # no-op, unless we try to ensure that .app bundle codepath doesn't additionally reset the UUIDs in some way.
+    assert result1.program1_onedir_w == result1.program1_onedir_w_app
+
+    # program2 is built using the same script as program1.
+    assert result1.program2_onedir == result1.program1_onedir
+    assert result1.program2_onefile == result1.program1_onefile
+
+    # program3 is built using different script.
+    assert result1.program3_onedir != result1.program1_onedir
+    assert result1.program3_onefile != result1.program1_onefile
+
+    # Build the test programs - second run.
+    pyi_builder_spec._dist_dir = tmp_path / 'dist-2'
+    pyi_builder_spec._build_dir = tmp_path / 'build-2'
+    pyi_builder_spec.test_spec(
+        'pyi_macos_executable_uuid.spec',
+        app_name='program1_onedir',
+    )
+
+    result2 = Result.create_result(pyi_builder_spec._dist_dir)
+    result2.display_result("Second build")
+
+    # Compare both results - the UUIDs should be identical across all pairs of corresponding programs.
+    assert result1 == result2

--- a/tests/functional/test_reproducibility.py
+++ b/tests/functional/test_reproducibility.py
@@ -9,6 +9,34 @@
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
 
+# NOTE: CPython does not, in fact, guarantee reproducibility of byte-compiled .pyc modules - see [1, 2, 3].
+#
+# In our case, the lack of .pyc reproducibility creeps up when trying to byte-compile the same module multiple times
+# *within the same python process*; the byte-compiled result of the very first attempt will differ from that of the
+# second attempt, while result of all subsequent attempts will be the same as the second attempt. Note that this does
+# not affect regular PyInstaller use (because each build is ran as a different process, so unless multiple targets are
+# built in the same .spec file, each module is byte-compiled at most once) as much as it does our test suite (where
+# multiple builds are executed within the context of the same `pytest` runner).
+#
+# The issues stemming from the non-deterministic behavior of FLAG_REF tracking can be, to some extent, mitigated by
+# post-processing the byte-code using `marshalparser` tool [4]. However, this comes at performance cost that makes it
+# unsuitable for the amount of processing done as part of our test suite. Furthermore, it does not seem to fully
+# mitigate the behavior in python >= 3.13, where additional non-reproducibility aspects were introduced by interning
+# of co_filename, co_name, and co_qualname [5].
+#
+# Therefore, to allow us to test at least some aspects of reproducibility, the tests in this file that perform multiple
+# subsequent build runs and compare results between them first perform a throw-away "calibration" build and ignore its
+# results. This should hopefully ensure reproducibility of the byte-compiled python code in subsequent, real build runs,
+# and ensure that tests work as expected regardless of the order in which they are executed (or when executed on their
+# own).
+#
+# References:
+# [1] https://github.com/astral-sh/uv/issues/10619
+# [2] https://github.com/python/cpython/issues/129724
+# [3] https://github.com/python/cpython/issues/78274
+# [4] https://pypi.org/project/marshalparser
+# [5] https://github.com/python/cpython/commit/2ba2c142a615abbd8138d253edfe02426c386961
+
 import dataclasses
 import filecmp
 import time
@@ -26,7 +54,12 @@ def test_reproducible_subsequent_builds(pyi_builder, tmp_path, monkeypatch):
     if is_win:
         monkeypatch.setenv('SOURCE_DATE_EPOCH', f"{time.time():.0f}")
 
-    # Two consecutive builds; ensure their build and dist dirs are different
+    # Two consecutive builds (preceded by a throw-away "calibration" one, as per note at the top of this file); ensure
+    # their build and dist dirs are different.
+    pyi_builder._dist_dir = tmp_path / 'dist-0'
+    pyi_builder._build_dir = tmp_path / 'build-0'
+    pyi_builder.test_script('pyi_helloworld.py')
+
     pyi_builder._dist_dir = tmp_path / 'dist-1'
     pyi_builder._build_dir = tmp_path / 'build-1'
     pyi_builder.test_script('pyi_helloworld.py')
@@ -146,12 +179,20 @@ def test_macos_executable_uuid(pyi_builder_spec, tmp_path):
             print("* program3_onedir:", self.program3_onedir)
             print("* program3_onefile:", self.program3_onefile)
 
+    # Build the test programs - throw-away "calibration" build, as per note at the top of this file.
+    pyi_builder_spec._dist_dir = tmp_path / 'dist-0'
+    pyi_builder_spec._build_dir = tmp_path / 'build-0'
+    pyi_builder_spec.test_spec(
+        'pyi_macos_executable_uuid.spec',
+        # Provide name of one application to appease the find/run-executable phase.
+        app_name='program1_onedir',
+    )
+
     # Build the test programs - first run.
     pyi_builder_spec._dist_dir = tmp_path / 'dist-1'
     pyi_builder_spec._build_dir = tmp_path / 'build-1'
     pyi_builder_spec.test_spec(
         'pyi_macos_executable_uuid.spec',
-        # Provide name of one application to appease the find/run-executable phase.
         app_name='program1_onedir',
     )
 

--- a/tests/functional/test_reproducibility.py
+++ b/tests/functional/test_reproducibility.py
@@ -1,0 +1,72 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2025, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+import filecmp
+import time
+
+from PyInstaller.compat import is_win
+
+
+def test_reproducible_subsequent_builds(pyi_builder, tmp_path, monkeypatch):
+    from PyInstaller.archive.readers import CArchiveReader
+
+    # On Windows, we need to set SOURCE_DATE_EPOCH for the build to be fully reproducible (i.e., the build timestamp
+    # that is embedded in the executable)
+    if is_win:
+        monkeypatch.setenv('SOURCE_DATE_EPOCH', f"{time.time():.0f}")
+
+    # Two consecutive builds; ensure their build and dist dirs are different
+    pyi_builder._dist_dir = tmp_path / 'dist-1'
+    pyi_builder._build_dir = tmp_path / 'build-1'
+    pyi_builder.test_script('pyi_helloworld.py')
+    executable1 = pyi_builder._find_executables("pyi_helloworld")[0]
+    print("First executable:", executable1)
+
+    pyi_builder._dist_dir = tmp_path / 'dist-2'
+    pyi_builder._build_dir = tmp_path / 'build-2'
+    pyi_builder.test_script('pyi_helloworld.py')
+    executable2 = pyi_builder._find_executables("pyi_helloworld")[0]
+    print("Second executable:", executable2)
+
+    pkg1 = CArchiveReader(executable1)
+    pkg2 = CArchiveReader(executable2)
+
+    # First, compare TOCs of embedded PYZ archives - so we can get detailed error if their elements differ.
+    def _find_pyz(pkg):
+        pyz = [name for name, (*_, typecode) in pkg.toc.items() if typecode == 'z']
+        return pyz[0]
+
+    pyz1_name = _find_pyz(pkg1)
+    pyz1 = pkg1.open_embedded_archive(pyz1_name)
+
+    pyz2_name = _find_pyz(pkg2)
+    pyz2 = pkg2.open_embedded_archive(pyz2_name)
+
+    assert pyz1.toc == pyz2.toc
+
+    # Compare PYZ archives bit-by-bit
+    pyz1_data = pkg1.extract(pyz1_name)
+    pyz2_data = pkg2.extract(pyz2_name)
+
+    assert pyz1_data == pyz2_data
+
+    # Compare PKG TOCs
+    assert pkg1.toc == pkg2.toc
+    assert pkg1.options == pkg2.options
+
+    # Compare PKG archives bit-by-bit
+    pkg1_data = pkg1.raw_pkg_data()
+    pkg2_data = pkg2.raw_pkg_data()
+
+    assert pkg1_data == pkg2_data
+
+    # Compare whole executables
+    assert filecmp.cmp(executable1, executable2, shallow=False)


### PR DESCRIPTION
Add basic build reproducibility test for all OSes - i.e., try to make two consecutive builds of the same program, and (naively) expect them to be the same.

Add a similar test that covers Mach-O image UUIDs in macOS executables (see #9057), which is the original reason for descent into this particular rabbit hole...

To have reproducible builds within the context of a CI run, we need to fix the name of the PYZ archive, because the default names include auto-incremented counter; the easiest way to address this is to simply set the destination name in the PKG to `PYZ.pyz`, regardless of what the original name was.

It also turns out that CPython does not guarantee to produce reproducible byte-compiled code for the modules. In particular, the result of the very first attempt to byte-compile a particular module ends up being different from subsequent ones (which are all the same) if they are made within the same python process. Therefore, to have these tests work regardless of order in which they are ran (especially if they are the first or the only one test) they must first perform a throw-away build to ensure that situation with byte-compilation is "normalized".

I've been looking into post-processing the byte-code with [`marshalparser`](https://pypi.org/project/marshalparser/), which fixes some of byte-code reproducibility issues (but not the additional ones that seem to have emerged with python 3.13...). But the performance impact makes it impractical, especially in the context of our CI...
