### PR TITLE
no-op pefile==2024.8.26's use of gc.collect() (#8762)

### DIFF
--- a/PyInstaller/depend/bindepend.py
+++ b/PyInstaller/depend/bindepend.py
@@ -1028,8 +1028,22 @@ if compat.is_linux:
 
 elif compat.is_win:
 
+    @functools.lru_cache()
+    def _no_op_pefile_gc():
+        # Disable pefile's reduntant and very slow call to gc.collect(). See #8762.
+        import types
+        import gc
+        import pefile
+
+        fake_gc = types.ModuleType("gc")
+        fake_gc.__dict__.update(gc.__dict__)
+        fake_gc.collect = lambda *_, **__: None
+        pefile.gc = fake_gc
+
     def _classify_binary_vs_data(filename):
         import pefile
+
+        _no_op_pefile_gc()
 
         # First check for MZ signature, which should allow us to quickly classify the majority of data files.
         try:

--- a/PyInstaller/hooks/pre_safe_import_module/hook-backports.py
+++ b/PyInstaller/hooks/pre_safe_import_module/hook-backports.py
@@ -1,0 +1,17 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2025, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+# This top-level namespace package might be provided by setuptools >= 71.0.0, which makes its vendored dependencies
+# public by appending path to its `setuptools._vendored` directory to `sys.path`. The following shared
+# pre-safe-import-module hook implementation checks whether this is the case, and, depending on situation, either
+# sets up aliases to prevent duplicate collection, or extends the search paths.
+from PyInstaller.utils.hooks.setuptools import pre_safe_import_module_for_top_level_namespace_packages \
+    as pre_safe_import_module  # noqa: F401

--- a/PyInstaller/hooks/pre_safe_import_module/hook-jaraco.py
+++ b/PyInstaller/hooks/pre_safe_import_module/hook-jaraco.py
@@ -1,0 +1,17 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2025, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+# This top-level namespace package might be provided by setuptools >= 71.0.0, which makes its vendored dependencies
+# public by appending path to its `setuptools._vendored` directory to `sys.path`. The following shared
+# pre-safe-import-module hook implementation checks whether this is the case, and, depending on situation, either
+# sets up aliases to prevent duplicate collection, or extends the search paths.
+from PyInstaller.utils.hooks.setuptools import pre_safe_import_module_for_top_level_namespace_packages \
+    as pre_safe_import_module  # noqa: F401

--- a/news/8762.bugfix.rst
+++ b/news/8762.bugfix.rst
@@ -1,0 +1,2 @@
+Work around performance issues introduced by superfluous usage of
+:func:`gc.collect` in ``pefile==2024.8.26``.

--- a/news/9149.bugfix.rst
+++ b/news/9149.bugfix.rst
@@ -1,0 +1,2 @@
+Avoid indirect usage of ``pkg_resources`` which is deprecated and scheduled to
+be removed in 2025-11-30.

--- a/news/9250.hooks.rst
+++ b/news/9250.hooks.rst
@@ -1,0 +1,4 @@
+Add pre-safe-import-module hooks for ``backports`` and ``jaraco``, in
+order to accommodate the ``setuptools``-vendored copies of these
+packages in situations when the ``setuptools`` vendor directory is not
+in python's search path at the start of the import analysis process.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,7 @@ keywords = [
 dependencies = [
     "setuptools >= 42.0.0",
     "altgraph",
-    # pefile 2024.8.26 contains performance regression that heavily impacts our binary dependency analysis
-    "pefile >= 2022.5.30, != 2024.8.26; sys_platform == 'win32'",
+    "pefile >= 2022.5.30 ; sys_platform == 'win32'",
     "pywin32-ctypes >= 0.2.1 ; sys_platform == 'win32'",
     "macholib >= 1.8 ; sys_platform == 'darwin'",
     "pyinstaller-hooks-contrib >= 2025.8",


### PR DESCRIPTION
The performance regression caused by pefile's explicit garbage collect doesn't look like it's going away any time soon (if ever). As an alternative to continuing to block users from upgrading their pefile version, replace pefile's reference to gc.collect() with a placebo function to *disable* the garbage collect.