### PR TITLE
Rework the search for python shared library

### DIFF
--- a/PyInstaller/building/build_main.py
+++ b/PyInstaller/building/build_main.py
@@ -683,10 +683,7 @@ class Analysis(Target):
 
         # Search for python shared library, which we need to collect into frozen application.
         logger.info('Looking for Python shared library...')
-        python_lib = bindepend.get_python_library_path()
-        if python_lib is None:
-            from PyInstaller.exceptions import PythonLibraryNotFoundError
-            raise PythonLibraryNotFoundError()
+        python_lib = bindepend.get_python_library_path()  # Raises PythonLibraryNotFoundError
         logger.info('Using Python shared library: %s', python_lib)
         if is_darwin and osxutils.is_framework_bundle_lib(python_lib):
             # If python library is located in macOS .framework bundle, collect the bundle, and create symbolic link to

--- a/PyInstaller/building/build_main.py
+++ b/PyInstaller/building/build_main.py
@@ -662,6 +662,12 @@ class Analysis(Target):
         """
         from PyInstaller.config import CONF
 
+        # Search for python shared library, which we need to collect into frozen application. Do this as the very
+        # first step, to minimize the amount of processing when the shared library cannot be found.
+        logger.info('Looking for Python shared library...')
+        python_lib = bindepend.get_python_library_path()  # Raises PythonLibraryNotFoundError
+        logger.info('Using Python shared library: %s', python_lib)
+
         logger.info("Running Analysis %s", self.tocbasename)
         logger.info("Target bytecode optimization level: %d", self.optimize)
 
@@ -681,10 +687,7 @@ class Analysis(Target):
         # Scan for legacy namespace packages.
         self.graph.scan_legacy_namespace_packages()
 
-        # Search for python shared library, which we need to collect into frozen application.
-        logger.info('Looking for Python shared library...')
-        python_lib = bindepend.get_python_library_path()  # Raises PythonLibraryNotFoundError
-        logger.info('Using Python shared library: %s', python_lib)
+        # Add python shared library to `binaries`.
         if is_darwin and osxutils.is_framework_bundle_lib(python_lib):
             # If python library is located in macOS .framework bundle, collect the bundle, and create symbolic link to
             # top-level directory.

--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -121,67 +121,10 @@ is_macos_11 = is_macos_11_compat or is_macos_11_native  # Big Sur or newer
 # This affects the shared library name, which has the "t" ABI suffix, as per:
 # https://github.com/python/steering-council/issues/221#issuecomment-1841593283
 #
-# It also affects the layout of PyConfig structure used by bootloader; consequently
-#  a) we need to inform bootloader what kind of build it is dealing with
-#  b) we must not mix up shared libraries, in case multiple builds are present on the system. Thus, strictly enforce the
-#     "t" ABI suffix in the PYDYLIB_NAMES, if applicable.
+# It also affects the layout of PyConfig structure used by bootloader; consequently we need to inform bootloader what
+# kind of build it is dealing with (only in python 3.13; with 3.14 and later, we use PEP741 configuration API in the
+# bootloader, and do not need to know the layout of PyConfig structure anymore)
 is_nogil = bool(sysconfig.get_config_var('Py_GIL_DISABLED'))
-
-_py_suffix = "t" if is_nogil else ""
-
-# On different platforms is different file for dynamic python library.
-_py_major, _py_minor = sys.version_info[:2]
-if is_win or is_cygwin:
-    PYDYLIB_NAMES = {
-        f'python{_py_major}{_py_minor}{_py_suffix}.dll',
-        f'libpython{_py_major}{_py_minor}{_py_suffix}.dll',
-        f'libpython{_py_major}.{_py_minor}{_py_suffix}.dll',
-    }  # For MSYS2 environment
-elif is_darwin:
-    # The suffix in .framework library name is capitalized, e.g., PythonT for freethreading-enabled build.
-    # The `libpython%d.%d%s.dylib` is there primarily for Anaconda installations, but it also serves as a fallback in
-    # .framework builds, where `/Library/Frameworks/Python.framework/Versions/3.X/lib/libpython3.13.dylib` is a symbolic
-    # link that points to `../Python`.
-    PYDYLIB_NAMES = {
-        f'Python{_py_suffix.upper()}',
-        f'.Python{_py_suffix.upper()}',
-        f'Python{_py_major}{_py_suffix.upper()}',
-        f'libpython{_py_major}.{_py_minor}{_py_suffix}.dylib',
-    }
-elif is_aix:
-    # Shared libs on AIX may be archives with shared object members, hence the ".a" suffix. However, starting with
-    # python 2.7.11 libpython?.?.so and Python3 libpython?.?m.so files are produced.
-    PYDYLIB_NAMES = {
-        f'libpython{_py_major}.{_py_minor}{_py_suffix}.a',
-        f'libpython{_py_major}.{_py_minor}{_py_suffix}.so',
-    }
-elif is_freebsd:
-    PYDYLIB_NAMES = {
-        f'libpython{_py_major}.{_py_minor}{_py_suffix}.so.1',
-        f'libpython{_py_major}.{_py_minor}{_py_suffix}.so.1.0',
-    }
-elif is_openbsd:
-    PYDYLIB_NAMES = {
-        f'libpython{_py_major}.{_py_minor}{_py_suffix}.so.0.0',
-    }
-elif is_hpux:
-    PYDYLIB_NAMES = {
-        f'libpython{_py_major}.{_py_minor}{_py_suffix}.so',
-    }
-elif is_unix:
-    # Other *nix platforms.
-    # Python 2 .so library on Linux is: libpython2.7.so.1.0
-    # Python 3 .so library on Linux is: libpython3.3.so.1.0
-    PYDYLIB_NAMES = {
-        f'libpython{_py_major}.{_py_minor}{_py_suffix}.so.1.0',
-        f'libpython{_py_major}.{_py_minor}{_py_suffix}.so',
-    }
-else:
-    raise SystemExit(
-        'ERROR: Your platform is not yet supported. Please define constant PYDYLIB_NAMES for your platform.'
-    )
-
-del _py_major, _py_minor, _py_suffix
 
 # In a virtual environment created by virtualenv (github.com/pypa/virtualenv) there exists sys.real_prefix with the path
 # to the base Python installation from which the virtual environment was created. This is true regardless of the version

--- a/PyInstaller/depend/bindepend.py
+++ b/PyInstaller/depend/bindepend.py
@@ -881,7 +881,23 @@ def get_python_library_path():
         # set to a non-empty string.
         (compat.is_darwin and sysconfig.get_config_var("PYTHONFRAMEWORK"))
     )
-    if not is_shared:
+
+    if is_shared:
+        expected_name = sysconfig.get_config_var('INSTSONAME')
+    elif compat.is_conda:
+        # While Anaconda provides Python shared library, the interpreter executable and shared library seem to be made
+        # separately; therefore, the interpreter has `Py_ENABLE_SHARED` set to 0 and `INSTSONAME` points to a static
+        # library. And so we need to fall back to the old guess-work.
+        py_major, py_minor = sys.version_info[:2]
+        py_suffix = "t" if compat.is_nogil else ""  # TODO: does Anaconda provide debug builds with "d" suffix?
+        if compat.is_darwin:
+            # macOS
+            expected_name = f"libpython{py_major}.{py_minor}{py_suffix}.dylib"
+        else:
+            # Linux; assume any other potential POSIX builds use the same naming scheme.
+            expected_name = f"libpython{py_major}.{py_minor}{py_suffix}.so.1.0"
+    else:
+        # Raise PythonLibraryNotFoundError
         from PyInstaller.exceptions import PythonLibraryNotFoundError
         option_str = (
             "either the `--enable-shared` or the `--enable-framework` option"
@@ -891,8 +907,6 @@ def get_python_library_path():
             "Python was built without a shared library, which is required by PyInstaller. "
             f"If you built Python from source, rebuild it with {option_str}."
         )
-
-    expected_name = sysconfig.get_config_var('INSTSONAME')
 
     # In Cygwin builds (and also MSYS2 python, although that should be handled by Windows-specific codepath...),
     # INSTSONAME is available, but the name has a ".dll.a" suffix; remove that trailing ".a".
@@ -904,14 +918,16 @@ def get_python_library_path():
     expected_basename = os.path.normcase(os.path.basename(expected_name))
 
     # Try to find the expected name among the libraries against which the Python executable is linked. This assumes that
-    # the Python executable was not statically linked against the library (as is the case with Debian-packaged Python).
-    imported_libraries = get_imports(compat.python_executable)  # (name, fullpath) tuples
-    for _, lib_path in imported_libraries:
-        if lib_path is None:
-            continue  # Skip unresolved imports
-        if os.path.normcase(os.path.basename(lib_path)) == expected_basename:  # Basename comparison
-            # Python library found. Return absolute path to it.
-            return lib_path
+    # the Python executable was not statically linked against the library (as is the case with Debian-packaged Python,
+    # or Anaconda Python).
+    if is_shared:
+        imported_libraries = get_imports(compat.python_executable)  # (name, fullpath) tuples
+        for _, lib_path in imported_libraries:
+            if lib_path is None:
+                continue  # Skip unresolved imports
+            if os.path.normcase(os.path.basename(lib_path)) == expected_basename:  # Basename comparison
+                # Python library found. Return absolute path to it.
+                return lib_path
 
     # As a fallback, try to find the library in several "standard" search locations...
     def _find_lib_in_libdirs(name, *libdirs):

--- a/PyInstaller/depend/bindepend.py
+++ b/PyInstaller/depend/bindepend.py
@@ -853,70 +853,113 @@ def get_python_library_path():
     Its location can usually be inferred from the Python interpreter executable, when the latter is dynamically
     linked against the shared library.
 
-    However, some situations require extra handling due to various quirks; for example, debian-based some linux
+    However, some situations require extra handling due to various quirks; for example, Debian-based linux
     distributions statically link the Python interpreter executable against the Python library, while also providing
     a shared library variant for external users.
     """
