### PR TITLE
build: fix handling of directories captured by glob in --add-data

### DIFF
--- a/PyInstaller/building/utils.py
+++ b/PyInstaller/building/utils.py
@@ -485,11 +485,18 @@ def format_binaries_and_datas(binaries_or_datas, workingdir=None):
 
         # Normalize paths.
         src_root_path_or_glob = os.path.normpath(src_root_path_or_glob)
-        if os.path.isfile(src_root_path_or_glob):
+
+        # If given source path is a file or directory path, pass it on.
+        # If not, treat it as a glob and pass on all matching paths. However, we need to preserve the directories
+        # captured by the glob - as opposed to collecting their contents into top-level target directory. Therefore,
+        # we set a flag which is used in subsequent processing to distinguish between original directory paths and
+        # directory paths that were captured by the glob.
+        if os.path.isfile(src_root_path_or_glob) or os.path.isdir(src_root_path_or_glob):
             src_root_paths = [src_root_path_or_glob]
+            was_glob = False
         else:
-            # List of the absolute paths of all source paths matching the current glob.
             src_root_paths = glob.glob(src_root_path_or_glob)
+            was_glob = True
 
         if not src_root_paths:
             raise SystemExit(f'ERROR: Unable to find {src_root_path_or_glob!r} when adding binary and data files.')
@@ -514,7 +521,12 @@ def format_binaries_and_datas(binaries_or_datas, workingdir=None):
                     #   "/top" from "/top/dir").
                     # * Normalizing the result to remove redundant relative paths (e.g., removing "./" from
                     #   "trg/./file").
-                    trg_dir = os.path.normpath(os.path.join(trg_root_dir, os.path.relpath(src_dir, src_root_path)))
+                    if was_glob:
+                        # Preserve directories captured by glob.
+                        rel_dir = os.path.relpath(src_dir, os.path.dirname(src_root_path))
+                    else:
+                        rel_dir = os.path.relpath(src_dir, src_root_path)
+                    trg_dir = os.path.normpath(os.path.join(trg_root_dir, rel_dir))
 
                     for src_file_basename in src_file_basenames:
                         src_file = os.path.join(src_dir, src_file_basename)

--- a/news/9108.bugfix.rst
+++ b/news/9108.bugfix.rst
@@ -1,0 +1,7 @@
+Fix behavior of :option:`--add-data` and :option:`--add-binary` when the
+given source path contains a glob that matches directories. PyInstaller
+now collects the matched directories themselves into the specified target
+directory instead of collecting their content into the specified target
+directory (i.e., the directories are preserved). This ensures that
+``--add-data data_dir:data_dir`` and ``--add-data data_dir/*:data_dir``
+end up behaving in the same way when the data directory contains sub-directories.

--- a/tests/functional/data/recursive_add_data/data-dir/dir1/dir1/file1.txt
+++ b/tests/functional/data/recursive_add_data/data-dir/dir1/dir1/file1.txt
@@ -1,0 +1,1 @@
+data-dir/dir1/dir1/file1.txt

--- a/tests/functional/data/recursive_add_data/data-dir/dir1/dir1/file2.txt
+++ b/tests/functional/data/recursive_add_data/data-dir/dir1/dir1/file2.txt
@@ -1,0 +1,1 @@
+data-dir/dir1/dir1/file2.txt

--- a/tests/functional/data/recursive_add_data/data-dir/dir1/dir2/file1.txt
+++ b/tests/functional/data/recursive_add_data/data-dir/dir1/dir2/file1.txt
@@ -1,0 +1,1 @@
+data-dir/dir1/dir2/file1.txt

--- a/tests/functional/data/recursive_add_data/data-dir/dir1/file1.txt
+++ b/tests/functional/data/recursive_add_data/data-dir/dir1/file1.txt
@@ -1,0 +1,1 @@
+data-dir/dir1/file1.txt

--- a/tests/functional/data/recursive_add_data/data-dir/dir2/dir1/file1.txt
+++ b/tests/functional/data/recursive_add_data/data-dir/dir2/dir1/file1.txt
@@ -1,0 +1,1 @@
+data-dir/dir2/dir1/file1.txt

--- a/tests/functional/data/recursive_add_data/data-dir/dir2/dir1/file2.txt
+++ b/tests/functional/data/recursive_add_data/data-dir/dir2/dir1/file2.txt
@@ -1,0 +1,1 @@
+data-dir/dir2/dir1/file2.txt

--- a/tests/functional/data/recursive_add_data/data-dir/dir3/dir1/file1.txt
+++ b/tests/functional/data/recursive_add_data/data-dir/dir3/dir1/file1.txt
@@ -1,0 +1,1 @@
+data-dir/dir3/dir1/file1.txt

--- a/tests/functional/data/recursive_add_data/data-dir/dir3/file1.txt
+++ b/tests/functional/data/recursive_add_data/data-dir/dir3/file1.txt
@@ -1,0 +1,1 @@
+data-dir/dir3/file1.txt

--- a/tests/functional/data/recursive_add_data/data-dir/dir3/file2.txt
+++ b/tests/functional/data/recursive_add_data/data-dir/dir3/file2.txt
@@ -1,0 +1,1 @@
+data-dir/dir3/file2.txt

--- a/tests/functional/data/recursive_add_data/data-dir/file1.txt
+++ b/tests/functional/data/recursive_add_data/data-dir/file1.txt
@@ -1,0 +1,1 @@
+data-dir/file1.txt

--- a/tests/functional/data/recursive_add_data/data-dir/file2.txt
+++ b/tests/functional/data/recursive_add_data/data-dir/file2.txt
@@ -1,0 +1,1 @@
+data-dir/file2.txt


### PR DESCRIPTION
Fix handling of directories captured by glob in the `format_binaries_and_datas` helpers; in contrast to the case when
the given source path is a directory and we collect the contents of that directory into the specified target directory, when the given source path contains a glob that matches directories (in addition or instead of files), those directories themselves should be collected into the specified target directory (as opposed to their content being collected into the specified target directory).
    
This aims to ensure that `--add-data data_dir:data_dir` and `--add-data data_dir/*:data_dir` end up behaving in the same way when `data_dir` contains sub-directories.