### PR TITLE
building: ensure suffix in co_filename of the entry-point's code object

### DIFF
--- a/tests/functional/scripts/pyi_arbitrary_ext.foo
+++ b/tests/functional/scripts/pyi_arbitrary_ext.foo
@@ -1,5 +1,24 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-# Verify that PyInstaller can load a script from a file with an arbitrary
-# extension, not just from ``.py`` files.
-print('hello')
+# Verify that PyInstaller can load a script from a file with an arbitrary extension, not just from ``.py`` files.
+#
+# Also check that both `__file__` attribute and the `co_filename` attribute of the code object have correct suffix.
+import os
+import sys
+
+print('Hello!')
+
+# Look up and display all relevant attributes...
+print(f"__file__: {__file__}")
+loader = sys.modules[__name__].__loader__
+print(f"loader: {loader}")
+co = loader.get_code(__name__)
+print(f"co_filename: {co.co_filename}")
+
+# ... before validating them.
+# We expect the original suffix to be found on both attributes.
+# NOTE: alas, the PKG archive stores the entry-point script entries without suffix, and the bootloader currently has no
+# way of restoring those, so it always sets the `__file__` attribute with .py suffix. For now, codify this behavior.
+if getattr(sys, 'frozen', False):
+    assert os.path.splitext(__file__)[1] == '.py'
+else:
+    assert os.path.splitext(__file__)[1] == '.foo'
+assert os.path.splitext(co.co_filename)[1] == '.foo'

--- a/tests/functional/scripts/pyi_no_ext
+++ b/tests/functional/scripts/pyi_no_ext
@@ -1,0 +1,24 @@
+# Verify that PyInstaller can load a script from a file with no extension, not just from ``.py`` files.
+#
+# Also check that both `__file__` attribute and the `co_filename` attribute of the code object have correct suffix.
+import os
+import sys
+
+print('Hello!')
+
+# Look up and display all relevant attributes...
+print(f"__file__: {__file__}")
+loader = sys.modules[__name__].__loader__
+print(f"loader: {loader}")
+co = loader.get_code(__name__)
+print(f"co_filename: {co.co_filename}")
+
+# ... before validating them.
+# We expect a .py suffix to be added to both attributes. This behavior specific to frozen application; in unfrozen
+# script, the suffix should be empty.
+if getattr(sys, 'frozen', False):
+    assert os.path.splitext(__file__)[1] == '.py'
+    assert os.path.splitext(co.co_filename)[1] == '.py'
+else:
+    assert os.path.splitext(__file__)[1] == ''
+    assert os.path.splitext(co.co_filename)[1] == ''

--- a/tests/functional/test_basic.py
+++ b/tests/functional/test_basic.py
@@ -595,9 +595,14 @@ def test_hook_collect_submodules(pyi_builder, script_dir):
     )
 
 
-# Test that PyInstaller can handle a script with an arbitrary extension.
-def test_arbitrary_ext(pyi_builder):
+# Test that PyInstaller can handle a script with an arbitrary extension/suffix.
+def test_arbitrary_entry_point_script_suffix(pyi_builder):
     pyi_builder.test_script('pyi_arbitrary_ext.foo')
+
+
+# Test that PyInstaller can handle a script with no extension/suffix.
+def test_no_entry_point_script_suffix(pyi_builder):
+    pyi_builder.test_script('pyi_no_ext')
 
 
 @onefile_only


### PR DESCRIPTION
When anonymizing path in `co_filename` of the entry-point script's code object, ensure that it always has a suffix - by taking the suffix from the original `co_filename` of code object produced by the `get_code_object()` helper.

In cases when the entry-point script's source file does not have a suffix, the `get_code_object()` helper adds a `.py` suffix to the `co_filename` in an attempt to mitigate issues with `traceback` module mistakenly trying to load POSIX executables as if they were source files (if the executable happens to be in the current working directory).

Fixes #9309, a regression that was introduced in dfa79a8.

Add a test with entry-point script that has no suffix, to prevent me from breaking this again.