### PR TITLE
fix x86_64 illumos detection

### DIFF
--- a/PyInstaller/_shared_with_waf.py
+++ b/PyInstaller/_shared_with_waf.py
@@ -52,7 +52,7 @@ def _pyi_machine(machine, system):
             return "intel"
 
     if system == "SunOS":
-        if machine.lower() in ("x86", "i86pc"):
+        if machine.lower() in ("x86_64", "x86", "i86pc"):
             return "intel"
         else:
             return "sparc"


### PR DESCRIPTION
When distinguishing between x86 and sparc on solaris/illumos, _pyi_machine() needs to
recognize an x86_64 system as intel rather than sparc.