-    def _find_lib_in_libdirs(*libdirs):
-        for libdir in libdirs:
-            for name in compat.PYDYLIB_NAMES:
-                full_path = os.path.join(libdir, name)
-                if not os.path.exists(full_path):
-                    continue
-                # Resolve potential symbolic links to achieve consistent results with linker-based search; e.g., on
-                # POSIX systems, linker resolves unversioned library names (python3.X.so) to versioned ones
-                # (libpython3.X.so.1.0) due to former being symbolic linkes to the latter. See #6831.
-                full_path = os.path.realpath(full_path)
-                if not os.path.exists(full_path):
-                    continue
-                return full_path
-        return None
 
-    # If this is Microsoft App Store Python, check the compat.base_path first. While compat.python_executable resolves
-    # to actual python.exe file, the latter contains a relative library reference that we fail to properly resolve.
-    if compat.is_ms_app_store:
-        python_libname = _find_lib_in_libdirs(compat.base_prefix)
-        if python_libname:
-            return python_libname
+    # With Windows Python builds, this is pretty straight-forward: `sys.dllhandle` provides a handle to the loaded
+    # Python DLL, and we can resolve its path using `GetModuleFileName()` from win32 API.
+    # This is applicable to python.org Windows builds, Anaconda on Windows, and MSYS2 Python.
+    if compat.is_win:
+        import _winapi
+        return _winapi.GetModuleFileName(sys.dllhandle)
 
