### PR TITLE
Deprecate onefile .app bundles on macOS

### DIFF
--- a/PyInstaller/building/makespec.py
+++ b/PyInstaller/building/makespec.py
@@ -781,6 +781,10 @@ def main(
     hiddenimports = hiddenimports or []
     upx_exclude = upx_exclude or []
 
+    if is_darwin and onefile and not console:
+        from PyInstaller.building.osx import WINDOWED_ONEFILE_DEPRCATION
+        logger.log(logging.DEPRECATION, WINDOWED_ONEFILE_DEPRCATION)
+
     # If file extension of the first script is '.pyw', force --windowed option.
     if is_win and os.path.splitext(scripts[0])[-1] == '.pyw':
         console = False

--- a/PyInstaller/building/osx.py
+++ b/PyInstaller/building/osx.py
@@ -15,6 +15,7 @@ import plistlib
 import shutil
 import subprocess
 
+from PyInstaller import log as logging
 from PyInstaller.building.api import COLLECT, EXE
 from PyInstaller.building.datastruct import Target, logger, normalize_toc
 from PyInstaller.building.utils import _check_path_overlap, _rmtree, process_collected_binary
@@ -29,10 +30,20 @@ if is_darwin:
 # `Contents/Frameworks`, where only .framework bundle directories are allowed to have dot in name.
 DOT_REPLACEMENT = '__dot__'
 
+WINDOWED_ONEFILE_DEPRCATION = (
+    "Onefile mode in combination with macOS .app bundles (windowed mode) don't make sense (a .app bundle can not be a "
+    "single file) and clashes with macOS's security. Please migrate to onedir mode. This will become an error "
+    "in v7.0."
+)
+
 
 class BUNDLE(Target):
     def __init__(self, *args, **kwargs):
         from PyInstaller.config import CONF
+
+        for item in args:
+            if isinstance(item, EXE) and not item.exclude_binaries:
+                logger.log(logging.DEPRECATION, WINDOWED_ONEFILE_DEPRCATION)
 
         # BUNDLE only has a sense under macOS, it is a noop on other platforms.
         if not is_darwin:

--- a/news/9049.deprecation.rst
+++ b/news/9049.deprecation.rst
@@ -1,0 +1,2 @@
+Onefile in combination with macOS's .app bundles will be blocked in v7.0 due to its being heavily penalised by macOS's
+security scanning and not providing a single file application anyway. Please use onedir mode instead.


### PR DESCRIPTION
The combination is borderline unusable and isn't really any closer to a single file application than a onedir windowed application.