### PR TITLE
tests: xfail reproducibility test for python < 3.11 on all platforms

### DIFF
--- a/tests/functional/test_reproducibility.py
+++ b/tests/functional/test_reproducibility.py
@@ -49,11 +49,11 @@ from PyInstaller import compat
 def test_reproducible_subsequent_builds(pyi_builder, tmp_path, monkeypatch):
     from PyInstaller.archive.readers import CArchiveReader
 
-    # On GHA ubuntu runner, we seem to be getting occasional test failure due to differences in collected modules'
-    # bytecode, in spite of the "calibration" step below. This seems to affect only linux and python < 3.11; most
-    # often, it fails with 3.9, but 3.8 and 3.10 have also been observed to fail. Since the lack of .pyc bytecode
-    # reproducibility seems to be out of our control, xfail the test.
-    if compat.is_linux and not compat.is_py311:
+    # On GHA ubuntu runners, we seem to be getting occasional test failure due to differences in collected modules'
+    # bytecode, in spite of the "calibration" step below. This seems to affect python < 3.11 on all platforms; most
+    # often, it fails on linux with 3.9, but 3.8 and 3.10 have also been observed to fail. Since the lack of .pyc
+    # bytecode reproducibility seems to be out of our control, xfail the test.
+    if not compat.is_py311:
         pytest.xfail("Issues with reproducibility of collected modules' bytecode.")
 
     # On Windows, we need to set SOURCE_DATE_EPOCH for the build to be fully reproducible (i.e., the build timestamp


### PR DESCRIPTION
By now, we have seen `test_reproducible_subsequent_builds` sporadically fail under python < 3.11 on all platforms, not just linux. So extend the `xfail` from 9c86659 / #9099 to all platforms.