### PR TITLE
Tests: Requirements: Scheduled weekly dependency update for week 27

### DIFF
--- a/tests/requirements-base.txt
+++ b/tests/requirements-base.txt
@@ -6,16 +6,16 @@
 # requirements-tools.txt and requirements-libraries.txt.
 
 # Work-around for a bug in execnet 1.4.1
-execnet >= 1.5.0
+execnet>=1.5.0
 
 # Testing framework.
-pytest >= 2.7.3
+pytest>=2.7.3
 
 # Plugin allowing running tests in parallel.
 pytest-xdist
 
 # Plugin to abort hanging tests.
-pytest-timeout >= 2.0.0
+pytest-timeout>=2.0.0
 
 # Allows specifying order without duplicates
 pytest-drop-dup-tests
@@ -25,4 +25,4 @@ pytest-rerunfailures
 
 # Better subprocess alternative with process tree support.
 # Not available on cygwin.
-psutil; sys_platform != 'cygwin'
+psutil; sys_platform != "cygwin"

--- a/tests/requirements-developer.txt
+++ b/tests/requirements-developer.txt
@@ -13,7 +13,7 @@
 ### Helpers for development
 
 ipython  # Better interactive Python shell.
-pyreadline ; sys_platform == 'win32'  # Colors in IPython, Windows-only package.
+pyreadline; sys_platform == "win32"  # Colors in IPython, Windows-only package.
 pycmd  # Contains 'py.cleanup' that removes all .pyc files and similar.
 
 ### Helpers for releases

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -20,7 +20,7 @@ ipython==9.4.0; python_version >= "3.11"
 keyring==25.6.0; python_version >= "3.9"
 matplotlib==3.10.3; python_version >= "3.10"
 numpy==2.3.1; python_version >= "3.11"
-pandas==2.3.0; python_version >= "3.9"
+pandas==2.3.1; python_version >= "3.9"
 pygments==2.19.2
 PyGObject==3.52.3; sys_platform == "linux" and python_version >= "3.9"
 # Official PySide2 wheels do not support python 3.11 or newer. Nor are they available for arm64 on macOS.
@@ -70,7 +70,7 @@ requests==2.32.4
 scipy==1.16.0; python_version >= "3.11"
 # simplejson is used for text_c_extension
 simplejson==3.20.1
-sphinx==8.3.0; python_version >= "3.11"
+sphinx==8.2.3; python_version >= "3.11"
 # Required for test_namespace_package
 sqlalchemy==2.0.41
 zope.interface==7.2

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -13,28 +13,28 @@
 # -------
 # These packages work with no (known) issues.
 babel==2.17.0
-Django==5.2.4; python_version >= '3.10'
+Django==5.2.4; python_version >= "3.10"
 future==1.0.0
-gevent==25.5.1; python_version >= '3.9'
-ipython==9.4.0; python_version >= '3.11'
-keyring==25.6.0; python_version >= '3.9'
-matplotlib==3.10.3; python_version >= '3.10'
-numpy==2.3.1; python_version >= '3.11'
-pandas==2.3.0; python_version >= '3.9'
+gevent==25.5.1; python_version >= "3.9"
+ipython==9.4.0; python_version >= "3.11"
+keyring==25.6.0; python_version >= "3.9"
+matplotlib==3.10.3; python_version >= "3.10"
+numpy==2.3.1; python_version >= "3.11"
+pandas==2.3.0; python_version >= "3.9"
 pygments==2.19.2
-PyGObject==3.52.3; sys_platform == 'linux' and python_version >= '3.9'
+PyGObject==3.52.3; sys_platform == "linux" and python_version >= "3.9"
 # Official PySide2 wheels do not support python 3.11 or newer. Nor are they available for arm64 on macOS.
-PySide2==5.15.2.1; python_version < '3.11' and (sys_platform != 'darwin' or platform_machine != 'arm64')
+PySide2==5.15.2.1; python_version < "3.11" and (sys_platform != "darwin" or platform_machine != "arm64")
 # PySide6 is a metapackage that depends on PySide6-Essentials and PySide6-Addons. Their versions are
 # usually kept in sync.
-PySide6==6.9.1; python_version >= '3.9'
-PySide6-Addons==6.9.1; python_version >= '3.9'
-PySide6-Essentials==6.9.1; python_version >= '3.9'
+PySide6==6.9.1; python_version >= "3.9"
+PySide6-Addons==6.9.1; python_version >= "3.9"
+PySide6-Essentials==6.9.1; python_version >= "3.9"
 # PyQt5 and add-on packages
 # We do not pin *-Qt5 packages (which contain Qt shared libraries), as Qt5 is not actively developed
 # anymore, and thus 5.15.x has a stable ABI. Plus, it seems that *-Qt5 5.15.2 wheels are available for
 # all platforms, while 5.15.11 are available only for macOS (and some of them only for arm64).
