### PR TITLE
Fix "libaries" typos

### DIFF
--- a/PyInstaller/building/splash.py
+++ b/PyInstaller/building/splash.py
@@ -209,7 +209,7 @@ class Splash(Target):
         # Scan for binary dependencies of the Tcl/Tk shared libraries, and add them to `binaries` TOC list (which
         # should really be called `dependencies` as it is not limited to binaries. But it is too late now, and
         # existing spec files depend on this naming). We specify these binary dependencies (which include the
-        # Tcl and Tk shared libaries themselves) even if the user's program uses tkinter and they would be collected
+        # Tcl and Tk shared libraries themselves) even if the user's program uses tkinter and they would be collected
         # anyway; let the collection mechanism deal with potential duplicates.
         tcltk_libs = [(os.path.basename(src_name), src_name, 'BINARY') for src_name in (self.tcl_lib, self.tk_lib)]
         self.binaries = bindepend.binary_dependency_analysis(tcltk_libs)

--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -888,7 +888,7 @@ _pyi_main_setup_splash_screen(struct PYI_CONTEXT *pyi_ctx)
     }
 
     /* Load Tcl/Tk shared libraries */
-    if (pyi_splash_load_shared_libaries(pyi_ctx->splash) != 0) {
+    if (pyi_splash_load_shared_libraries(pyi_ctx->splash) != 0) {
         PYI_WARNING("Failed to load Tcl/Tk shared libraries for splash screen!\n");
         goto cleanup;
     }

--- a/bootloader/src/pyi_splash.c
+++ b/bootloader/src/pyi_splash.c
@@ -159,7 +159,7 @@ pyi_splash_setup(struct SPLASH_CONTEXT *splash, const struct PYI_CONTEXT *pyi_ct
  * Start the splash screen.
  *
  * As this uses bound functions from Tcl/Tk shared libraries, it must
- * be called after the shared libaries have been loaded and their
+ * be called after the shared libraries have been loaded and their
  * symbols bound.
  *
  * The splash screen needs to run in a separate thread, otherwise
@@ -348,7 +348,7 @@ pyi_splash_is_splash_requirement(struct SPLASH_CONTEXT *splash, const char *name
 
 /* Load Tcl/Tk shared libraries and bind required symbols (functions). */
 int
-pyi_splash_load_shared_libaries(struct SPLASH_CONTEXT *splash)
+pyi_splash_load_shared_libraries(struct SPLASH_CONTEXT *splash)
 {
     PYI_DEBUG("SPLASH: loading Tcl library from: %s\n", splash->tcl_libpath);
     PYI_DEBUG("SPLASH: loading Tk library from: %s\n", splash->tk_libpath);
@@ -439,7 +439,7 @@ pyi_splash_finalize(struct SPLASH_CONTEXT *splash)
      * in a weird state of tkinter. */
     dylib_tcltk->Tcl_Finalize();
 
-    PYI_DEBUG("SPLASH: unloading Tcl/Tk shared libaries...\n");
+    PYI_DEBUG("SPLASH: unloading Tcl/Tk shared libraries...\n");
     pyi_dylib_tcltk_cleanup(&splash->dylib_tcltk);
 
     PYI_DEBUG("SPLASH: cleanup complete!\n");

--- a/bootloader/src/pyi_splash.h
+++ b/bootloader/src/pyi_splash.h
@@ -129,7 +129,7 @@ struct PYI_CONTEXT;
  */
 int pyi_splash_setup(struct SPLASH_CONTEXT *splash, const struct PYI_CONTEXT *pyi_ctx);
 
-int pyi_splash_load_shared_libaries(struct SPLASH_CONTEXT *splash);
+int pyi_splash_load_shared_libraries(struct SPLASH_CONTEXT *splash);
 int pyi_splash_finalize(struct SPLASH_CONTEXT *splash);
 int pyi_splash_start(struct SPLASH_CONTEXT *splash, const char *executable);
 


### PR DESCRIPTION
While reviewing the Debian package's automatic lintian system, it flagged that there was a mispelling of "libaries" in the `bootloader/Linux-64bit-intel/run_d` binary.  This pull request fixes all of the instances of "libaries" I found in the code.