### PR TITLE
hookutils: add get_installer_for_dist as replacement for get_installer

### DIFF
--- a/PyInstaller/hooks/hook-numpy.py
+++ b/PyInstaller/hooks/hook-numpy.py
@@ -33,14 +33,14 @@
 
 from PyInstaller import compat
 from PyInstaller.utils.hooks import (
-    get_installer,
+    get_installer_for_dist,
     collect_dynamic_libs,
 )
 
 from packaging.version import Version
 
 numpy_version = Version(compat.importlib_metadata.version("numpy")).release
-numpy_installer = get_installer('numpy')
+numpy_installer = get_installer_for_dist('numpy')
 
 hiddenimports = []
 datas = []

--- a/PyInstaller/utils/hooks/__init__.py
+++ b/PyInstaller/utils/hooks/__init__.py
@@ -19,6 +19,7 @@ import fnmatch
 from pathlib import Path
 from collections import deque
 from typing import Callable
+import warnings
 
 import packaging.requirements
 
@@ -1052,6 +1053,24 @@ def copy_metadata(package_name: str, recursive: bool = False):
     return out
 
 
+def get_installer_for_dist(dist_name: str):
+    """
+    Try to find which package manager installed the specified distribution.
+
+    :param dist: Distribution name to check
+    :return: Package manager or None
+    """
+    try:
+        dist = importlib_metadata.distribution(dist_name)
+        installer_text = dist.read_text('INSTALLER')
+        if installer_text is not None:
+            return installer_text.strip()
+    except importlib_metadata.PackageNotFoundError:
+        pass
+
+    return None
+
+
 def get_installer(module: str):
     """
     Try to find which package manager installed a module.
@@ -1059,6 +1078,14 @@ def get_installer(module: str):
     :param module: Module to check
     :return: Package manager or None
     """
+
+    # Deprecation warning
+    warnings.warn(
+        "get_installer() hook utility function is deprecated. Use get_installer_for_dist() instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
     # Resolve distribution for given module/package name (e.g., enchant -> pyenchant).
     pkg_to_dist = importlib_metadata.packages_distributions()
     dist_names = pkg_to_dist.get(module)

--- a/news/9067.bugfix.rst
+++ b/news/9067.bugfix.rst
@@ -1,0 +1,3 @@
+Fix detection of installer type (``conda``, ``pip``) and execution of
+corresponding installer-specific part of the ``numpy`` hook when using
+python 3.10 and ``numpy`` >= 2.0.0.

--- a/news/9067.deprecation.rst
+++ b/news/9067.deprecation.rst
@@ -1,0 +1,2 @@
+``PyInstaller.utils.hooks.get_installer`` hook utility function is now
+deprecated in favor of new ``PyInstaller.utils.hooks.get_installer_for_dist``.

--- a/news/9067.feature.rst
+++ b/news/9067.feature.rst
@@ -1,0 +1,2 @@
+Implement new hook utility function, ``PyInstaller.utils.hooks.get_installer_for_dist``,
+intended to replace ``PyInstaller.utils.hooks.get_installer``.


### PR DESCRIPTION
It turns out that under python 3.10 with numpy >= 2.0.0 installed either via pip or Anaconda, `get_installer` hook utility function returns `None`. This in turn prevents [Anaconda-specific](https://github.com/pyinstaller/pyinstaller/blob/02997d3fef2c571eaca7aebf9707f5d246faf1f5/PyInstaller/hooks/hook-numpy.py#L55-L59) and [pip-specific](https://github.com/pyinstaller/pyinstaller/blob/02997d3fef2c571eaca7aebf9707f5d246faf1f5/PyInstaller/hooks/hook-numpy.py#L65-L67) parts of the hook from being executed.

This happens because `numpy` >= 2.0.0 does not include `top_level.txt` file in the metadata anymore, and `importlib.metadata` in 3.10 stdlib requires this file for mapping of top-level importable names to distribution names (i.e., `importlib.metadata.packages_distributions()`).

Consequently, our attempt in `get_installer` to resolve the module name ("numpy") into dist name here
https://github.com/pyinstaller/pyinstaller/blob/02997d3fef2c571eaca7aebf9707f5d246faf1f5/PyInstaller/utils/hooks/__init__.py#L1063-L1069
fails, and we do not attempt to read the contents INSTALLER from metadata at all.

In python >= 3.11, stdlib `importlib.metadata.packages_distributions` added fallback that infers top-level importable names if they are not explicitly given via `top_level.txt`. With python 3.8 and 3.9, we use `importlib-metadata` instead, and if it is recent enough (>= 4.8.1), it also includes support for inferring top-level importable names (we mandate >= 4.6, though). So the issue is quite localized. 

We could solve this by having `get_installer` also try to treat passed name as dist name. Or by using `importlib-metadata` >= 4.13 for python < 3.11. But I think this is a good opportunity to stop (ab)using importable names , and start querying the installer for dist name instead. Hence the deprecation of old `get_installer` and introduction of `get_installer_for_dist`.

At the moment, there is exactly one use of this helper in the base repository (the `numpy` hook, which is updated to use the new helper). In contrib hooks repository, there are two - [hook-enchant.py](https://github.com/pyinstaller/pyinstaller-hooks-contrib/blob/960af41fae0175bc6a6877245806e0f3b575fe53/_pyinstaller_hooks_contrib/stdhooks/hook-enchant.py#L45) and [hook-rtree](https://github.com/pyinstaller/pyinstaller-hooks-contrib/blob/960af41fae0175bc6a6877245806e0f3b575fe53/_pyinstaller_hooks_contrib/stdhooks/hook-rtree.py#L22); I suppose to keep those hooks compatible with older PyInstaller versions, we will need to backport `get_installer_for_dist` into `_pyinstaller_hooks_contrib.compat`.