### PR TITLE
bootloader: fix building under Termux and on linux with glibc <= v2.24

### DIFF
--- a/bootloader/src/pyi_utils_posix.c
+++ b/bootloader/src/pyi_utils_posix.c
@@ -31,7 +31,9 @@
 #include <signal.h> /* kill */
 #include <sys/stat.h> /* struct stat */
 #include <sys/wait.h>
-#include <sys/sem.h> /* SysV semaphore API */
+#if defined(HAVE_SYS_SEM_H)
+    #include <sys/sem.h> /* SysV semaphore API */
+#endif
 
 #include <dirent.h>
 
@@ -554,6 +556,7 @@ pyi_utils_create_child(struct PYI_CONTEXT *pyi_ctx)
      * The first choice for API would be un-named POSIX signals, but this
      * is not supported on macOS. So we use the old SysV signals API... */
 
+#if defined(HAVE_SYS_SEM_H)
     /* Argument for semctl(); according to API, we need to provide our
      * own union definition... */
     union {
@@ -586,6 +589,7 @@ pyi_utils_create_child(struct PYI_CONTEXT *pyi_ctx)
             goto cleanup;
         }
     }
+#endif /* defined(HAVE_SYS_SEM_H) */
 
     /* macOS: Apple Events handling */
 #if defined(__APPLE__) && defined(WINDOWED)
@@ -624,6 +628,7 @@ pyi_utils_create_child(struct PYI_CONTEXT *pyi_ctx)
         char *const *argv = (pyi_ctx->pyi_argv != NULL) ? pyi_ctx->pyi_argv : pyi_ctx->argv;
         const int argc = (pyi_ctx->pyi_argv != NULL) ? pyi_ctx->pyi_argc : pyi_ctx->argc;
 
+#if defined(HAVE_SYS_SEM_H)
         /* Wait on the sync semaphore */
         if (sem_id >= 0) {
             PYI_DEBUG("LOADER: waiting on sync semaphore...\n");
@@ -634,6 +639,7 @@ pyi_utils_create_child(struct PYI_CONTEXT *pyi_ctx)
                 PYI_PERROR("semop", "Failed to wait on sync semaphore!\n");
             }
         }
+#endif /* defined(HAVE_SYS_SEM_H) */
 
         /* Modify the LISTEN_PID environment variable, if necessary */
         if (_pyi_set_systemd_env() != 0) {
@@ -699,6 +705,7 @@ pyi_utils_create_child(struct PYI_CONTEXT *pyi_ctx)
         signal(signum, signal_handler);
     }
 
+#if defined(HAVE_SYS_SEM_H)
     if (sem_id >= 0) {
         PYI_DEBUG("LOADER: signalling the sync semaphore...\n");
         sem_op.sem_num = 0;
@@ -708,6 +715,7 @@ pyi_utils_create_child(struct PYI_CONTEXT *pyi_ctx)
             PYI_PERROR("semop", "Failed to signal the sync semaphore!\n");
         }
     }
+#endif /* defined(HAVE_SYS_SEM_H) */
 
 #if defined(__APPLE__) && defined(WINDOWED)
     /* macOS: forward events to child */
@@ -772,11 +780,13 @@ pyi_utils_create_child(struct PYI_CONTEXT *pyi_ctx)
 
 cleanup:
     /* Destroy the sync semaphore (if available) */
+#if defined(HAVE_SYS_SEM_H)
     if (sem_id >= 0) {
         if (semctl(sem_id, 0, IPC_RMID) < 0) {
             PYI_WARNING("LOADER: failed to destroy sync semaphore (errno %d)!\n", errno);
         }
     }
+#endif /* defined(HAVE_SYS_SEM_H) */
 
     /* Clean up the modified copy of command-line arguments (currently
      * applicable only to macOS windowed bootloader builds). */

--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -651,6 +651,11 @@ def configure(ctx):
     # Check for presence of stdbool.h
     ctx.check(header_name='stdbool.h', mandatory=False)
 
+    # On non-Windows, check for availability of sys/sem.h, as we use SysV semaphore to synchronize onefile parent and
+    # child process. It should be available on most platforms, except for example Termux, due to its Android base.
+    if ctx.env.DEST_OS != 'win32':
+        ctx.check(header_name='sys/sem.h', mandatory=False)
+
     # The old ``function_name`` parameter to ``check_cc`` is no longer supported. This code is based on old waf
     # source at
     # https://gitlab.com/ita1024/waf/commit/62fe305d04ed37b1be1a3327a74b2fee6c458634#255b2344e5268e6a34bedd2f8c4680798344fec7.

--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -539,6 +539,10 @@ def configure(ctx):
             #     _BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE
             ctx.env.append_value('DEFINES', '_DEFAULT_SOURCE')
 
+            # Required due to bogus check in `sys/ipc.h` header shipped with glibc <= 2.24.
+            # See https://github.com/pyinstaller/pyinstaller/issues/9020
+            ctx.env.append_value('DEFINES', '_XOPEN_SOURCE=700')
+
             # TODO: What other platforms support _FORTIFY_SOURCE macro? macOS?
             # TODO: macOS's CLang appears to support this macro as well. See:
             # https://marc.info/?l=cfe-dev&m=122032133830183

--- a/news/9020.bootloader.rst
+++ b/news/9020.bootloader.rst
@@ -1,0 +1,3 @@
+(Linux) Have the bootloader build script define ``_XOPEN_SOURCE=700``
+to work around a bogus check in ``sys/ipc.h`` header shipped with
+older glibc versions (<= v2.24).

--- a/news/9082.bootloader.rst
+++ b/news/9082.bootloader.rst
@@ -1,0 +1,6 @@
+(POSIX) Have the bootloader build script check for availability of
+``sys/sem.h`` and disable the semaphore-based sync part in the onefile
+codepath if the said header is unavailable. This restores the ability to
+compile bootloader under Termux, where where ``sys/sem.h`` (and the SysV
+semaphore API) is unavailable due to deliberate lack of support for it
+in the underlying Android base.


### PR DESCRIPTION
Have the `wscript` check for presence of `sys/sem.h` header and disable the semaphore-based sync part in the onefile codepath if the said header is unavailable. This restores the ability to compile bootloader under Termux, where where `sys/sem.h` (and the SysV semaphore API) is unavailable due to deliberate lack of support for it in the underlying Android base. Closes #9082.

While we're making changes there, also apply the change from #9020 (define `_XOPEN_SOURCE=700`) to fix building with older glibc header (<= v2.24), for example with Anaconda's v2.17. Closes #9020.