### PR TITLE
ci: fix the Termux CI flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -514,11 +514,15 @@ jobs:
       - name: Checkout PyInstaller code
         uses: actions/checkout@v4
 
+      # Explicitly set CC=clang, to prevent `pip` from trying to build `psutil` extensions with `x86_64-linux-android-clang`,
+      # which (in contrast to `clang` and `gcc`) does not seem to set `__ANDROID_API__` and `__ANDROID_MIN_SDK_VERSION__`;
+      # consequently, `/usr/include/ifaddrs.h` header does not provide `getifaddrs()` and `freeifaddrs()`, leading to build error.
       - name: Run tests in container
         run: |
           docker run -v"$PWD:/io" termux/termux-docker:x86_64 bash -ec '
             echo "*** Installing system dependencies ***"
             pkg install -y python ldd binutils
+            export CC=clang
             echo "*** Installing PyInstaller ***"
             cp -fr /io $HOME/PyInstaller
             cd $HOME/PyInstaller


### PR DESCRIPTION
Something changed in the latest version of Termux (or its packages), and now installation of `psutil` fails due to `getifaddrs()` and `freeifaddrs()` functions not being exported from the system `ifaddrs.h` header.

This, in turn, seems to be caused by `pip` trying to compile the `psutil` extensions with `x86_64-linux-android-clang`, which does not define `__ANDROID_API__` and `__ANDROID_MIN_SDK_VERSION__`. On the other hand, "regular" `clang` and `gcc` (which are symlinked to the same underlying executable) define those, and can compile `psutil`.

Therefore, explicitly set `CC=clang` at the start of the workflow.