### PR TITLE
hooks: update numpy hook for compatibility with NumPy v2.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -390,13 +390,13 @@ jobs:
             mingw-w64-${{matrix.env}}-python-pytest-xdist
             mingw-w64-${{matrix.env}}-python-pytest-timeout
             mingw-w64-${{matrix.env}}-python-pywin32
-            mingw-w64-${{matrix.env}}-python-pillow
             mingw-w64-${{matrix.env}}-python-gobject
 
       # Some msys2 python packages are not available for i686 anymore:
       #  - numpy
       #  - pefile
       #  - psutil (removed with update to psutil 6.1.1; see https://github.com/msys2/MINGW-packages/commit/7f1c75b33a5aebb89899f99f5fa656c623eeb9ed)
+      #  - pillow (see https://github.com/msys2/MINGW-packages/commit/a7d88c34aa36adce78ba71633711412a24d8792c)
       # If running in 64-bit environment, install the said packages here.
       # Otherwise, we will run tests without these packages (note that
       # if not installed here, `pefile` will end up installed via `pip`
@@ -408,6 +408,7 @@ jobs:
           mingw-w64-${{matrix.env}}-python-numpy
           mingw-w64-${{matrix.env}}-python-pefile
           mingw-w64-${{matrix.env}}-python-psutil
+          mingw-w64-${{matrix.env}}-python-pillow
 
       - name: Checkout PyInstaller code
         uses: actions/checkout@v4

--- a/PyInstaller/hooks/hook-numpy.py
+++ b/PyInstaller/hooks/hook-numpy.py
@@ -79,6 +79,12 @@ else:
     if numpy_version >= (1, 25):
         hiddenimports += ['numpy.core._multiarray_tests']
 
+# Starting with v2.3.0, we need to add `numpy._core._exceptions` to hiddenimports; in previous versions, this module
+# was picked up due to explicit import in `numpy._core._methods`, which was removed as part of cleanup in
+# https://github.com/numpy/numpy/commit/a51a4f5c10aa9b7962ff1e7e9b5f9b7d91c51489
+if numpy_version >= (2, 3, 0):
+    hiddenimports += ['numpy._core._exceptions']
+
 # This hidden import was removed from NumPy hook in v1.25.0 (https://github.com/numpy/numpy/pull/22666). According to
 # comment in the linked PR, it should have been unnecessary since v1.19.
 if compat.is_conda and numpy_version < (1, 19):

--- a/news/9162.hooks.rst
+++ b/news/9162.hooks.rst
@@ -1,0 +1,1 @@
+Update the ``numpy`` hook for compatibility with NumPy v2.3.0.

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -19,7 +19,7 @@ gevent==25.5.1; python_version >= '3.9'
 ipython==9.2.0; python_version >= '3.11'
 keyring==25.6.0; python_version >= '3.9'
 matplotlib==3.10.3; python_version >= '3.10'
-numpy==2.2.6; python_version >= '3.10'
+numpy==2.3.0; python_version >= '3.11'
 pandas==2.2.3; python_version >= '3.9'
 pygments==2.19.1
 PyGObject==3.52.3; sys_platform == 'linux' and python_version >= '3.9'
@@ -89,6 +89,8 @@ Pillow==11.2.1; python_version >= '3.9'
 
 # Python 3.10
 # -----------
+numpy==2.2.6; python_version == '3.10'
+
 sphinx==8.1.3; python_version == '3.10'  # pyup: ignore
 ipython==8.32.0; python_version == '3.10' # pyup: ignore
 


### PR DESCRIPTION
Starting with `numpy` 2.3.0, we need to add `numpy._core._exceptions` to hidden imports, because a refactoring/cleanup removed the last explicit import that did not happen inside an extension module.