### PR TITLE
ci: promote python 3.14 workflows from development to release 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14-dev']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
         os: ['windows-latest', 'ubuntu-24.04', 'macos-15-intel', 'macos-14']
         # Split macOS workflows between macos-15-intel (x86_64) and macos-14 (arm64)
         # runners to cover both architectures without running all combinations.
@@ -40,7 +40,7 @@ jobs:
             os: 'macos-14'
           - python-version: '3.12'
             os: 'macos-14'
-          - python-version: '3.14-dev'
+          - python-version: '3.14'
             os: 'macos-14'
           - python-version: '3.9'
             os: 'macos-15-intel'
@@ -321,7 +321,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.13t', '3.14t-dev']
+        python-version: ['3.13t', '3.14t']
         os: ['windows-latest', 'ubuntu-24.04', 'macos-15-intel', 'macos-14']
       fail-fast: false
     steps:

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -27,9 +27,9 @@ PyGObject==3.54.3; sys_platform == "linux" and python_version >= "3.9"
 PySide2==5.15.2.1; python_version < "3.11" and (sys_platform != "darwin" or platform_machine != "arm64")
 # PySide6 is a metapackage that depends on PySide6-Essentials and PySide6-Addons. Their versions are
 # usually kept in sync.
-PySide6==6.9.3; python_version >= "3.9"
-PySide6-Addons==6.9.3; python_version >= "3.9"
-PySide6-Essentials==6.9.3; python_version >= "3.9"
+PySide6==6.9.3; python_version >= "3.9" and python_version < "3.14"
+PySide6-Addons==6.9.3; python_version >= "3.9" and python_version < "3.14"
+PySide6-Essentials==6.9.3; python_version >= "3.9" and python_version < "3.14"
 # PyQt5 and add-on packages
 # We do not pin *-Qt5 packages (which contain Qt shared libraries), as Qt5 is not actively developed
 # anymore, and thus 5.15.x has a stable ABI. Plus, it seems that *-Qt5 5.15.2 wheels are available for


### PR DESCRIPTION
Now that python 3.14.0 was released and that GHA promptly made it available, we can promote our python 3.14 CI workflows from development to release variant with complete set of installed libraries.

As far as I can tell, from the packages we install and test here, only `PySide6` does not support python 3.14 yet. `PyQt5-sip`, `PyQt6-sip`, and `zope.interface` are missing binary wheels for 3.14, but they are successfully built from source.