-PyQt5-sip==12.17.0; python_version >= '3.9'
+PyQt5-sip==12.17.0; python_version >= "3.9"
 PyQt5==5.15.11
 PyQt3D==5.15.7
 PyQtChart==5.15.7
@@ -48,33 +48,33 @@ PyQtWebEngine==5.15.7
 # but in contrast to Qt5 and PyQt5 bindings, the versions here must usually be kept in sync with the
 # version of corresponding PyQt bindings packages. That is because Qt6 is under active development, and
 # thus the ABI is still changing.
-PyQt6-sip==13.10.2; python_version >= '3.9'
-PyQt6==6.9.1; python_version >= '3.9'
-PyQt6-Qt6==6.9.1; python_version >= '3.9'
-PyQt6-3D==6.9.0; python_version >= '3.9'
-PyQt6-3D-Qt6==6.9.1; python_version >= '3.9'
-PyQt6-Charts==6.9.0; python_version >= '3.9'
-PyQt6-Charts-Qt6==6.9.1; python_version >= '3.9'
-PyQt6-DataVisualization==6.9.0; python_version >= '3.9'
-PyQt6-DataVisualization-Qt6==6.9.1; python_version >= '3.9'
-PyQt6-Graphs==6.9.0; python_version >= '3.9'
-PyQt6-Graphs-Qt6==6.9.1; python_version >= '3.9'
-PyQt6-NetworkAuth==6.9.0; python_version >= '3.9'
-PyQt6-NetworkAuth-Qt6==6.9.1; python_version >= '3.9'
-PyQt6-QScintilla==2.14.1; python_version >= '3.9'  # Does not have a corresponding -Qt6 package
-PyQt6-WebEngine==6.9.0; python_version >= '3.9'
-PyQt6-WebEngine-Qt6==6.9.1; python_version >= '3.9'
+PyQt6-sip==13.10.2; python_version >= "3.9"
+PyQt6==6.9.1; python_version >= "3.9"
+PyQt6-Qt6==6.9.1; python_version >= "3.9"
+PyQt6-3D==6.9.0; python_version >= "3.9"
+PyQt6-3D-Qt6==6.9.1; python_version >= "3.9"
+PyQt6-Charts==6.9.0; python_version >= "3.9"
+PyQt6-Charts-Qt6==6.9.1; python_version >= "3.9"
+PyQt6-DataVisualization==6.9.0; python_version >= "3.9"
+PyQt6-DataVisualization-Qt6==6.9.1; python_version >= "3.9"
+PyQt6-Graphs==6.9.0; python_version >= "3.9"
+PyQt6-Graphs-Qt6==6.9.1; python_version >= "3.9"
+PyQt6-NetworkAuth==6.9.0; python_version >= "3.9"
+PyQt6-NetworkAuth-Qt6==6.9.1; python_version >= "3.9"
+PyQt6-QScintilla==2.14.1; python_version >= "3.9"  # Does not have a corresponding -Qt6 package
+PyQt6-WebEngine==6.9.0; python_version >= "3.9"
+PyQt6-WebEngine-Qt6==6.9.1; python_version >= "3.9"
 python-dateutil==2.9.0.post0
 pytz==2025.2
 requests==2.32.4
-scipy==1.16.0; python_version >= '3.11'
+scipy==1.16.0; python_version >= "3.11"
 # simplejson is used for text_c_extension
 simplejson==3.20.1
-sphinx==8.3.0; python_version >= '3.11'
+sphinx==8.3.0; python_version >= "3.11"
 # Required for test_namespace_package
 sqlalchemy==2.0.41
 zope.interface==7.2
-Pillow==11.3.0; python_version >= '3.9'
+Pillow==11.3.0; python_version >= "3.9"
 
 
 # Python versions not supported / supported for older package versions
@@ -89,58 +89,58 @@ Pillow==11.3.0; python_version >= '3.9'
 
 # Python 3.10
 # -----------
-numpy==2.2.6; python_version == '3.10'  # pyup: ignore
-scipy==1.15.3; python_version == '3.10'  # pyup: ignore
+numpy==2.2.6; python_version == "3.10"  # pyup: ignore
+scipy==1.15.3; python_version == "3.10"  # pyup: ignore
 
-sphinx==8.1.3; python_version == '3.10'  # pyup: ignore
-ipython==8.32.0; python_version == '3.10' # pyup: ignore
+sphinx==8.1.3; python_version == "3.10"  # pyup: ignore
+ipython==8.32.0; python_version == "3.10" # pyup: ignore
 
 # Python 3.9
 # ----------
