### PR TITLE
analysis: account for hook-excluded but externally-referenced subpackages

### DIFF
--- a/PyInstaller/depend/analysis.py
+++ b/PyInstaller/depend/analysis.py
@@ -406,7 +406,7 @@ class PyiModuleGraph(ModuleGraph):
                 else:
                     base_module_name = target_module_partname
 
-                def _exclude_module(module_name, excluded_imports):
+                def _exclude_module(module_name, excluded_imports, referrer_name):
                     """
                     Helper for checking whether given module should be excluded.
                     Returns the name of exclusion rule if module should be excluded, None otherwise.
@@ -416,13 +416,32 @@ class PyiModuleGraph(ModuleGraph):
                         excluded_import_parts = excluded_import.split('.')
                         match = module_name_parts[:len(excluded_import_parts)] == excluded_import_parts
                         if match:
+                            # Check if the referrer is (was!) subject to the same rule. Because if it was and was
+                            # analyzed anyway, some other import chain must have overrode the exclusion, and we should
+                            # waive it here. A package hook might exclude a part (a subpackage) of the said package to
+                            # prevent its collection when there are no external references; but when they are (for
+                            # example, user explicitly imports the said subpackage in their program), we must let the
+                            # subpackage import its submodules.
+                            referrer_name_parts = referrer_name.split('.')
+                            referrer_match = referrer_name_parts[:len(excluded_import_parts)] == excluded_import_parts
+                            if referrer_match:
+                                logger.debug(
+                                    "Deactivating suppression rule %r for module %r because it also applies to the "
+                                    "referrer (%r)...", excluded_import, module_name, referrer_name
+                                )
+                                continue
+
                             return excluded_import
                     return None
 
                 # First, check if base module name is to be excluded.
                 # This covers both basic `import a` and `import a.b.c`, as well as `from d import e, f` where base
                 # module `d` is excluded.
-                excluded_import_rule = _exclude_module(base_module_name, excluded_imports)
+                excluded_import_rule = _exclude_module(
+                    base_module_name,
+                    excluded_imports,
+                    source_module.identifier,
+                )
                 if excluded_import_rule:
                     logger.debug(
                         "Suppressing import of %r from module %r due to excluded import %r specified in a hook for %r "
@@ -437,7 +456,11 @@ class PyiModuleGraph(ModuleGraph):
                     filtered_target_attr_names = []
                     for target_attr_name in target_attr_names:
                         submodule_name = base_module_name + '.' + target_attr_name
-                        excluded_import_rule = _exclude_module(submodule_name, excluded_imports)
+                        excluded_import_rule = _exclude_module(
+                            submodule_name,
+                            excluded_imports,
+                            source_module.identifier,
+                        )
                         if excluded_import_rule:
                             logger.debug(
                                 "Suppressing import of %r from module %r due to excluded import %r specified in a hook "

--- a/PyInstaller/depend/analysis.py
+++ b/PyInstaller/depend/analysis.py
@@ -397,12 +397,12 @@ class PyiModuleGraph(ModuleGraph):
                         # Module in a package; base name must be the parent package name!
                         base_module_name = '.'.join(source_module.identifier.split('.')[:-1])
 
-                    if target_module_partname:
-                        base_module_name += '.' + target_module_partname
-
                     # Adjust the base module name based on level
                     if level > 1:
                         base_module_name = '.'.join(base_module_name.split('.')[:-(level - 1)])
+
+                    if target_module_partname:
+                        base_module_name += '.' + target_module_partname
                 else:
                     base_module_name = target_module_partname
 

--- a/news/9193.bugfix.rst
+++ b/news/9193.bugfix.rst
@@ -1,0 +1,6 @@
+Attempt to mitigate the issue with module exclusion when a top-level
+package hook excludes its own subpackage to prevent its collection
+in the absence of any external references; such exclusion rule would
+prevent collection of modules from such subpackage even when it is
+supposed to be collected due to an external reference (for example, an
+explicit import from the user's program).

--- a/news/9197.bugfix.rst
+++ b/news/9197.bugfix.rst
@@ -1,0 +1,3 @@
+Fix a bug in module exclusion part of analysis codepath that would cause
+certain types of relative imports to be misinterpreted and thus fail to
+exclude them.

--- a/tests/functional/modules/pyi_excluded_subpackage/hooks/hook-mypackage.py
+++ b/tests/functional/modules/pyi_excluded_subpackage/hooks/hook-mypackage.py
@@ -1,0 +1,2 @@
+# Exclude the optional subpackage
+excludedimports = ['mypackage.optional']

--- a/tests/functional/modules/pyi_excluded_subpackage/modules/mypackage/__init__.py
+++ b/tests/functional/modules/pyi_excluded_subpackage/modules/mypackage/__init__.py
@@ -1,0 +1,1 @@
+from . import mandatory  # noqa: F401

--- a/tests/functional/modules/pyi_excluded_subpackage/modules/mypackage/mandatory/__init__.py
+++ b/tests/functional/modules/pyi_excluded_subpackage/modules/mypackage/mandatory/__init__.py
@@ -1,0 +1,1 @@
+from .a import an_important_symbol  # noqa: F401

--- a/tests/functional/modules/pyi_excluded_subpackage/modules/mypackage/mandatory/a.py
+++ b/tests/functional/modules/pyi_excluded_subpackage/modules/mypackage/mandatory/a.py
@@ -1,0 +1,44 @@
+# This module contains an "unused" function (not called from anywhere in the package itself) that adds reference to the
+# optional subpackage by importing a function from it. This simulates scenario where the said optional subpackage might
+# be excluded by the top-level package hook; so that it is collected only if some external code (user's program or 3rd
+# party package) is importing it.
+
+
+def an_unused_function(ref_type):
+    # A whole lot of different imports: subpackage vs submodule in it, function from package or submodule (the package
+    # imports it from submodule), relative vs. absolute imports. The goal is to ensure that all of these are properly
+    # interpreted by the exclusion mechanism, and end up being excluded as necessary.
+    if ref_type == 0:
+        import mypackage.optional
+        return mypackage.optional.optional_function()
+    elif ref_type == 1:
+        from mypackage import optional
+        return optional.optional_function()
+    elif ref_type == 2:
+        from .. import optional
+        return optional.optional_function()
+    elif ref_type == 3:
+        import mypackage.optional.b
+        return mypackage.optional.b.optional_function()
+    elif ref_type == 4:
+        from mypackage.optional import b
+        return b.optional_function()
+    elif ref_type == 5:
+        from ..optional import b
+        return b.optional_function()
+    elif ref_type == 6:
+        from mypackage.optional import optional_function
+        return optional_function()
+    elif ref_type == 7:
+        from ..optional import optional_function
+        return optional_function()
+    elif ref_type == 8:
+        from mypackage.optional.b import optional_function
+        return optional_function()
+    elif ref_type == 9:
+        from ..optional.b import optional_function
+        return optional_function()
+
+
+# This symbol is imported by mypackage.mandatory, so we cannot get away by excluding this module.
+an_important_symbol = 42

--- a/tests/functional/modules/pyi_excluded_subpackage/modules/mypackage/optional/__init__.py
+++ b/tests/functional/modules/pyi_excluded_subpackage/modules/mypackage/optional/__init__.py
@@ -1,0 +1,1 @@
+from .b import optional_function  # noqa: F401

--- a/tests/functional/modules/pyi_excluded_subpackage/modules/mypackage/optional/b.py
+++ b/tests/functional/modules/pyi_excluded_subpackage/modules/mypackage/optional/b.py
@@ -1,0 +1,2 @@
+def optional_function():
+    return 42

--- a/tests/functional/test_module_exclusion.py
+++ b/tests/functional/test_module_exclusion.py
@@ -13,6 +13,9 @@ import pathlib
 
 import pytest
 
+# Run the tests here in onedir mode only - onefile offers no additional insights in this context.
+pytestmark = pytest.mark.parametrize('pyi_builder', ['onedir'], indirect=True)
+
 # Directory with testing modules used in some tests.
 _MODULES_DIR = pathlib.Path(__file__).parent / 'modules'
 

--- a/tests/functional/test_module_exclusion.py
+++ b/tests/functional/test_module_exclusion.py
@@ -13,6 +13,8 @@ import pathlib
 
 import pytest
 
+from PyInstaller.utils.tests import importorskip, requires
+
 # Run the tests here in onedir mode only - onefile offers no additional insights in this context.
 pytestmark = pytest.mark.parametrize('pyi_builder', ['onedir'], indirect=True)
 
@@ -93,3 +95,20 @@ def test_subpackage_exclusion(pyi_builder, with_reference):
         source_code,
         pyi_args=pyi_args,
     )
+
+
+# Our hook for sqlalchemy excludes sqlalchemy.testing. Make sure explicitly importing the said subpackage works.
+# See #9193.
+@importorskip('sqlalchemy')
+def test_subpackage_exclusion_sqlalchemy_testing(pyi_builder):
+    pyi_builder.test_source("""
+        import sqlalchemy.testing
+        """)
+
+
+# Our hook for numpy excludes numpy.f2py for numpy < 2.0. Make sure explicitly importing the said subpackage works.
+@requires('numpy < 2.0')
+def test_subpackage_exclusion_numpy_f2py(pyi_builder):
+    pyi_builder.test_source("""
+        import numpy.f2py
+        """)

--- a/tests/functional/test_module_exclusion.py
+++ b/tests/functional/test_module_exclusion.py
@@ -52,3 +52,44 @@ def test_module_exclusion(exclude_args, exclude_hooks, pyi_builder):
         pyi_args=pyi_args,
         run_from_path=True
     )
+
+
+# Tests for excluded subpackage from the top-level package hook. Ensure that such subpackage is excluded when the only
+# reference comes from within the corresponding top-level package (or one of its submodules/subpackages). However, if
+# the subpackage is referred from external source (e.g., user's program), then it should be collected and the exclusion
+# rule from the top-level package hook should not block collection of submodules from that subpackage.
+@pytest.mark.parametrize("with_reference", [False, True], ids=["noref", "ref"])
+def test_subpackage_exclusion(pyi_builder, with_reference):
+    pyi_args = [
+        '--paths',
+        str(_MODULES_DIR / 'pyi_excluded_subpackage' / 'modules'),
+        '--additional-hooks-dir',
+        str(_MODULES_DIR / 'pyi_excluded_subpackage' / 'hooks'),
+    ]
+
+    if with_reference:
+        # Explicit reference to excluded subpackage in user's program; we expect the subpackage to be fully collected.
+        source_code = (
+            """
+            import mypackage.optional  # is importable if its submodules are also collected.
+            assert mypackage.optional.optional_function() == 42
+            """
+        )
+    else:
+        # No reference to excluded subpackage other than in top-level package; we expect the subpackage to be excluded.
+        source_code = (
+            """
+            import importlib.util
+
+            import mypackage
+
+            # Ensure the optional subpackage is unavailable
+            optional_spec = importlib.util.find_spec('mypackage.optional')
+            assert optional_spec == None, "mypackage.optional is collected, but should not be!"
+            """
+        )
+
+    pyi_builder.test_source(
+        source_code,
+        pyi_args=pyi_args,
+    )


### PR DESCRIPTION
When evaluating a module name against the applicable set of exclusion rules, waive any rule that also applies to the name of the module's referrer (i.e., the module that imported the module currently under evaluation).

This aims to fix the problem that arises when a hook for a top-level package (for exaple, `sqlalchemy`) excludes a subpackage (for example, `sqlalchemy.testing`) to prevent its collection in the absence of any external references (i.e., not coming from `sqlalchemy` itself). When there are actually external references, the collection of `sqlalchemy.testing` is allowed, but not of its submodules (for example, `sqlalchemy.testing.config`), leading to module-not-found errors when `sqlalchemy.testing` tries to import those submodules.

In the above example, we want to suspend the `sqlalchemy.testing` exclusion rule (from the top-level `sqlalchemy` hook) when module name is `sqlalchemy.testing.config` and its referer is `sqlalchemy.testing`, which is a sign of a subpackage referring to its submodules. The fact that `sqlalchemy.testing` is a referer tells us that it was previously analyzed, in spite of this particular exclusion rule (i.e., due to an import chain that did not trigger this exclusion rule; with exclusion rules being tied to referrers and their parents).

Closes #9193.

While coming up with the test package for stand-alone test, it turned out that exclusion codepath incorrectly interpreted certain kinds of relative imports - so fix that as well.

Add the said test, plus tests with real packages (`sqlalchemy.testing` from #9193, and `numpy.f2py` for numpy < 2.0). Run the exclusion tests only in onedir mode to avoid wasting time with onefile (which makes no difference for these end-to-end exclusion tests).