-    # Try to get Python library name from the Python executable. It assumes that Python library is not statically
-    # linked.
+    # On other (POSIX) platforms, the name of the Python shared library is available in the `INSTSONAME` variable
+    # exposed by the `sysconfig` module. There is also the `LDLIBRARY` variable, which points to the unversioned .so
+    # symbolic link for linking purposes; however, we are interested in the actual, fully-versioned soname.
+    # This should cover all variations in the naming schemes across different platforms as well as different build
+    # options (debug build, free-threaded build, etc.).
+
+    # First, try to catch Python builds that were not made with shared library (or .framework bundle on macOS) enabled.
+    # In such builds, `INSTSONAME` seems to point to the static library, which is of no use to us.
+    is_shared = (
+        # Builds made with `--enable-shared` have `Py_ENABLE_SHARED` set to 1. This is true even for Debian-packaged
+        # Python, which has the `python` executable statically linked against the Python library.
+        sysconfig.get_config_var("Py_ENABLE_SHARED") or
+        # On macOS, builds made with `--enable-framework` have `Py_ENABLE_SHARED` set to 0, but have `PYTHONFRAMEWORK`
+        # set to a non-empty string.
+        (compat.is_darwin and sysconfig.get_config_var("PYTHONFRAMEWORK"))
+    )
+    if not is_shared:
+        from PyInstaller.exceptions import PythonLibraryNotFoundError
+        option_str = (
+            "either the `--enable-shared` or the `--enable-framework` option"
+            if compat.is_darwin else "the `--enable-shared` option"
+        )
+        raise PythonLibraryNotFoundError(
+            "Python was built without a shared library, which is required by PyInstaller. "
+            f"If you built Python from source, rebuild it with {option_str}."
+        )
+
+    expected_name = sysconfig.get_config_var('INSTSONAME')
+
+    # In Cygwin builds (and also MSYS2 python, although that should be handled by Windows-specific codepath...),
+    # INSTSONAME is available, but the name has a ".dll.a" suffix; remove that trailing ".a".
+    if (compat.is_win or compat.is_cygwin) and os.path.normcase(expected_name).endswith('.dll.a'):
+        expected_name = expected_name[:-2]
+
+    # NOTE: on macOS with .framework bundle build, INSTSONAME contains full name of the .framework library, for example
+    # `Python.framework/Versions/3.13/Python`. Pre-compute a basename for comparisons that are using only basename.
+    expected_basename = os.path.normcase(os.path.basename(expected_name))
+
+    # Try to find the expected name among the libraries against which the Python executable is linked. This assumes that
+    # the Python executable was not statically linked against the library (as is the case with Debian-packaged Python).
     imported_libraries = get_imports(compat.python_executable)  # (name, fullpath) tuples
     for _, lib_path in imported_libraries:
         if lib_path is None:
             continue  # Skip unresolved imports
