### PR TITLE
ci: mitigate failure of Windows + free-threaded python 3.13 pipeline

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -156,6 +156,9 @@ filterwarnings =
    error::ResourceWarning:
 ; ... and force pytest to raise an error if the ResourceWarning is emitted during test cleanup.
    error::pytest.PytestUnraisableExceptionWarning:
+; Exempt "unclosed <socket.socket ...>" ResourceWarning, which seems to be triggered by
+; pytest-rerunfailures when used with pytest >= 8.4.0 under free-threaded python 3.13.
+   default:unclosed <socket.socket:ResourceWarning:
 
 # Display summary info for (s)skipped, (X)xpassed, (x)xfailed, (f)failed and (e)errored tests
 # Skip doctest text files


### PR DESCRIPTION
Our `CI / tests (3.13t, windows-latest)` pipeline has been failing since early June 2025, coinciding with update of `pytest` to 8.4.0. The failure comes from `ResourceWarning` instances about unclosed sockets, which our `filterwarnings`  turn into errors (as part of effort to detect unclosed file handles).

The `ResourceWarning` comes from `pytest-rerunfailures`, which indeed does not explicitly close the sockets it uses for communication with worker processes spawned by `pytest-xdist`.

The issue appeared with `pytest` 8.4.0, due to changes in pytest-dev/pytest@868e1d2 ensuring that very early and very late warnings are collected.

As a work-around on our side, avoid turning `unclosed <socket.socket` `ResouceWarning` instances into errors, since the primary aim of these errors was catching unclosed file descriptors.