### PR TITLE
loader: set module's file path to source .py file if available

### DIFF
--- a/PyInstaller/hooks/rthooks/pyi_rth_inspect.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_inspect.py
@@ -71,14 +71,30 @@ def _pyi_rthook():
 
             # If filename ends with .py suffix and does not correspond to frozen entry-point script, convert it to
             # corresponding .pyc in `sys._MEIPASS` or `sys._MEIPASS/base_library.zip`.
+            #
+            # However, if the module is not part of `base_library.zip` and its source file exists, return the path
+            # to the .py file - this matches the change made in #9139, which has the `PyiFrozenLoader` set the module's
+            # file path to the source .py file if the said source .py file exists.
             if filename.endswith('.py'):
                 pyc_filename = filename + 'c'
-                prefix = BASE_LIBRARY if pyc_filename in base_library_files else SYS_PREFIX
-                return os.path.normpath(os.path.join(prefix, pyc_filename))
-        elif filename.startswith(SYS_PREFIX) and filename.endswith('.pyc'):
+                if pyc_filename in base_library_files:
+                    # .pyc file is part of base_library.zip
+                    return os.path.normpath(os.path.join(BASE_LIBRARY, pyc_filename))
+                else:
+                    # .pyc file is part of the PYZ archive; first, check if the source .py file exists...
+                    fullpath = os.path.normpath(os.path.join(SYS_PREFIX, filename))
+                    if os.path.isfile(fullpath):
+                        return fullpath
+                    # ... otherwise return full path to the (fictional) .pyc file
+                    return fullpath + 'c'
+        elif filename.startswith(SYS_PREFIX):
             # If filename is already PyInstaller-compatible, prevent any further processing (i.e., with original
             # implementation).
-            return filename
+            if filename.endswith('.pyc'):
+                return filename
+            if filename.endswith('.py') and os.path.isfile(filename):
+                return filename
+
         # Use original implementation as a fallback.
         return _orig_inspect_getsourcefile(object)
 

--- a/PyInstaller/loader/pyimod02_importers.py
+++ b/PyInstaller/loader/pyimod02_importers.py
@@ -400,15 +400,23 @@ class PyiFrozenLoader:
         self._pyz_entry_name = pyz_entry_name
         self._is_package = is_package
 
-        # Compute the module file path, as if module was located on filesyste.
+        # Compute the module file path, as if module was located on filesystem.
+        #
+        # If the corresponding source .py file exists on the filesystem (i.e., it was also collected into the
+        # frozen application), have the module file path point to it, as per
+        # https://docs.python.org/3/library/importlib.html#importlib.abc.ExecutionLoader.get_filename
+        #
         # NOTE: since we are using sys._MEIPASS as prefix, we need to construct path from full PYZ entry name
         # (so that a module with `name`=`jaraco.text` and `pyz_entry_name`=`setuptools._vendor.jaraco.text`
         # ends up with path set to `sys._MEIPASS/setuptools/_vendor/jaraco/text/__init__.pyc` instead of
         # `sys._MEIPASS/jaraco/text/__init__.pyc`).
         if is_package:
-            module_file = os.path.join(sys._MEIPASS, pyz_entry_name.replace('.', os.path.sep), '__init__.pyc')
+            module_file = os.path.join(sys._MEIPASS, pyz_entry_name.replace('.', os.path.sep), '__init__.py')
         else:
-            module_file = os.path.join(sys._MEIPASS, pyz_entry_name.replace('.', os.path.sep) + '.pyc')
+            module_file = os.path.join(sys._MEIPASS, pyz_entry_name.replace('.', os.path.sep) + '.py')
+
+        if not os.path.isfile(module_file):
+            module_file += 'c'  # Have the module file path point to fictional .pyc file.
 
         # These properties are defined as part of importlib.abc.FileLoader. They are used by our implementation
         # (e.g., module name validation, get_filename(), get_source(), get_resource_reader()), and might also be used
