### PR TITLE
Mitigate issues with pkg_resources deprecation warning, take 2

### DIFF
--- a/PyInstaller/hooks/hook-pytz.py
+++ b/PyInstaller/hooks/hook-pytz.py
@@ -14,3 +14,7 @@ from PyInstaller.utils.hooks import collect_data_files
 # On Linux pytz installed from distribution repository uses zoneinfo from /usr/share/zoneinfo/ and no data files might
 # be collected.
 datas = collect_data_files('pytz')
+
+# pytz references pkg_resources in a fall-back codepath that should normally not be reached; add an exclude to prevent
+# (now deprecated) pkg_resources from being pulled in the frozen application.
+excludedimports = ['pkg_resources']

--- a/PyInstaller/hooks/rthooks/pyi_rth_pkgres.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_pkgres.py
@@ -33,8 +33,15 @@ def _pyi_rthook():
     import os
     import pathlib
     import sys
+    import warnings
 
-    import pkg_resources
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            category=UserWarning,
+            message="pkg_resources is deprecated",
+        )
+        import pkg_resources
 
     import pyimod02_importers  # PyInstaller's bootstrap module
 

--- a/news/9154.hooks.rst
+++ b/news/9154.hooks.rst
@@ -1,0 +1,3 @@
+Have the ``pytz`` hook exclude ``pkg_resources``, to prevent the latter
+from being collected due to a reference in the fallback resource
+loading codepath in ``pytz`` that should normally not be reached.


### PR DESCRIPTION
Follow-up to #9151.

In `pytz` hook, add an `excludedimports = ['pkg_resources']` to prevent `pkg_resources` from being pulled in due to a reference in a fallback codepath for resource loading that should normally not be reached. See https://github.com/orgs/pyinstaller/discussions/8920#discussioncomment-13322314.

Also, it is going to be a great hassle to exclude all such references to `pkg_resources`; so it might be better to simply suppress the warning in the run-time hook when we import `pkg_resources`. In the end, this problem will solve itself once `pkg_resources` is finally truly removed.