-        for name in compat.PYDYLIB_NAMES:
-            if os.path.normcase(os.path.basename(lib_path)) == name:
-                # Python library found. Return absolute path to it.
-                return lib_path
+        if os.path.normcase(os.path.basename(lib_path)) == expected_basename:  # Basename comparison
+            # Python library found. Return absolute path to it.
+            return lib_path
 
-    # Work around for Python venv having VERSION.dll rather than pythonXY.dll
-    if compat.is_win and any([os.path.normcase(lib_name) == 'version.dll' for lib_name, _ in imported_libraries]):
-        pydll = 'python%d%d.dll' % sys.version_info[:2]
-        return resolve_library_path(pydll, [os.path.dirname(compat.python_executable)])
+    # As a fallback, try to find the library in several "standard" search locations...
+    def _find_lib_in_libdirs(name, *libdirs):
+        for libdir in libdirs:
+            full_path = os.path.join(libdir, name)
+            if not os.path.exists(full_path):
+                continue
+            # Resolve potential symbolic links to achieve consistent results with linker-based search; e.g., on
+            # POSIX systems, linker resolves unversioned library names (python3.X.so) to versioned ones
+            # (libpython3.X.so.1.0) due to former being symbolic linkes to the latter. See #6831.
+            full_path = os.path.realpath(full_path)
+            if not os.path.exists(full_path):
+                continue
+            return full_path
+        return None
 
     # Search the `sys.base_prefix` and `lib` directory in `sys.base_prefix`.
     # This covers various Python installations in case we fail to infer the shared library location for whatever reason;
     # Anaconda Python, `uv` and `rye` Python, etc.
     python_libname = _find_lib_in_libdirs(
+        expected_name,  # Full name
         compat.base_prefix,
         os.path.join(compat.base_prefix, 'lib'),
     )
     if python_libname:
         return python_libname
 
