### PR TITLE
ci: allow main CI workflows to be manually triggered [skip ci]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:  # Allow workflow to be manually triggered
   pull_request:  # Trigger on PRs opened against develop branch
     branches:
       - develop

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,7 @@
 name: Lint
 
 on:
+  workflow_dispatch:  # Allow workflow to be manually triggered
   pull_request:  # Trigger on PRs opened against develop branch
     branches:
       - develop

--- a/.github/workflows/validate-new-news.yml
+++ b/.github/workflows/validate-new-news.yml
@@ -2,6 +2,7 @@
 name: Validate new news entries
 
 on:
+  workflow_dispatch:  # Allow workflow to be manually triggered
   pull_request:  # Trigger on PRs opened against develop branch
     branches:
       - develop


### PR DESCRIPTION
As a follow-up to removal of `push` trigger from the CI workflow in  #9223, add a `workflow_dispatch` to main CI workflows (ci, lint, validate-new-news) in order to allow them to be manually triggered.

The main use case for this is for me to run the CI against a branche in my fork during development phase; without having to open a PR (here or there) or pushing "enable CI on this branch" commit to the branch.