### PR TITLE
hookutils: setuptools: fix detection of vendored modules

### DIFF
--- a/PyInstaller/utils/hooks/setuptools.py
+++ b/PyInstaller/utils/hooks/setuptools.py
@@ -102,7 +102,7 @@ def _retrieve_setuptools_info():
             if candidate_file_attr is not None:
                 candidate_path = pathlib.Path(candidate_file_attr).parent.resolve()
                 is_vendored = any([
-                    setuptools_vendor_path in candidate_path.parents
+                    setuptools_vendor_path in candidate_path.parents or candidate_path == setuptools_vendor_path
                     for setuptools_vendor_path in setuptools_vendor_paths
                 ])
                 vendored_status[candidate_name] = is_vendored

--- a/news/9102.bugfix.rst
+++ b/news/9102.bugfix.rst
@@ -1,0 +1,3 @@
+Fix detection of ``setuptools``-vendored modules (i.e., not packages)
+in the ``PyInstaller.utils.hooks.setuptools.SetuptoolsInfo`` hook utility
+class; for example, the ``setuptools/_vendor/typing_extensions.py`` module.


### PR DESCRIPTION
Fix detection of `setuptools`-vendored modules (i.e., not packages) in the `SetuptoolsInfo` hook utility class; for example, the `setuptools/_vendor/typing_extensions.py` module.

When determining whether a package/module is vendored by `setuptools`, we need to check if `setuptools` vendor directory path is in parents of the candidate path, and also if the candidate path itself is the same as the vendor directory path. The first check covers vendored packages, but the second check is required to correctly handle vendored modules.