### PR TITLE
build: Replace deprecated wheel.bdist_wheel with setuptools's copy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
             ls ../PyInstaller/bootloader/Windows-64bit-arm
 
       - name: Update pip
-        run: python -m pip install --upgrade pip setuptools wheel build
+        run: python -m pip install --upgrade pip setuptools build
 
       # On (macos-14, python 3.10), (macos-13, python 3.11) and (macos-14, python 3.11)
       # combinations the initial `setuptools` installation seems to contain `.opt-1.pyc`
@@ -386,7 +386,6 @@ jobs:
             mingw-w64-${{matrix.env}}-gcc
             mingw-w64-${{matrix.env}}-python
             mingw-w64-${{matrix.env}}-python-pip
-            mingw-w64-${{matrix.env}}-python-wheel
             mingw-w64-${{matrix.env}}-python-setuptools
             mingw-w64-${{matrix.env}}-python-pywin32-ctypes
             mingw-w64-${{matrix.env}}-python-packaging
@@ -449,9 +448,9 @@ jobs:
         uses: cygwin/cygwin-install-action@master
         with:
           platform: x86_64
-          # NOTE: some of the provided packages (python39-wheel,
-          # python39-setuptools, python39-packaging, python39-pytest) are
-          # out-of-date, and we instead install PyPI wheels.
+          # NOTE: some of the provided packages (python39-setuptools,
+          # python39-packaging, python39-pytest) are out-of-date, and we instead
+          # install PyPI wheels.
           #
           # NOTE: for some reason, python39-pip depends on python39-sphinx,
           # which is an old sphinx v4.4.0 package. This version contains
@@ -482,7 +481,7 @@ jobs:
           python --version
 
       - name: Update pip and base test tools
-        run: python -m pip install --progress-bar=off --upgrade pip setuptools wheel build --requirement tests/requirements-base.txt sphinx
+        run: python -m pip install --progress-bar=off --upgrade pip setuptools --requirement tests/requirements-base.txt sphinx
 
       - name: Install PyInstaller
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,7 +26,7 @@ jobs:
         python-version: 3.8
 
     - name: Install dependencies
-      run: pip install --upgrade flake8 wheel setuptools yapf==0.32.0 toml
+      run: pip install --upgrade flake8 yapf==0.32.0 toml
 
     - name: Test that yapf has been applied
       # If this check fails for your PR, run `yapf -rip .`

--- a/.github/workflows/validate-new-news.yml
+++ b/.github/workflows/validate-new-news.yml
@@ -20,7 +20,7 @@ jobs:
         run: python scripts/verify-news-fragments.py
 
       - name: Install towncrier
-        run: pip install -q -U setuptools wheel towncrier
+        run: pip install -q -U towncrier
 
       - name: Run towncrier
         run: towncrier --draft

--- a/PyInstaller/utils/hooks/__init__.py
+++ b/PyInstaller/utils/hooks/__init__.py
@@ -1001,7 +1001,7 @@ def copy_metadata(package_name: str, recursive: bool = False):
                     "1. uninstall the zipped egg:\n"
                     f"  pip uninstall {package_name}\n"
                     "2. make sure pip and its dependencies are up-to-date:\n"
-                    "  python -m pip install --upgrade pip wheel setuptools\n"
+                    "  python -m pip install --upgrade pip setuptools\n"
                     "3. install the package:\n"
                     f"  pip install {package_name}\n"
                     "To install a package from source, pass the path to the source directory to 'pip install' command."

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -35,7 +35,7 @@ RUN pip wheel -r tests/requirements-tools.txt -w wheels
 
 # Recent versions of python docker image do not provide setuptools and wheel with python (>= 3.12) by default.
 # See: https://github.com/docker-library/python/issues/952
-RUN pip install --upgrade setuptools wheel build
+RUN pip install --upgrade setuptools build
 
 # Build a wheel for PyInstaller. Do this last and use as few files as possible to maximize cache-ability.
 COPY COPYING.txt .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,11 +80,7 @@ coalesce_brackets = true
 blank_line_before_nested_class_or_def = false
 
 [build-system]
-# Tells pip to install wheel before trying to install PyInstaller
-# from an sdist or from Github.
-# Installing without wheel uses legacy `python setup.py install`
-# which has issues with unicode paths.
 requires = [
-	"wheel",
-	"setuptools >= 42.0.0",
+  # Required for setuptools.command.bdist_wheel.bdist_wheel
+	"setuptools >= 70.1.0",
 ]

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ import sys
 import os
 
 from setuptools import setup
+from setuptools.command.bdist_wheel import bdist_wheel
 
 #-- plug-in building the bootloader
 
@@ -23,11 +24,6 @@ from distutils.command.build import build
 # python < 3.10, pywin32-ctypes on Windows). These dependencies are not required for the subset of functionality that is
 # used here in the `setup.py`.
 os.environ["_PYINSTALLER_SETUP_PY"] = "1"
-
-try:
-    from wheel.bdist_wheel import bdist_wheel
-except ImportError:
-    raise SystemExit("Error: Building wheels requires the 'wheel' package. Please `pip install wheel` then try again.")
 
 
 class build_bootloader(Command):

--- a/tests/requirements-developer.txt
+++ b/tests/requirements-developer.txt
@@ -18,7 +18,6 @@ pycmd  # Contains 'py.cleanup' that removes all .pyc files and similar.
 
 ### Helpers for releases
 
-wheel>0.24.0  # For creating .whl packages
 twine         # For secure upload of tar.gz to PYPI.
 
 towncrier==22.8.0    # For creating the change-log file.


### PR DESCRIPTION
The `wheel.bdist_wheel` module has moved into setuptools. The former is being removed, albeit with a deprecated `from setuptools.command.bdist_wheel import bdist_wheel` compatibility shim in its place.

See: https://github.com/pypa/wheel/pull/655

Hopefully, it'll like its new home...