### PR TITLE
tests: test_time_sleep: allow slightly shorter elapsed time interval

### DIFF
--- a/tests/functional/test_misc.py
+++ b/tests/functional/test_misc.py
@@ -479,6 +479,7 @@ def test_time_sleep(pyi_builder, windowed):
 
         ITERATIONS = 5
         DELAY = 1  # seconds
+        TOL = 50  # milliseconds
 
         elapsed = []
         for i in range(ITERATIONS):
@@ -496,7 +497,7 @@ def test_time_sleep(pyi_builder, windowed):
             # We are trying to catch cases when the elapsed time interval is *shorter* than the requested delay, which
             # indicates mis-behaving time.sleep() as per #8104. Typically the elapsed time interval is a bit longer than
             # the requested delay, but the delta varies depending on system scheduling and load.
-            if delta < 0:
+            if delta < 0 and abs(delta) >= TOL:
                 status = 'TOO SHORT'
                 test_ok = False
             else:


### PR DESCRIPTION
Allow the elapsed time interval to be slightly shorter than the specified sleep interval; as seen [on our CI](https://github.com/pyinstaller/pyinstaller/actions/runs/17567989789/job/49898642249?pr=9238), the delta might be -0.0000 milliseconds. For now, use 50 ms tolerance, just to be on the safe side; the test is trying to catch large discrepancies, i.e., near-zero elapsed times (and thus deltas close to a full second).