### PR TITLE
modulegraph: try to look for .py or .pyi files that accompany extensions

### DIFF
--- a/news/9084.feature.rst
+++ b/news/9084.feature.rst
@@ -1,0 +1,4 @@
+Extend analysis code so that when extension module is encountered, it
+checks for the presence of an adjacent ``.py`` or ``.pyi`` file, and
+if present, attempt to perform import analysis on such accompanying
+source/interface file.


### PR DESCRIPTION
When modulegraph encounters an extension module, have it check for adjacent `.py` or `.pyi` files (in that order of priority). If such accompanying source (or interface) file is available, compile it into code object to perform import analysis on it.

This attempts to improve import analysis of extension modules, which on their own cannot be analyzed by modulegraph. However, sometimes cythonized packages ship both binary extensions and original .py files, or the extensions have accompanying .pyi files; both of those can be analyzed for imports as if they were regular source files, and might provide information about at least some, if not all, imports that are made within the extension.