### PR TITLE
ci: remove QT_QPA_PLATFORM=offscreen for non-Windows Qt tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
             libespeak1 libxcb-image0 libxcb-keysyms1 libxcb-render-util0 \
             libxkbcommon-x11-0 libxcb-icccm4 libxcb1 openssl \
             libxcb-randr0-dev libxcb-xtest0-dev libxcb-xinerama0-dev \
-            libxcb-shape0-dev libxcb-xkb-dev xvfb \
+            libxcb-shape0-dev libxcb-xkb-dev libxcb-cursor0 xvfb \
             libopengl0 libegl1 \
             libpulse0 libpulse-mainloop-glib0 \
             gstreamer1.0-plugins-base libgstreamer-gl1.0-0 \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,13 +219,6 @@ jobs:
         run: |
           python -m pip install --progress-bar=off --upgrade --requirement tests/requirements-libraries.txt
 
-      - name: Set up extra environment variables (non-Windows)
-        if: ${{ !startsWith(matrix.os, 'windows') }}
-        run: |
-          # Run Qt-based tests with offscreen backend. This seems to break QtWebEngine tests on Windows, so
-          # apply it only here, in non-Windows path.
-          echo "QT_QPA_PLATFORM=offscreen" >> $GITHUB_ENV
-
       - name: Start display server
         if: startsWith(matrix.os, 'ubuntu')
         run: |


### PR DESCRIPTION
Remove `QT_QPA_PLATFORM=offscreen` for non-Windows Qt tests.

Preliminary tests with PySide6 6.9.0 indicate that offscreen platform backend randomly breaks the QtWebEngine test on arm64 macOS (i.e., the `macos-14` runner); see [here](https://github.com/rokm/pyinstaller/actions/runs/14224706692) and [here](https://github.com/rokm/pyinstaller/actions/runs/14230408816).

And even on the remaining unaffected platform (linux), it likely makes more sense to test with the default platform rather than offscreen.