### PR TITLE
Revise the anonymization of co_filename in collected code objects

### DIFF
--- a/PyInstaller/archive/readers.py
+++ b/PyInstaller/archive/readers.py
@@ -174,7 +174,7 @@ class CArchiveReader:
 
         entry = self.toc.get(name)
         if entry is None:
-            raise KeyError(f"No entry named {name} found in the archive!")
+            raise KeyError(f"No entry named {name!r} found in the archive!")
 
         entry_offset, data_length, uncompressed_length, compression_flag, typecode = entry
         with open(self._filename, "rb") as fp:
@@ -203,7 +203,7 @@ class CArchiveReader:
 
         entry = self.toc.get(name)
         if entry is None:
-            raise KeyError(f"No entry named {name} found in the archive!")
+            raise KeyError(f"No entry named {name!r} found in the archive!")
 
         entry_offset, data_length, uncompressed_length, compression_flag, typecode = entry
 
@@ -213,7 +213,7 @@ class CArchiveReader:
         elif typecode == PKG_ITEM_ZIPFILE:
             raise NotAnArchiveError("Zipfile archives not supported yet!")
         else:
-            raise NotAnArchiveError(f"Entry {name} is not a supported embedded archive!")
+            raise NotAnArchiveError(f"Entry {name!r} is not a supported embedded archive!")
 
 
 def pkg_archive_contents(filename, recursive=True):

--- a/PyInstaller/archive/writers.py
+++ b/PyInstaller/archive/writers.py
@@ -19,7 +19,7 @@ import struct
 import sys
 import zlib
 
-from PyInstaller.building.utils import get_code_object, strip_paths_in_code
+from PyInstaller.building.utils import get_code_object, replace_filename_in_code_object
 from PyInstaller.compat import BYTECODE_MAGIC, is_win, strict_collect_mode
 from PyInstaller.loader.pyimod01_archive import PYZ_ITEM_MODULE, PYZ_ITEM_NSPKG, PYZ_ITEM_PKG
 
@@ -86,7 +86,20 @@ class ZlibArchiveWriter:
             src_basename, _ = os.path.splitext(os.path.basename(src_path))
             if src_basename == '__init__':
                 typecode = PYZ_ITEM_PKG
-        data = marshal.dumps(code_dict[name])
+
+        code_object = code_dict[name]
+
+        # Replace co_filename on code object with anonymized version without absolute path to the module.
+        # Do this only for modules and packages (but not for namespace packages with dummy code objects).
+        if typecode != PYZ_ITEM_NSPKG:
+            if typecode == PYZ_ITEM_PKG:
+                co_filename = os.path.join(*name.split('.'), '__init__.py')
+            else:
+                co_filename = os.path.join(*name.split('.')) + '.py'
+            code_object = replace_filename_in_code_object(code_object, co_filename)
+
+        # Serialize
+        data = marshal.dumps(code_object)
 
         # First compress, then encrypt.
         obj = zlib.compress(data, cls._COMPRESSION_LEVEL)
@@ -211,7 +224,8 @@ class CArchiveWriter:
             # by the bootloader. For that, we need to know target optimization level, which is stored in typecode.
             optim_level = {'s': 0, 's1': 1, 's2': 2}[typecode]
             code = get_code_object(dest_name, src_name, optimize=optim_level)
-            code = strip_paths_in_code(code)
+            co_filename = dest_name + os.path.splitext(src_name)[1]  # Use dest name with suffix from source filename.
+            code = replace_filename_in_code_object(code, co_filename)
             return self._write_blob(fp, marshal.dumps(code), dest_name, 's', compress=compress)
         elif typecode in ('m', 'M'):
             # Read the PYC file. We do not perform compilation here (in contrast to script files in the above branch),
@@ -221,7 +235,8 @@ class CArchiveWriter:
             assert data[:4] == BYTECODE_MAGIC
             # Skip the PYC header, load the code object.
             code = marshal.loads(data[16:])
-            code = strip_paths_in_code(code)
+            co_filename = dest_name + '.py'  # Use dest name with added .py suffix.
+            code = replace_filename_in_code_object(code, co_filename)
             # These module entries are loaded and executed within the bootloader, which requires only the code
             # object, without the PYC header.
             return self._write_blob(fp, marshal.dumps(code), dest_name, typecode, compress=compress)

