### PR TITLE
tests: re-enable recursion limit tests on macOS + python 3.14

### DIFF
--- a/tests/unit/test_recursion_limit.py
+++ b/tests/unit/test_recursion_limit.py
@@ -12,17 +12,8 @@
 import pytest
 
 from PyInstaller.lib.modulegraph import modulegraph
-from PyInstaller import compat
 from PyInstaller import configure
 from PyInstaller import __main__ as pyi_main
-
-# Recursion limit tests crash python interpreter with macOS builds of python >= 3.14.0a6.
-# See: https://github.com/python/cpython/issues/131543
-# Only "standard" python interpreter is affected; the free-threading variant seems to work as expected.
-pytestmark = pytest.mark.skipif(
-    compat.is_py314 and compat.is_darwin and not compat.is_nogil,
-    reason="Deep recursion crashes python interpreter.",
-)
 
 
 @pytest.fixture


### PR DESCRIPTION
Re-enable recursion limit tests on macOS + python 3.14, as the issue with interpeter crash should be resolved in 3.14.0rc2. See python/cpython#137573.