### PR TITLE
cleanup: replace occurrences of U+02D9 with backtick character

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,6 +20,11 @@ jobs:
         git fetch origin ${{ github.base_ref }}
         git fetch origin ${{ github.ref }}
         git checkout FETCH_HEAD --
+
+    # Prevent @rokm from accidentally adding U+02D9 characters instead of backticks.
+    - name: Ensure that no U+02D9 characters are present
+      run: "! git grep -I $'\u02d9'"
+
     - name: Setup Python
       uses: actions/setup-python@v5
       with:

--- a/PyInstaller/building/build_main.py
+++ b/PyInstaller/building/build_main.py
@@ -524,7 +524,7 @@ class Analysis(Target):
         self.hookspath = []
         # Prepend directories in `hookspath` (`--additional-hooks-dir`) to take precedence over those from the entry
         # points. Expand starting tilde into user's home directory, as a work-around for tilde not being expanded by
-        # shell when using ˙--additional-hooks-dir=~/path/abc` instead of ˙--additional-hooks-dir ~/path/abc` (or when
+        # shell when using `--additional-hooks-dir=~/path/abc` instead of `--additional-hooks-dir ~/path/abc` (or when
         # the path argument is quoted).
         if hookspath:
             self.hookspath.extend([(os.path.expanduser(path), HOOK_PRIORITY_USER_HOOKS) for path in hookspath])
@@ -1126,7 +1126,7 @@ def build(spec, distpath, workpath, clean_build):
     from PyInstaller.config import CONF
 
     # Ensure starting tilde in distpath / workpath is expanded into user's home directory. This is to work around for
-    # tilde not being expanded when using ˙--workpath=~/path/abc` instead of ˙--workpath ~/path/abc` (or when the path
+    # tilde not being expanded when using `--workpath=~/path/abc` instead of `--workpath ~/path/abc` (or when the path
     # argument is quoted). See https://github.com/pyinstaller/pyinstaller/issues/696
     distpath = os.path.abspath(os.path.expanduser(distpath))
     workpath = os.path.abspath(os.path.expanduser(workpath))

