### PR TITLE
loader: have __file__ attribute use .py suffix instead of .pyc one

### DIFF
--- a/doc/runtime-information.rst
+++ b/doc/runtime-information.rst
@@ -41,7 +41,7 @@ from a bundled script, the PyInstaller bootloader will set the module's
 
 For example, if you import ``mypackage.mymodule`` from a bundled script, then
 the ``__file__`` attribute of that module will be ``sys._MEIPASS +
-'mypackage/mymodule.pyc'``.  So if you have a data file at
+'mypackage/mymodule.py'``.  So if you have a data file at
 ``mypackage/file.dat`` that you added to the bundle at ``mypackage/file.dat``,
 the following code will get its path (in both the non-bundled and the bundled
 case)::
@@ -107,7 +107,7 @@ Or the pathlib_ equivalent::
     path_to_dat = Path(__file__).resolve().with_name("file.dat")
 
 And ``my_script.py`` is **not** part of a package (not in a folder containing
-an ``__init_.py``), then ``__file__`` will be ``[app root]/my_script.pyc``
+an ``__init__.py``), then ``__file__`` will be ``[app root]/my_script.py``
 meaning that if you put ``file.dat`` in the root of your package, using::
 
     PyInstaller --add-data="/path/to/file.dat:."
@@ -116,7 +116,7 @@ It will be found correctly at runtime without changing ``my_script.py``.
 
 If ``__file__`` is checked from inside a package or library (say
 ``my_library.data``) then ``__file__`` will be
-``[app root]/my_library/data.pyc`` and :option:`--add-data` should mirror that::
+``[app root]/my_library/data.py`` and :option:`--add-data` should mirror that::
 
     PyInstaller --add-data="/path/to/my_library/file.dat:./my_library"
 

--- a/news/9141.moduleloader.rst
+++ b/news/9141.moduleloader.rst
@@ -1,0 +1,9 @@
+Have the ``PyiFrozenLoader`` use the .py suffix instead of .pyc one
+for module's file path (the file path stored in the loader's ``path``
+attribute and the module's ``__file__`` attribute). This should improve
+compatibility with 3rd party code that assumes that the module's
+``__file__`` attribute points to the source .py file; odd-case scenarios
+such as checking for file's existence, trying to query its creation time
+or trying to read it as a source file can now be accommodated by simply
+collecting the source .py files, rather than also having to exclude the
+byte-compiled module from the PYZ archive.

--- a/tests/functional/scripts/pyi_module__file__attribute.py
+++ b/tests/functional/scripts/pyi_module__file__attribute.py
@@ -10,9 +10,9 @@
 #-----------------------------------------------------------------------------
 
 # Test the value of the __file__ attribute; for a frozen package, it should be:
-#   sys.prefix/package/__init__.pyc
+#   sys.prefix/package/__init__.py
 # and for a frozen module, it should be:
-#   sys.prefix/module.pyc
+#   sys.prefix/module.py
 
 import os
 import sys
@@ -20,8 +20,8 @@ import sys
 import shutil as module
 import xml.sax as package
 
-correct_mod = os.path.join(sys.prefix, 'shutil.pyc')
-correct_pkg = os.path.join(sys.prefix, 'xml', 'sax', '__init__.pyc')
+correct_mod = os.path.join(sys.prefix, 'shutil.py')
+correct_pkg = os.path.join(sys.prefix, 'xml', 'sax', '__init__.py')
 
 # Print.
 print(('Actual   mod.__file__: %s' % module.__file__))

--- a/tests/functional/test_import.py
+++ b/tests/functional/test_import.py
@@ -21,6 +21,27 @@ from PyInstaller.utils.tests import importorskip, xfail
 _MODULES_DIR = pathlib.Path(__file__).parent / 'modules'
 
 
+# Test that PyiFrozenLoader.get_source() works as expected when source .py file is available.
+def test_loader_get_source(pyi_builder):
+    pyi_builder.test_source(
+        """
+        import pyi_dummy_module
+        from pyimod02_importers import PyiFrozenLoader
+
+        # Ensure the module is handled by PyiFrozenLoader.
+        loader = pyi_dummy_module.__loader__
+        assert isinstance(loader, PyiFrozenLoader)
+
+        # Check that loader.get_source() returns source from the .py file.
+        assert loader.get_source('pyi_dummy_module') is not None
+        """,
+        pyi_args=[
+            '--add-data',
+            f'{_MODULES_DIR / "pyi_dummy_module.py"}:.',
+        ]
+    )
+
+
 def test_nameclash(pyi_builder):
     # test-case for issue #964: Nameclashes in module information gathering All pyinstaller specific module attributes
     # should be prefixed, to avoid nameclashes.


### PR DESCRIPTION
Have our `PyiFrozenLoader` use the .py suffix instead of .pyc when computing the module's file path (i.e., when setting the loader's `path` attribute and the module's `__file__` attribute). This allows us to better accommodate *creative* uses of `__file__` attribute in 3rd party code (e.g., checking for file's existence, querying its creation/modification time, loading it as a source file), by just collecting the source .py files (which we often need to do anyway) and without having to forego the byte-compiled version in the PYZ archive.

Closes #9134 and #9137.
Supersedes and closes #9139.