### PR TITLE
tests: try to improve QtWebEngine tests

### DIFF
--- a/PyInstaller/utils/conftest.py
+++ b/PyInstaller/utils/conftest.py
@@ -18,6 +18,7 @@ import re
 import shutil
 import subprocess
 import sys
+import time
 
 # Set a handler for the root-logger to inhibit 'basicConfig()' (called in PyInstaller.log) is setting up a stream
 # handler writing to stderr. This avoids log messages to be written (and captured) twice: once on stderr and
@@ -355,6 +356,7 @@ class AppBuilder:
 
         # Run the executable
         self._display_message('RUN-EXE', f'Running {exe_path!r}, args: {args!r}')
+        start_time = time.time()
         process = popen_implementation(args, executable=exe_path, env=prog_env, cwd=prog_cwd)
 
         # Wait for the process to finish. If no run-time (= timeout) is specified, we expect the process to exit on
@@ -365,8 +367,11 @@ class AppBuilder:
         try:
             timeout = runtime if runtime else _EXE_TIMEOUT
             stdout, stderr = process.communicate(timeout=timeout)
+            elapsed = time.time() - start_time
             retcode = process.returncode
-            self._display_message('RUN-EXE', f'Process exited on its own with return code {retcode}.')
+            self._display_message(
+                'RUN-EXE', f'Process exited on its own after {elapsed:.1f} seconds with return code {retcode}.'
+            )
         except (subprocess.TimeoutExpired) if psutil is None else (psutil.TimeoutExpired, subprocess.TimeoutExpired):
             if runtime:
                 # When 'runtime' is set, the expired timeout is a good sign that the executable was running successfully

--- a/tests/functional/test_qt.py
+++ b/tests/functional/test_qt.py
@@ -576,6 +576,11 @@ def test_Qt_QtWebEngineWidgets_PyQt6(pyi_builder):
     check_requirement('PyQt6-Qt6 == 6.6.3') and is_win,
     reason='PyQt6 6.6.3 PyPI wheels for Windows are missing Qt6WebChannelQuick shared library.'
 )
+@pytest.mark.flaky(
+    # The generated .app bundle seems to sporadically freeze during shutdown on GHA macos-14 runners.
+    condition=is_darwin,
+    reruns=1,
+)
 def test_Qt_QtWebEngineQuick_PyQt6(pyi_builder):
     _test_Qt_QtWebEngineQuick(pyi_builder, 'PyQt6')
 
@@ -593,6 +598,11 @@ def test_Qt_QtWebEngineWidgets_PySide6(pyi_builder):
 @pytest.mark.skipif(
     check_requirement('PySide6 == 6.5.0') and is_win,
     reason='PySide6 6.5.0 PyPI wheels for Windows are missing opengl32sw.dll.'
+)
+@pytest.mark.flaky(
+    # The generated .app bundle seems to sporadically freeze during shutdown on GHA macos-14 runners.
+    condition=is_darwin,
+    reruns=1,
 )
 def test_Qt_QtWebEngineQuick_PySide6(pyi_builder):
     _test_Qt_QtWebEngineQuick(pyi_builder, 'PySide6')

--- a/tests/functional/test_qt.py
+++ b/tests/functional/test_qt.py
@@ -417,10 +417,12 @@ def _test_Qt_QtWebEngineWidgets(pyi_builder, qt_flavor):
 
             def verify_and_quit(self):
                 # Make sure the renderer process is alive.
+                print("Checking the result of renderer process...", file=sys.stderr)
                 if self.result != self.EXPECTED:
                     raise ValueError(
                         f"JS result is {{self.result!r}} but expected {{self.EXPECTED!r}}. "
                         "Is the QtWebEngine renderer process running properly?")
+                print("Exiting application's main loop...", file=sys.stderr)
                 app.quit()
 
         view = QWebEngineView()
@@ -430,11 +432,15 @@ def _test_Qt_QtWebEngineWidgets(pyi_builder, qt_flavor):
         js_result_tester = JSResultTester()
         js_result_tester.setup(view)
 
+        print("Entering application's main loop...", file=sys.stderr)
         if is_qt6:
             # Qt6: exec_() is deprecated in PySide6 and removed from PyQt6 in favor of exec()
             res = app.exec()
         else:
             res = app.exec_()