-    # On Unix-like systems, perform search in the configured library search locations. This should be done after
-    # exhausting all other options; it primarily caters to debian-packaged Python, but we need to make sure that we do
-    # not collect shared library from system-installed Python when the current interpreter is in fact some other Python
-    # build (for example, `uv` or `rye` Python of the same version as system-installed Python).
-    if compat.is_unix:
-        for name in compat.PYDYLIB_NAMES:
-            python_libname = resolve_library_path(name)
-            if python_libname:
-                return python_libname
+    # Perform search in the configured library search locations. This should be done after exhausting all other options;
+    # it primarily caters to Debian-packaged Python, but we need to make sure that we do not collect shared library from
+    # system-installed Python when the current interpreter is in fact some other Python build (for example, `uv` or
+    # `rye` Python of the same version as system-installed Python).
+    python_libname = resolve_library_path(expected_basename)  # Basename
+    if python_libname:
+        return python_libname
 
-    # Python library NOT found. Return None and let the caller deal with this.
-    return None
+    # Not found. Raise a PythonLibraryNotFoundError with corresponding message.
+    from PyInstaller.exceptions import PythonLibraryNotFoundError
+
+    message = f"ERROR: Python shared library ({expected_name!r}) was not found!"
+    if compat.is_linux and os.path.isfile('/etc/debian_version'):
+        # The shared library is provided by `libpython3.x` package (i.e., no need to install full `python3-dev`).
+        pkg_name = f"libpython3.{sys.version_info.minor}"
+        message += (
+            " If you are using system python on Debian/Ubuntu, you might need to install a separate package by running "
+            f"`apt install {pkg_name}`."
+        )
+
+    raise PythonLibraryNotFoundError(message)
 
 
 #- Binary vs data (re)classification

--- a/PyInstaller/exceptions.py
+++ b/PyInstaller/exceptions.py
@@ -9,8 +9,6 @@
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
 
-from PyInstaller import compat
-
 
 class ExecCommandFailed(SystemExit):
     pass
@@ -54,21 +52,9 @@ class RemovedWinSideBySideSupportError(SystemExit):
         )
 
 
-_MISSING_PYTHON_LIB_MSG = \
-"""ERROR: Python library not found: {0}
-    This means your Python installation does not come with proper shared library files.
-    This usually happens due to missing development package, or unsuitable build parameters of the Python installation.
-
-    * On Debian/Ubuntu, you need to install Python development packages:
-      * apt-get install python3-dev
-      * apt-get install python-dev
-    * If you are building Python by yourself, rebuild with `--enable-shared` (or, `--enable-framework` on macOS).
-"""  # noqa: E122
-
-
-class PythonLibraryNotFoundError(IOError):
-    def __init__(self):
-        super().__init__(_MISSING_PYTHON_LIB_MSG.format(", ".join(compat.PYDYLIB_NAMES),))
+class PythonLibraryNotFoundError(SystemExit):
+    def __init__(self, message):
+        super().__init__(f"ERROR: {message}")
 
 
 class InvalidSrcDestTupleError(SystemExit):

--- a/news/9218.feature.rst
+++ b/news/9218.feature.rst
@@ -1,0 +1,33 @@
+Rework the search for python shared library in order to reduce amount of
+guess-work and better accommodate variations in naming across platforms
+and due to different build options (e.g., debug build with "d" suffix,
+free-thread build with "t" suffix, combination of both).
+
+On Windows, the loaded python DLL is now resolved by calling ``GetModuleFileName``
+on the handle exposed by :data:`sys.dllhandle`; this applies to python.org Windows
+builds, Anaconda python on Windows, and MSYS2 python.
+
+On other platforms, first explicitly verify that shared library is enabled,
+by checking the value of ``Py_ENABLE_SHARED`` variable exposed by the
+``sysconfig`` module. On macOS, also check if .framework bundle is
+enabled instead, which is implied by a non-empty ``PYTHONFRAMEWORK``
+variable in ``sysconfig``. If shared library is enabled, use ``INSTSONAME``
+variable exposed by ``sysconfig`` module as the only source of truth
+w.r.t. its name. This works even with Debian-packaged python and
+``astral-sh/python-build-standalone`` POSIX builds; while they have
+their ``python`` executable statically linked against python shared
+library, they seem to properly set these variables.
+
+In contrast, both Linux and macOS builds of Anaconda python seem to
+build their interpreter executable and python shared library separately,
+so the interpreter reports ``Py_ENABLE_SHARED`` variable to be set to ``0``
+(and ``INSTSONAME`` gives name of the static library). Therefore, for
+Anaconda python on non-Windows, use the old approach of guessing the
+library name from the major and minor version and whether free-threading
+is enabled or not (i.e., the presence of the "t" suffix).
+
+Adjust the error messages; display the part about rebuilding python with
+``--enable-shared`` option only if we detect lack of support for shared
+library. Similarly, display the part about Debian package only if we
+are running under Debian or its derivative; and advise to install
+``libpython3.X`` package rather than ``python3-dev``.