--- a/PyInstaller/archive/writers.py
+++ b/PyInstaller/archive/writers.py
@@ -77,26 +77,24 @@ class ZlibArchiveWriter:
         name, src_path, typecode = entry
         assert typecode in {'PYMODULE', 'PYMODULE-1', 'PYMODULE-2'}
 
-        typecode = PYZ_ITEM_MODULE
-        if src_path in ('-', None):
-            # This is a NamespacePackage, modulegraph marks them by using the filename '-'. (But wants to use None,
-            # so check for None, too, to be forward-compatible.)
-            typecode = PYZ_ITEM_NSPKG
-        else:
-            src_basename, _ = os.path.splitext(os.path.basename(src_path))
-            if src_basename == '__init__':
-                typecode = PYZ_ITEM_PKG
+        if src_path in {'-', None}:
+            # PEP-420 namespace package; these do not have code objects, but we still need an entry in PYZ to inform our
+            # run-time module finder/loader of the package's existence. So create a TOC entry for 0-byte data blob,
+            # and write no data.
+            return (name, (PYZ_ITEM_NSPKG, fp.tell(), 0))
 
         code_object = code_dict[name]
 
+        src_basename, _ = os.path.splitext(os.path.basename(src_path))
+        if src_basename == '__init__':
+            typecode = PYZ_ITEM_PKG
+            co_filename = os.path.join(*name.split('.'), '__init__.py')
+        else:
+            typecode = PYZ_ITEM_MODULE
+            co_filename = os.path.join(*name.split('.')) + '.py'
+
         # Replace co_filename on code object with anonymized version without absolute path to the module.
-        # Do this only for modules and packages (but not for namespace packages with dummy code objects).
-        if typecode != PYZ_ITEM_NSPKG:
-            if typecode == PYZ_ITEM_PKG:
-                co_filename = os.path.join(*name.split('.'), '__init__.py')
-            else:
-                co_filename = os.path.join(*name.split('.')) + '.py'
-            code_object = replace_filename_in_code_object(code_object, co_filename)
+        code_object = replace_filename_in_code_object(code_object, co_filename)
 
         # Serialize
         data = marshal.dumps(code_object)

--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -28,8 +28,7 @@ from PyInstaller import log as logging
 from PyInstaller.archive.writers import CArchiveWriter, ZlibArchiveWriter
 from PyInstaller.building.datastruct import Target, _check_guts_eq, normalize_pyz_toc, normalize_toc
 from PyInstaller.building.utils import (
-    _check_guts_toc, _make_clean_directory, _rmtree, process_collected_binary, get_code_object, strip_paths_in_code,
-    compile_pymodule
+    _check_guts_toc, _make_clean_directory, _rmtree, process_collected_binary, get_code_object, compile_pymodule
 )
 from PyInstaller.building.splash import Splash  # argument type validation in EXE
 from PyInstaller.compat import is_cygwin, is_darwin, is_linux, is_win, strict_collect_mode, is_nogil, is_aix
@@ -152,9 +151,6 @@ class PYZ(Target):
                     # The module was likely written for different Python version; exclude it
                     continue
             archive_toc.append(entry)
-
-        # Remove leading parts of paths in code objects.
-        self.code_dict = {name: strip_paths_in_code(code) for name, code in self.code_dict.items()}
 
         # Create the archive
         ZlibArchiveWriter(self.name, archive_toc, code_dict=self.code_dict)

--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -138,11 +138,12 @@ class PYZ(Target):
         logger.info("Building PYZ (ZlibArchive) %s", self.name)
 
         # Ensure code objects are available for all modules we are about to collect.
+        # NOTE: PEP-420 namespace packages (marked by src_path being set to '-') do not have code objects.
         # NOTE: `self.toc` is already sorted by names.
         archive_toc = []
         for entry in self.toc:
             name, src_path, typecode = entry
