### PR TITLE
bootloader: use -Wno-error=unused-command-line-argument with clang

### DIFF
--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -508,11 +508,18 @@ def configure(ctx):
         # For clang, also enable extra warnings and treat them as errors. Similarly to gcc, do not treat warnings about
         # unused variables and unused functions as errors.
         ctx.env.append_value(
-            'CFLAGS', [
+            'CFLAGS',
+            [
                 '-Wall',
                 '-Werror',
                 '-Wno-error=unused-variable',
                 '-Wno-error=unused-function',
+                # Passing `clang -fPIE -pie` via `CC` environment variable to create position-independent bootloader
+                # executables causes `clang` to emit following warnings when compiling object files due to `-pie`
+                # being linker-stage flag:
+                #   clang: warning: argument unused during compilation: '-pie' [-Wunused-command-line-argument]
+                # Make them non-fatal.
+                '-Wno-error=unused-command-line-argument',
             ]
         )
 


### PR DESCRIPTION
When building with `clang`, avoid treating `unused-command-line-argument` warnings as errors.

One way for users to create position-independent bootloader executables is to pass `clang -fPIE -pie` via the `CC` environment variable; the first flag enables position-independent code in generated object files, while the second one enables creation of position-independent executable during the linking stage.

However, this causes `clang` to emit warnings about `-pie` flag not being used during object-file compilation stage:

```
clang: warning: argument unused during compilation: '-pie' [-Wunused-command-line-argument]
```

Since cc793af turned on -Wall and -Werror for clang, these warnings are treated as errors and end up breaking the build. Restore the old behavior by making them non-fatal.

Fixes #9299.