-Django==4.2.8; python_version == '3.9'  # pyup: ignore
+Django==4.2.8; python_version == "3.9"  # pyup: ignore
 
-numpy==2.0.1; python_version == '3.9'  # pyup: ignore
-scipy==1.13.1; python_version == '3.9'  # pyup: ignore
-matplotlib==3.9.3; python_version == '3.9'  # pyup: ignore
+numpy==2.0.1; python_version == "3.9"  # pyup: ignore
+scipy==1.13.1; python_version == "3.9"  # pyup: ignore
+matplotlib==3.9.3; python_version == "3.9"  # pyup: ignore
 
-sphinx==7.4.7; python_version == '3.9'  # pyup: ignore
+sphinx==7.4.7; python_version == "3.9"  # pyup: ignore
 
-ipython==8.18.1; python_version == '3.9'  # pyup: ignore
+ipython==8.18.1; python_version == "3.9"  # pyup: ignore
 
 # Python 3.8
 # ----------
-importlib_resources==6.4.5; python_version == '3.8'  # pyup: ignore
+importlib_resources==6.4.5; python_version == "3.8"  # pyup: ignore
 
-Django==4.2.8; python_version == '3.8'  # pyup: ignore
+Django==4.2.8; python_version == "3.8"  # pyup: ignore
 
-numpy==1.24.3; python_version == '3.8'  # pyup: ignore
-scipy==1.10.1; python_version == '3.8'  # pyup: ignore
-pandas==2.0.3; python_version == '3.8'  # pyup: ignore
-matplotlib==3.7.3; python_version == '3.8'  # pyup: ignore
+numpy==1.24.3; python_version == "3.8"  # pyup: ignore
+scipy==1.10.1; python_version == "3.8"  # pyup: ignore
+pandas==2.0.3; python_version == "3.8"  # pyup: ignore
+matplotlib==3.7.3; python_version == "3.8"  # pyup: ignore
 
-PyGObject==3.48.2; sys_platform == 'linux' and python_version == '3.8'  # pyup: ignore
+PyGObject==3.48.2; sys_platform == "linux" and python_version == "3.8"  # pyup: ignore
 
-PyQt5-sip==12.15.0; python_version == '3.8'  # pyup: ignore
-PyQt6-sip==13.8.0; python_version == '3.8'  # pyup: ignore
-PyQt6==6.7.1; python_version == '3.8'  # pyup: ignore
-PyQt6-Qt6==6.7.3; python_version == '3.8'  # pyup: ignore
-PyQt6-3D==6.7.0; python_version == '3.8'  # pyup: ignore
-PyQt6-3D-Qt6==6.7.3; python_version == '3.8'  # pyup: ignore
-PyQt6-Charts==6.7.0; python_version == '3.8'  # pyup: ignore
-PyQt6-Charts-Qt6==6.7.3; python_version == '3.8'  # pyup: ignore
-PyQt6-DataVisualization==6.7.0; python_version == '3.8'  # pyup: ignore
-PyQt6-DataVisualization-Qt6==6.7.3; python_version == '3.8'  # pyup: ignore
-PyQt6-NetworkAuth==6.7.0; python_version == '3.8'  # pyup: ignore
-PyQt6-NetworkAuth-Qt6==6.7.3; python_version == '3.8'  # pyup: ignore
+PyQt5-sip==12.15.0; python_version == "3.8"  # pyup: ignore
+PyQt6-sip==13.8.0; python_version == "3.8"  # pyup: ignore
+PyQt6==6.7.1; python_version == "3.8"  # pyup: ignore
+PyQt6-Qt6==6.7.3; python_version == "3.8"  # pyup: ignore
+PyQt6-3D==6.7.0; python_version == "3.8"  # pyup: ignore
+PyQt6-3D-Qt6==6.7.3; python_version == "3.8"  # pyup: ignore
+PyQt6-Charts==6.7.0; python_version == "3.8"  # pyup: ignore
+PyQt6-Charts-Qt6==6.7.3; python_version == "3.8"  # pyup: ignore
+PyQt6-DataVisualization==6.7.0; python_version == "3.8"  # pyup: ignore
+PyQt6-DataVisualization-Qt6==6.7.3; python_version == "3.8"  # pyup: ignore
+PyQt6-NetworkAuth==6.7.0; python_version == "3.8"  # pyup: ignore
+PyQt6-NetworkAuth-Qt6==6.7.3; python_version == "3.8"  # pyup: ignore
 