-            if name not in self.code_dict:
+            if src_path not in {'-', None} and name not in self.code_dict:
                 # The code object is not available from the ModuleGraph's cache; re-create it.
                 optim_level = {'PYMODULE': 0, 'PYMODULE-1': 1, 'PYMODULE-2': 2}[typecode]
                 try:

--- a/PyInstaller/building/utils.py
+++ b/PyInstaller/building/utils.py
@@ -21,12 +21,12 @@ import shutil
 import struct
 import subprocess
 import sys
+import types
 import zipfile
 
 from PyInstaller import compat
 from PyInstaller import log as logging
 from PyInstaller.compat import is_aix, is_darwin, is_win, is_linux
-from PyInstaller.config import CONF
 from PyInstaller.exceptions import InvalidSrcDestTupleError
 from PyInstaller.utils import misc
 
@@ -603,30 +603,18 @@ def get_code_object(modname, filename, optimize):
     return code_object
 
 
-def strip_paths_in_code(co, new_filename=None):
-    # Paths to remove from filenames embedded in code objects
-    replace_paths = sys.path + CONF['pathex']
-    # Make sure paths end with os.sep and the longest paths are first
-    replace_paths = sorted((os.path.join(f, '') for f in replace_paths), key=len, reverse=True)
-
-    if new_filename is None:
-        original_filename = os.path.normpath(co.co_filename)
-        for f in replace_paths:
-            if original_filename.startswith(f):
-                new_filename = original_filename[len(f):]
-                break
-
-        else:
-            return co
-
-    code_func = type(co)
+def replace_filename_in_code_object(code_object, filename):
+    """
+    Recursively replace the `co_filename` in the given code object and code objects stored in its `co_consts` entries.
+    Primarily used to anonymize collected code objects, i.e., by removing the build environment's paths from them.
+    """
 
     consts = tuple(
-        strip_paths_in_code(const_co, new_filename) if isinstance(const_co, code_func) else const_co
-        for const_co in co.co_consts
+        replace_filename_in_code_object(const_co, filename) if isinstance(const_co, types.CodeType) else const_co
+        for const_co in code_object.co_consts
     )
 
-    return co.replace(co_consts=consts, co_filename=new_filename)
+    return code_object.replace(co_consts=consts, co_filename=filename)
 
 
 def _should_include_system_binary(binary_tuple, exceptions):
@@ -705,8 +693,10 @@ def compile_pymodule(name, src_path, workpath, optimize, code_cache=None):
         else:
             raise ValueError(f"Invalid python module file {src_path}; unhandled extension {ext}!")
 
-    # Strip code paths from the code object
-    code_object = strip_paths_in_code(code_object)
+    # Replace co_filename in code object with anonymized filename that does not contain full path. Construct the
+    # relative filename from module name, similar how we earlier constructed the `pyc_path`.
+    co_filename = os.path.join(*parent_dirs, mod_basename + '.py')
+    code_object = replace_filename_in_code_object(code_object, co_filename)
 
     # Write complete .pyc module to in-memory stream. Then, check if .pyc file already exists, compare contents, and
     # (re)write it only if different. This avoids unnecessary (re)writing of the file, and in turn also avoids
@@ -847,12 +837,13 @@ def create_base_library_zip(filename, modules_toc, code_cache=None):
             if basename == '__init__':
                 dest_name += os.sep + '__init__'
             dest_name += '.pyc'  # Always .pyc, regardless of optimization level.
+            # Replace full-path co_filename in code object with `dest_name` (and shorten suffix from .pyc to .py).
+            code = replace_filename_in_code_object(code, dest_name[:-1])
             # Write the .pyc module
             with io.BytesIO() as fc:
                 fc.write(compat.BYTECODE_MAGIC)
                 fc.write(struct.pack('<I', 0b01))  # PEP-552: hash-based pyc, check_source=False
                 fc.write(b'\00' * 8)  # Match behavior of `building.utils.compile_pymodule`
-                code = strip_paths_in_code(code)  # Strip paths
                 marshal.dump(code, fc)
                 # Use a ZipInfo to set timestamp for deterministic build.
                 info = zipfile.ZipInfo(dest_name)

