### PR TITLE
Add CI workflow for Termux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -502,3 +502,28 @@ jobs:
         run: >
             python -m pytest
             -n 3 --maxfail 3 --durations 10 tests/unit tests/functional
+
+  test-termux:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PyInstaller code
+        uses: actions/checkout@v4
+
+      - name: Run tests in container
+        run: |
+          docker run -v"$PWD:/io" termux/termux-docker:x86_64 bash -ec '
+            echo "*** Installing system dependencies ***"
+            pkg install -y python ldd binutils
+            echo "*** Installing PyInstaller ***"
+            cp -fr /io $HOME/PyInstaller
+            cd $HOME/PyInstaller
+            cd bootloader
+            python waf all
+            cd ..
+            python -m pip install .
+            echo "*** Installing test requirements ***"
+            python -m pip install -r tests/requirements-base.txt
+            echo "*** Running tests ***"
+            export FORCE_COLOR=1
+            python -m pytest -n 4 --maxfail 3 --durations 10 tests/unit tests/functional
+          '

--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -96,6 +96,9 @@ is_unix = is_linux or is_solar or is_aix or is_freebsd or is_hpux or is_openbsd
 # compiled bootloaders. On musl systems, ldd with no arguments prints 'musl' and its version.
 is_musl = is_linux and "musl" in subprocess.run(["ldd"], capture_output=True, encoding="utf-8").stderr
 
+# Termux - terminal emulator and Linux environment app for Android.
+is_termux = is_linux and hasattr(sys, 'getandroidapilevel')
+
 # macOS version
 _macos_ver = tuple(int(x) for x in platform.mac_ver()[0].split('.')) if is_darwin else None
 

--- a/tests/functional/test_basic.py
+++ b/tests/functional/test_basic.py
@@ -19,7 +19,7 @@ import re
 
 import pytest
 
-from PyInstaller.compat import is_cygwin, is_darwin, is_win
+from PyInstaller.compat import is_cygwin, is_darwin, is_termux, is_win
 from PyInstaller.utils.tests import importorskip, skipif, xfail, onedir_only, onefile_only
 
 
@@ -423,7 +423,10 @@ def test_user_preferred_locale(pyi_builder):
         """
     )
 
-    # Find executable and run additional tests with locale set via LC_ALL
+    # Find executable and run additional tests with locale set via LC_ALL.
+    if is_termux:
+        return
+
     exes = pyi_builder._find_executables('test_source')
     assert len(exes) == 1
 

--- a/tests/unit/test_depend_utils.py
+++ b/tests/unit/test_depend_utils.py
@@ -97,6 +97,7 @@ def test_ctypes_util_find_library_as_default_argument():
 
 
 @pytest.mark.linux
+@pytest.mark.skipif(compat.is_termux, reason="Termux does not have libc.so")
 def test_ldconfig_cache():
     utils.load_ldconfig_cache()
 


### PR DESCRIPTION
As discussed in https://github.com/pyinstaller/pyinstaller/pull/9088#issuecomment-2779717349, add a basic CI workflow for  Termux using `termux/termux-docker:x86_64` Docker container.

I cannot seem to get `pkg install` to work in the container's build phase, even with steps from https://github.com/pyinstaller/pyinstaller/pull/9088#issuecomment-2780177165 (that's both on my Fedora box with `podman` and on the GHA ubuntu runner with `docker`). So we forego the container customization/build; instead, we run the base image as-is, and set everything up and run the tests in one long `bash` command.