### PR TITLE
Collect python's standard extensions into `python3.x/lib-dynload`

### DIFF
--- a/PyInstaller/building/build_main.py
+++ b/PyInstaller/building/build_main.py
@@ -33,7 +33,7 @@ from PyInstaller.building.osx import BUNDLE
 from PyInstaller.building.splash import Splash
 from PyInstaller.building.utils import (
     _check_guts_toc, _check_guts_toc_mtime, _should_include_system_binary, format_binaries_and_datas, compile_pymodule,
-    add_suffix_to_extension, postprocess_binaries_toc_pywin32, postprocess_binaries_toc_pywin32_anaconda,
+    destination_name_for_extension, postprocess_binaries_toc_pywin32, postprocess_binaries_toc_pywin32_anaconda,
     create_base_library_zip
 )
 from PyInstaller.compat import is_win, is_conda, is_darwin, is_linux
@@ -813,21 +813,11 @@ class Analysis(Target):
         self.binaries += self.graph.make_binaries_toc()
 
         # Convert extension module names into full filenames, and append suffix. Ensure that extensions that come from
-        # the lib-dynload are collected into _MEIPASS/lib-dynload instead of directly into _MEIPASS.
+        # the lib-dynload are collected into _MEIPASS/python3.x/lib-dynload instead of directly into _MEIPASS.
         for idx, (dest, source, typecode) in enumerate(self.binaries):
             if typecode != 'EXTENSION':
                 continue
-
-            # Convert to full filename and append suffix
-            dest, source, typecode = add_suffix_to_extension(dest, source, typecode)
-
-            # Divert into lib-dyload, if necessary (i.e., if file comes from lib-dynload directory) and its destination
-            # path does not already have a directory prefix.
-            src_parent = os.path.basename(os.path.dirname(source))
-            if src_parent == 'lib-dynload' and not os.path.dirname(os.path.normpath(dest)):
-                dest = os.path.join('lib-dynload', dest)
-
-            # Update
+            dest = destination_name_for_extension(dest, source, typecode)
             self.binaries[idx] = (dest, source, typecode)
 
         # Perform initial normalization of `datas` and `binaries`

--- a/PyInstaller/building/utils.py
+++ b/PyInstaller/building/utils.py
@@ -93,10 +93,13 @@ def destination_name_for_extension(module_name, src_name, typecode):
     src_path = pathlib.Path(src_name)
     dest_elements[-1] = src_path.name
 
-    # Extensions that originate from python's python3.x/lib-dynload directory should be diverted into lib-dynload
-    # destination directory instead of being collected into top-level application directory. See #5604.
+    # Extensions that originate from python's python3.x/lib-dynload directory should be diverted into
+    # python3.x/lib-dynload destination directory instead of being collected into top-level application directory.
+    # See #5604 for original motivation (using just lib-dynload), and #9204 for extension (using python3.x/lib-dynload).
     if src_path.parent.name == 'lib-dynload':
-        dest_elements = ['lib-dynload', *dest_elements]
+        python_dir = f'python{sys.version_info.major}.{sys.version_info.minor}'
+        if src_path.parent.parent.name == python_dir:
+            dest_elements = [python_dir, 'lib-dynload', *dest_elements]
 
     return os.path.join(*dest_elements)
 
@@ -635,7 +638,7 @@ def _should_include_system_binary(binary_tuple, exceptions):
     exclude_system_libraries method.
     """
     dest = binary_tuple[0]
-    if dest.startswith('lib-dynload'):
+    if dest.startswith(f'python{sys.version_info.major}.{sys.version_info.minor}/lib-dynload'):
         return True
     src = binary_tuple[1]
     if fnmatch.fnmatch(src, '*python*'):

--- a/PyInstaller/building/utils.py
+++ b/PyInstaller/building/utils.py
@@ -25,7 +25,7 @@ import zipfile
 
 from PyInstaller import compat
 from PyInstaller import log as logging
-from PyInstaller.compat import EXTENSION_SUFFIXES, is_aix, is_darwin, is_win, is_linux
+from PyInstaller.compat import is_aix, is_darwin, is_win, is_linux
 from PyInstaller.config import CONF
 from PyInstaller.exceptions import InvalidSrcDestTupleError
 from PyInstaller.utils import misc
@@ -77,31 +77,28 @@ def _check_guts_toc(attr_name, old_toc, new_toc, last_build):
         _check_guts_toc_mtime(attr_name, old_toc, new_toc, last_build)
 
 
-def add_suffix_to_extension(dest_name, src_name, typecode):
+def destination_name_for_extension(module_name, src_name, typecode):
     """
