### PR TITLE
ci: enable basic CI with free-threading python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.13t']
         os: ['windows-latest', 'ubuntu-24.04', 'macos-13', 'macos-14']
         # Split macOS workflows between macos-13 (x86_64) and macos-14 (arm64)
         # runners to cover both architectures without running all combinations.
@@ -214,8 +214,12 @@ jobs:
         run: |
           python -m pip install --progress-bar=off --upgrade --requirement tests/requirements-base.txt
 
+      # Give python 3.13t same treatment as development version and avoid trying to install packges
+      # from requirements-libraries.txt. This is necessary because not all packages provide free-threaded
+      # builds of their wheels yet, and we have no way of filtering them in the requirements file.
+      # This should be remedied in python 3.14 with the new `sys_abi_feature` environment marker (PEP 780).
       - name: Install test dependencies (tools and libraries)
-        if: ${{ !endsWith(matrix.python-version, '-dev') }}
+        if: ${{ !endsWith(matrix.python-version, '-dev') && matrix.python-version != '3.13t' }}
         run: |
           python -m pip install --progress-bar=off --upgrade --requirement tests/requirements-libraries.txt
 

--- a/tests/functional/scripts/pyi_multiprocessing_pool.py
+++ b/tests/functional/scripts/pyi_multiprocessing_pool.py
@@ -24,7 +24,7 @@ def main(start_method):
     with multiprocessing.Pool(processes=4) as pool:
         print('Evaluate f(10) asynchronously...')
         result = pool.apply_async(f, [10])
-        assert result.get(timeout=1) == 100
+        assert result.get() == 100
 
         print('Evaluate f(0..9)...')
         assert pool.map(f, range(10)) == [x**2 for x in range(10)]

--- a/tests/functional/scripts/pyi_multiprocessing_subprocess_environment.py
+++ b/tests/functional/scripts/pyi_multiprocessing_subprocess_environment.py
@@ -24,7 +24,7 @@ def main(start_method):
     print('Running subprocess(es)...')
     with multiprocessing.Pool(processes=4) as pool:
         result = pool.apply_async(get_sys_meipass)
-        subprocess_meipass = result.get(timeout=1)
+        subprocess_meipass = result.get()
 
         print(f"sys._MEIPASS in main process: {sys._MEIPASS}")
         print(f"sys._MEIPASS in sub-process: {subprocess_meipass}")


### PR DESCRIPTION
`actions/setup-python` added support for free-threaded python (>= 3.13) about two months ago, so we can now run a basic CI with this variant as well.