@@ -504,10 +512,13 @@ class PyiFrozenLoader:
 
         https://docs.python.org/3/library/importlib.html#importlib.abc.InspectLoader.get_source
         """
-        # FIXME: according to python docs "if source code is available, then the [getfilename()] method should return
-        # the path to the source file, regardless of whether a bytecode was used to load the module.". At the moment,
-        # our implementation always returns pyc suffix.
-        filename = self.path[:-1]
+
+        # The `path` attribute (which is also returned from `get_filename()`) should already point to the source .py
+        # file if the latter exists. If not, the `path` points to a fictional `.pyc` file in the same location; if that
+        # is the case, try to load adjacent `.py` file, although at this point, it is very unlikely that it exists...
+        filename = self.path
+        if filename.endswith('.pyc'):
+            filename = filename[:-1]
 
         try:
             # Read in binary mode, then decode

--- a/news/9139.moduleloader.rst
+++ b/news/9139.moduleloader.rst
@@ -1,0 +1,9 @@
+Have the ``PyiFrozenLoader`` set the module's file path (i.e., the
+loader's ``path`` attribute and the module's ``__file__`` attribute)
+to the source .py file if the latter is available (i.e., was
+explicitly collected into the frozen application in addition to
+the byte-compiled module in the PYZ archive). This improves compatibility
+with 3rd-party code that naively assumes that the module's ``__file__``
+attribute always points to the source .py file, and either tries to load it
+as a source file, or attempts to perform filesystem-based operations
+under assumption that the file and/or its parent directory exist.

--- a/tests/functional/modules/pyi_module_file_attribute/mypackage/mod_a.py
+++ b/tests/functional/modules/pyi_module_file_attribute/mypackage/mod_a.py
@@ -1,0 +1,1 @@
+# mypackage.mod_a: module that is supposed to be collected only into PYZ archive.

--- a/tests/functional/modules/pyi_module_file_attribute/mypackage/mod_b.py
+++ b/tests/functional/modules/pyi_module_file_attribute/mypackage/mod_b.py
@@ -1,0 +1,1 @@
+# mypackage.mod_b: module that is supposed to be collected both into PYZ archive and as a source .py file.

--- a/tests/functional/test_import.py
+++ b/tests/functional/test_import.py
@@ -21,6 +21,62 @@ from PyInstaller.utils.tests import importorskip, xfail
 _MODULES_DIR = pathlib.Path(__file__).parent / 'modules'
 
 
+# Ensure that our module loader sets module's `__file__` attribute to source .py file, if it is available.
+def test_module_file_attribute(pyi_builder, monkeypatch):
+    # Patch Analysis to set module_collection_mode for the modules.
+    import PyInstaller.building.build_main
+
+    class _Analysis(PyInstaller.building.build_main.Analysis):
+        def __init__(self, *args, **kwargs):
+            kwargs['module_collection_mode'] = {
+                'mypackage.mod_a': 'pyz',
+                'mypackage.mod_b': 'pyz+py',
+            }
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr('PyInstaller.building.build_main.Analysis', _Analysis)
+
+    extra_path = _MODULES_DIR / 'pyi_module_file_attribute'
+
+    pyi_builder.test_source(
+        """
+        import sys
+        import os
+
+        import mypackage.mod_a
+        import mypackage.mod_b
+
+        # This module is collected only into PYZ archive, so __file__ should point at fictional .pyc file.
+        expected_a = os.path.join(sys._MEIPASS, 'mypackage', 'mod_a.pyc')
+        file_a = mypackage.mod_a.__file__
+        loader_path_a = mypackage.mod_a.__loader__.path
+
+        print("mypackage.mod_a:", file=sys.stderr)
+        print(f" - __file__: {file_a}", file=sys.stderr)
+        print(f" - __loader__.path: {loader_path_a}", file=sys.stderr)
+        print(f" - expected: {expected_a}", file=sys.stderr)
+
+        assert file_a == expected_a
+        assert loader_path_a == expected_a
+
+        # This module is collected both into PYZ archive and as a source .py file, so __file__ should point at the
+        # source .py file.
+        expected_b = os.path.join(sys._MEIPASS, 'mypackage', 'mod_b.py')
+        file_b = mypackage.mod_b.__file__
+        loader_path_b = mypackage.mod_b.__loader__.path
+
+        print("mypackage.mod_b:", file=sys.stderr)
+        print(f" - __file__: {file_b}", file=sys.stderr)
+        print(f" - __loader__.path: {loader_path_b}", file=sys.stderr)
+        print(f" - expected: {expected_a}", file=sys.stderr)
+
+        assert file_b == expected_b
+        assert loader_path_b == expected_b
+        """,
+        pyi_args=['--path', str(extra_path)],
+    )
+
+
 def test_nameclash(pyi_builder):
     # test-case for issue #964: Nameclashes in module information gathering All pyinstaller specific module attributes
     # should be prefixed, to avoid nameclashes.


### PR DESCRIPTION
Have our `PyiFrozenLoader` set the module's file path (i.e., the loader's `path` attribute and the module's `__file__` attribute) to the source .py file if the latter is available (i.e., was explicitly collected into the frozen application in addition to the byte-compiled version in the PYZ archive).
    
This brings our loader's behavior in compliance with the description of `importlib.abc.ExecutionLoader.get_filename`, which states that, "If source code is available, then the method should return the path to the source file, regardless of whether a bytecode was used to load the module."
    
Returning the path to the source .py file (instead of fictional .pyc file in the same location) improves compatibility with 3rd-party code that naively assumes that the module's `__file__` attribute always points to the source .py file, and either tries to load it as a source file, or attempts to perform filesystem-based operations under assumption that the file and/or its parent directory exist.

Closes #9134 and #9137. 

While running some basic tests with a model from `transformers` (that reproduces #9134), I ran into some additional warnings that were caused by our `inspect.getsourcefile()` override always resolving relative .py filenames into .pyc module names; so its behavior also needed to be updated to match the behavior of the loader (i.e., the relative .py filename into absolute .py filename, if the said source .py file exists).