### PR TITLE
bindepend: extend handling of missing libraries

### DIFF
--- a/news/9186.bugfix.rst
+++ b/news/9186.bugfix.rst
@@ -1,0 +1,4 @@
+(non-Windows) Ensure that binary dependency analysis creates symbolic
+links in top-level application directory for shared libraries that are
+not resolvable during binary dependency analysis but are nevertheless
+collected due to being explicitly collected by a hook or by the user.


### PR DESCRIPTION
Extend the handling of missing libraries in binary dependency analysis that was introduced in b1cd590: in cases when we have a missing dependency for which we suppress the warning because we know that the shared library in question was, in fact, collected (for example, due to being discovered as another binary's dependency, or due to having been explicitly collected by a hook or by the user), we might also need to create a corresponding symbolic link to the top-level application directory (on non-Windows platforms), just as we would for discovered shared libraries.

This is important especially on macOS, where our library path rewriting assumes that all dependent libraries are available in the top-level application directory, or linked into it.

If the shared library in question was discovered as dependency of another binary, then symbolic link entry would be created at that point; but this does not happen for shared libraries that are never seen by binary dependency analysis (i.e., are collected by a hook or by the user).