### PR TITLE
Remove line break in code block

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -126,8 +126,8 @@ enhancements on these are welcome.
   above.
 
 Before using any contributed platform, you need to build the PyInstaller
-bootloader. This will happen automatically when you ``pip install
-pyinstaller`` provided that you have an appropriate C compiler (typically
+bootloader. This will happen automatically when you ``pip install pyinstaller``
+provided that you have an appropriate C compiler (typically
 either ``gcc`` or ``clang``) and zlib's development headers already installed.
 
 


### PR DESCRIPTION
When viewed on https://github.com/pyinstaller/pyinstaller?tab=readme-ov-file#untested-platforms, a code block looks like this:
<img width="614" alt="{B3989377-CF72-4D07-8545-0468DD7E0414}" src="https://github.com/user-attachments/assets/aff17bef-54e0-407c-9a70-7a60f91c03a5" />
This is obviously unintended behaviour, and should therefore be changed to this:
<img width="633" alt="{7BDC98B8-6E1C-447F-9656-1433E676782C}" src="https://github.com/user-attachments/assets/b0042c43-e7a4-4fb1-ab59-e641fe6aa65c" />

This pull request should fix this.