### PR TITLE
Update license to SPDX standard

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ dynamic = ["version"]
 description = "PyInstaller bundles a Python application and all its dependencies into a single package."
 readme = "README.rst"
 requires-python = ">=3.8, <3.15"
-license.text = "GPLv2-or-later with a special exception which allows to use PyInstaller to build and distribute non-free programs (including commercial ones)"
+license.text = "GPL-2.0-or-later WITH a special exception which allows to use PyInstaller to build and distribute non-free programs (including commercial ones)"
 authors = [
     { name = "Hartmut Goebel" },
     { name = "Giovanni Bajo" },


### PR DESCRIPTION
With [PEP 639](https://peps.python.org/pep-0639/), the standard for license is [SPDX](https://spdx.org/licenses/).
So I think this refers to [GPL-2.0-or-later](https://spdx.org/licenses/GPL-2.0-or-later.html)

This makes it easier for tools to determine which license is used.

Also, make the WITH capital to follow SPDX close: https://spdx.github.io/spdx-spec/v3.0.1/annexes/spdx-license-expressions/#additive-with-operator