### PR TITLE
hooks: add pre-safe-import-module hook for gi.overrides

### DIFF
--- a/PyInstaller/hooks/pre_safe_import_module/hook-gi.overrides.py
+++ b/PyInstaller/hooks/pre_safe_import_module/hook-gi.overrides.py
@@ -1,0 +1,26 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2025, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+from PyInstaller import compat
+from PyInstaller.utils import hooks as hookutils
+
+
+def pre_safe_import_module(api):
+    if compat.is_linux:
+        # See comment in the adjacent `hook-gi.py`.
+        try:
+            paths = hookutils.get_module_attribute(api.module_name, "__path__")
+        except Exception:
+            # Most likely `gi.overrides` cannot be imported.
+            paths = []
+
+        for path in paths:
+            api.append_package_path(path)

--- a/PyInstaller/hooks/pre_safe_import_module/hook-gi.py
+++ b/PyInstaller/hooks/pre_safe_import_module/hook-gi.py
@@ -24,6 +24,9 @@ def pre_safe_import_module(api):
         # The modulegraph has no way of knowing this, so we need extend the package path in this hook. Otherwise,
         # only the first location is scanned, and the `gi.repository` ends up missing.
         #
+        # ADDENDUM: it looks like the `gi.overrides` can also be split across both locations, so we need a similar
+        # hook for `gi.overrides` as well.
+        #
         # NOTE: the `get_package_paths`/`get_package_all_paths` helpers read the paths from package's spec without
         # importing the (top-level) package, so they do not catch run-time path modifications. Instead, we use
         # `get_module_attribute` to import the package in isolated process and query its `__path__` attribute.

--- a/news/9126.hooks.rst
+++ b/news/9126.hooks.rst
@@ -1,0 +1,5 @@
+Add pre-safe-import-module hook for ``gi.overrides`` to properly handle
+cases where the ``gi.overrides`` package is split between
+``/usr/lib64/python3.X/site-packages/gi/overrides`` and
+``/usr/lib/python3.X/site-packages/gi/overrides`` (i.e., RPM packages
+for Fedora/RHEL and their derivatives, such as openEuler).


### PR DESCRIPTION
On RHEL/Fedora based systems, the `gi.overrides` package may be split between `/usr/lib64/python3.X/site-packages/gi/overrides` and `/usr/lib/python3.X/site-packages/gi/overrides`, similarly to its parent `gi` package.

To properly handle this case (i.e., be able to discover modules in both locations), we therefore need to duplicate the
pre-safe-import-module hook for `gi` into a pre-safe-import-module hook for `gi.overrides`.

See #9125.