### PR TITLE
Fix for failing test_site_module_disabled on macOS and python 3.9

### DIFF
--- a/PyInstaller/hooks/hook-_osx_support.py
+++ b/PyInstaller/hooks/hook-_osx_support.py
@@ -1,0 +1,19 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2025, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+# Prevent conditional import of `distutils` in `_osx_support.compiler_fixup()` in python < 3.10 from pulling in
+# `distutils`; this function is called only from `distutils` itself, which ensures that the module is available as
+# needed. Blocking this import prevents `distutils` (and nowadays `setuptools`) from being pulled into even very
+# basic applications when built with python < 3.10.
+#
+# See: https://github.com/python/cpython/blob/f3994ade31a563d49806cf6a681d1b1115fccaa3/Lib/_osx_support.py#L430-L434
+
+excludedimports = ['distutils']

--- a/tests/functional/scripts/pyi_site_module_disabled.py
+++ b/tests/functional/scripts/pyi_site_module_disabled.py
@@ -9,14 +9,20 @@
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
 
-# Test that the Pythons 'site' module is disabled and Python is not searching for any user-specific site directories.
-
-# Check that option -S is passed to Python interpreter and that sys.path has not been modified.
+# Test that the Python's `site` module is disabled and Python is not searching for any user-specific site directories;
+# in frozen application, this is effectively checking that PyInstaller's bootloader sets the `site_import` flag in the
+# `PyConfig` structure is set to 0 (equivalent of passing -S to python interpreter executable).
 
 import sys
 
-# The option -S tells Python not to import `site` on startup. If the site module has already been imported,
-# abort the test immediately.
+# With `python -S` option (and equivalent `PyConfig.site_import = 0`) set, Python should not import `site` module on
+# the startup. Therefore, check that is not imported yet.
+#
+# NOTE: in the frozen application, the module might end up imported as a dependency of another module that is imported
+# when PyInstaller's run-time hooks are imported. If the frozen test script fails at this point, it is best to check
+# what run-time hooks were ran, and what imports were made from them; this test script is very simple, so it should
+# not warrant imports of many modules with run-time hooks. However, a package like `setuptools` might end up being
+# pulled in, for example, via reference to `distutils` (for which it provides replacement).
 if 'site' in sys.modules:
     raise SystemExit('site module already imported')
 
@@ -40,5 +46,5 @@ if site.USER_SITE is not None:
 # This should never happen, USER_BASE is not a site-modules folder and is only used by distutils
 # for installing module datas.
 if site.USER_BASE is not None:
-    if site.USER_SITE in sys.path:
+    if site.USER_BASE in sys.path:
         raise SystemExit('USER_BASE found in sys.path!')


### PR DESCRIPTION
Over the last few days, the `test_site_module_disabled` started to fail on macOS python 3.9 runner (e.g., [here](https://github.com/pyinstaller/pyinstaller/actions/runs/14001775971/job/39212391324?pr=9067)).

The failure is caused by `site` module being already imported at the start of the test, which is explicitly checking that this is not the case (as `site` module should be disabled in the interpreter config, and thus not imported during its initialization). 

It turns out that this is caused by import of `setuptools` in the run-time hook for `setuptools`, but only with `setuptools` v77.0.3 that was released on Mar 20. The import chain is `pyi_rth_setuptools.py` -> `setuptools` -> `setuptools.dist` -> `setuptools.command` -> `setuptools._distutils.command` -> `setuptools._distutils.command.build_ext` -> `site`,
and was likely brought about by https://github.com/pypa/setuptools/commit/1d120d919bd6d5cb8ba1b179c2099bd947d2c466.

It also turns out that the failing test under python 3.9 on macOS is collecting `setuptools`, while the (succeeding) tests under other versions (and OSes) are not. The offending import chain turns out to be: `pyi_site_module_disabled.py` -> `site` -> `_sitebuiltins` -> `pydoc` -> `sysconfig` -> `_osx_support` -> `distutils` (-> `setuptools`).

This is caused by a [conditional import in `_osx_support.compiler_fixup`](https://github.com/python/cpython/blob/f3994ade31a563d49806cf6a681d1b1115fccaa3/Lib/_osx_support.py#L430-L434), which itself seems to be intended to be used by `distutils`.

This explains why we are seeing this only on macOS, and only with python 3.9 - latest `setuptools` do not  support python 3.8 anymore, and the use of `distutils.log` in `_osx_support.compiler_fixup` was removed in python >= 3.10.

Therefore, add a hook for `_osx_support` that excludes `distutils`. In addition to fixing the failing test, this should also ensure that `distutils` / `setuptools` do no end up pulled into basic applications that import either `site` or `sysconfig` (or a module that imports either of these) when building with python 3.8 or 3.9 on macOs.