### PR DESCRIPTION
Rework the search for python shared library to reduce amount of guess-work.

On Windows, we should have a decent source of truth always available: calling `GetModuleFileName()` win32 function on the handle exposed by [`sys.dllhandle`](https://docs.python.org/3/library/sys.html#sys.dllhandle) gives us full path to the loaded python DLL.

On other platforms, we use `INSTSONAME` variable from `sysconfig` module, which should contain the "true" name of the python shared library:
- `libpython3.9.so.1.0`, `libpython3.10.so.1.0`, `libpython3.11.so.1.0`, `libpython3.12.so.1.0`, `libpython3.13.so.1.0`, `libpython3.13t.so.1.0`, `libpython3.14.so.1.0`, `libpython3.14t.so.1.0` for various versions packaged by Fedora
- `libpython3.13.so.1.0` on Debian Trixie
- `libpython3.8.so.rh-python38-1.0` for python 3.8 from SCL on CentOS7 - we could now resolve this without `rh-python38-python-devel` package which provided "generic" `libpython3.8.so` for linking...
- `libpython3.13.so.1.0`, `libpython3.13d.so.1.0`, `libpython3.13t.so.1.0`, `libpython3.13td.so.1.0` for all four variants of `astral-sh/python-build-standalone` builds for 3.13 on Linux
- `libpython3.8.so.1.0` on FreeBSD 13.x
- `libpython3.12.so.0.0` on OpenBSD 7.7
- `libpython3.9.a`, `libpython3.11.a`, `libpython3.12.a` on AIX 7.2 (these are not static libraries, but archives that contain multi-arch shared libraries)
- `Python.framework/Versions/3.12/Python`, `Python.framework/Versions/3.13/Python`, `PythonT.framework/Versions/3.13/PythonT`, `Python.framework/Versions/3.14/Python`, `PythonT.framework/Versions/3.14/PythonT` for python.org builds on macOS
- `libpython3.10.dylib`, `libpython3.13td.dylib` for `astral-sh/python-build-standalone` builds on macOS

We now also explicitly try to detect if shared library was enabled by checking `Py_ENABLE_SHARED` variable in `sysconfig`; because if not (when value is 0), `INSTSONAME` appears to contain name of the static library, which is of no use to us. The exception to this is when .framework bundle is enabled on macOS, in which case `Py_ENABLE_SHARED` is 0, but `PYTHONFRAMEWORK` is non-empty.

The sole exception from the above is Anaconda python, which on macOS and Linux seems to build their interpreter executable and shared library separately. So when querying `Py_ENABLE_SHARED` from interpreter, we get 0, and `INSTSONAME` contains name of the static library (In contrast to Debian-packaged python and `astral-sh/python-build-standalone` builds, which, in spite of also having interpreter statically linked against python library, report the values in `sysconfig` for shared library). Therefore, for Anaconda python, we keep trying to guess the name of the shared library based on major/minor version and whether build is free-threaded or not (the "t" suffix). 

The error messages are a bit more targeted now; the part about building python with `--enable-shared` is now shown only if we believe shared library is not enabled (and we add the part about `--enable-framework` only if running on macOS). Similarly, the part about Debian package is included in the error message only if we (believe we) are running under Debian or its derivative; and we now advise to install `libpython3.X` package rather than `python3-dev` (which installs the former in addition to a whole lot of other unnecessary packages).


