### PR TITLE
fix: deduplicate PYTHONPATH paths

### DIFF
--- a/PyInstaller/building/build_main.py
+++ b/PyInstaller/building/build_main.py
@@ -635,7 +635,7 @@ class Analysis(Target):
         if spec_pathex is not None:
             pathex.extend(spec_pathex)
         # Normalize paths in pathex and make them absolute.
-        return [absnormpath(p) for p in pathex]
+        return list(set(absnormpath(p) for p in pathex))
 
     def _check_guts(self, data, last_build):
         if Target._check_guts(self, data, last_build):

--- a/PyInstaller/building/build_main.py
+++ b/PyInstaller/building/build_main.py
@@ -635,7 +635,7 @@ class Analysis(Target):
         if spec_pathex is not None:
             pathex.extend(spec_pathex)
         # Normalize paths in pathex and make them absolute.
-        return list(set(absnormpath(p) for p in pathex))
+        return list(dict.fromkeys(absnormpath(p) for p in pathex))
 
     def _check_guts(self, data, last_build):
         if Target._check_guts(self, data, last_build):


### PR DESCRIPTION
In lesser cases, this can needlessly pollute the PYTHONPATH environment variable with duplicates, and, in greater cases, can even exceed the environment variable length limit (32767), even when it should otherwise function fine. This simple optimization helps both scenarios and shouldn't negatively affect anything else.