-PySide6==6.6.3.1; python_version == '3.8'  # pyup: ignore
-PySide6-Addons==6.6.3.1; python_version == '3.8'  # pyup: ignore
-PySide6-Essentials==6.6.3.1; python_version == '3.8'  # pyup: ignore
+PySide6==6.6.3.1; python_version == "3.8"  # pyup: ignore
+PySide6-Addons==6.6.3.1; python_version == "3.8"  # pyup: ignore
+PySide6-Essentials==6.6.3.1; python_version == "3.8"  # pyup: ignore
 
-sphinx==7.1.2; python_version == '3.8'  # pyup: ignore
+sphinx==7.1.2; python_version == "3.8"  # pyup: ignore
 
-ipython==8.12.1; python_version == '3.8'  # pyup: ignore
+ipython==8.12.1; python_version == "3.8"  # pyup: ignore
 
-Pillow==10.4.0; python_version == '3.8'  # pyup: ignore
+Pillow==10.4.0; python_version == "3.8"  # pyup: ignore
 
-keyring==25.5.0; python_version == '3.8'  # pyup: ignore
+keyring==25.5.0; python_version == "3.8"  # pyup: ignore

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -93,15 +93,15 @@ numpy==2.2.6; python_version == "3.10"  # pyup: ignore
 scipy==1.15.3; python_version == "3.10"  # pyup: ignore
 
 sphinx==8.1.3; python_version == "3.10"  # pyup: ignore
-ipython==8.32.0; python_version == "3.10" # pyup: ignore
+ipython==8.37.0; python_version == "3.10" # pyup: ignore
 
 # Python 3.9
 # ----------
-Django==4.2.8; python_version == "3.9"  # pyup: ignore
+Django==4.2.23; python_version == "3.9"  # pyup: ignore
 
-numpy==2.0.1; python_version == "3.9"  # pyup: ignore
+numpy==2.0.2; python_version == "3.9"  # pyup: ignore
 scipy==1.13.1; python_version == "3.9"  # pyup: ignore
-matplotlib==3.9.3; python_version == "3.9"  # pyup: ignore
+matplotlib==3.9.4; python_version == "3.9"  # pyup: ignore
 
 sphinx==7.4.7; python_version == "3.9"  # pyup: ignore
 
@@ -111,12 +111,12 @@ ipython==8.18.1; python_version == "3.9"  # pyup: ignore
 # ----------
 importlib_resources==6.4.5; python_version == "3.8"  # pyup: ignore
 
-Django==4.2.8; python_version == "3.8"  # pyup: ignore
+Django==4.2.23; python_version == "3.8"  # pyup: ignore
 
-numpy==1.24.3; python_version == "3.8"  # pyup: ignore
+numpy==1.24.4; python_version == "3.8"  # pyup: ignore
 scipy==1.10.1; python_version == "3.8"  # pyup: ignore
 pandas==2.0.3; python_version == "3.8"  # pyup: ignore
-matplotlib==3.7.3; python_version == "3.8"  # pyup: ignore
+matplotlib==3.7.5; python_version == "3.8"  # pyup: ignore
 
 PyGObject==3.48.2; sys_platform == "linux" and python_version == "3.8"  # pyup: ignore
 
@@ -139,7 +139,7 @@ PySide6-Essentials==6.6.3.1; python_version == "3.8"  # pyup: ignore
 
 sphinx==7.1.2; python_version == "3.8"  # pyup: ignore
 
-ipython==8.12.1; python_version == "3.8"  # pyup: ignore
+ipython==8.12.3; python_version == "3.8"  # pyup: ignore
 
 Pillow==10.4.0; python_version == "3.8"  # pyup: ignore
 

--- a/tests/requirements-tools.txt
+++ b/tests/requirements-tools.txt
@@ -16,10 +16,10 @@
 # binary PyPI wheels may be available only for released python versions
 # (i.e., they might be unavailable for pre-release versions).
 
-pywin32; sys_platform == 'win32'
+pywin32; sys_platform == "win32"
 
 lxml
 xmldiff
 
 # Used for strict validation of generated macOS .app bundles
-xattr; sys_platform == 'darwin'
+xattr; sys_platform == "darwin"


### PR DESCRIPTION
Because I'm at the moment using script that uses `packaging.requirements.Requirement` for parsing requirements and printing modified their updated versions, the first commit enforces double-quotes in the markers found in all requirements files (as well as some other minor stylistic changes). The goal is to make changes in subsequent commits easier to track.

Second commit is the standard weekly update - hopefully same as pyup-bot would have come up with.

Third one is one-time update of pinned versions of older packages for older python versions, which might have seen a compatible update since the pin was made (for example, `numpy==1.24.3` to `numpy==1.24.4` for python 3.8 and `numpy==2.0.1` to `numpy==2.0.2` for 3.9). Might run this more often, too (but then I need to exempt old PyQt6-\*-Qt6 from update, because they are not pinned properly, in contrast to their corresponding PyQt6-\* packages).