### PR TITLE
hookutils: conda: fix path matching in collect_dynamic_libs helper

### DIFF
--- a/news/9113.bugfix.rst
+++ b/news/9113.bugfix.rst
@@ -1,0 +1,4 @@
+(Windows) Fix collection of DLLs from Anaconda-installed ``numpy`` and
+its depedencies (MKL, OpenBLAS, TBB, etc.) when the file paths recorded
+in the metadata end up using Windows-style separators instead of POSIX
+ones.


### PR DESCRIPTION
Fix path matching in conda-specific `collect_dynamic_libs` helper.

The list of files obtained from `Distribution` contains instances of `PackagePath`, which, even on Windows, inherits from `pathlib.PurePosixPath`. As such, it does not properly handle paths that contain Windows-style separator; and as seen in #9113, those might sometimes end up being used in paths recorded in distribution metadata. When this happens, the path prefix check in `collect_dynamic_libs` always fails, and empty list is returned.

To fix the problem, turn `lib_dir` into `pathlib.PurePath`, and cast `file` into `pathlib.PurePath` before comparing its `parent` to `lib_dir`; this way, the comparison will be performed with separators being properly normalized.