### PR TITLE
bootloader: fix compile errors when building for 32-bit with MSVC

### DIFF
--- a/bootloader/src/pyi_pyconfig_pep741.c
+++ b/bootloader/src/pyi_pyconfig_pep741.c
@@ -40,7 +40,7 @@ static char *_wchar_to_utf8(const wchar_t *string_w)
     char *buffer;
     char *ptr;
     size_t len;
-    int i;
+    size_t i;
 
     /* For each input wide-character, the worst-case output is four bytes.
      * Plus, we need a terminating NUL character. Make sure that the
@@ -123,7 +123,7 @@ _locale_encoding_to_utf8(
 
         ret = snprintf(output_buffer, output_buffer_size, "%s", string_utf8);
         free(string_utf8);
-        if (ret < 0 || ret >= output_buffer_size) {
+        if (ret < 0 || (size_t)ret >= output_buffer_size) {
             return NULL;
         }
         return output_buffer;


### PR DESCRIPTION
Fix couple of signed-vs-unsigned comparison warnings in the new PEP-741 codepath that are emitted when compiling bootloader for 32-bit with MSVC (and end up being treated as errors due to our compiler settings).

Courtesy of the [anti-virus check workflow](https://github.com/pyinstaller/pyinstaller/actions/runs/16704844652/job/47281423245), which performs a 32-bit MSVC build.