-    Take a TOC entry (dest_name, src_name, typecode) and adjust the dest_name for EXTENSION to include the full library
-    suffix.
+    Take a TOC entry (dest_name, src_name, typecode) and determine the full destination name for the extension.
     """
-    # No-op for non-extension
-    if typecode != 'EXTENSION':
-        return dest_name, src_name, typecode
 
-    # If dest_name completely fits into end of the src_name, it has already been processed.
-    if src_name.endswith(dest_name):
-        return dest_name, src_name, typecode
+    assert typecode == 'EXTENSION'
 
-    # Change the dotted name into a relative path. This places C extensions in the Python-standard location.
-    dest_name = dest_name.replace('.', os.sep)
-    # In some rare cases extension might already contain a suffix. Skip it in this case.
-    if os.path.splitext(dest_name)[1] not in EXTENSION_SUFFIXES:
-        # Determine the base name of the file.
-        base_name = os.path.basename(dest_name)
-        assert '.' not in base_name
-        # Use this file's existing extension. For extensions such as ``libzmq.cp36-win_amd64.pyd``, we cannot use
-        # ``os.path.splitext``, which would give only the ```.pyd`` part of the extension.
-        dest_name = dest_name + os.path.basename(src_name)[len(base_name):]
+    # The `module_name` should be the extension's importable module name, such as `psutil._psutil_linux` or
+    # `numpy._core._multiarray_umath`. Reconstruct the directory structure from parent package name(s), if any.
+    dest_elements = module_name.split('.')
 
-    return dest_name, src_name, typecode
+    # We have the base name of the extension file (the last element in the module name), but we do not know the
+    # full extension suffix. We can take that from source name; for simplicity, replace the whole base name part.
+    src_path = pathlib.Path(src_name)
+    dest_elements[-1] = src_path.name
+
+    # Extensions that originate from python's python3.x/lib-dynload directory should be diverted into lib-dynload
+    # destination directory instead of being collected into top-level application directory. See #5604.
+    if src_path.parent.name == 'lib-dynload':
+        dest_elements = ['lib-dynload', *dest_elements]
+
+    return os.path.join(*dest_elements)
 
 
 def process_collected_binary(

--- a/PyInstaller/depend/analysis.py
+++ b/PyInstaller/depend/analysis.py
@@ -42,7 +42,7 @@ from copy import deepcopy
 
 from PyInstaller import HOMEPATH, PACKAGEPATH
 from PyInstaller import log as logging
-from PyInstaller.building.utils import add_suffix_to_extension
+from PyInstaller.building.utils import destination_name_for_extension
 from PyInstaller.compat import (
     BAD_MODULE_TYPES, BINARY_MODULE_TYPES, MODULE_TYPES_TO_TOC_DICT, PURE_PYTHON_MODULE_TYPES, PY3_BASE_MODULES,
     VALID_MODULE_TYPES, importlib_load_source, is_win
@@ -1006,10 +1006,10 @@ def get_bootstrap_modules():
         mod = __import__(mod_name)  # C extension.
         if hasattr(mod, '__file__'):
             mod_file = os.path.abspath(mod.__file__)
-            if os.path.basename(os.path.dirname(mod_file)) == 'lib-dynload':
-                # Divert extensions originating from python's lib-dynload directory, to match behavior of #5604.
-                mod_name = os.path.join('lib-dynload', mod_name)
-            loader_mods.append(add_suffix_to_extension(mod_name, mod_file, 'EXTENSION'))
+            # Resolve full destination name for extension, diverting it into lib-dynload directory if
+            # necessary (to match behavior for extension collection introduced in #5604).
+            mod_dest = destination_name_for_extension(mod_name, mod_file, 'EXTENSION')
+            loader_mods.append((mod_dest, mod_file, 'EXTENSION'))
     loader_mods.append(('struct', os.path.abspath(mod_struct.__file__), 'PYMODULE'))
     # Loader/bootstrap modules.
     # NOTE: These modules should be kept simple without any complicated dependencies.

--- a/PyInstaller/depend/analysis.py
+++ b/PyInstaller/depend/analysis.py
@@ -1006,7 +1006,7 @@ def get_bootstrap_modules():
         mod = __import__(mod_name)  # C extension.
         if hasattr(mod, '__file__'):
             mod_file = os.path.abspath(mod.__file__)
-            # Resolve full destination name for extension, diverting it into lib-dynload directory if
+            # Resolve full destination name for extension, diverting it into python3.x/lib-dynload directory if
             # necessary (to match behavior for extension collection introduced in #5604).
             mod_dest = destination_name_for_extension(mod_name, mod_file, 'EXTENSION')
             loader_mods.append((mod_dest, mod_file, 'EXTENSION'))

--- a/bootloader/src/pyi_pyconfig_pep587.c
+++ b/bootloader/src/pyi_pyconfig_pep587.c
@@ -245,10 +245,7 @@ _pyi_pyconfig_set_module_search_paths(PyConfig *config, const struct PYI_CONTEXT
 int
 pyi_pyconfig_pep587_set_module_search_paths(PyConfig *config, const struct PYI_CONTEXT *pyi_ctx)
 {
-#if !defined(_WIN32)
-    /* Py_DecodeLocale / PyMem_RawFree in non-Windows codepath. */
     const struct DYLIB_PYTHON *dylib_python = pyi_ctx->dylib_python;
-#endif
 
     /* TODO: instead of stitching together char strings and converting
      * them, we could probably stitch together wide-char strings directly,
@@ -262,13 +259,16 @@ pyi_pyconfig_pep587_set_module_search_paths(PyConfig *config, const struct PYI_C
     int ret = 0;
     int i;
 
+    const int python_major = dylib_python->version / 100;
+    const int python_minor = dylib_python->version % 100;
+
     /* home/base_library.zip */
-    if (snprintf(base_library_path, PYI_PATH_MAX, "%s%c%s", pyi_ctx->application_home_dir, PYI_SEP, "base_library.zip") >= PYI_PATH_MAX) {
+    if (snprintf(base_library_path, PYI_PATH_MAX, "%s" PYI_SEPSTR "base_library.zip", pyi_ctx->application_home_dir) >= PYI_PATH_MAX) {
         return -1;
     }
 
-    /* home/lib-dynload */
-    if (snprintf(lib_dynload_path, PYI_PATH_MAX, "%s%c%s", pyi_ctx->application_home_dir, PYI_SEP, "lib-dynload") >= PYI_PATH_MAX) {
+    /* home/python3.x/lib-dynload */
+    if (snprintf(lib_dynload_path, PYI_PATH_MAX, "%s" PYI_SEPSTR "python%d.%d" PYI_SEPSTR "lib-dynload", pyi_ctx->application_home_dir, python_major, python_minor) >= PYI_PATH_MAX) {
         return -1;
     }
 

--- a/bootloader/src/pyi_pyconfig_pep741.c
+++ b/bootloader/src/pyi_pyconfig_pep741.c
@@ -215,6 +215,9 @@ pyi_pyconfig_pep741_set_module_search_paths(PyInitConfig *config, const struct P
 
     char *module_search_paths_utf8[3];
 
+    const int python_major = dylib_python->version / 100;
+    const int python_minor = dylib_python->version % 100;
+
     /* On Windows, the pyi_ctx->application_home_dir is already in UTF-8.
      * On other platforms, we need to convert it, but then we can use
      * the converted string as base for other paths. */
@@ -233,13 +236,13 @@ pyi_pyconfig_pep741_set_module_search_paths(PyInitConfig *config, const struct P
 #endif
 
     /* home/base_library.zip */
-    if (snprintf(base_library_path_utf8, PYI_PATH_MAX, "%s%c%s", home_dir_utf8, PYI_SEP, "base_library.zip") >= PYI_PATH_MAX) {
+    if (snprintf(base_library_path_utf8, PYI_PATH_MAX, "%s" PYI_SEPSTR "base_library.zip", home_dir_utf8) >= PYI_PATH_MAX) {
         PYI_ERROR("Failed to construct path to base_library.zip - path is too long!\n");
         return -1;
     }
 
-    /* home/lib-dynload */
-    if (snprintf(lib_dynload_path_utf8, PYI_PATH_MAX, "%s%c%s", home_dir_utf8, PYI_SEP, "lib-dynload") >= PYI_PATH_MAX) {
+    /* home/python3.x/lib-dynload */
+    if (snprintf(lib_dynload_path_utf8, PYI_PATH_MAX, "%s" PYI_SEPSTR "python%d.%d" PYI_SEPSTR "lib-dynload", home_dir_utf8, python_major, python_minor) >= PYI_PATH_MAX) {
         PYI_ERROR("Failed to construct path to lib-dynload directory - path is too long!\n");
         return -1;
     }

--- a/news/9212.feature.rst
+++ b/news/9212.feature.rst
@@ -1,0 +1,8 @@
+(POSIX) Adjust the destination directory for collected python's standard
+extensions, from ``lib-dynload`` to ``python3.x/lib-dynload`` directory,
+in order to preserve the relative relationship between the extension
+location and the (grand-parent) shared library directory that is commonly
+found in POSIX python environments. This is required for compatibility
+with upcoming Linux builds of ``astral-sh/python-build-standalone#`` that
+will set relative library paths in extensions via both ``DT_NEEDED`` and
+``DT_RPATH``.

--- a/tests/unit/test_building_utils.py
+++ b/tests/unit/test_building_utils.py
@@ -10,6 +10,7 @@
 #-----------------------------------------------------------------------------
 
 import os
+import sys
 import pathlib
 
 import pytest
@@ -114,8 +115,9 @@ def test_format_binaries_and_datas_with_bracket(tmp_path):
 
 
 def test_should_include_system_binary():
+    python_dir = f'python{sys.version_info.major}.{sys.version_info.minor}'
     CASES = [
-        ('lib-dynload/any', '/usr/lib64/any', [], True),
+        (f'{python_dir}/lib-dynload/any', f'/usr/lib64/{python_dir}/lib-dynload/any', [], True),
         ('libany', '/lib64/libpython.so', [], True),
         ('any', '/lib/python/site-packages/any', [], True),
         ('libany', '/etc/libany', [], True),

--- a/tests/unit/test_building_utils.py
+++ b/tests/unit/test_building_utils.py
@@ -9,7 +9,6 @@
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
 
-import importlib.machinery
 import os
 import pathlib
 
@@ -112,51 +111,6 @@ def test_format_binaries_and_datas_with_bracket(tmp_path):
 
     res = utils.format_binaries_and_datas(datas, str(tmp_path))
     assert res == expected
-
-
-def test_add_suffix_to_extension():
-    SUFFIX = importlib.machinery.EXTENSION_SUFFIXES[0]
-    # Each test case is a tuple of four values:
-    #  * input dest_name
-    #  * output (expected) dest_name
-    #  * src
-    #  * typecode
-    # where (dest_name, src_name, typecode) is a TOC entry tuple.
-    # All paths are in POSIX format (and are converted to OS-specific path during the test itself).
-    CASES = [
-        # Stand-alone extension module
-        ('mypkg',
-         'mypkg' + SUFFIX,
-         'lib38/site-packages/mypkg' + SUFFIX,
-         'EXTENSION'),
-        # Extension module nested in a package
-        ('pkg.subpkg._extension',
-         'pkg/subpkg/_extension' + SUFFIX,
-         'lib38/site-packages/pkg/subpkg/_extension' + SUFFIX,
-         'EXTENSION'),
-        # Built-in extension originating from lib-dynload
-        ('lib-dynload/_extension',
-         'lib-dynload/_extension' + SUFFIX,
-         'lib38/lib-dynload/_extension' + SUFFIX,
-         'EXTENSION'),
-    ]  # yapf: disable
-
-    for case in CASES:
-        dest_name1 = str(pathlib.PurePath(case[0]))
-        dest_name2 = str(pathlib.PurePath(case[1]))
-        src_name = str(pathlib.PurePath(case[2]))
-        typecode = case[3]
-
-        toc = (dest_name1, src_name, typecode)
-        toc_expected = (dest_name2, src_name, typecode)
-
-        # Ensure that processing a TOC entry produces expected result.
-        toc2 = utils.add_suffix_to_extension(*toc)
-        assert toc2 == toc_expected
-
-        # Ensure that processing an already-processed TOC entry leaves it unchanged (i.e., does not mangle it).
-        toc3 = utils.add_suffix_to_extension(*toc2)
-        assert toc3 == toc2
 
 
 def test_should_include_system_binary():


### PR DESCRIPTION
Fix for the relative-path-issue part of #9204. 

It's probably not a bad idea to preserve the relative relationship between the extension location and the (grand-parent) shared library directory, even without the requirements imposed by desire to use `DT_NEEDED`. 

I guess the name of the new first-level directory could be anything, but I don't see a reason to go out of our way to make things different from the original python environment.