### PR TITLE
Assorted cleanup for better AIX support

### DIFF
--- a/PyInstaller/archive/writers.py
+++ b/PyInstaller/archive/writers.py
@@ -328,7 +328,7 @@ class SplashWriter:
     #     uint32_t requirements_offset;
     # } SPLASH_DATA_HEADER;
     #
-    _HEADER_FORMAT = '!16s 16s 16s II II II'
+    _HEADER_FORMAT = '!32s 32s 16s II II II'
     _HEADER_LENGTH = struct.calcsize(_HEADER_FORMAT)
 
     # The created archive is compressed by the CArchive, so no need to compress the data here.
@@ -399,8 +399,8 @@ class SplashWriter:
                 enc_value = value.encode("utf-8")
                 if len(enc_value) >= limit:
                     raise ValueError(
-                        f"Length of the encoded field {field_name!r} is greater or equal to the limit of {limit} "
-                        "characters!"
+                        f"Length of the encoded field {field_name!r} ({len(enc_value)}) is greater or equal to the "
+                        f"limit of {limit} characters!"
                     )
 
                 return enc_value
@@ -408,8 +408,8 @@ class SplashWriter:
             # Write header
             header_data = struct.pack(
                 self._HEADER_FORMAT,
-                _encode_str(tcl_libname, 'tcl_libname', 16),
-                _encode_str(tk_libname, 'tk_libname', 16),
+                _encode_str(tcl_libname, 'tcl_libname', 32),
+                _encode_str(tk_libname, 'tk_libname', 32),
                 _encode_str(tklib, 'tklib', 16),
                 script_len,
                 script_offset,

--- a/PyInstaller/building/splash.py
+++ b/PyInstaller/building/splash.py
@@ -19,7 +19,7 @@ from PyInstaller.archive.writers import SplashWriter
 from PyInstaller.building import splash_templates
 from PyInstaller.building.datastruct import Target
 from PyInstaller.building.utils import _check_guts_eq, _check_guts_toc, misc
-from PyInstaller.compat import is_darwin
+from PyInstaller.compat import is_aix, is_darwin
 from PyInstaller.depend import bindepend
 from PyInstaller.utils.hooks.tcl_tk import tcltk_info
 
@@ -240,6 +240,21 @@ class Splash(Target):
         self.splash_requirements = set(filter(_filter_requirement, self.splash_requirements))
 
         logger.debug("Splash Requirements: %s", self.splash_requirements)
+
+        # On AIX, the Tcl and Tk shared libraries might in fact be ar archives with shared object inside it, and need to
+        # be `dlopen`'ed with full name (for example, `libtcl.a(libtcl.so.8.6)` and `libtk.a(libtk.so.8.6)`. So if the
+        # library's suffix is .a, adjust the name accordingly, assuming fixed format for the shared object name.
+        # Adjust the names at the end of this method, because preceding steps use `self.tcl_lib` and `self.tk_lib` for
+        # filesystem-based operations and need the original filenames.
+        if is_aix:
+            _, ext = os.path.splitext(self.tcl_lib)
+            if ext == '.a':
+                tcl_major, tcl_minor = tcltk_info.tcl_version
+                self.tcl_lib += f"(libtcl.so.{tcl_major}.{tcl_minor})"
+            _, ext = os.path.splitext(self.tk_lib)
+            if ext == '.a':
+                tk_major, tk_minor = tcltk_info.tk_version
+                self.tk_lib += f"(libtk.so.{tk_major}.{tk_minor})"
 
         self.__postinit__()
 

--- a/PyInstaller/building/splash.py
+++ b/PyInstaller/building/splash.py
@@ -228,7 +228,11 @@ class Splash(Target):
         def _filter_requirement(filename):
             if filename not in collected_files:
                 # Item is not bundled, so warn the user about it. This actually may happen on some tkinter installations
-                # that are missing the license.terms file.
+                # that are missing the license.terms file - as this file has no effect on operation of splash screen,
+                # suppress the warning for it.
+                if os.path.basename(filename) == 'license.terms':
+                    return False
+
                 logger.warning(
                     "The local Tcl/Tk installation is missing the file %s. The behavior of the splash screen is "
                     "therefore undefined and may be unsupported.", filename

--- a/PyInstaller/building/utils.py
+++ b/PyInstaller/building/utils.py
@@ -258,8 +258,16 @@ def process_collected_binary(
             )
             logger.debug("Output from strip command:\n%s", p.stdout)
         except subprocess.CalledProcessError as e:
-            logger.warning("Failed to run strip on %r!", cached_name, exc_info=True)
-            logger.warning("Output from strip command:\n%s", e.stdout)
+            show_warning = True
+
+            # On AIX, strip utility raises an error when ran against already-stripped binary. Catch the corresponding
+            # message (`0654-419 The specified archive file was already stripped.`) and suppress the warning.
+            if is_aix and "0654-419" in e.stdout:
+                show_warning = False
+
+            if show_warning:
+                logger.warning("Failed to run strip on %r!", cached_name, exc_info=True)
+                logger.warning("Output from strip command:\n%s", e.stdout)
         except Exception:
             logger.warning("Failed to run strip on %r!", cached_name, exc_info=True)
 

--- a/PyInstaller/building/utils.py
+++ b/PyInstaller/building/utils.py
@@ -25,7 +25,7 @@ import zipfile
 
 from PyInstaller import compat
 from PyInstaller import log as logging
-from PyInstaller.compat import EXTENSION_SUFFIXES, is_darwin, is_win, is_linux
+from PyInstaller.compat import EXTENSION_SUFFIXES, is_aix, is_darwin, is_win, is_linux
 from PyInstaller.config import CONF
 from PyInstaller.exceptions import InvalidSrcDestTupleError
 from PyInstaller.utils import misc
@@ -238,6 +238,11 @@ def process_collected_binary(
         if is_darwin:
             # The default strip behavior breaks some shared libraries under macOS.
             strip_options = ["-S"]  # -S = strip only debug symbols.
+        elif is_aix:
+            # Set -X32_64 flag to have strip transparently process both 32-bit and 64-bit binaries, without user having
+            # to set OBJECT_MODE environment variable prior to the build. Also accommodates potential mixed-case
+            # scenario, for example a 32-bit utility program being collected into a 64-bit application bundle.
+            strip_options = ["-X32_64"]
 
         cmd = ["strip", *strip_options, cached_name]
         logger.info("Executing: %s", " ".join(cmd))

--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -510,6 +510,7 @@ pyi_main(struct PYI_CONTEXT *pyi_ctx)
         );
         if (modify_ld_library_path) {
             if (pyi_utils_set_library_search_path(pyi_ctx->application_home_dir) < 0) {
+                PYI_ERROR("Failed to set library search path via environment variable!\n");
                 return -1;
             }
         }
@@ -894,6 +895,7 @@ _pyi_main_onefile_parent(struct PYI_CONTEXT *pyi_ctx)
      * already made in the common codepath. */
 #if !defined(_WIN32) && !defined(__APPLE__) && !defined(__CYGWIN__)
     if (pyi_utils_set_library_search_path(pyi_ctx->application_home_dir) == -1) {
+        PYI_ERROR("Failed to set library search path via environment variable!\n");
         return -1;
     }
 #endif /* !defined(_WIN32) && !defined(__APPLE__) */
@@ -941,7 +943,10 @@ _pyi_main_onefile_parent(struct PYI_CONTEXT *pyi_ctx)
      * where files were extracted) to the child process via
      * corresponding environment variable. */
     PYI_DEBUG("LOADER: setting _PYI_APPLICATION_HOME_DIR to %s\n", pyi_ctx->application_home_dir);
-    pyi_setenv("_PYI_APPLICATION_HOME_DIR", pyi_ctx->application_home_dir);
+    if (pyi_setenv("_PYI_APPLICATION_HOME_DIR", pyi_ctx->application_home_dir) < 0) {
+        PYI_ERROR("Failed to set application home directory via environment variable!\n");
+        return -1;
+    }
 
     /* Start the child process that will execute user's program. */
     PYI_DEBUG("LOADER: starting the child process...\n");

--- a/bootloader/src/pyi_pythonlib.c
+++ b/bootloader/src/pyi_pythonlib.c
@@ -44,54 +44,7 @@ int
 pyi_pylib_load(struct PYI_CONTEXT *pyi_ctx)
 {
     const struct ARCHIVE *archive = pyi_ctx->archive;
-    char dll_name[MAX_DLL_NAME_LEN];
-    size_t dll_name_len;
     char dll_fullpath[PYI_PATH_MAX];
-
-    /* On AIX, the name of shared library path might be an archive, because
-     * the 'ar' archives can be used for both static and shared objects.
-     * A shared library can be loaded from such an archive like this:
-     *   dlopen("libpythonX.Y.a(libpythonX.Y.so)", RTLD_MEMBER)
-     * This means that if python library name ends with '.a' suffix, we
-     * need to change it into:
-     *   libpython3.6.a(libpython3.6.so)
-     * Shared libraries whose names end with .so may be used as-is. */
-#ifdef AIX
-    /* Determine if shared lib is in `libpython?.?.so` or
-     * `libpython?.?.a(libpython?.?.so)` format. */
-    char *p;
-    if ((p = strrchr(archive->python_libname, '.')) != NULL && strcmp(p, ".a") == 0) {
-        uint32_t pyver_major;
-        uint32_t pyver_minor;
-
-        pyver_major = archive->python_version / 100;
-        pyver_minor = archive->python_version % 100;
-
-        dll_name_len = snprintf(
-            dll_name,
-            MAX_DLL_NAME_LEN,
-            "libpython%d.%d.a(libpython%d.%d.so)",
-            pyver_major,
-            pyver_minor,
-            pyver_major,
-            pyver_minor
-        );
-    } else {
-        dll_name_len = snprintf(dll_name, MAX_DLL_NAME_LEN, "%s", archive->python_libname);
-    }
-#else
-    dll_name_len = snprintf(dll_name, MAX_DLL_NAME_LEN, "%s", archive->python_libname);
-#endif
-
-    if (dll_name_len >= MAX_DLL_NAME_LEN) {
-        PYI_ERROR(
-            "Reported length (%d) of Python shared library name (%s) exceeds buffer size (%d)\n",
-            dll_name_len,
-            archive->python_libname,
-            MAX_DLL_NAME_LEN
-        );
-        return -1;
-    }
 
 #ifdef _WIN32
     /* If ucrtbase.dll exists in top-level application directory, load
@@ -111,8 +64,8 @@ pyi_pylib_load(struct PYI_CONTEXT *pyi_ctx)
 #endif
 
     /* Look for python shared library in top-level application directory */
-    if (pyi_path_join(dll_fullpath, pyi_ctx->application_home_dir, dll_name) == NULL) {
-        PYI_ERROR("Path of Python shared library (%s) and its name (%s) exceed buffer size (%d)\n", pyi_ctx->application_home_dir, PYI_PATH_MAX);
+    if (pyi_path_join(dll_fullpath, pyi_ctx->application_home_dir, archive->python_libname) == NULL) {
+        PYI_ERROR("Path of Python shared library (%s) and its name (%s) exceed buffer size (%d)\n", pyi_ctx->application_home_dir, archive->python_libname, PYI_PATH_MAX);
         return -1;
     }
 

--- a/bootloader/src/pyi_splash.c
+++ b/bootloader/src/pyi_splash.c
@@ -177,13 +177,13 @@ pyi_splash_setup(struct SPLASH_CONTEXT *splash, const struct PYI_CONTEXT *pyi_ct
 int
 pyi_splash_start(struct SPLASH_CONTEXT *splash, const char *executable)
 {
-    PI_Tcl_MutexLock(&splash->context_mutex);
-
     /* Make sure shared libraries have been loaded and their symbols
      * bound. */
     if (!splash->dlls_fully_loaded) {
         return -1;
     }
+
+    PI_Tcl_MutexLock(&splash->context_mutex);
 
     /* This functions needs to be called before everything else is done
      * with Tcl, otherwise the behavior of Tcl is undefined. */

--- a/bootloader/src/pyi_splash.h
+++ b/bootloader/src/pyi_splash.h
@@ -24,10 +24,10 @@
 struct SPLASH_DATA_HEADER
 {
     /* Filename of the Tcl shared library, e.g., tcl86t.dll */
-    char tcl_libname[16];
+    char tcl_libname[32];
 
     /* Filename of the Tk shared library, e.g. tk86t.dll */
-    char tk_libname[16];
+    char tk_libname[32];
 
     /* Tk module library root, e.g. "tk/" */
     char tk_lib[16];

--- a/bootloader/src/pyi_utils_posix.c
+++ b/bootloader/src/pyi_utils_posix.c
@@ -364,15 +364,19 @@ pyi_recursive_rmdir(const char *dir_path)
 pyi_dylib_t
 pyi_utils_dlopen(const char *filename)
 {
-    int flags = RTLD_NOW | RTLD_GLOBAL;
-
 #ifdef AIX
-    /* Append the RTLD_MEMBER to the open mode for 'dlopen()'
-     * in order to load shared object member from library. */
-    flags |= RTLD_MEMBER;
+    /* On AIX, if we are trying to load a shared object in an .a archive
+     * (e.g., `/path/to/libpython3.9.a(libpython3.9.so)`), we need to
+     * set `RTLD_MEMBER` flag. It seems that we can use this flag with
+     * regular shared library (.so) files as well, so we can get away
+     * with having it always set (otherwise, we would need to check
+     * whether the passed filename ends with ')' or not). For RTLD_MEMBER
+     * to be defined, the program needs to be compiled with _ALL_SOURCE
+     * defined, which is done globally in the `waf` build script. */
+    return dlopen(filename, RTLD_NOW | RTLD_GLOBAL | RTLD_MEMBER);
+#else
+    return dlopen(filename, RTLD_NOW | RTLD_GLOBAL);
 #endif
-
-    return dlopen(filename, flags);
 }
 
 int

--- a/bootloader/src/pyi_utils_posix.c
+++ b/bootloader/src/pyi_utils_posix.c
@@ -48,22 +48,7 @@
 #endif
 
 #include <dirent.h>
-
-/*
- * On AIX  RTLD_MEMBER  flag is only visible when _ALL_SOURCE flag is defined.
- *
- * There are quite a few issues with xlC compiler. GCC is much better,
- * Without flag _ALL_SOURCE gcc get stuck on the RTLD_MEMBER flax when
- * compiling the bootloader.
- * This fix was tested wigh gcc on AIX6.1.
- */
-#if defined(AIX) && !defined(_ALL_SOURCE)
-    #define _ALL_SOURCE
-    #include <dlfcn.h>
-    #undef  _ALL_SOURCE
-#else
-    #include <dlfcn.h>
-#endif
+#include <dlfcn.h> /* dlopen, dlclose */
 
 #ifndef SIGCLD
     #define SIGCLD SIGCHLD /* not defined on macOS */

--- a/bootloader/tools/strip.py
+++ b/bootloader/tools/strip.py
@@ -47,6 +47,15 @@ def configure(conf):
     # Additional flags to be passed to the `strip` command.
     conf.env.append_value('STRIPFLAGS', '')
 
+    # On AIX, `strip` utility needs to be explicitly told to process 32-bit object files (-X32), 64-bit object files
+    # (-X64), or either/both (-X32_64). Unless set via `OBJECT_MODE` environment variable, the default is 32-bit mode,
+    # which results in an error when we build 64-bit bootloader. Therefore, explicitly set -X32_64 to work with
+    # either 32-bit or 64-bit build. This should also eliminate potential mismatches between `OBJECT_MODE` setting
+    # (which is honored by IBM's `xlc` compiler but not by `/opt/freeware/bin/gcc`) and `--target-arch=` command-line
+    # option passed to `waf` (which can be used to force 64-bit build with `gcc`).
+    if conf.env.DEST_OS == 'aix':
+        conf.env.append_value('STRIPFLAGS', '-X32_64')
+
 
 class StripTask(Task.Task):
     run_str = '${STRIP} ${STRIPFLAGS} ${SRC}'

--- a/bootloader/tools/strip.py
+++ b/bootloader/tools/strip.py
@@ -23,7 +23,26 @@ def configure(conf):
     cc_path = os.path.dirname(conf.env.CC[0])
     environ = getattr(conf, 'environ', os.environ)
     env_paths = environ.get('PATH', '').split(os.pathsep)
-    conf.find_program('strip', path_list=[cc_path, *env_paths])
+
+    # Candidate name(s) for `strip` executable.
+    strip_candidate_names = ['strip']
+
+    # If we are using gcc-based or clang-based cross-compiler toolchain, prefer its version of `strip`, which should
+    # have the same name prefix as the compiler executable (for example `powerpc64le-linux-gnu-gcc` would have
+    # accompanying `powerpc64le-linux-gnu-strip`). The system might also have a "native" `strip` utility, which might
+    # not be able to handle the executables produced by cross-compiler.
+    if conf.env.CC_NAME == 'gcc' or conf.env.CC_NAME == 'clang':
+        # The actual name of gcc/clang executable.
+        cc_name = os.path.splitext(os.path.basename(conf.env.CC[0]))[0]
+        # Replace gcc/clang part in the name.
+        strip_name = cc_name.replace(conf.env.CC_NAME, 'strip')
+        # If we have a candidate name different than plain strip, prepend it to the list. Explicitly guard against
+        # failed substitution as well (strip_name == cc_name), to prevent any chance of erroneously using C compiler
+        # executable in lieu of strip utility.
+        if strip_name != 'strip' and strip_name != cc_name:
+            strip_candidate_names.insert(0, strip_name)
+
+    conf.find_program(strip_candidate_names, var='STRIP', path_list=[cc_path, *env_paths])
 
     # Additional flags to be passed to the `strip` command.
     conf.env.append_value('STRIPFLAGS', '')

--- a/bootloader/tools/strip.py
+++ b/bootloader/tools/strip.py
@@ -13,12 +13,19 @@
 #
 # Based on waf's playground example:
 # https://gitlab.com/ita1024/waf/-/blob/d976678d5f6ee5cf913b7828a7d4f345db7bf6de/playground/strip/strip_hack.py
+import os
 
 from waflib import Task, TaskGen
 
 
 def configure(conf):
-    conf.find_program('strip')
+    # Look for the `strip` executable; first in the same directory as the C compiler executable, then in PATH.
+    cc_path = os.path.dirname(conf.env.CC[0])
+    environ = getattr(conf, 'environ', os.environ)
+    env_paths = environ.get('PATH', '').split(os.pathsep)
+    conf.find_program('strip', path_list=[cc_path, *env_paths])
+
+    # Additional flags to be passed to the `strip` command.
     conf.env.append_value('STRIPFLAGS', '')
 
 

--- a/bootloader/tools/strip.py
+++ b/bootloader/tools/strip.py
@@ -1,4 +1,3 @@
-#! /usr/bin/env python3
 #-----------------------------------------------------------------------------
 # Copyright (c) 2014-2023, PyInstaller Development Team.
 #
@@ -9,35 +8,11 @@
 #
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
-"""
-Strip a program/library after it is created. Use this tool as an example.
 
-Usage::
-
-    bld.program(features='strip', source='main.c', target='foo')
-
-By using::
-
-    @TaskGen.feature('cprogram', 'cxxprogram', 'fcprogram')
-
-
-If stripping at installation time is preferred, use the following::
-
-    import shutil, os
-    from waflib import Build
-    from waflib.Tools import ccroot
-    def copy_fun(self, src, tgt, **kw):
-        shutil.copy2(src, tgt)
-        os.chmod(tgt, kw.get('chmod', Utils.O644))
-        try:
-            tsk = kw['tsk']
-        except KeyError:
-            pass
-        else:
-            if isinstance(tsk.task, ccroot.link_task):
-                self.cmd_and_log('strip %s' % tgt)
-    Build.InstallContext.copy_fun = copy_fun
-"""
+# Strip the binary after it is created.
+#
+# Based on waf's playground example:
+# https://gitlab.com/ita1024/waf/-/blob/d976678d5f6ee5cf913b7828a7d4f345db7bf6de/playground/strip/strip_hack.py
 
 from waflib import Task, TaskGen
 
@@ -47,17 +22,38 @@ def configure(conf):
     conf.env.append_value('STRIPFLAGS', '')
 
 
-class strip(Task.Task):
+class StripTask(Task.Task):
     run_str = '${STRIP} ${STRIPFLAGS} ${SRC}'
-    color = 'BLUE'
-    after = ['cprogram', 'cshlib']
+    color = 'YELLOW'  # Same color as linking step
+    no_errcheck_out = True
+
+    def keyword(self):
+        return 'Stripping binary'
+
+    def runnable_status(self):
+        if self in self.run_after:
+            self.run_after.remove(self)
+
+        ret = super().runnable_status()
+        if ret == Task.ASK_LATER:
+            return ret
+
+        if self.generator.link_task.hasrun == Task.SUCCESS:
+            # Linking step was executed - binary was (re)created); run the strip task.
+            return Task.RUN_ME
+
+        return Task.SKIP_ME
 
 
 @TaskGen.feature('strip')
 @TaskGen.after('apply_link')
-def add_strip_task(self):
-    try:
-        link_task = self.link_task
-    except AttributeError:
+def apply_strip_to_build(self):
+    link_task = getattr(self, 'link_task', None)
+    if link_task is None:
         return
-    self.create_task('strip', link_task.outputs[0])
+
+    exe_node = self.link_task.outputs[0]
+
+    # NOTE: original implementation sets both input and output to exe_node, but with version of `waf` we are using, this
+    # raises dependency-cycle error.
+    self.create_task('StripTask', exe_node)

--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -109,14 +109,6 @@ def is_musl(ctx):
     return re.search(rb'--target=\S+-musl', spec) or re.search(rb'Target: .*musl', spec)
 
 
-def find_program_next_to_cc(ctx, name, var):
-    # Tries to find a program in the same directory as cc or on the normal PATH.
-    environ = getattr(ctx, 'environ', os.environ)
-    path = [os.path.dirname(ctx.env.CC[0])]
-    path.extend(environ.get('PATH', '').split(os.pathsep))
-    ctx.find_program(name, var=var, path_list=path)
-
-
 def options(ctx):
     ctx.load('compiler_c')
 
@@ -751,10 +743,9 @@ def configure(ctx):
     if ctx.env.DEST_OS == 'linux' and ctx.check_cc(linkflags='-Wl,--as-needed', mandatory=False):
         ctx.env.append_value('LINKFLAGS', '-Wl,--as-needed')
 
+    # When not building with MSVC, strip the bootloader executables to reduce their size.
     if not is_msvc_target(ctx):
-        # This tool allows reducing the size of executables.
-        find_program_next_to_cc(ctx, 'strip', var='STRIP')
-        ctx.load('strip', tooldir='tools')
+        ctx.load('strip', tooldir='tools')  # Load strip feature/tool from ./tools directory.
 
     def windowed(name, baseenv):
         """Setup windowed environment based on `baseenv`."""
@@ -821,7 +812,6 @@ def configure(ctx):
     windowed('releasew', release_env)
 
 
-# TODO Use 'strip' command to decrease the size of compiled bootloaders.
 def build(ctx):
     if not ctx.variant:
         ctx.fatal('Call "python waf all" to compile all bootloaders.')
@@ -842,11 +832,8 @@ def build(ctx):
         # is mandatory for the given platform.
         ctx.objects(source=ctx.path.ant_glob('zlib/*.c'), target='STATIC_ZLIB', includes='zlib')
 
-    # By default strip final executables to make them smaller.
-    features = 'strip'
-    if is_msvc_target(ctx):
-        # Do not strip bootloaders when using MSVC.
-        features = ''
+    # Unless we are building with MSVC, strip bootloader executables to make them smaller.
+    features = '' if is_msvc_target(ctx) else 'strip'
 
     ctx.objects(source=ctx.path.ant_glob('src/*.c', excl="src/main.c"), includes='src windows zlib', target="OBJECTS")
 

--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -640,6 +640,9 @@ def configure(ctx):
         # Opting out of dynamically linked zlib can be done either with the --static-zlib option or with the
         # PYI_STATIC_ZLIB=1 environment variable.
         static_zlib = bool(int(os.environ.get("PYI_STATIC_ZLIB", '0'))) or ctx.options.static_zlib
+        # On AIX, use static build of bundled zlib.
+        if ctx.env.DEST_OS == 'aix':
+            static_zlib = True
         if static_zlib:
             # This serves as a signal to later on when the C code gets compiled.
             ctx.env.LIB_Z = None
@@ -861,10 +864,6 @@ def build(ctx):
             'THR',  # may be used on FreBSD
         ]
         staticlibs = []
-        if ctx.env.DEST_OS == 'aix':
-            # link statically with zlib, case sensitive
-            libs.remove('Z')
-            staticlibs.append('z')
 
         ctx.env.link_with_dynlibs = libs
         ctx.env.link_with_staticlibs = staticlibs

--- a/doc/bootloader-building.rst
+++ b/doc/bootloader-building.rst
@@ -388,10 +388,6 @@ Otherwise (64-bit Python), you should use the following commands::
     export OBJECT_MODE=64
     python ./waf all
 
-.. note:: The correct setting of :envvar:`OBJECT_MODE` may also be needed
-   when you use PyInstaller to package your application; for example, when
-   :option:`--strip` option is enabled.
-
 .. note:: While :envvar:`OBJECT_MODE` environment variable is honored by
    IBM's :command:`xlc_r` compiler, the :command:`gcc` compiler from *AIX
    Toolbox for Open Source Software* (found in :command:`/opt/freeware/bin/gcc`)

--- a/doc/bootloader-building.rst
+++ b/doc/bootloader-building.rst
@@ -361,56 +361,64 @@ Building for AIX
 * By default AIX builds 32-bit executables.
 * For 64-bit executables set the environment variable :envvar:`OBJECT_MODE`.
 
-If Python was built as a 64-bit executable
-then the AIX utilities that work with binary files
-(e.g., .o, and .a) may need the flag ``-X64``.
-Rather than provide this flag with every command,
-the preferred way to provide this setting
-is to use the environment variable :envvar:`OBJECT_MODE`.
-Depending on whether Python was build as a 32-bit or a 64-bit executable
-you may need to set or unset
-the environment variable :envvar:`OBJECT_MODE`.
+When creating a 64-bit build, the compiler and other AIX utilities that
+work with binary files (for example, the :command:`strip` utility) may
+need to be passed the ``-X64`` flag to force 64-bit mode. Rather than
+passing this flag to every command, the preferred way to provide this
+setting is to use the :envvar:`OBJECT_MODE` environment variable.
 
-To determine the size the following command can be used::
+Depending on whether you are using 32-bit or 64-bit Python build,
+you may therefore need to set or unset the :envvar:`OBJECT_MODE` environment
+variable prior to running  ``waf`` in order to build a matching type of the
+bootloader executable.
 
-    $ python -c "import sys; print(sys.maxsize <= 2**32)"
-    True
+To determine whether you are using 32-bit or 64-bit Python, use the following
+command::
 
-When the answer is ``True`` (as above) Python was build as a 32-bit
-executable.
+    python -c "import sys; print(sys.maxsize <= 2**32)"
 
-When working with a 32-bit Python executable proceed as follows::
+If the output of above command is ``True``, your Python is 32-bit, and
+you should build bootloader using the following commands::
 
     unset OBJECT_MODE
-    ./waf configure all
+    python ./waf all
 
-When working with a 64-bit Python executable proceed as follows::
+Otherwise (64-bit Python), you should use the following commands::
 
     export OBJECT_MODE=64
-    ./waf configure all
+    python ./waf all
 
-.. note:: The correct setting of :envvar:`OBJECT_MODE` is also needed when you
-   use PyInstaller to package your application.
+.. note:: The correct setting of :envvar:`OBJECT_MODE` may also be needed
+   when you use PyInstaller to package your application; for example, when
+   :option:`--strip` option is enabled.
 
-To build the bootloader you will need a compiler compatible (identical)
-with the one used to build python.
+.. note:: While :envvar:`OBJECT_MODE` environment variable is honored by
+   IBM's :command:`xlc_r` compiler, the :command:`gcc` compiler from *AIX
+   Toolbox for Open Source Software* (found in :command:`/opt/freeware/bin/gcc`)
+   does not seem to honor it. When using this compiler, you need to set
+   the target architecture by passing ``--target-arch`` option to ``waf``,
+   for example::
+
+     python ./waf all --target-arch=64bit
+
+To build the bootloader, you will need a compiler compatible (identical)
+with the one that was used to build Python itself.
 
 .. note:: Python compiled with a different version of gcc that you are using
    might not be compatible enough.
    GNU tools are not always binary compatible.
 
-If you do not know which compiler that was,
-this command can help you determine
-if the compiler was gcc or an IBM compiler::
+To identify the compiler that was used to build Python, you can use the
+following command::
 
     python -c "import sysconfig; print(sysconfig.get_config_var('CC'))"
 
-If the compiler is gcc you may need additional RPMs installed
+If the compiler is :command:`gcc` you may need additional RPMs installed
 to support the GNU run-time dependencies.
 
-When the IBM compiler is used no additional prerequisites are expected.
-The recommended value for :envvar:`CC` with the IBM compilers is
-`:command:xlc_r`.
+When the IBM compiler is used, no additional prerequisites are expected.
+The recommended value for :envvar:`CC` environment variable with the
+IBM compiler is :command:`xlc_r`.
 
 
 Building for FreeBSD

--- a/news/9111.bugfix.1.rst
+++ b/news/9111.bugfix.1.rst
@@ -1,0 +1,4 @@
+(AIX) Fix the name of Tcl and Tk shared libraries used by splash screen;
+if said shared libraries are ``.a`` archives, we need to load the shared
+object from the archives (e.g., ``libtcl.a(libtcl.so.8.6)`` and
+``libtk.a(libtk.so.8.6)``).

--- a/news/9111.bugfix.2.rst
+++ b/news/9111.bugfix.2.rst
@@ -1,0 +1,3 @@
+When collecting files for splash screen, suppress warning about
+``license.terms`` not being found in the ``tk8.x`` directory; this seems
+to be the case in most Tcl/Tk installations found on POSIX systems.

--- a/news/9111.bugfix.rst
+++ b/news/9111.bugfix.rst
@@ -1,0 +1,2 @@
+(AIX) Fix use of ``strip`` utility on collected binaries; pass the ``-x32_64``
+flag to enable transparent processing of either 32-bit or 64-bit binaries.

--- a/news/9111.bugfix.rst
+++ b/news/9111.bugfix.rst
@@ -1,2 +1,4 @@
 (AIX) Fix use of ``strip`` utility on collected binaries; pass the ``-x32_64``
 flag to enable transparent processing of either 32-bit or 64-bit binaries.
+Suppress warnings on ``strip`` errors when a collected binary is already
+stripped.

--- a/news/9111.build.1.rst
+++ b/news/9111.build.1.rst
@@ -1,0 +1,1 @@
+Remove duplicated check for the ``strip`` utility.

--- a/news/9111.build.2.rst
+++ b/news/9111.build.2.rst
@@ -1,0 +1,4 @@
+When building bootloader with a cross-compiler toolchain, have the build
+script look for toolchain-provided version of ``strip`` utility (for
+example, ``powerpc64le-linux-gnu-strip`` that is shipped with
+``powerpc64le-linux-gnu-gcc``) and prefer it over the system-provided one.

--- a/news/9111.build.3.rst
+++ b/news/9111.build.3.rst
@@ -1,0 +1,3 @@
+(AIX) Pass ``-X32_64`` flag to ``strip`` utility to have it transparently
+process either 32-bit or 64-bit executable, without user having to explicitly
+set the :envvar:`OBJECT_MODE`` environment variable.

--- a/news/9111.build.rst
+++ b/news/9111.build.rst
@@ -1,0 +1,4 @@
+Prevent the ``strip`` utility from being ran twice when building bootloader
+executables; fixes errors with ``strip`` utilities that disallow being
+ran against already-stripped binaries (for example, the ``strip`` utility
+on AIX).

--- a/news/9111.doc.rst
+++ b/news/9111.doc.rst
@@ -1,0 +1,3 @@
+Update documentation about building bootloader on AIX; add a note about
+``/opt/freeware/gcc`` from *AIX Toolbox for Open Source Software* not
+honoring the :envvar:`OBJECT_MODE` environment variable.


### PR DESCRIPTION
This is an initial round of changes coming from my tinkering with AIX 7.2 VM, which I sought to set up to obtain answers to following questions:

- Can the equivalent of [this code block](https://github.com/pyinstaller/pyinstaller/blob/306d4d92580fea7be7ff2c89ba112cdc6f73fac1/bootloader/src/pyi_pythonlib.c#L51-L84) be performed at application build time rather than at run-time (i.e., resolve the full library path during analysis and store it for bootloader to use directly)? [-> Yes, it can.]

- If this sort of adjustment needs to be done for Python shared library, does it also need to be done for Tcl and Tk shared libraries when splash screen is used? [-> Yes, it does, otherwise libraries fail to load.]

- Is it safe to use [RTLD_MEMBER flag with `dlopen`](https://github.com/pyinstaller/pyinstaller/blob/306d4d92580fea7be7ff2c89ba112cdc6f73fac1/bootloader/src/pyi_utils_posix.c#L387) even if shared library is NOT a shared object in an `.a` archive (i.e., is a standard "stand-alone" .so file) [-> Yes, it seems to work even in that case].

But before that, we need to overcome bunch of quirks related to building the bootloader - some of those are general, but end up causing problems only on AIX...

---

First, it turns out that when bootloader executable is built, we end up running `strip` against it *twice* - once during the `build_{variant}` command, and once during the `install_{variant}` command. On linux and macOS, this goes unnoticed, but on AIX, the `strip` utility raises an error when being ran against an already-stripped binary. This was also observed in #4211, but was not properly investigated because the origin of original error message there was mis-diagnosed.

Updating our `strip` feature/tool [to the latest version of what I assume was the original source](https://gitlab.com/ita1024/waf/-/blob/master/playground/strip/strip_hack.py) seems to take care of this, as it now explicitly checks whether the preceding linking step was ran or not (because during the install command, the executable is *not* re-linked again).

---

Similarly, we are also checking for `strip` utility itself twice, as evident from the build log (e..g, [here](https://github.com/pyinstaller/pyinstaller/actions/runs/14696796758/job/41239507226#step:15:45)):

```
...
Checking for linker flags -Wl,--as-needed                      : yes
Checking for program 'strip'                                   : /usr/bin/strip
Checking for program 'strip'                                   : /usr/bin/strip
'configure' finished successfully (0.608s)
...
```

The first check comes from the [wscript itself](https://github.com/pyinstaller/pyinstaller/blob/306d4d92580fea7be7ff2c89ba112cdc6f73fac1/bootloader/wscript#L754-L757) and [the second one from feature/tool script that is loaded immediately afterwards](https://github.com/pyinstaller/pyinstaller/blob/306d4d92580fea7be7ff2c89ba112cdc6f73fac1/bootloader/tools/strip.py#L46). Since both checks are using same environment variable to store the result, the second check is essentially a no-op and re-uses whatever was set in the first check.

We now perform the check only in the feature/tool (which now also incorporates the extended search path part from the first check).

---

While we're fixing `strip` detection, re-introduce support for automatic detection of `strip` utility that comes with cross-compiler toolchains. For example, if compiler is `powerpc64le-linux-gnu-gcc`, we should look for `powerpc64le-linux-gnu-strip`, and use that instead of base system's `strip` (which is unlikely to handle executable's of cross-compiled architecture).

We used to have this sort of detection, but it was removed in #6218; since then, the correct name of `strip` utility had to be passed via `STRIP` environment variable.

It is also worth noting that the old detection code did not sufficiently guard against failed compiler name substitution; it tried to replace `gcc` or `clang` in the name with `strip`, so when compiler's name was `xlc_r`, that erroneously became the name for the strip utility as well - which was the true case of errors in #4211.

---

When using `strip` on AIX, pass it the `-X32_64` flag to have it transparently handle either 32-bit or 64-bit binaries.

Long ago, we used to explicitly set `-X32` or `-X64` depending on the build type. This was removed by #4731 (in attempt to address #4211); while the argument that 32-bit vs 64-bit operation mode should be controlled via `OBJECT_MODE` environment variable is technically true, it holds only for `xlc_r` + `strip` combination (which both honor this environment variable). Notably, the `/opt/freeware/bin/gcc` compiler from *AIX Toolbox for Open Source* does not seem to honor this environment variable, and requires user to force 64-bit by passing `--target-arch=64bit` to `waf`; in this case, also having to set the environment variable seems rather extraneous.

And besides, as mentioned earlier, the issue with unrecognized arguments being passed to `xlc_r` in #4211 was caused by strip program name being incorrectly set to `xlc_r`.

---

Update the documentation section about building bootloader on AIX - add a note about `/opt/freeware/bin/gcc` compiler from *AIX Toolbox for Open Source* not honoring the `OBJECT_MODE` environment variable, and reword other parts.

---

In the PyInstaller's build/assembly code, also pass `-X32_64` flag to the strip utility, and suppress warnings coming from errors that are triggered due to already-stripped binaries. (On the off chance that frozen application is being built with strip option enabled).

---

Finally, move the AIX-specific adjustment of Python shared library name from bootloader (run-time) into building code (build-time).

Perform the same kind of name adjustment for Tcl and Tk shared libraries when building with splash screen enabled; this allows the said shared libraries to be loaded when running splash-enabled application in ssh session with X forwarding.
