### PR TITLE
analysis: keep track of modules that are not collected into PYZ archive

### DIFF
--- a/news/9135.bugfix.rst
+++ b/news/9135.bugfix.rst
@@ -1,0 +1,5 @@
+The `Analysis` class now keeps track of pure-python modules that are not
+collected into PYZ archive (i.e., are not listed in the ``Analysis.pure``
+TOC list); the corresponding entries are added to a separate TOC list
+that is also under modification-time check, which allows us to detect
+modifications and re-run the analysis.


### PR DESCRIPTION
Have the `Analysis` class keep track of pure-python modules that are not collected into PYZ archive. Such modules are now tracked in a special `Analysis._modules_outside_pyz` TOC list that is subject of modification-time check; this ensures that analysis is ran again whenever such a module is modified.

Up until now , analysis was re-run on modifications of modules that are collected into PYZ archive (since these are tracked in the `Analysis.pure` TOC list, also subject to modification-time check), but not modules that are not collected into PYZ archive: modules that are collected into `base_library.zip`, modules that are collected as .pyc files (either due to module collection mode setting, or due to `noarchive=True` option), or modules that are collected only as source .py files (although modification to these would be caught due to entries in the `Analysis.datas` TOC list).

Fixes #9135.