### PR TITLE
ci: update lint workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,16 +1,9 @@
 name: CI
 
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events for develop branch.
 on:
-  push:
+  pull_request:  # Trigger on PRs opened against develop branch
     branches:
-      - 'develop'
-  pull_request:
-    branches:
-      - '**'
-      - '!master'
-      - '!pyup/**'
+      - develop
 
 env:
   # Colored pytest output on CI despite not having a tty

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,11 @@
 name: CI
 
 # Controls when the action will run. Triggers the workflow on push or pull request
-# events for develop and v4 branche.
+# events for develop branch.
 on:
   push:
     branches:
       - 'develop'
-      - 'v4'
   pull_request:
     branches:
       - '**'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,10 +1,9 @@
 name: Lint
 
 on:
-  pull_request:  # Trigger on PRs to develop and v4
+  pull_request:  # Trigger on PRs opened against develop branch
     branches:
       - develop
-      - v4
 
 jobs:
   run:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,10 +27,10 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: 3.x
 
     - name: Install dependencies
-      run: pip install --upgrade flake8 yapf==0.32.0 toml
+      run: pip install --upgrade flake8 yapf==0.43.0 toml
 
     - name: Test that yapf has been applied
       # If this check fails for your PR, run `yapf -rip .`

--- a/.github/workflows/validate-new-news.yml
+++ b/.github/workflows/validate-new-news.yml
@@ -2,10 +2,9 @@
 name: Validate new news entries
 
 on:
-  pull_request:  # Trigger on PRs to develop and v4
+  pull_request:  # Trigger on PRs opened against develop branch
     branches:
       - develop
-      - v4
 
 jobs:
   run:

--- a/PyInstaller/fake-modules/pyi_splash.py
+++ b/PyInstaller/fake-modules/pyi_splash.py
@@ -82,7 +82,7 @@ def _initialize():
 
     :return:
     """
-    global _initialized, _ipc_socket, _ipc_socket_closed
+    global _initialized, _ipc_socket_closed
 
     # If _ipc_port is zero, the splash screen is intentionally suppressed (for example, we are in sub-process spawned
     # via sys.executable). Mark the splash screen as initialized, but do not attempt to connect.

--- a/tests/requirements-base.txt
+++ b/tests/requirements-base.txt
@@ -21,7 +21,8 @@ pytest-timeout>=2.0.0
 pytest-drop-dup-tests
 
 # Rerun flaky (apple event related) tests
-pytest-rerunfailures
+# Avoid pytest-rerunfailures v16.0 due to https://github.com/pytest-dev/pytest-rerunfailures/issues/302
+pytest-rerunfailures!=16.0
 
 # Better subprocess alternative with process tree support.
 # Not available on cygwin.


### PR DESCRIPTION
I've noticed our `lint` workflow is more lenient than my local runs of `flake8`. Turns out this is because it is running python 3.8 and is not using the latest version of `flake8` (which dropped support for python 3.8 in v7.2.0).

Also clean up the workflow .yml files a bit by removing the `v4` branch from `on.*.branches` list.