### PR TITLE
hooks/scipy: Collect Debian's custom scipy.__config__{SOABI}__ submodule

### DIFF
--- a/PyInstaller/hooks/hook-scipy.py
+++ b/PyInstaller/hooks/hook-scipy.py
@@ -11,8 +11,9 @@
 
 import glob
 import os
+import sysconfig
 
-from PyInstaller.compat import is_win
+from PyInstaller.compat import is_win, is_linux
 from PyInstaller.utils.hooks import (
     get_module_file_attribute,
     check_requirement,
@@ -43,6 +44,12 @@ hiddenimports = ['scipy._lib.%s' % m for m in ['messagestream', "_ccallback_c", 
 # to be added to hiddenimports.
 if check_requirement("scipy >= 1.14.0"):
     hiddenimports += ['scipy._lib.array_api_compat.numpy.fft']
+
+# If scipy is provided by Debian's python3-scipy, its scipy.__config__ submodule is renamed to a dynamically imported
+# scipy.__config__${SOABI}__
+# https://salsa.debian.org/python-team/packages/scipy/-/blob/1255922cf7c52b05aa44fb733449953cd9adb815/debian/patches/scipy_config_SOABI.patch
+if is_linux and "dist-packages" in get_module_file_attribute("scipy"):
+    hiddenimports.append('scipy.__config__' + sysconfig.get_config_var('SOABI') + '__')
 
 # The `scipy._lib.array_api_compat.numpy` module performs a `from numpy import *`; in numpy 2.0.0, `numpy.f2py` was
 # added to `numpy.__all__` attribute, but at the same time, the upstream numpy hook adds `numpy.f2py` to

--- a/news/9069.hooks.rst
+++ b/news/9069.hooks.rst
@@ -1,0 +1,1 @@
+Fix ``ModuleNotFoundError`` for ``scipy`` when provided by Debian's ``python3-scipy`` package.


### PR DESCRIPTION
The `python3-scipy` Debian/apt package renames `scipy.__config__` to a dynamically imported submodule with `sysconfig.get_config_var('SOABI')` in it.

https://salsa.debian.org/python-team/packages/scipy/-/blob/1255922cf7c52b05aa44fb733449953cd9adb815/debian/patches/scipy_config_SOABI.patch

Not fond of this one. Open to better ideas?