--- a/PyInstaller/building/makespec.py
+++ b/PyInstaller/building/makespec.py
@@ -721,7 +721,7 @@ def main(
         specpath = DEFAULT_SPECPATH
     else:
         # Expand starting tilde into user's home directory, as a work-around for tilde not being expanded by shell when
-        # using ˙--specpath=~/path/abc` instead of ˙--specpath ~/path/abc` (or when the path argument is quoted).
+        # using `--specpath=~/path/abc` instead of `--specpath ~/path/abc` (or when the path argument is quoted).
         specpath = os.path.expanduser(specpath)
     # If cwd is the root directory of PyInstaller, generate the .spec file in ./appname/ subdirectory.
     if specpath == HOMEPATH:

--- a/PyInstaller/building/osx.py
+++ b/PyInstaller/building/osx.py
@@ -192,7 +192,7 @@ class BUNDLE(Target):
     #
     # 4. There may not be any content in the top level of a bundle. In other words, if a bundle has a `Contents`
     #    or a `Versions` directory at its top level, there may be no other files or directories alongside them. The
-    #    sole exception is that alongside ˙Versions˙, there may be symlinks to files and directories in
+    #    sole exception is that alongside `Versions`, there may be symlinks to files and directories in
     #    `Versions/Current`. This rule is important for nested .framework bundles that we collect from python packages.
     #
     # Next, let us consider the consequences of violating each of the above requirements:
@@ -204,13 +204,13 @@ class BUNDLE(Target):
     #
     # 2. Putting code (a dylib or a .framework bundle) into `Contents/Resources` causes it to be treated as a resource;
     #    the outer signature (i.e., of the whole .app bundle) does not know that this nested content is actually a code.
-    #    Consequently, signing the bundle with ˙codesign --deep` will NOT sign binaries placed in the
+    #    Consequently, signing the bundle with `codesign --deep` will NOT sign binaries placed in the
     #    `Contents/Resources`, which may result in missing signatures when .app bundle is verified for notarization.
     #    This might be worked around by signing each binary separately, and then signing the whole bundle (without the
-    #    `--deep˙ option), but requires the user to keep track of the offending binaries.
+    #    `--deep` option), but requires the user to keep track of the offending binaries.
     #
     # 3. If a directory in `Contents/MacOS` contains a dot in the name, code-signing the bundle fails with
-    #    ˙bundle format unrecognized, invalid, or unsuitable` due to code signing machinery treating directory as a
+    #    `bundle format unrecognized, invalid, or unsuitable` due to code signing machinery treating directory as a
     #    nested .framework bundle directory.
     #
     # 4. If nested .framework bundle is malformed, the signing of the .app bundle might succeed, but subsequent
@@ -235,7 +235,7 @@ class BUNDLE(Target):
     #   `numpy/.dylibs`, `scipy/.dylibs`, etc.
     #
     #   Qt QML components may also contain a dot in their name; couple of examples from `PySide2` package:
-    #   `PySide2/Qt/qml/QtQuick.2`, ˙PySide2/Qt/qml/QtQuick/Controls.2˙, ˙PySide2/Qt/qml/QtQuick/Particles.2˙, etc.
+    #   `PySide2/Qt/qml/QtQuick.2`, `PySide2/Qt/qml/QtQuick/Controls.2`, `PySide2/Qt/qml/QtQuick/Particles.2`, etc.
     #
     #   The packages' metadata directories also invariably contain dots in the name due to version (for example,
     #   `numpy-1.24.3.dist-info`).

--- a/PyInstaller/building/splash.py
+++ b/PyInstaller/building/splash.py
@@ -449,7 +449,7 @@ class Splash(Target):
     @staticmethod
     def _uses_tkinter(tkinter_file, binaries):
         # Test for _tkinter extension instead of tkinter module, because user might use a different wrapping library for
-        # Tk. Use `pathlib.PurePath˙ in comparisons to account for case normalization and separator normalization.
+        # Tk. Use `pathlib.PurePath` in comparisons to account for case normalization and separator normalization.
         tkinter_file = pathlib.PurePath(tkinter_file)
         for dest_name, src_name, typecode in binaries:
             if pathlib.PurePath(src_name) == tkinter_file:

--- a/PyInstaller/depend/imphookapi.py
+++ b/PyInstaller/depend/imphookapi.py
@@ -468,8 +468,8 @@ class PostGraphAPI:
     def set_module_collection_mode(self, name, mode):
         """"
         Set the package/module collection mode for the specified module name. If `name` is `None`, the hooked
-        module/package name is used. `mode` can be one of valid mode strings (`'pyz'`, `'pyc'`, ˙'py'˙, `'pyz+py'`,
-        ˙'py+pyz'`) or `None`, which clears the setting for the module/package - but only  within this hook's context!
+        module/package name is used. `mode` can be one of valid mode strings (`'pyz'`, `'pyc'`, `'py'`, `'pyz+py'`,
+        `'py+pyz'`) or `None`, which clears the setting for the module/package - but only  within this hook's context!
         """
         if name is None:
             name = self.__name__

--- a/PyInstaller/hooks/hook-numpy.py
+++ b/PyInstaller/hooks/hook-numpy.py
@@ -108,7 +108,7 @@ if numpy_version < (1, 22, 0) or numpy_version > (1, 22, 1):
 # In numpy v2.0.0, numpy.f2py submodule has been added to numpy's `__all__` attribute. Therefore, using
 # `from numpy import *` leads to an error if `numpy.f2py` is excluded (seen in scipy 1.14). The exclusion in earlier
 # releases was not reported to cause any issues, so keep it around. Although it should be noted that it does break an
-# explicit import (i.e., ˙import numpy.f2py`) from user's code as well, because it prevents collection of other
+# explicit import (i.e., `import numpy.f2py`) from user's code as well, because it prevents collection of other
 # submodules from `numpy.f2py`.
 if numpy_version < (2, 0):
     excludedimports += [

--- a/PyInstaller/utils/hooks/__init__.py
+++ b/PyInstaller/utils/hooks/__init__.py
@@ -970,7 +970,7 @@ def copy_metadata(package_name: str, recursive: bool = False):
 
         # We support only `importlib_metadata.PathDistribution`, since we need to rely on its private `_path` attribute
         # to obtain the path to metadata file/directory. But we need to account for possible sub-classes and vendored
-        # variants (`setuptools._vendor.importlib_metadata.PathDistribution˙), so just check that `_path` is available.
+        # variants (`setuptools._vendor.importlib_metadata.PathDistribution`), so just check that `_path` is available.
         if not hasattr(dist, '_path'):
             raise RuntimeError(
                 f"Unsupported distribution type {type(dist)} for {package_name} - does not have _path attribute"
@@ -985,7 +985,7 @@ def copy_metadata(package_name: str, recursive: bool = False):
         if not isinstance(src_path, Path):
             # NOTE: `src_path.parent` is also an instance of `zipfile.Path` or `zipp.Path`, and calling its `is_file()`
             # method returns False, because the root of zip file is (rightfully) considered a directory. Therefore, we
-            # convert the path to `pathlib.Path˙ by taking the parent of `src_path.parent` (which turns out to be a
+            # convert the path to `pathlib.Path` by taking the parent of `src_path.parent` (which turns out to be a
             # `pathlib.Path`) and add to it the name of the `src_path.parent` (the name of .egg file).
             try:
                 src_parent = src_path.parent.parent / src_path.parent.name

--- a/PyInstaller/utils/hooks/qt/_modules_info.py
+++ b/PyInstaller/utils/hooks/qt/_modules_info.py
@@ -76,7 +76,7 @@
 #
 # The `qt_dynamic_dependencies_dict`_ from the original approach was constructed using several information sources, as
 # documented `here
-# <https://github.com/pyinstaller/pyinstaller/blob/fbf7948be85177dd44b41217e9f039e1d176de6b/PyInstaller/utils/hooks/qt.py#L266-L362>˙_.
+# <https://github.com/pyinstaller/pyinstaller/blob/fbf7948be85177dd44b41217e9f039e1d176de6b/PyInstaller/utils/hooks/qt.py#L266-L362>`_.
 #
 # In the current approach, the relations stored in the `QT_MODULES_INFO`_ list were determined directly, by inspecting
 # the Qt source code. This requires some prior knowledge of how the Qt code is organized (repositories and individual Qt

--- a/PyInstaller/utils/osx.py
+++ b/PyInstaller/utils/osx.py
@@ -324,7 +324,7 @@ def update_exe_identifier(filename, pkg_filename):
 
 class InvalidBinaryError(Exception):
     """
-    Exception raised by ˙get_binary_architectures˙ when it is passed an invalid binary.
+    Exception raised by `get_binary_architectures` when it is passed an invalid binary.
     """
     pass
 

--- a/doc/hooks-config.rst
+++ b/doc/hooks-config.rst
@@ -57,7 +57,7 @@ from the system ``/usr/share`` directory.
 
 **Options**
 
- * ``languages`` [*list of strings*]: list of locales (e.g., ˙en_US˙) for
+ * ``languages`` [*list of strings*]: list of locales (e.g., `en_US`) for
    which translations should be collected. By default, ``gi`` hooks
    collect all available translations.
 

--- a/doc/spec-files.rst
+++ b/doc/spec-files.rst
@@ -368,7 +368,7 @@ The following options are supported by this mechanism:
   initialized. This option is equivalent to Python's ``-v`` command-line
   option. It is automatically enabled when :ref:`verbose imports
   <getting python's verbose imports>` are enabled via PyInstaller's own
-  ˙˙--debug imports`` option.
+  ``--debug imports`` option.
 
 * ``'u'`` or ``'unbuffered'``: enable unbuffered stdout and stderr. Equivalent
   to Python's ``-u`` command-line option.

--- a/tests/functional/modules/pyi_module_exclusion/hooks/hook-mymodule_feature3.py
+++ b/tests/functional/modules/pyi_module_exclusion/hooks/hook-mymodule_feature3.py
@@ -1,5 +1,5 @@
 # This hook should not be loaded at all.
-# `mymodule_feature3` is imported by `mymodule_main.submodule_feature3` via import of ˙mymodule_feature3.submodule1`,
+# `mymodule_feature3` is imported by `mymodule_main.submodule_feature3` via import of `mymodule_feature3.submodule1`,
 # but the hook for `mymodule_main` explicitly excludes `mymodule_feature3`. Therefore, if exclusion is applied correctly
 # during processing of modules' imports (as opposed to a post-processing step), and if exclusion rules are applied in
 # recursive way, this hook will not be loaded.

--- a/tests/functional/scripts/pyi_importlib_resources.py
+++ b/tests/functional/scripts/pyi_importlib_resources.py
@@ -336,7 +336,7 @@ assert data.splitlines() == expected_data.splitlines()
 
 # Try to get a data file in a sub-directory via two paths. The read contents should be the same.
 # If we do not provide our own resource reader, neither way of accessing works in frozen version with back-ported
-# importlib_resources (˙˙FileNotFoundError: Can't open orphan path˙˙).
+# importlib_resources (``FileNotFoundError: Can't open orphan path``).
 # It works correctly with built-in importlib.resources in python 3.9 (even if we do not implement a resource reader).
 expected_data = b"""Data entry #2 in `subpkg1/data`.\n"""
 


### PR DESCRIPTION
Replace occurrences of the "dot above" (U+02D9) character with the intended backtick character.

These all came from me; on my keyboard layout, the backtick character (` = ASCII 96 = U+0060) is produced by Alt + 7, while pressing Alt + 8 (followed by spacebar) produces the Unicode "dot above" character (˙ = U+02D9). Which, given sufficiently small fonts and lack of attention, ends up being similar enough (except when it ends up messing the rst / markdown).