--- a/PyInstaller/building/utils.py
+++ b/PyInstaller/building/utils.py
@@ -560,45 +560,41 @@ def get_code_object(modname, filename, optimize):
     This is a simplifed non-performant version which circumvents __pycache__.
     """
 
-    if filename in ('-', None):
-        # This is a NamespacePackage, modulegraph marks them by using the filename '-'. (But wants to use None, so
-        # check for None, too, to be forward-compatible.)
-        logger.debug('Compiling namespace package %s', modname)
-        txt = '#\n'
-        code_object = compile(txt, filename, 'exec', optimize=optimize)
+    # Once upon a time, we compiled dummy code objects for PEP-420 namespace packages. We do not do that anymore.
+    assert filename not in {'-', None}, "Called with PEP-420 namespace package!"
+
+    _, ext = os.path.splitext(filename)
+    ext = ext.lower()
+
+    if ext == '.pyc':
+        # The module is available in binary-only form. Read the contents of .pyc file using helper function, which
+        # supports reading from either stand-alone or archive-embedded .pyc files.
+        logger.debug('Reading code object from .pyc file %s', filename)
+        pyc_data = _read_pyc_data(filename)
+        code_object = marshal.loads(pyc_data[16:])
     else:
+        # Assume this is a source .py file, but allow an arbitrary extension (other than .pyc, which is taken in
+        # the above branch). This allows entry-point scripts to have an arbitrary (or no) extension, as tested by
+        # the `test_arbitrary_ext` in `test_basic.py`.
+        logger.debug('Compiling python script/module file %s', filename)
+
+        with open(filename, 'rb') as f:
+            source = f.read()
+
+        # If entry-point script has no suffix, append .py when compiling the source. In POSIX builds, the executable
+        # has no suffix either; this causes issues with `traceback` module, as it tries to read the executable file
+        # when trying to look up the code for the entry-point script (when current working directory contains the
+        # executable).
         _, ext = os.path.splitext(filename)
-        ext = ext.lower()
+        if not ext:
+            logger.debug("Appending .py to compiled entry-point name...")
+            filename += '.py'
 
-        if ext == '.pyc':
-            # The module is available in binary-only form. Read the contents of .pyc file using helper function, which
-            # supports reading from either stand-alone or archive-embedded .pyc files.
-            logger.debug('Reading code object from .pyc file %s', filename)
-            pyc_data = _read_pyc_data(filename)
-            code_object = marshal.loads(pyc_data[16:])
-        else:
-            # Assume this is a source .py file, but allow an arbitrary extension (other than .pyc, which is taken in
-            # the above branch). This allows entry-point scripts to have an arbitrary (or no) extension, as tested by
-            # the `test_arbitrary_ext` in `test_basic.py`.
-            logger.debug('Compiling python script/module file %s', filename)
-
-            with open(filename, 'rb') as f:
-                source = f.read()
-
-            # If entry-point script has no suffix, append .py when compiling the source. In POSIX builds, the executable
-            # has no suffix either; this causes issues with `traceback` module, as it tries to read the executable file
-            # when trying to look up the code for the entry-point script (when current working directory contains the
-            # executable).
-            _, ext = os.path.splitext(filename)
-            if not ext:
-                logger.debug("Appending .py to compiled entry-point name...")
-                filename += '.py'
-
-            try:
-                code_object = compile(source, filename, 'exec', optimize=optimize)
-            except SyntaxError:
-                logger.warning("Sytnax error while compiling %s", filename)
-                raise
+        try:
+            code_object = compile(source, filename, 'exec', optimize=optimize)
+        except SyntaxError:
+            logger.warning("Sytnax error while compiling %s", filename)
+            raise
 
     return code_object
 

--- a/PyInstaller/loader/pyimod01_archive.py
+++ b/PyInstaller/loader/pyimod01_archive.py
@@ -109,6 +109,10 @@ class ZlibArchiveReader:
             return None
         typecode, entry_offset, entry_length = entry
 
+        # PEP-420 namespace package does not have a data blob.
+        if typecode == PYZ_ITEM_NSPKG:
+            return None
+
         # Read data blob
         try:
             with open(self._filename, "rb") as fp:
@@ -127,7 +131,7 @@ class ZlibArchiveReader:
 
         try:
             obj = zlib.decompress(obj)
-            if typecode in (PYZ_ITEM_MODULE, PYZ_ITEM_PKG, PYZ_ITEM_NSPKG) and not raw:
+            if typecode in (PYZ_ITEM_MODULE, PYZ_ITEM_PKG) and not raw:
                 obj = marshal.loads(obj)
         except EOFError as e:
             raise ImportError(f"Failed to unmarshal PYZ entry {name!r}!") from e

--- a/PyInstaller/loader/pyimod01_archive.py
+++ b/PyInstaller/loader/pyimod01_archive.py
@@ -106,7 +106,8 @@ class ZlibArchiveReader:
         # Look up entry
         entry = self.toc.get(name)
         if entry is None:
-            return None
+            raise KeyError(f"No entry named {name!r} found in the archive!")
+
         typecode, entry_offset, entry_length = entry
 
         # PEP-420 namespace package does not have a data blob.

--- a/PyInstaller/utils/cliutils/archive_viewer.py
+++ b/PyInstaller/utils/cliutils/archive_viewer.py
@@ -180,6 +180,7 @@ class ArchiveViewer:
                 raise NotImplementedError(f"Extraction from archive type {type(archive)} not implemented!")
         except Exception as e:
             print(f"Failed to extract data for entry {name!r} from {archive_name!r}: {e}", file=sys.stderr)
+            return
 
         # Write to file
         filename = input('Output filename? ')

--- a/PyInstaller/utils/cliutils/archive_viewer.py
+++ b/PyInstaller/utils/cliutils/archive_viewer.py
@@ -174,6 +174,8 @@ class ArchiveViewer:
                 data = archive.extract(name)
             elif isinstance(archive, ZlibArchiveReader):
                 data = archive.extract(name, raw=True)
+                if data is None:
+                    raise ValueError("Entry has no associated data!")
             else:
                 raise NotImplementedError(f"Extraction from archive type {type(archive)} not implemented!")
         except Exception as e:

--- a/news/9226.feature.rst
+++ b/news/9226.feature.rst
@@ -1,0 +1,7 @@
+Rework the anonymization of the ``co_filename`` attribute in collected
+code objects - instead of trying to obtain anonymized relative name by
+removing known path prefixes from the original absolute-path ``co_filename``,
+we now construct the anonymized relative name directly from the collected
+module's (or script's) destination name w.r.t. its destination container
+(i.e., the ``PKG`` archive, the ``PYZ`` archive, or the ``base_library.zip``
+archive).

--- a/tests/functional/test_code_object_anonymization.py
+++ b/tests/functional/test_code_object_anonymization.py
@@ -1,0 +1,106 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2025, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+import collections
+import os
+import io
+import marshal
+import zipfile
+
+from PyInstaller.loader.pyimod01_archive import PYZ_ITEM_MODULE, PYZ_ITEM_PKG
+from PyInstaller.archive.readers import CArchiveReader, PKG_ITEM_PYPACKAGE, PKG_ITEM_PYMODULE, PKG_ITEM_PYSOURCE
+
+
+def _analyze_collected_code_objects(filename):
+    # Construct lists of expected and found co_filename values, along with metadata (pkg/pyz and name). We compare these
+    # lists at the end, and rely on pytest to produce a nicely formatted diff if there is a mismatch....
+    Entry = collections.namedtuple('Entry', ['location', 'name', 'co_filename'])
+    expected_entries = []
+    found_entries = []
+
+    # PKG archive: all modules and scripts - bootstrap modules, bootstrap script, run-time hooks, entry-point script.
+    pkg_archive = CArchiveReader(filename)
+
+    for name, (*_, typecode) in pkg_archive.toc.items():
+        if typecode not in {PKG_ITEM_PYPACKAGE, PKG_ITEM_PYMODULE, PKG_ITEM_PYSOURCE}:
+            continue
+
+        expected_co_filename = name + '.py'
+        expected_entries.append(Entry('PKG', name, expected_co_filename))
+
+        code_object = marshal.loads(pkg_archive.extract(name))
+        found_entries.append(Entry('PKG', name, code_object.co_filename))
+
+    # base_library.zip - either in PKG archive, or in _internal next to executable.
+    baselib_zip_filename = os.path.join(os.path.dirname(filename), '_internal', 'base_library.zip')
+    if os.path.isfile(baselib_zip_filename):
+        baselib_zip = zipfile.ZipFile(baselib_zip_filename, mode='r')
+    else:
+        # onefile mode
+        baselib_zip = zipfile.ZipFile(io.BytesIO(pkg_archive.extract('base_library.zip')), mode='r')
+
+    for entry in baselib_zip.infolist():
+        # Turn the entry filename into expected co_filename by changing .pyc extension into .py. The entries in .zip
+        # file have POSIX separators, which need to be normalized for comparison on Windows.
+        expected_co_filename = os.path.normpath(entry.filename)[:-1]
+        expected_entries.append(Entry('base_library.zip', entry.filename, expected_co_filename))
+
+        code_object = marshal.loads(baselib_zip.read(entry)[16:])  # skip the .pyc header (16 bytes)
+        found_entries.append(Entry('base_library.zip', entry.filename, code_object.co_filename))
+
+    # PYZ archive: all modules and packages.
+    pyz_archive = pkg_archive.open_embedded_archive('PYZ.pyz')
+
+    for name, (typecode, *_) in pyz_archive.toc.items():
+        # Analyze only modules and packages (i.e., ignore PEP-420 namespace package entries).
+        if typecode not in {PYZ_ITEM_MODULE, PYZ_ITEM_PKG}:
+            continue
+
+        if typecode == PYZ_ITEM_MODULE:
+            expected_co_filename = os.path.join(*name.split('.')) + '.py'
+        else:
+            expected_co_filename = os.path.join(*name.split('.'), '__init__.py')
+        expected_entries.append(Entry('PYZ', name, expected_co_filename))
+
+        code_object = pyz_archive.extract(name)
+        found_entries.append(Entry('PYZ', name, code_object.co_filename))
+
+    # Compare the obtained lists
+    assert expected_entries == found_entries
+
+
+def test_co_filename_anonymization(pyi_builder):
+    pyi_args = [
+        # stdlib packages with run-time hooks
+        '--hiddenimport',
+        'inspect',
+        '--hiddenimport',
+        'multiprocessing',
+        # setuptools for its vendored packages
+        '--hiddenimport',
+        'setuptools',
+        # PyInstaller's "fake" modules/packages
+        '--hiddenimport',
+        'pyi_splash',
+        '--hiddenimport',
+        '_pyi_rth_utils.tempfile',
+        '--hiddenimport',
+        '_pyi_rth_utils.qt',
+    ]
+
+    pyi_builder.test_source("""
+        print("Hello!")
+        """, pyi_args=pyi_args)
+
+    executables = pyi_builder._find_executables("test_source")
+    assert len(executables) == 1
+
+    _analyze_collected_code_objects(executables[0])


### PR DESCRIPTION
Revise the logic for anonymization of `co_filename` in collected code objects. Instead of trying to remove known path prefixes from the current `co_filename`, we now construct the target `co_filename` based on the code object's destination container and destination name within it.

This should address the issue with `co_filename` of PyInstaller's bootstrap modules not being properly anonymized when PyInstaller is installed in editable mode - https://github.com/pyinstaller/pyinstaller/issues/9204#issuecomment-3177151033. It should also ensure that anonymization takes place even if paths in `sys.path` and the absolute-path in `co_filename` happen to use different character case on Windows. And it should also ensure that vendored packages and modules with their locations added to `sys.path` end up with anonymized `co_filename` that corresponds to their "long" name - for example, the `co_filename` of `setuptools._vendor.jaraco.text` is now replaced with `setuptools/_vendor/jaraco/text/__init__.py` instead of `jaraco/text/__init__.py`.

The second part of this PR removes the creation of dummy/empty code objects for PEP-420 namespace packages. Instead, we now write TOC entries with zero data length to the PYZ TOC. The only place that needs to be somewhat adjusted for that is the `archive-viewer` utility (our frozen module finder/loader implementation already ignored these dummy code objects for PEP-420 namespace packages).