### PR TITLE
ci: Reduce test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,11 +40,17 @@ jobs:
             os: 'macos-14'
           - python-version: '3.12'
             os: 'macos-14'
+          - python-version: '3.13t'
+            os: 'macos-14'
+          - python-version: '3.14-dev'
+            os: 'macos-14'
           - python-version: '3.9'
             os: 'macos-13'
           - python-version: '3.11'
             os: 'macos-13'
           - python-version: '3.13'
+            os: 'macos-13'
+          - python-version: '3.14t-dev'
             os: 'macos-13'
       fail-fast: false
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.13t', '3.14-dev', '3.14t-dev']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14-dev']
         os: ['windows-latest', 'ubuntu-24.04', 'macos-15-intel', 'macos-14']
         # Split macOS workflows between macos-15-intel (x86_64) and macos-14 (arm64)
         # runners to cover both architectures without running all combinations.
@@ -40,8 +40,6 @@ jobs:
             os: 'macos-14'
           - python-version: '3.12'
             os: 'macos-14'
-          - python-version: '3.13t'
-            os: 'macos-14'
           - python-version: '3.14-dev'
             os: 'macos-14'
           - python-version: '3.9'
@@ -49,8 +47,6 @@ jobs:
           - python-version: '3.11'
             os: 'macos-15-intel'
           - python-version: '3.13'
-            os: 'macos-15-intel'
-          - python-version: '3.14t-dev'
             os: 'macos-15-intel'
       fail-fast: false
     steps:
@@ -320,6 +316,32 @@ jobs:
           # loading PyInstaller's pytest.ini.
           cd ~
           python -m PyInstaller.utils.run_tests --include_only=pyi_hooksample.
+
+  test-freethreaded:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: ['3.13t', '3.14t-dev']
+        os: ['windows-latest', 'ubuntu-24.04', 'macos-15-intel', 'macos-14']
+      fail-fast: false
+    steps:
+      - name: Checkout PyInstaller code
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Update pip
+        run: python -m pip install --upgrade pip
+
+      - name: Install PyInstaller
+        run: python -m pip install . --requirement tests/requirements-base.txt
+
+      - name: Run tests
+        id: run-tests
+        run: pytest tests/functional/test_freethreading.py
 
   test-alpine:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,8 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.13t', '3.14-dev', '3.14t-dev']
-        os: ['windows-latest', 'ubuntu-24.04', 'macos-13', 'macos-14']
-        # Split macOS workflows between macos-13 (x86_64) and macos-14 (arm64)
+        os: ['windows-latest', 'ubuntu-24.04', 'macos-15-intel', 'macos-14']
+        # Split macOS workflows between macos-15-intel (x86_64) and macos-14 (arm64)
         # runners to cover both architectures without running all combinations.
         exclude:
           - python-version: '3.8'
@@ -45,13 +45,13 @@ jobs:
           - python-version: '3.14-dev'
             os: 'macos-14'
           - python-version: '3.9'
-            os: 'macos-13'
+            os: 'macos-15-intel'
           - python-version: '3.11'
-            os: 'macos-13'
+            os: 'macos-15-intel'
           - python-version: '3.13'
-            os: 'macos-13'
+            os: 'macos-15-intel'
           - python-version: '3.14t-dev'
-            os: 'macos-13'
+            os: 'macos-15-intel'
       fail-fast: false
     steps:
       - name: Checkout PyInstaller code


### PR DESCRIPTION
In the hopes of making CI slightly less long a wait...

* Propagate the *one macOS architecture per Python version* filter to Python 3.14 and 3.13t.

* <s>Split the platforms between 3.13 and 3.13t then repeat for 3.14 and 3.14t but the other way around so that all platforms run free threaded and GIL variants once.</s>

<s>This gives us a regular 3 platforms by 7 Python versions matrix, albeit with arm64 and free threading scattered about. The main `tests` stage goes from 30 jobs to 21.</s>