### PR TITLE
Fixes for compiling bootloader on Solaris 10 systems

### DIFF
--- a/PyInstaller/_shared_with_waf.py
+++ b/PyInstaller/_shared_with_waf.py
@@ -52,7 +52,7 @@ def _pyi_machine(machine, system):
             return "intel"
 
     if system == "SunOS":
-        if "i86pc" in machine.lower() or "i86pc" in platform.machine().lower():
+        if machine.lower() in ("x86", "i86pc"):
             return "intel"
         else:
             return "sparc"

--- a/PyInstaller/_shared_with_waf.py
+++ b/PyInstaller/_shared_with_waf.py
@@ -52,10 +52,10 @@ def _pyi_machine(machine, system):
             return "intel"
 
     if system == "SunOS":
-        if "sun" in machine.lower() or "sun" in platform.machine().lower():
-            return "sparc"
-        else:
+        if "i86pc" in machine.lower() or "i86pc" in platform.machine().lower():
             return "intel"
+        else:
+            return "sparc"
 
     if system != "Linux":
         # No architecture specifier for anything par Linux.

--- a/PyInstaller/_shared_with_waf.py
+++ b/PyInstaller/_shared_with_waf.py
@@ -50,7 +50,7 @@ def _pyi_machine(machine, system):
             return "arm"
         else:
             return "intel"
-        
+
     if system == "SunOS":
         if "sun" in machine.lower() or "sun" in platform.machine().lower():
             return "sparc"

--- a/PyInstaller/_shared_with_waf.py
+++ b/PyInstaller/_shared_with_waf.py
@@ -50,6 +50,12 @@ def _pyi_machine(machine, system):
             return "arm"
         else:
             return "intel"
+        
+    if system == "SunOS":
+        if "sun" in machine.lower() or "sun" in platform.machine().lower():
+            return "sparc"
+        else:
+            return "intel"
 
     if system != "Linux":
         # No architecture specifier for anything par Linux.

--- a/PyInstaller/depend/dylib.py
+++ b/PyInstaller/depend/dylib.py
@@ -200,7 +200,6 @@ _unix_excludes = {
     r'libnss_nis.*\.so(\..*)?',
     r'libnss_nisplus.*\.so(\..*)?',
     r'libresolv\.so(\..*)?',
-    r'libsocket\.so(\..*)?',
     r'libutil\.so(\..*)?',
     # graphical interface libraries come with graphical stack (see libglvnd)
     r'libE?(Open)?GLX?(ESv1_CM|ESv2)?(dispatch)?\.so(\..*)?',
@@ -238,6 +237,10 @@ _aix_excludes = {
     r'libz\.a',
 }
 
+_solaris_excludes = {
+    r'libsocket\.so(\..*)?',
+}
+
 _cygwin_excludes = {
     r'cygwin1\.dll',
 }
@@ -250,6 +253,10 @@ elif compat.is_cygwin:
 elif compat.is_aix:
     # The exclude list for AIX differs from other *nix platforms.
     _excludes |= _aix_excludes
+elif compat.is_solar:
+    # The exclude list for Solaris differs from other *nix platforms.
+    _excludes |= _solaris_excludes
+    _excludes |= _unix_excludes
 elif compat.is_unix:
     # Common excludes for *nix platforms -- except AIX.
     _excludes |= _unix_excludes

--- a/PyInstaller/depend/dylib.py
+++ b/PyInstaller/depend/dylib.py
@@ -200,6 +200,7 @@ _unix_excludes = {
     r'libnss_nis.*\.so(\..*)?',
     r'libnss_nisplus.*\.so(\..*)?',
     r'libresolv\.so(\..*)?',
+    r'libsocket\.so(\..*)?',
     r'libutil\.so(\..*)?',
     # graphical interface libraries come with graphical stack (see libglvnd)
     r'libE?(Open)?GLX?(ESv1_CM|ESv2)?(dispatch)?\.so(\..*)?',

--- a/bootloader/src/pyi_pyconfig.c
+++ b/bootloader/src/pyi_pyconfig.c
@@ -25,12 +25,14 @@
 #include "pyi_utils.h"
 
 #ifndef HAVE_WCSDUP
-wchar_t *wcsdup(const wchar_t *s)
+static wchar_t
+*wcsdup(const wchar_t *s)
 {
     size_t len = wcslen(s) + 1;
     wchar_t *new_s = malloc(len * sizeof(wchar_t));
-    if (new_s)
+    if (new_s) {
         wcscpy(new_s, s);
+    }
     return new_s;
 }
 #endif

--- a/bootloader/src/pyi_pyconfig.c
+++ b/bootloader/src/pyi_pyconfig.c
@@ -24,6 +24,16 @@
 #include "pyi_main.h"
 #include "pyi_utils.h"
 
+#ifndef HAVE_WCSDUP
+wchar_t *wcsdup(const wchar_t *s)
+{
+    size_t len = wcslen(s) + 1;
+    wchar_t *new_s = malloc(len * sizeof(wchar_t));
+    if (new_s)
+        wcscpy(new_s, s);
+    return new_s;
+}
+#endif
 
 /*
  * Clean up and free the PyiRuntimeOptions structure created by

--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -686,7 +686,7 @@ def configure(ctx):
         ('unistd.h' if ctx.env.DEST_OS == 'darwin' else 'stdlib.h', 'mkdtemp'),
         ('libgen.h', 'dirname'),
         ('libgen.h', 'basename'),
-        ('wchar.h',  'wcsdup')
+        ('wchar.h', 'wcsdup')
     ):
         ctx.check(
             fragment=SNIP_FUNCTION % (header, function_name),

--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -686,6 +686,7 @@ def configure(ctx):
         ('unistd.h' if ctx.env.DEST_OS == 'darwin' else 'stdlib.h', 'mkdtemp'),
         ('libgen.h', 'dirname'),
         ('libgen.h', 'basename'),
+        ('wchar.h',  'wcsdup')
     ):
         ctx.check(
             fragment=SNIP_FUNCTION % (header, function_name),


### PR DESCRIPTION
Hi,

This is my first contribution so apologies if something is not quite right!

The changes included in this commit make PyInstaller work on Solaris 10 machines (SPARC and Intel). The reason for these changes are that bootloaders built on recent versions of Solaris (11.4) are brittle due to the changes between the release version and subsequent patches provided by Oracle. In my travels a build generated on a fully updated 11.4 system would not work on an un-updated 11.4 system or Solaris 10. Thus I tried building on Solaris 10 (u11 specifically) with the changes included which is forward compatible.

A brief description of the changes is as follows:
1. dylib.py - exclude libsocket.so as this is specific to the Solaris installation and causes symbol errors otherwise
2. _shared_with_waf.py - add identifier for SPARC vs Intel as bootloaders built on one do not work on the other
3. wscript - test for wcsdup (see below)
4. pyi_pyconfig.c - add definition for wcsdup which is not available on Solaris 10u11

Additionally, in order to get my code working on Solaris I had to override pyi_rth_multiprocessing.py with a blank file via the hooks mechanism in order to stop it from trying to load forkserver logic. I haven't included this as I'm not sure of the ramifications but I'm including it here for anyone else that runs across the issue.