+        print("Exited application's main loop!", file=sys.stderr)
+
+        print("Calling sys.exit()...", file=sys.stderr)
         sys.exit(res)
         """, **USE_WINDOWED_KWARG
     )
@@ -461,6 +467,8 @@ def _test_Qt_QtWebEngineQuick(pyi_builder, qt_flavor):
             from {qt_flavor}.QtWebEngineQuick import QtWebEngineQuick
         else:
             from {qt_flavor}.QtWebEngine import QtWebEngine as QtWebEngineQuick
+
+        # Must be called before QGuiApplication is instantiated!
         QtWebEngineQuick.initialize()
 
         app = QGuiApplication(sys.argv)
@@ -475,39 +483,56 @@ def _test_Qt_QtWebEngineQuick(pyi_builder, qt_flavor):
                 WebEngineView {{
                     id: view
                     anchors.fill: parent
-                    Component.onCompleted: loadHtml('
-                        <!doctype html>
-                        <html lang="en">
-                            <head>
-                                <meta charset="utf-8">
-                                <title>Test web page</title>
-                            </head>
-                            <body>
-                                <p>This is a test web page.</p>
-                            </body>
-                        </html>
-                    ')
-                }}
-                Connections {{
-                    target: view
-                    function onLoadingChanged(loadRequest) {{
+                    Component.onCompleted: () => {{
+                        console.info("Loading HTML...")
+                        loadHtml('
+                            <!doctype html>
+                            <html lang="en">
+                                <head>
+                                    <meta charset="utf-8">
+                                    <title>Test web page</title>
+                                </head>
+                                <body>
+                                    <p>This is a test web page.</p>
+                                </body>
+                            </html>
+                        ')
+                    }}
+                    onLoadingChanged: (loadRequest) => {{
+                        console.info("Web page loading status changed: " + loadRequest.status)
                         if (loadRequest.status !== WebEngineView.LoadStartedStatus) {{
-                            Qt.quit()
+                            console.info("Page loading finished; running shutdown timer (" + timer.interval + " ms)!")
+                            timer.running = true
                         }}
+                    }}
+                }}
+                Timer {{
+                    id: timer
+                    interval: 1000
+                    running: false
+                    repeat: false
+                    onTriggered: () => {{
+                        console.info("Shutdown timer triggered; exiting application's main loop...")
+                        Qt.quit()
                     }}
                 }}
             }}
         ''')
 
         if not engine.rootObjects():
-            sys.exit(-1)
+            raise RuntimeError("No root objects loaded from QML!")
 
+        print("Entering application's main loop...", file=sys.stderr)
         if is_qt6:
             # Qt6: exec_() is deprecated in PySide6 and removed from PyQt6 in favor of exec()
             res = app.exec()
         else:
             res = app.exec_()
+        print("Exited application's main loop!", file=sys.stderr)
+
         del engine
+
+        print("Calling sys.exit()...", file=sys.stderr)
         sys.exit(res)
         """, **USE_WINDOWED_KWARG
     )


### PR DESCRIPTION
The `test_Qt_QtWebEngineQuick_*` is lately failing on our `macos-14` runners just often enough to be a nuisance.

This PR contains two commits from a branch I was using when trying to debug the problem.

The first commit adds program's run-time to the "Process exited on its own..." message in `AppBuilder._run_executable_`. 

In this particular case this is useful because we are building and running the test program in both POSIX and .app bundle variants, so knowing that POSIX variant took 5 seconds to run before the .app bundle one got stuck sort of invalidates my initial assumption that the problem are long run times due to CPU congestion on the runner.

The second commit adds couple of print() messages to the QtWebEngine tests (both widget and QtQuick variants), in order to allow us to pin-point where the test program was stuck when it timed-out. Turns out that for `test_Qt_QtWebEngineQuick_` this happens *after* we exit application's main loop.

I've also added a one-second delay between `test_Qt_QtWebEngineQuick_` completing the page loading request and before we exit the main loop (which is something we do in the widget variant of  the test). Since then, I've had multiple CI runs without a failure. So I figure the best way to provoke one is to open an actual PR :) If (when?) it fails again, though, we are going to slap a `flaky` marker on it.
