### PR TITLE
splash screen: add support for Tcl/Tk 9

### DIFF
--- a/PyInstaller/archive/writers.py
+++ b/PyInstaller/archive/writers.py
@@ -327,9 +327,10 @@ class SplashWriter:
     #
     # typedef struct _splash_data_header
     # {
-    #     char tcl_libname[16];
-    #     char tk_libname[16];
-    #     char tk_lib[16];
+    #     char tcl_shared_library_name[32];
+    #     char tk_shared_library_name[32];
+    #     char tcl_module_directory_name[16];
+    #     char tk_module_directory_name[16];
     #
     #     uint32_t script_len;
     #     uint32_t script_offset;
@@ -341,20 +342,31 @@ class SplashWriter:
     #     uint32_t requirements_offset;
     # } SPLASH_DATA_HEADER;
     #
-    _HEADER_FORMAT = '!32s 32s 16s II II II'
+    _HEADER_FORMAT = '!32s 32s 16s 16s II II II'
     _HEADER_LENGTH = struct.calcsize(_HEADER_FORMAT)
 
     # The created archive is compressed by the CArchive, so no need to compress the data here.
 
-    def __init__(self, filename, name_list, tcl_libname, tk_libname, tklib, image, script):
+    def __init__(
+        self,
+        filename,
+        requirements_list,
+        tcl_shared_library_name,
+        tk_shared_library_name,
+        tcl_module_directory_name,
+        tk_module_directory_name,
+        image,
+        script,
+    ):
         """
         Writer for splash screen resources that are bundled into the CArchive as a single archive/entry.
 
         :param filename: The filename of the archive to create
-        :param name_list: List of filenames for the requirements array
-        :param str tcl_libname: Name of the tcl shared library file
-        :param str tk_libname: Name of the tk shared library file
-        :param str tklib: Root of tk library (e.g. tk/)
+        :param requirements_list: List of filenames for the requirements array
+        :param str tcl_shared_library_name: Basename of the Tcl shared library
+        :param str tk_shared_library_name: Basename of the Tk shared library
+        :param str tcl_module_directory_name: Basename of the Tcl module directory (e.g., tcl/)
+        :param str tk_module_directory_name: Basename of the Tk module directory (e.g., tk/)
         :param Union[str, bytes] image: Image like object
         :param str script: The tcl/tk script to execute to create the screen.
         """
@@ -369,7 +381,7 @@ class SplashWriter:
                 filename = filename.replace(os.path.sep, '\\')
             return filename
 
-        name_list = [_normalize_filename(name) for name in name_list]
+        requirements_list = [_normalize_filename(name) for name in requirements_list]
 
         with open(filename, "wb") as fp:
             # Reserve space for the header.
@@ -380,7 +392,7 @@ class SplashWriter:
             # null-byte, that keeps the list short memory wise and makes it iterable from C.
             requirements_len = 0
             requirements_offset = fp.tell()
-            for name in name_list:
+            for name in requirements_list:
                 name = name.encode('utf-8') + b'\0'
                 fp.write(name)
                 requirements_len += len(name)
@@ -421,9 +433,10 @@ class SplashWriter:
             # Write header
             header_data = struct.pack(
                 self._HEADER_FORMAT,
-                _encode_str(tcl_libname, 'tcl_libname', 32),
-                _encode_str(tk_libname, 'tk_libname', 32),
-                _encode_str(tklib, 'tklib', 16),
+                _encode_str(tcl_shared_library_name, 'tcl_shared_library_name', 32),
+                _encode_str(tk_shared_library_name, 'tk_shared_library_name', 32),
+                _encode_str(tcl_module_directory_name, 'tcl_module_directory_name', 16),
+                _encode_str(tk_module_directory_name, 'tk_module_directory_name', 16),
                 script_len,
                 script_offset,
                 image_len,

--- a/PyInstaller/building/splash.py
+++ b/PyInstaller/building/splash.py
@@ -182,6 +182,8 @@ class Splash(Target):
             #
             # NOTE: these paths use the *destination* layout for Tcl/Tk scripts, which uses unversioned tcl and tk
             # directories (see `PyInstaller.utils.hooks.tcl_tk.collect_tcl_tk_files`).
+            os.path.join(tcltk_info.TCL_ROOTNAME, "init.tcl"),
+            # Core Tk
             os.path.join(tcltk_info.TK_ROOTNAME, "license.terms"),
             os.path.join(tcltk_info.TK_ROOTNAME, "text.tcl"),
             os.path.join(tcltk_info.TK_ROOTNAME, "tk.tcl"),

--- a/PyInstaller/building/splash.py
+++ b/PyInstaller/building/splash.py
@@ -21,31 +21,8 @@ from PyInstaller.building.datastruct import Target
 from PyInstaller.building.utils import _check_guts_eq, _check_guts_toc, misc
 from PyInstaller.compat import is_aix, is_darwin
 from PyInstaller.depend import bindepend
-from PyInstaller.utils.hooks.tcl_tk import tcltk_info
-
-try:
-    from PIL import Image as PILImage
-except ImportError:
-    PILImage = None
 
 logger = logging.getLogger(__name__)
-
-# These requirement files are checked against the current splash screen script. If you wish to modify the splash screen
-# and run into tcl errors/bad behavior, this is a good place to start and add components your implementation of the
-# splash screen might use.
-# NOTE: these paths use the *destination* layout for Tcl/Tk scripts, which uses unversioned tcl and tk directories
-# (see `PyInstaller.utils.hooks.tcl_tk.collect_tcl_tk_files`).
-splash_requirements = [
-    # prepended tcl/tk binaries
-    os.path.join(tcltk_info.TK_ROOTNAME, "license.terms"),
-    os.path.join(tcltk_info.TK_ROOTNAME, "text.tcl"),
-    os.path.join(tcltk_info.TK_ROOTNAME, "tk.tcl"),
-    # Used for customizable font
-    os.path.join(tcltk_info.TK_ROOTNAME, "ttk", "ttk.tcl"),
-    os.path.join(tcltk_info.TK_ROOTNAME, "ttk", "fonts.tcl"),
-    os.path.join(tcltk_info.TK_ROOTNAME, "ttk", "cursors.tcl"),
-    os.path.join(tcltk_info.TK_ROOTNAME, "ttk", "utils.tcl"),
-]
 
 
 class Splash(Target):
@@ -124,7 +101,9 @@ class Splash(Target):
             frozen applications with long startup times. Default: ``True``
         :type always_on_top: bool
         """
-        from ..config import CONF
+        from PyInstaller.config import CONF
+        from PyInstaller.utils.hooks.tcl_tk import tcltk_info
+
         Target.__init__(self)
 
         # Splash screen is not supported on macOS. It operates in a secondary thread and macOS disallows UI operations
@@ -141,7 +120,7 @@ class Splash(Target):
 
         # Check if the Tcl/Tk version is supported.
         logger.info("Verifying Tcl/Tk compatibility with splash screen requirements")
-        self._check_tcl_tk_compatibility()
+        self._check_tcl_tk_compatibility(tcltk_info)
 
         # Make image path relative to .spec file
         if not os.path.isabs(image_file):
@@ -197,7 +176,20 @@ class Splash(Target):
             # application directory, which, at tme moment, is true in practically all cases.
             os.path.basename(self.tcl_lib),
             os.path.basename(self.tk_lib),
-            *splash_requirements,
+            # The list of requirements below is based on the current implementation of splash screen script. If you want
+            # to extend the splash screen functionality and run into Tcl/Tk errors, chances are that additional Tk
+            # components need to be added here.
+            #
+            # NOTE: these paths use the *destination* layout for Tcl/Tk scripts, which uses unversioned tcl and tk
+            # directories (see `PyInstaller.utils.hooks.tcl_tk.collect_tcl_tk_files`).
+            os.path.join(tcltk_info.TK_ROOTNAME, "license.terms"),
+            os.path.join(tcltk_info.TK_ROOTNAME, "text.tcl"),
+            os.path.join(tcltk_info.TK_ROOTNAME, "tk.tcl"),
+            # Used for customizable font
+            os.path.join(tcltk_info.TK_ROOTNAME, "ttk", "ttk.tcl"),
+            os.path.join(tcltk_info.TK_ROOTNAME, "ttk", "fonts.tcl"),
+            os.path.join(tcltk_info.TK_ROOTNAME, "ttk", "cursors.tcl"),
+            os.path.join(tcltk_info.TK_ROOTNAME, "ttk", "utils.tcl"),
         ])
 
         logger.info("Collect Tcl/Tk data files for the splash screen")
@@ -303,6 +295,15 @@ class Splash(Target):
     def assemble(self):
         logger.info("Building Splash %s", self.name)
 
+        # Check if PIL/pillow is available.
+        try:
+            from PIL import Image as PILImage
+        except ImportError:
+            PILImage = None
+
+        # Required to pass tcltk_info.TK_ROOTNAME to SplashWriter
+        from PyInstaller.utils.hooks.tcl_tk import tcltk_info
+
         # Function to resize a given image to fit into the area defined by max_img_size.
         def _resize_image(_image, _orig_size):
             if PILImage:
@@ -387,7 +388,7 @@ class Splash(Target):
         )
 
     @staticmethod
-    def _check_tcl_tk_compatibility():
+    def _check_tcl_tk_compatibility(tcltk_info):
         tcl_version = tcltk_info.tcl_version  # (major, minor) tuple
         tk_version = tcltk_info.tk_version
 

--- a/PyInstaller/building/splash.py
+++ b/PyInstaller/building/splash.py
@@ -382,6 +382,7 @@ class Splash(Target):
             self.splash_requirements,
             os.path.basename(self.tcl_lib),  # tcl86t.dll
             os.path.basename(self.tk_lib),  # tk86t.dll
+            tcltk_info.TCL_ROOTNAME,
             tcltk_info.TK_ROOTNAME,
             image,
             self.script

--- a/PyInstaller/building/splash.py
+++ b/PyInstaller/building/splash.py
@@ -194,6 +194,12 @@ class Splash(Target):
             os.path.join(tcltk_info.TK_ROOTNAME, "ttk", "utils.tcl"),
         ])
 
+        if tcltk_info.tk_version >= (9, 0):
+            self.splash_requirements.update([
+                os.path.join(tcltk_info.TK_ROOTNAME, "scaling.tcl"),
+                os.path.join(tcltk_info.TK_ROOTNAME, "tclIndex"),  # required for auto-load of scaling.tcl
+            ])
+
         logger.info("Collect Tcl/Tk data files for the splash screen")
         tcltk_tree = tcltk_info.data_files  # 3-element tuple TOC
         if self.full_tk:

--- a/PyInstaller/building/splash_templates.py
+++ b/PyInstaller/building/splash_templates.py
@@ -126,7 +126,7 @@ splash_canvas_text = r"""
         -font myFont \
         -tag vartext \
         -anchor sw
-trace variable status_text w \
+trace add variable status_text write \
     [list canvas_text_update .root.canvas vartext]
 set status_text "%(default_text)s"
 """

--- a/PyInstaller/utils/hooks/tcl_tk.py
+++ b/PyInstaller/utils/hooks/tcl_tk.py
@@ -48,12 +48,17 @@ def _get_tcl_tk_info():
     tcl_data_dir = tcl.eval("info library")
 
     # Check if Tcl/Tk is built with multi-threaded support (built with --enable-threads), as indicated by the presence
-    # of optional `threaded` member in `tcl_platform` array.
-    try:
-        tcl.getvar("tcl_platform(threaded)")  # Ignore the actual value.
+    # of optional `threaded` member in `tcl_platform` array. Tcl 9.0 removed the --enable-threads flag, and is always
+    # built with multi-threaded support (and thus the `threaded` array member has been removed).
+    TCL_MAJOR = int(_tkinter.TCL_VERSION.split(".")[0])
+    if TCL_MAJOR >= 9:
         tcl_threaded = True
-    except tkinter.TclError:
-        tcl_threaded = False
+    else:
+        try:
+            tcl.getvar("tcl_platform(threaded)")  # Ignore the actual value.
+            tcl_threaded = True
+        except tkinter.TclError:
+            tcl_threaded = False
 
     return {
         "available": True,

--- a/PyInstaller/utils/hooks/tcl_tk.py
+++ b/PyInstaller/utils/hooks/tcl_tk.py
@@ -285,10 +285,13 @@ class TclTkInfo:
             lib_name = os.path.basename(lib_path)
             lib_name_lower = lib_name.lower()  # lower-case for comparisons
 
-            if 'tcl' in lib_name_lower:
-                tcl_lib = lib_path
-            elif 'tk' in lib_name_lower:
+            # First check for Tk library, because it is unlikely that 'tk' will appear in the name of the Tcl shared
+            # library, while 'tcl' could appear in the name of the Tk shared library. For example, Fedora 43 ships
+            # both Tcl/Tk 8.6 and 9.0, and in the latter, the libraries are named `libtcl9.0.so` and `libtcl9tk9.0.so`.
+            if 'tk' in lib_name_lower:
                 tk_lib = lib_path
+            elif 'tcl' in lib_name_lower:
+                tcl_lib = lib_path
 
         return tcl_lib, tk_lib
 

--- a/bootloader/src/pyi_dylib_tcltk.c
+++ b/bootloader/src/pyi_dylib_tcltk.c
@@ -161,6 +161,7 @@ static int _pyi_dylib_tcltk_import_tcl_symbols(struct DYLIB_TCLTK *dylib)
     }
     _IMPORT_FUNCTION(Tcl_SetVar2Ex)
     _IMPORT_FUNCTION(Tcl_GetObjResult)
+    _IMPORT_FUNCTION(Tcl_SetObjResult)
 
     _IMPORT_FUNCTION(Tcl_EvalFile)
     if (dylib->tcl_major >= 9) {

--- a/bootloader/src/pyi_dylib_tcltk.c
+++ b/bootloader/src/pyi_dylib_tcltk.c
@@ -99,21 +99,30 @@ static int _pyi_dylib_tcltk_import_tcl_symbols(struct DYLIB_TCLTK *dylib)
     /* Function names always contain ASCII characters, so we can safely
      * format ANSI string (obtained via stringification) into wide-char
      * message string. */
-    #define _IMPORT_FUNCTION(name) \
-        PYI_EXT_FUNC_BIND(dylib->handle_tcl, name, dylib->name); \
-        if (!dylib->name) { \
+    #define _IMPORT_FUNCTION_EX(name, dest_name) \
+        PYI_EXT_FUNC_BIND_EX(dylib->handle_tcl, dest_name, name, dylib->dest_name); \
+        if (!dylib->dest_name) { \
             PYI_WINERROR_W(L"GetProcAddress", L"Failed to import symbol %hs from Tcl DLL.\n", #name); \
             return -1; \
         }
 #else
     /* Extend PYI_EXT_FUNC_BIND() with error handling. */
-    #define _IMPORT_FUNCTION(name) \
-        PYI_EXT_FUNC_BIND(dylib->handle_tcl, name, dylib->name); \
-        if (!dylib->name) { \
+    #define _IMPORT_FUNCTION_EX(name, dest_name) \
+        PYI_EXT_FUNC_BIND_EX(dylib->handle_tcl, dest_name, name, dylib->dest_name); \
+        if (!dylib->dest_name) { \
             PYI_ERROR("Failed to import symbol %s from Tcl shared library: %s\n", #name, dlerror()); \
             return -1; \
         }
 #endif
+
+    #define _IMPORT_FUNCTION(name) _IMPORT_FUNCTION_EX(name, name)
+
+    /* Bind the GetVersion function and query the major version of Tcl,
+     * in order to determine whether we should bind functions to prototypes
+     * with 64-bit arguments (Tcl >= 9.0) or 32-bit arguments (Tcl < 9.0). */
+    _IMPORT_FUNCTION(Tcl_GetVersion)
+    dylib->Tcl_GetVersion(&dylib->tcl_major, NULL, NULL, NULL);
+    PYI_DEBUG("DYLIB: binding Tcl with major version %d.\n", dylib->tcl_major);
 
     _IMPORT_FUNCTION(Tcl_Init)
     _IMPORT_FUNCTION(Tcl_CreateInterp)
@@ -123,7 +132,11 @@ static int _pyi_dylib_tcltk_import_tcl_symbols(struct DYLIB_TCLTK *dylib)
     _IMPORT_FUNCTION(Tcl_FinalizeThread)
     _IMPORT_FUNCTION(Tcl_DeleteInterp)
 
-    _IMPORT_FUNCTION(Tcl_CreateThread)
+    if (dylib->tcl_major >= 9) {
+        _IMPORT_FUNCTION_EX(Tcl_CreateThread, Tcl_CreateThread_9)
+    } else {
+        _IMPORT_FUNCTION_EX(Tcl_CreateThread, Tcl_CreateThread_8)
+    }
     _IMPORT_FUNCTION(Tcl_GetCurrentThread)
     _IMPORT_FUNCTION(Tcl_JoinThread)
     _IMPORT_FUNCTION(Tcl_MutexLock)
@@ -139,18 +152,30 @@ static int _pyi_dylib_tcltk_import_tcl_symbols(struct DYLIB_TCLTK *dylib)
     _IMPORT_FUNCTION(Tcl_SetVar2)
     _IMPORT_FUNCTION(Tcl_CreateObjCommand)
     _IMPORT_FUNCTION(Tcl_GetString)
-    _IMPORT_FUNCTION(Tcl_NewStringObj)
-    _IMPORT_FUNCTION(Tcl_NewByteArrayObj)
+    if (dylib->tcl_major >= 9) {
+        _IMPORT_FUNCTION_EX(Tcl_NewStringObj, Tcl_NewStringObj_9)
+        _IMPORT_FUNCTION_EX(Tcl_NewByteArrayObj, Tcl_NewByteArrayObj_9)
+    } else {
+        _IMPORT_FUNCTION_EX(Tcl_NewStringObj, Tcl_NewStringObj_8)
+        _IMPORT_FUNCTION_EX(Tcl_NewByteArrayObj, Tcl_NewByteArrayObj_8)
+    }
     _IMPORT_FUNCTION(Tcl_SetVar2Ex)
     _IMPORT_FUNCTION(Tcl_GetObjResult)
 
     _IMPORT_FUNCTION(Tcl_EvalFile)
-    _IMPORT_FUNCTION(Tcl_EvalEx)
-    _IMPORT_FUNCTION(Tcl_EvalObjv)
-    _IMPORT_FUNCTION(Tcl_Alloc)
+    if (dylib->tcl_major >= 9) {
+        _IMPORT_FUNCTION_EX(Tcl_EvalEx, Tcl_EvalEx_9)
+        _IMPORT_FUNCTION_EX(Tcl_EvalObjv, Tcl_EvalObjv_9)
+        _IMPORT_FUNCTION_EX(Tcl_Alloc, Tcl_Alloc_9)
+    } else {
+        _IMPORT_FUNCTION_EX(Tcl_EvalEx, Tcl_EvalEx_8)
+        _IMPORT_FUNCTION_EX(Tcl_EvalObjv, Tcl_EvalObjv_8)
+        _IMPORT_FUNCTION_EX(Tcl_Alloc, Tcl_Alloc_8)
+    }
     _IMPORT_FUNCTION(Tcl_Free)
 
 #undef _IMPORT_FUNCTION
+#undef _IMPORT_FUNCTION_EX
 
     return 0;
 }

--- a/bootloader/src/pyi_dylib_tcltk.c
+++ b/bootloader/src/pyi_dylib_tcltk.c
@@ -150,6 +150,7 @@ static int _pyi_dylib_tcltk_import_tcl_symbols(struct DYLIB_TCLTK *dylib)
 
     _IMPORT_FUNCTION(Tcl_GetVar2)
     _IMPORT_FUNCTION(Tcl_SetVar2)
+    _IMPORT_FUNCTION(Tcl_UnsetVar2)
     _IMPORT_FUNCTION(Tcl_CreateObjCommand)
     _IMPORT_FUNCTION(Tcl_GetString)
     if (dylib->tcl_major >= 9) {

--- a/bootloader/src/pyi_dylib_tcltk.h
+++ b/bootloader/src/pyi_dylib_tcltk.h
@@ -26,6 +26,8 @@
 
 #include "pyi_global.h"
 
+#include <stddef.h>  /* ptrdiff_t */
+
 /* Macros defined in Tcl and copied over for easier understanding of the code */
 #define TCL_OK 0
 #define TCL_ERROR 1
@@ -82,6 +84,9 @@ typedef enum
  * Tcl shared library and bound functions imported from it.
  */
 
+/* Version */
+PYI_EXT_FUNC_PROTO(void, Tcl_GetVersion, (int *, int *, int *, int *))
+
 /* Tcl Initialization/Destruction */
 PYI_EXT_FUNC_PROTO(int, Tcl_Init, (Tcl_Interp *))
 PYI_EXT_FUNC_PROTO(Tcl_Interp*, Tcl_CreateInterp, (void))
@@ -92,7 +97,8 @@ PYI_EXT_FUNC_PROTO(void, Tcl_FinalizeThread, (void))
 PYI_EXT_FUNC_PROTO(void, Tcl_DeleteInterp, (Tcl_Interp *))
 
 /* Threading */
-PYI_EXT_FUNC_PROTO(int, Tcl_CreateThread, (Tcl_ThreadId *, Tcl_ThreadCreateProc *, ClientData, int, int))
+PYI_EXT_FUNC_PROTO(int, Tcl_CreateThread_8, (Tcl_ThreadId *, Tcl_ThreadCreateProc *, ClientData, unsigned, int)) /* Tcl < 9.0: 32-bit stackSize argument */
+PYI_EXT_FUNC_PROTO(int, Tcl_CreateThread_9, (Tcl_ThreadId *, Tcl_ThreadCreateProc *, ClientData, size_t, int)) /* Tcl >= 9.0: 64-bit stackSize argument */
 PYI_EXT_FUNC_PROTO(Tcl_ThreadId, Tcl_GetCurrentThread, (void))
 PYI_EXT_FUNC_PROTO(int, Tcl_JoinThread, (Tcl_ThreadId, int *))
 PYI_EXT_FUNC_PROTO(void, Tcl_MutexLock, (Tcl_Mutex *))
@@ -101,7 +107,7 @@ PYI_EXT_FUNC_PROTO(void, Tcl_MutexFinalize, (Tcl_Mutex *))
 PYI_EXT_FUNC_PROTO(void, Tcl_ConditionFinalize, (Tcl_Condition *))
 PYI_EXT_FUNC_PROTO(void, Tcl_ConditionNotify, (Tcl_Condition *))
 PYI_EXT_FUNC_PROTO(void, Tcl_ConditionWait, (Tcl_Condition *, Tcl_Mutex *, const Tcl_Time *))
-PYI_EXT_FUNC_PROTO(void, Tcl_ThreadQueueEvent, (Tcl_ThreadId, Tcl_Event *, Tcl_QueuePosition))
+PYI_EXT_FUNC_PROTO(void, Tcl_ThreadQueueEvent, (Tcl_ThreadId, Tcl_Event *, int))
 PYI_EXT_FUNC_PROTO(void, Tcl_ThreadAlert, (Tcl_ThreadId threadId))
 
 /* Tcl interpreter manipulation */
@@ -109,16 +115,21 @@ PYI_EXT_FUNC_PROTO(const char*, Tcl_GetVar2, (Tcl_Interp *, const char *, const 
 PYI_EXT_FUNC_PROTO(const char*, Tcl_SetVar2, (Tcl_Interp *, const char *, const char *, const char *, int))
 PYI_EXT_FUNC_PROTO(Tcl_Command, Tcl_CreateObjCommand, (Tcl_Interp *, const char *, Tcl_ObjCmdProc *, ClientData, Tcl_CmdDeleteProc *))
 PYI_EXT_FUNC_PROTO(char *, Tcl_GetString, (Tcl_Obj *))
-PYI_EXT_FUNC_PROTO(Tcl_Obj *, Tcl_NewStringObj, (const char *, int))
-PYI_EXT_FUNC_PROTO(Tcl_Obj *, Tcl_NewByteArrayObj, (const unsigned char *, int))
+PYI_EXT_FUNC_PROTO(Tcl_Obj *, Tcl_NewStringObj_8, (const char *, int)) /* Tcl < 9.0: 32-bit length argument */
+PYI_EXT_FUNC_PROTO(Tcl_Obj *, Tcl_NewStringObj_9, (const char *, ptrdiff_t)) /* Tcl >= 9.0: 64-bit length argument */
+PYI_EXT_FUNC_PROTO(Tcl_Obj *, Tcl_NewByteArrayObj_8, (const unsigned char *, int)) /* Tcl < 9.0: 32-bit numBytes argument */
+PYI_EXT_FUNC_PROTO(Tcl_Obj *, Tcl_NewByteArrayObj_9, (const unsigned char *, ptrdiff_t)) /* Tcl >= 9.0: 64-bit numBytes argument */
 PYI_EXT_FUNC_PROTO(Tcl_Obj *, Tcl_SetVar2Ex, (Tcl_Interp *, const char *, const char *, Tcl_Obj *, int))
 PYI_EXT_FUNC_PROTO(Tcl_Obj *, Tcl_GetObjResult, (Tcl_Interp *))
 
 /* Evaluating scripts and memory functions */
 PYI_EXT_FUNC_PROTO(int, Tcl_EvalFile, (Tcl_Interp *, const char *))
-PYI_EXT_FUNC_PROTO(int, Tcl_EvalEx, (Tcl_Interp *, const char *, int, int))
-PYI_EXT_FUNC_PROTO(int, Tcl_EvalObjv, (Tcl_Interp *, int, Tcl_Obj * const[], int))
-PYI_EXT_FUNC_PROTO(char *, Tcl_Alloc, (unsigned int))
+PYI_EXT_FUNC_PROTO(int, Tcl_EvalEx_8, (Tcl_Interp *, const char *, int, int)) /* Tcl < 9.0: 32-bit numBytes argument */
+PYI_EXT_FUNC_PROTO(int, Tcl_EvalEx_9, (Tcl_Interp *, const char *, ptrdiff_t, int)) /* Tcl >= 9.0: 64-bit numBytes argument */
+PYI_EXT_FUNC_PROTO(int, Tcl_EvalObjv_8, (Tcl_Interp *, int, Tcl_Obj * const[], int)) /* Tcl < 9.0: 32-bit objc argument */
+PYI_EXT_FUNC_PROTO(int, Tcl_EvalObjv_9, (Tcl_Interp *, ptrdiff_t, Tcl_Obj * const[], int)) /* Tcl >= 9.0: 64-bit objc argument */
+PYI_EXT_FUNC_PROTO(char *, Tcl_Alloc_8, (unsigned)) /* Tcl < 9.0: 32-bit size argument */
+PYI_EXT_FUNC_PROTO(char *, Tcl_Alloc_9, (size_t)) /* Tcl >= 9.0: 64-bit size argument */
 PYI_EXT_FUNC_PROTO(void, Tcl_Free, (char *))
 
 /* Tk functions */
@@ -132,7 +143,12 @@ struct DYLIB_TCLTK
     pyi_dylib_t handle_tcl;
     pyi_dylib_t handle_tk;
 
+    /* Major version of Tcl */
+    int tcl_major;
+
     /* Function pointers for imported functions: Tcl */
+    PYI_EXT_FUNC_ENTRY(Tcl_GetVersion)
+
     PYI_EXT_FUNC_ENTRY(Tcl_Init)
     PYI_EXT_FUNC_ENTRY(Tcl_CreateInterp)
     PYI_EXT_FUNC_ENTRY(Tcl_FindExecutable)
@@ -141,7 +157,8 @@ struct DYLIB_TCLTK
     PYI_EXT_FUNC_ENTRY(Tcl_FinalizeThread)
     PYI_EXT_FUNC_ENTRY(Tcl_DeleteInterp)
 
-    PYI_EXT_FUNC_ENTRY(Tcl_CreateThread)
+    PYI_EXT_FUNC_ENTRY(Tcl_CreateThread_8)
+    PYI_EXT_FUNC_ENTRY(Tcl_CreateThread_9)
     PYI_EXT_FUNC_ENTRY(Tcl_GetCurrentThread)
     PYI_EXT_FUNC_ENTRY(Tcl_JoinThread)
     PYI_EXT_FUNC_ENTRY(Tcl_MutexLock)
@@ -157,15 +174,20 @@ struct DYLIB_TCLTK
     PYI_EXT_FUNC_ENTRY(Tcl_SetVar2)
     PYI_EXT_FUNC_ENTRY(Tcl_CreateObjCommand)
     PYI_EXT_FUNC_ENTRY(Tcl_GetString)
-    PYI_EXT_FUNC_ENTRY(Tcl_NewStringObj)
-    PYI_EXT_FUNC_ENTRY(Tcl_NewByteArrayObj)
+    PYI_EXT_FUNC_ENTRY(Tcl_NewStringObj_8)
+    PYI_EXT_FUNC_ENTRY(Tcl_NewStringObj_9)
+    PYI_EXT_FUNC_ENTRY(Tcl_NewByteArrayObj_8)
+    PYI_EXT_FUNC_ENTRY(Tcl_NewByteArrayObj_9)
     PYI_EXT_FUNC_ENTRY(Tcl_SetVar2Ex)
     PYI_EXT_FUNC_ENTRY(Tcl_GetObjResult)
 
     PYI_EXT_FUNC_ENTRY(Tcl_EvalFile)
-    PYI_EXT_FUNC_ENTRY(Tcl_EvalEx)
-    PYI_EXT_FUNC_ENTRY(Tcl_EvalObjv)
-    PYI_EXT_FUNC_ENTRY(Tcl_Alloc)
+    PYI_EXT_FUNC_ENTRY(Tcl_EvalEx_8)
+    PYI_EXT_FUNC_ENTRY(Tcl_EvalEx_9)
+    PYI_EXT_FUNC_ENTRY(Tcl_EvalObjv_8)
+    PYI_EXT_FUNC_ENTRY(Tcl_EvalObjv_9)
+    PYI_EXT_FUNC_ENTRY(Tcl_Alloc_8)
+    PYI_EXT_FUNC_ENTRY(Tcl_Alloc_9)
     PYI_EXT_FUNC_ENTRY(Tcl_Free)
 
     /* Function pointers for imported functions: Tk */

--- a/bootloader/src/pyi_dylib_tcltk.h
+++ b/bootloader/src/pyi_dylib_tcltk.h
@@ -121,6 +121,7 @@ PYI_EXT_FUNC_PROTO(Tcl_Obj *, Tcl_NewByteArrayObj_8, (const unsigned char *, int
 PYI_EXT_FUNC_PROTO(Tcl_Obj *, Tcl_NewByteArrayObj_9, (const unsigned char *, ptrdiff_t)) /* Tcl >= 9.0: 64-bit numBytes argument */
 PYI_EXT_FUNC_PROTO(Tcl_Obj *, Tcl_SetVar2Ex, (Tcl_Interp *, const char *, const char *, Tcl_Obj *, int))
 PYI_EXT_FUNC_PROTO(Tcl_Obj *, Tcl_GetObjResult, (Tcl_Interp *))
+PYI_EXT_FUNC_PROTO(void, Tcl_SetObjResult, (Tcl_Interp *, Tcl_Obj *))
 
 /* Evaluating scripts and memory functions */
 PYI_EXT_FUNC_PROTO(int, Tcl_EvalFile, (Tcl_Interp *, const char *))
@@ -180,6 +181,7 @@ struct DYLIB_TCLTK
     PYI_EXT_FUNC_ENTRY(Tcl_NewByteArrayObj_9)
     PYI_EXT_FUNC_ENTRY(Tcl_SetVar2Ex)
     PYI_EXT_FUNC_ENTRY(Tcl_GetObjResult)
+    PYI_EXT_FUNC_ENTRY(Tcl_SetObjResult)
 
     PYI_EXT_FUNC_ENTRY(Tcl_EvalFile)
     PYI_EXT_FUNC_ENTRY(Tcl_EvalEx_8)

--- a/bootloader/src/pyi_dylib_tcltk.h
+++ b/bootloader/src/pyi_dylib_tcltk.h
@@ -113,6 +113,7 @@ PYI_EXT_FUNC_PROTO(void, Tcl_ThreadAlert, (Tcl_ThreadId threadId))
 /* Tcl interpreter manipulation */
 PYI_EXT_FUNC_PROTO(const char*, Tcl_GetVar2, (Tcl_Interp *, const char *, const char *, int))
 PYI_EXT_FUNC_PROTO(const char*, Tcl_SetVar2, (Tcl_Interp *, const char *, const char *, const char *, int))
+PYI_EXT_FUNC_PROTO(int, Tcl_UnsetVar2, (Tcl_Interp *, const char *, const char *, int))
 PYI_EXT_FUNC_PROTO(Tcl_Command, Tcl_CreateObjCommand, (Tcl_Interp *, const char *, Tcl_ObjCmdProc *, ClientData, Tcl_CmdDeleteProc *))
 PYI_EXT_FUNC_PROTO(char *, Tcl_GetString, (Tcl_Obj *))
 PYI_EXT_FUNC_PROTO(Tcl_Obj *, Tcl_NewStringObj_8, (const char *, int)) /* Tcl < 9.0: 32-bit length argument */
@@ -173,6 +174,7 @@ struct DYLIB_TCLTK
 
     PYI_EXT_FUNC_ENTRY(Tcl_GetVar2)
     PYI_EXT_FUNC_ENTRY(Tcl_SetVar2)
+    PYI_EXT_FUNC_ENTRY(Tcl_UnsetVar2)
     PYI_EXT_FUNC_ENTRY(Tcl_CreateObjCommand)
     PYI_EXT_FUNC_ENTRY(Tcl_GetString)
     PYI_EXT_FUNC_ENTRY(Tcl_NewStringObj_8)

--- a/bootloader/src/pyi_global.h
+++ b/bootloader/src/pyi_global.h
@@ -61,6 +61,8 @@
  *    to bind the function (using GetProcAddress on Windows, dlsym on
  *    other platforms).. The destination location is typically a field in
  *    function-table structure, defined via PYI_EXT_FUNC_ENTRY.
+ *  - PYI_EXT_FUNC_BIND_EX: same as above, but with additional argument
+ *    that specifies the type name that was used with PYI_EXT_FUNC_ENTRY.
  */
 #ifdef _WIN32
     typedef HMODULE pyi_dylib_t;
@@ -73,8 +75,8 @@
 
     /* GetProcAddress() returns FARPROC, a function pointer, which can
      * be cast to a different function pointer. */
-    #define PYI_EXT_FUNC_BIND(handle, name, dest) \
-        dest = (_PYI_ ## name ## _TYPE)GetProcAddress(handle, #name);
+    #define PYI_EXT_FUNC_BIND_EX(handle, type, name, dest) \
+        dest = (_PYI_ ## type ## _TYPE)GetProcAddress(handle, #name);
 
 #else /* ifdef _WIN32 */
     #include <dlfcn.h> /* dlsym(), dlerror() */
@@ -93,11 +95,11 @@
      * in practice, the cast should be safe on contemporary platforms).
      * To avoid warnings when using gcc with -pedantic option turned on,
      * we perform type-punning through union. */
-    #define PYI_EXT_FUNC_BIND(handle, name, dest) \
+    #define PYI_EXT_FUNC_BIND_EX(handle, type, name, dest) \
         do {\
             /* This union requires its own scope */ \
             union { \
-                _PYI_ ## name ## _TYPE func_ptr; \
+                _PYI_ ## type ## _TYPE func_ptr; \
                 void *obj_ptr; \
             } alias; \
             /* Store object pointer */ \
@@ -107,6 +109,10 @@
         } while(0)
 
 #endif  /* ifdef _WIN32 */
+
+/* This simplified macro assumes that the type name passed to the
+ * PYI_EXT_FUNC_ENTRY matches the symbol name. */
+#define PYI_EXT_FUNC_BIND(handle, name, dest) PYI_EXT_FUNC_BIND_EX(handle, name, name, dest)
 
 
 /*

--- a/bootloader/src/pyi_global.h
+++ b/bootloader/src/pyi_global.h
@@ -222,6 +222,7 @@
 /* MSVC provides _stricmp() in-lieu of POSIX strcasecmp() */
 #if defined(_WIN32) && defined(_MSC_VER)
     #define strcasecmp(string1, string2) _stricmp(string1, string2)
+    #define strncasecmp(string1, string2, count) _strnicmp(string1, string2, count)
 #endif
 
 /* Byte-order conversion macros */

--- a/bootloader/src/pyi_splash.c
+++ b/bootloader/src/pyi_splash.c
@@ -180,6 +180,7 @@ int
 pyi_splash_start(struct SPLASH_CONTEXT *splash, const char *executable)
 {
     const struct DYLIB_TCLTK *dylib_tcltk = splash->dylib_tcltk;
+    int ret;
 
     /* Make sure shared libraries have been loaded and their symbols
      * bound. */
@@ -213,13 +214,24 @@ pyi_splash_start(struct SPLASH_CONTEXT *splash, const char *executable)
      * methods provided by Tcl. This function will return TCL_ERROR if it is
      * either not implemented (Tcl is not threaded) or an error occurs.
      * Since we only support threaded Tcl, the error is fatal. */
-    if (dylib_tcltk->Tcl_CreateThread(
-        &splash->thread_id, /* location to store thread ID */
-        _splash_init, /* procedure/function to run in the new thread */
-        splash, /* parameters to pass to procedure */
-        0, /* use default stack size */
-        splash->thread_joinable ? TCL_THREAD_JOINABLE : TCL_THREAD_NOFLAGS /* flags */
-    ) != TCL_OK) {
+     if (dylib_tcltk->tcl_major >= 9) {
+         ret = dylib_tcltk->Tcl_CreateThread_9(
+            &splash->thread_id, /* location to store thread ID */
+            _splash_init, /* procedure/function to run in the new thread */
+            splash, /* parameters to pass to procedure */
+            0, /* use default stack size */
+            splash->thread_joinable ? TCL_THREAD_JOINABLE : TCL_THREAD_NOFLAGS /* flags */
+        );
+    } else {
+        ret = dylib_tcltk->Tcl_CreateThread_8(
+            &splash->thread_id, /* location to store thread ID */
+            _splash_init, /* procedure/function to run in the new thread */
+            splash, /* parameters to pass to procedure */
+            0, /* use default stack size */
+            splash->thread_joinable ? TCL_THREAD_JOINABLE : TCL_THREAD_NOFLAGS /* flags */
+        );
+    }
+    if (ret != TCL_OK) {
         PYI_ERROR("SPLASH: Tcl is not threaded. Only threaded Tcl is supported.\n");
         dylib_tcltk->Tcl_MutexUnlock(&splash->context_mutex);
         pyi_splash_finalize(splash);
@@ -638,12 +650,18 @@ pyi_splash_update_text(struct SPLASH_CONTEXT *splash, const char *text)
 int
 pyi_splash_send(struct SPLASH_CONTEXT *splash, bool async, const void *user_data, pyi_splash_event_proc proc)
 {
+    const struct DYLIB_TCLTK *dylib_tcltk = splash->dylib_tcltk;
+
     int rc = 0;
     struct Splash_Event *ev;
     Tcl_Condition cond = NULL;
 
     /* Tcl will free this event once it was serviced. */
-    ev = (struct Splash_Event *)splash->dylib_tcltk->Tcl_Alloc(sizeof(struct Splash_Event));
+    if (dylib_tcltk->tcl_major >= 9) {
+        ev = (struct Splash_Event *)dylib_tcltk->Tcl_Alloc_9(sizeof(struct Splash_Event));
+    } else {
+        ev = (struct Splash_Event *)dylib_tcltk->Tcl_Alloc_8(sizeof(struct Splash_Event));
+    }
 
     ev->ev.proc = (Tcl_EventProc *)_splash_event_proc;
     ev->splash = splash;
@@ -660,7 +678,7 @@ pyi_splash_send(struct SPLASH_CONTEXT *splash, bool async, const void *user_data
     _splash_event_send(splash, (Tcl_Event *)ev, &cond, &splash->call_mutex, async);
 
     if (!async) {
-        splash->dylib_tcltk->Tcl_ConditionFinalize(&cond);
+        dylib_tcltk->Tcl_ConditionFinalize(&cond);
     }
     return rc;
 }
@@ -772,15 +790,24 @@ _tcl_source_Command(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj
     if (pyi_path_exists(dylib_tcltk->Tcl_GetString(objv[objc - 1]))) {
         /* Create a new objv array for the original source command
          * named _source. */
-        _source_objv = (Tcl_Obj **)dylib_tcltk->Tcl_Alloc(sizeof(Tcl_Obj *) * objc);
-        _source_objv[0] = dylib_tcltk->Tcl_NewStringObj("_source", -1);
+        if (dylib_tcltk->tcl_major >= 9) {
+            _source_objv = (Tcl_Obj **)dylib_tcltk->Tcl_Alloc_9(sizeof(Tcl_Obj *) * objc);
+            _source_objv[0] = dylib_tcltk->Tcl_NewStringObj_9("_source", -1);
+        } else {
+            _source_objv = (Tcl_Obj **)dylib_tcltk->Tcl_Alloc_8(sizeof(Tcl_Obj *) * objc);
+            _source_objv[0] = dylib_tcltk->Tcl_NewStringObj_8("_source", -1);
+        }
 
         for (i = 1; i < objc; i++) {
             _source_objv[i] = objv[i];
         }
 
         /* Execute `_source` with the given arguments */
-        rc = dylib_tcltk->Tcl_EvalObjv(interp, objc, _source_objv, 0);
+        if (dylib_tcltk->tcl_major >= 9) {
+            rc = dylib_tcltk->Tcl_EvalObjv_9(interp, objc, _source_objv, 0);
+        } else {
+            rc = dylib_tcltk->Tcl_EvalObjv_8(interp, objc, _source_objv, 0);
+        }
         dylib_tcltk->Tcl_Free((char *) _source_objv);
 
         return rc;
@@ -872,7 +899,11 @@ _splash_init(ClientData client_data)
     ) == NULL;
 
     /* Replace `source` command for use in minimal environment. */
-    dylib_tcltk->Tcl_EvalEx(splash->interp, "rename ::source ::_source", -1, 0);
+    if (dylib_tcltk->tcl_major >= 9) {
+        dylib_tcltk->Tcl_EvalEx_9(splash->interp, "rename ::source ::_source", -1, 0);
+    } else {
+        dylib_tcltk->Tcl_EvalEx_8(splash->interp, "rename ::source ::_source", -1, 0);
+    }
     err |= dylib_tcltk->Tcl_CreateObjCommand(
         splash->interp,
         "source",
@@ -915,14 +946,22 @@ _splash_init(ClientData client_data)
 
     /* Extract the image from the splash resources, and pass it to Tcl/Tk
      * via the `_image_data` variable. */
-    image_data_obj = dylib_tcltk->Tcl_NewByteArrayObj(splash->image, splash->image_len);
+    if (dylib_tcltk->tcl_major >= 9) {
+        image_data_obj = dylib_tcltk->Tcl_NewByteArrayObj_9(splash->image, splash->image_len);
+    } else {
+        image_data_obj = dylib_tcltk->Tcl_NewByteArrayObj_8(splash->image, splash->image_len);
+    }
     dylib_tcltk->Tcl_SetVar2Ex(splash->interp, "_image_data", NULL, image_data_obj, TCL_GLOBAL_ONLY);
 
     /* Tcl/Tk creates a copy of the image, so we can free our buffer */
     free(splash->image);
     splash->image = NULL;
 
-    err = dylib_tcltk->Tcl_EvalEx(splash->interp, splash->script, splash->script_len, TCL_GLOBAL_ONLY);
+    if (dylib_tcltk->tcl_major >= 9) {
+        err = dylib_tcltk->Tcl_EvalEx_9(splash->interp, splash->script, splash->script_len, TCL_GLOBAL_ONLY);
+    } else {
+        err = dylib_tcltk->Tcl_EvalEx_8(splash->interp, splash->script, splash->script_len, TCL_GLOBAL_ONLY);
+    }
 
     if (err) {
         PYI_DEBUG("SPLASH: Tcl error: %s\n", dylib_tcltk->Tcl_GetString(dylib_tcltk->Tcl_GetObjResult(splash->interp)));

--- a/bootloader/src/pyi_splash.c
+++ b/bootloader/src/pyi_splash.c
@@ -97,22 +97,29 @@ pyi_splash_setup(struct SPLASH_CONTEXT *splash, const struct PYI_CONTEXT *pyi_ct
     strncpy(splash->application_home_dir, pyi_ctx->application_home_dir, PYI_PATH_MAX); /* both buffers are guaranteed to be PYI_PATH_MAX-sized */
 
     /* Tcl shared library */
-    if (pyi_path_join(splash->tcl_shared_library, pyi_ctx->application_home_dir, data_header->tcl_libname) == NULL) {
+    if (pyi_path_join(splash->tcl_shared_library, pyi_ctx->application_home_dir, data_header->tcl_shared_library_name) == NULL) {
         PYI_WARNING("SPLASH: length of Tcl shared library path exceeds maximum path length!\n");
         free(data_header);
         return -1;
     }
 
     /* Tk shared library */
-    if (pyi_path_join(splash->tk_shared_library, pyi_ctx->application_home_dir, data_header->tk_libname) == NULL) {
+    if (pyi_path_join(splash->tk_shared_library, pyi_ctx->application_home_dir, data_header->tk_shared_library_name) == NULL) {
         PYI_WARNING("SPLASH: length of Tk shared library path exceeds maximum path length!\n");
         free(data_header);
         return -1;
     }
 
+    /* Tcl modules directory */
+    if (pyi_path_join(splash->tcl_modules_dir, pyi_ctx->application_home_dir, data_header->tcl_module_directory_name) == NULL) {
+        PYI_WARNING("SPLASH: length of Tcl module directory path exceeds maximum path length!\n");
+        free(data_header);
+        return -1;
+    }
+
     /* Tk modules directory */
-    if (pyi_path_join(splash->tk_modules_dir, pyi_ctx->application_home_dir, data_header->tk_lib) == NULL) {
-        PYI_WARNING("SPLASH: length of Tk shared library path exceeds maximum path length!\n");
+    if (pyi_path_join(splash->tk_modules_dir, pyi_ctx->application_home_dir, data_header->tk_module_directory_name) == NULL) {
+        PYI_WARNING("SPLASH: length of Tk module directory path exceeds maximum path length!\n");
         free(data_header);
         return -1;
     }

--- a/bootloader/src/pyi_splash.c
+++ b/bootloader/src/pyi_splash.c
@@ -703,20 +703,74 @@ pyi_splash_send(struct SPLASH_CONTEXT *splash, bool async, const void *user_data
  * instead.
  *
  * We override the internal function, because we want to run Tcl in a very
- * minimal environment and do not want to initialize the standard library.
+ * minimal environment.
  */
 static int
 _tclInit_Command(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
     /**
-     * This function would normally do a search in some common and
-     * specific paths to find an `init.tcl` file. Once found, every script
-     * next to it would be executed (`auto.tcl`, `clock.tcl`, etc.) to
-     * define the standard library.
-     * This initialization script would normally set `$auto_path` to be
-     * the folder where `init.tcl` was found, usually the `tclX.Y` directory
-     * inside python's Tcl distribution directory.
-     */
+     * Execute the collected `init.tcl` script in order to set up Tcl's
+     * command auto-load mechanism (the `undefined` handler, the
+     * `auto_path` variable, etc).
+     *
+     * This overrides the default implementation, which searches for the
+     * `init.tcl` script in several pre-defined locations. In our case,
+     * we know exactly where to find it; similarly, we also know that all
+     * our .tcl modules are available in only one location, so try to
+     * restrict the auto-load search paths as much as possible.
+     *
+     * In earlier versions of splash screen, the implementation of this
+     * function was a no-op. However, with Tcl/Tk >= 9, it seems that the
+     * `Tk_init()` function and the modules it loads expect to be able
+     * to auto-load some of the commands provided by other Tk modules.
+     * While we could provide implementation of `undefined` handler that
+     * statically resolves the couple of commands required by the Tk
+     * modules used by splash screen, this does not work when full Tk
+     * is bundled with the application (either because this is onedir
+     * application that uses `tkinter`, or because full collection was
+     * enabled via `full_tk` flag passed to splash screen build options;
+     * in that case, additional modules are loaded (see our override
+     * for `source` command), with additional dependencies. Therefore,
+     * at least at the moment, it seems more reasonable to use the
+     * auto-load mechanism provided by `init.tcl`. */
+    int rc;
+    struct SPLASH_CONTEXT *splash = (struct SPLASH_CONTEXT *)clientData;
+    const struct DYLIB_TCLTK *dylib_tcltk = splash->dylib_tcltk;
+    char init_script_path[PYI_PATH_MAX];
+
+    /* Set tcl_library variable */
+    dylib_tcltk->Tcl_SetVar2(interp, "tcl_library", NULL, splash->tcl_modules_dir, TCL_GLOBAL_ONLY);
+
+    /* Unset tcl_pkgPath variable, to prevent paths from it from being
+     * added to the auto_path by init.tcl. On POSIX platforms, this variable
+     * contains hard-coded paths to system directories. */
+    dylib_tcltk->Tcl_UnsetVar2(interp, "tcl_pkgPath", NULL, TCL_GLOBAL_ONLY);
+
+    /* Initialize auto_path variable with empty string. This prevents
+     * `init.tcl` from trying to initialize it from `TCLLIBPATH`
+     * environment variable, if the latter happens to be available.
+     * See: https://github.com/tcltk/tcl/blob/core-9-0-0/library/init.tcl#L44-L58 */
+    dylib_tcltk->Tcl_SetVar2(interp, "auto_path", NULL, "", TCL_GLOBAL_ONLY);
+
+    /* Run the init.tcl file */
+    pyi_path_join(init_script_path, splash->tcl_modules_dir, "init.tcl");
+    rc = dylib_tcltk->Tcl_EvalFile(interp, init_script_path);
+    if (rc == TCL_OK) {
+        PYI_DEBUG("TCL: 'tclInit' command: init.tcl successfully loaded.\n");
+    } else {
+        PYI_DEBUG("TCL: 'tclInit' command: init.tcl failed to load with status code %d and message: %s.\n", rc, dylib_tcltk->Tcl_GetString(dylib_tcltk->Tcl_GetObjResult(splash->interp)));
+        return rc;
+    }
+
+    /* On Windows, `init.tcl` seems to add not only `tcl_library` to the
+     * `auto_path`, but also its parent directory as well as `../lib`
+     * directory relative to the executable's location. In our restricted
+     * interpreter, we want none of that - so re-set the `auto_path` to
+     * contain only the `tcl_library` location. */
+    dylib_tcltk->Tcl_SetVar2(interp, "auto_path", NULL, splash->tcl_modules_dir, TCL_GLOBAL_ONLY);
+
+    PYI_DEBUG("TCL: 'tclInit' command: 'auto_path' after init: %s\n", dylib_tcltk->Tcl_GetVar2(splash->interp, "auto_path", NULL, TCL_GLOBAL_ONLY));
+
     return TCL_OK;
 }
 

--- a/bootloader/src/pyi_splash.c
+++ b/bootloader/src/pyi_splash.c
@@ -93,6 +93,9 @@ pyi_splash_setup(struct SPLASH_CONTEXT *splash, const struct PYI_CONTEXT *pyi_ct
      * process uses zero padding and is ensuring that strings themselves
      * have no more than N-1 characters long. */
 
+    /* Top-level application directory */
+    strncpy(splash->application_home_dir, pyi_ctx->application_home_dir, PYI_PATH_MAX); /* both buffers are guaranteed to be PYI_PATH_MAX-sized */
+
     /* Tcl shared library */
     if (pyi_path_join(splash->tcl_libpath, pyi_ctx->application_home_dir, data_header->tcl_libname) == NULL) {
         PYI_WARNING("SPLASH: length of Tcl shared library path exceeds maximum path length!\n");
@@ -782,12 +785,72 @@ _tcl_source_Command(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj
     struct SPLASH_CONTEXT *splash = (struct SPLASH_CONTEXT *)clientData;
     const struct DYLIB_TCLTK *dylib_tcltk = splash->dylib_tcltk;
     Tcl_Obj **_source_objv;
+    char *filename;
     int rc;
     int i;
 
-    /* Check if the file to be sourced exists. The filename
-     * is always the last (objc-1) parameter passed to the command */
-    if (pyi_path_exists(dylib_tcltk->Tcl_GetString(objv[objc - 1]))) {
+#if defined(LAUNCH_DEBUG)
+    PYI_DEBUG("TCL: 'source' command:\n");
+    for (i = 0; i < objc; i++) {
+        PYI_DEBUG("TCL:  - arg[%i]: %s\n", i, dylib_tcltk->Tcl_GetString(objv[i]));
+    }
+#endif
+
+    /* The filename is always the last (objc-1) parameter passed to the
+     * source command. */
+     filename = dylib_tcltk->Tcl_GetString(objv[objc - 1]);
+
+    /* Prevent loading of files that are outside of the top-level application
+     * directory. This would indicate issues with interpreter setup, which is
+     * supposed to be completely isolated. On Windows and macOS, use case-insensitive
+     * comparison to simulate case-insensitive filesystem. On Windows, we must also
+     * normalize separators, because Tcl appears to be using POSIX-style forward slash. */
+    if (1) {
+        bool ok;
+
+#if defined(_WIN32)
+        char normalized_filename[PYI_PATH_MAX];
+        if (snprintf(normalized_filename, PYI_PATH_MAX, "%s", filename) >= PYI_PATH_MAX) {
+            Tcl_Obj *error_obj;
+            PYI_DEBUG("TCL: 'source' command: path to file %s is too long!\n", filename);
+            if (dylib_tcltk->tcl_major >= 9) {
+                error_obj = dylib_tcltk->Tcl_NewStringObj_9("attempted to source file with path that exceeds maximum buffer size", -1);
+            } else {
+                error_obj = dylib_tcltk->Tcl_NewStringObj_8("attempted to source file with path that exceeds maximum buffer size", -1);
+            }
+            dylib_tcltk->Tcl_SetObjResult(interp, error_obj);
+            return TCL_ERROR;
+        } else {
+            char *p = normalized_filename;
+            while (*p != 0) {
+                if (*p == '/') {
+                    *p = '\\';
+                }
+                p++;
+            }
+            ok = strncasecmp(normalized_filename, splash->application_home_dir, strlen(splash->application_home_dir)) == 0;
+        }
+#elif defined(__APPLE__)
+        ok = strncasecmp(filename, splash->application_home_dir, strlen(splash->application_home_dir)) == 0;
+#else
+        ok = strncmp(filename, splash->application_home_dir, strlen(splash->application_home_dir)) == 0;
+#endif
+
+        if (!ok) {
+            Tcl_Obj *error_obj;
+            PYI_DEBUG("TCL: 'source' command: file %s is not rooted in top-level application directory (%s) - raising error!\n", filename, splash->application_home_dir);
+            if (dylib_tcltk->tcl_major >= 9) {
+                error_obj = dylib_tcltk->Tcl_NewStringObj_9("attempted to source file outside of top-level application directory", -1);
+            } else {
+                error_obj = dylib_tcltk->Tcl_NewStringObj_8("attempted to source file outside of top-level application directory", -1);
+            }
+            dylib_tcltk->Tcl_SetObjResult(interp, error_obj);
+            return TCL_ERROR;
+        }
+    }
+
+    /* Check if the file to be sourced exists. */
+    if (pyi_path_exists(filename)) {
         /* Create a new objv array for the original source command
          * named _source. */
         if (dylib_tcltk->tcl_major >= 9) {
@@ -803,19 +866,25 @@ _tcl_source_Command(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj
         }
 
         /* Execute `_source` with the given arguments */
+        PYI_DEBUG("TCL: 'source' command: loading file: %s\n", filename);
         if (dylib_tcltk->tcl_major >= 9) {
             rc = dylib_tcltk->Tcl_EvalObjv_9(interp, objc, _source_objv, 0);
         } else {
             rc = dylib_tcltk->Tcl_EvalObjv_8(interp, objc, _source_objv, 0);
         }
         dylib_tcltk->Tcl_Free((char *) _source_objv);
+        if (rc == TCL_OK) {
+            PYI_DEBUG("TCL: 'source' command: file %s successfully loaded.\n", filename);
+        } else {
+            PYI_DEBUG("TCL: 'source' command: file %s failed to load with status code %d and message: %s.\n", filename, rc, dylib_tcltk->Tcl_GetString(dylib_tcltk->Tcl_GetObjResult(splash->interp)));
+        }
 
         return rc;
     }
 
     /* If the file does not exist, we return OK */
+    PYI_DEBUG("TCL: 'source' command: file %s does not exist - ignoring.\n", filename);
     return TCL_OK;
-
 }
 
 /*

--- a/bootloader/src/pyi_splash.c
+++ b/bootloader/src/pyi_splash.c
@@ -754,6 +754,7 @@ _tclInit_Command(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *c
 
     /* Run the init.tcl file */
     pyi_path_join(init_script_path, splash->tcl_modules_dir, "init.tcl");
+    PYI_DEBUG("TCL: 'tclInit' command: running init.tcl from: %s\n", init_script_path);
     rc = dylib_tcltk->Tcl_EvalFile(interp, init_script_path);
     if (rc == TCL_OK) {
         PYI_DEBUG("TCL: 'tclInit' command: init.tcl successfully loaded.\n");
@@ -808,20 +809,35 @@ _tcl_findLibrary_Command(ClientData clientData, Tcl_Interp *interp, int objc, Tc
     const struct DYLIB_TCLTK *dylib_tcltk = splash->dylib_tcltk;
     char init_script_path[PYI_PATH_MAX];
 
+#if defined(LAUNCH_DEBUG)
+    int i;
+    PYI_DEBUG("TCL: 'findLibrary' command:\n");
+    for (i = 0; i < objc; i++) {
+        PYI_DEBUG("TCL:  - arg[%i]: %s\n", i, dylib_tcltk->Tcl_GetString(objv[i]));
+    }
+#endif
+
     /* In our minimal environment, this function is only called once,
      * from Tk_Init. So we only implement the behavior for Tk. Other
      * libraries are therefore not supported. We do not check the version
      * of `tk`, since the library packed by PyInstaller at build time is
      * guaranteed to be compatible. */
     if (strncmp(dylib_tcltk->Tcl_GetString(objv[4]), "tk.tcl", 64) == 0) {
-        pyi_path_join(init_script_path, splash->tk_modules_dir, dylib_tcltk->Tcl_GetString(objv[4]));
+        pyi_path_join(init_script_path, splash->tk_modules_dir, "tk.tcl");
+        PYI_DEBUG("TCL: 'findLibrary' command: running tk.tcl from: %s\n", init_script_path);
         dylib_tcltk->Tcl_SetVar2(interp, "tk_library", NULL, splash->tk_modules_dir, TCL_GLOBAL_ONLY);
         rc = dylib_tcltk->Tcl_EvalFile(interp, init_script_path);
+        if (rc == TCL_OK) {
+            PYI_DEBUG("TCL: 'findLibrary' command: tk.tcl successfully loaded.\n");
+        } else {
+            PYI_DEBUG("TCL: 'findLibrary' command: tk.tcl failed to load with status code %d and message: %s.\n", rc, dylib_tcltk->Tcl_GetString(dylib_tcltk->Tcl_GetObjResult(splash->interp)));
+        }
         return rc;
     }
 
     /* We do not expect this function to be called for any other library,
      * but just in case, return that the library was not found. */
+    PYI_DEBUG("TCL: 'findLibrary' command: unsupported library!\n");
     return TCL_ERROR;
 }
 
@@ -957,6 +973,7 @@ static int
 _tcl_exit_Command(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
     struct SPLASH_CONTEXT *splash = (struct SPLASH_CONTEXT *)clientData;
+    PYI_DEBUG("TCL: 'exit' command: exiting main loop.\n");
     splash->exit_main_loop = true;
     return TCL_OK;
 }

--- a/bootloader/src/pyi_splash.c
+++ b/bootloader/src/pyi_splash.c
@@ -97,21 +97,21 @@ pyi_splash_setup(struct SPLASH_CONTEXT *splash, const struct PYI_CONTEXT *pyi_ct
     strncpy(splash->application_home_dir, pyi_ctx->application_home_dir, PYI_PATH_MAX); /* both buffers are guaranteed to be PYI_PATH_MAX-sized */
 
     /* Tcl shared library */
-    if (pyi_path_join(splash->tcl_libpath, pyi_ctx->application_home_dir, data_header->tcl_libname) == NULL) {
+    if (pyi_path_join(splash->tcl_shared_library, pyi_ctx->application_home_dir, data_header->tcl_libname) == NULL) {
         PYI_WARNING("SPLASH: length of Tcl shared library path exceeds maximum path length!\n");
         free(data_header);
         return -1;
     }
 
     /* Tk shared library */
-    if (pyi_path_join(splash->tk_libpath, pyi_ctx->application_home_dir, data_header->tk_libname) == NULL) {
+    if (pyi_path_join(splash->tk_shared_library, pyi_ctx->application_home_dir, data_header->tk_libname) == NULL) {
         PYI_WARNING("SPLASH: length of Tk shared library path exceeds maximum path length!\n");
         free(data_header);
         return -1;
     }
 
     /* Tk modules directory */
-    if (pyi_path_join(splash->tk_lib, pyi_ctx->application_home_dir, data_header->tk_lib) == NULL) {
+    if (pyi_path_join(splash->tk_modules_dir, pyi_ctx->application_home_dir, data_header->tk_lib) == NULL) {
         PYI_WARNING("SPLASH: length of Tk shared library path exceeds maximum path length!\n");
         free(data_header);
         return -1;
@@ -365,11 +365,11 @@ pyi_splash_is_splash_requirement(struct SPLASH_CONTEXT *splash, const char *name
 int
 pyi_splash_load_shared_libraries(struct SPLASH_CONTEXT *splash)
 {
-    PYI_DEBUG("SPLASH: loading Tcl library from: %s\n", splash->tcl_libpath);
-    PYI_DEBUG("SPLASH: loading Tk library from: %s\n", splash->tk_libpath);
+    PYI_DEBUG("SPLASH: loading Tcl library from: %s\n", splash->tcl_shared_library);
+    PYI_DEBUG("SPLASH: loading Tk library from: %s\n", splash->tk_shared_library);
 
     /* Load shared libraries and bind symbols */
-    splash->dylib_tcltk = pyi_dylib_tcltk_load(splash->tcl_libpath, splash->tk_libpath);
+    splash->dylib_tcltk = pyi_dylib_tcltk_load(splash->tcl_shared_library, splash->tk_shared_library);
     if (splash->dylib_tcltk == NULL) {
         PYI_ERROR("SPLASH: failed to load Tcl/Tk shared libraries!\n");
         return -1;
@@ -745,7 +745,7 @@ _tcl_findLibrary_Command(ClientData clientData, Tcl_Interp *interp, int objc, Tc
     int rc;
     struct SPLASH_CONTEXT *splash = (struct SPLASH_CONTEXT *)clientData;
     const struct DYLIB_TCLTK *dylib_tcltk = splash->dylib_tcltk;
-    char initScriptPath[PYI_PATH_MAX];
+    char init_script_path[PYI_PATH_MAX];
 
     /* In our minimal environment, this function is only called once,
      * from Tk_Init. So we only implement the behavior for Tk. Other
@@ -753,9 +753,9 @@ _tcl_findLibrary_Command(ClientData clientData, Tcl_Interp *interp, int objc, Tc
      * of `tk`, since the library packed by PyInstaller at build time is
      * guaranteed to be compatible. */
     if (strncmp(dylib_tcltk->Tcl_GetString(objv[4]), "tk.tcl", 64) == 0) {
-        pyi_path_join(initScriptPath, splash->tk_lib, dylib_tcltk->Tcl_GetString(objv[4]));
-        dylib_tcltk->Tcl_SetVar2(interp, "tk_library", NULL, splash->tk_lib, TCL_GLOBAL_ONLY);
-        rc = dylib_tcltk->Tcl_EvalFile(interp, initScriptPath);
+        pyi_path_join(init_script_path, splash->tk_modules_dir, dylib_tcltk->Tcl_GetString(objv[4]));
+        dylib_tcltk->Tcl_SetVar2(interp, "tk_library", NULL, splash->tk_modules_dir, TCL_GLOBAL_ONLY);
+        rc = dylib_tcltk->Tcl_EvalFile(interp, init_script_path);
         return rc;
     }
 

--- a/bootloader/src/pyi_splash.h
+++ b/bootloader/src/pyi_splash.h
@@ -23,14 +23,17 @@
  * This struct is a header describing the rest of this archive item */
 struct SPLASH_DATA_HEADER
 {
-    /* Filename of the Tcl shared library, e.g., tcl86t.dll */
-    char tcl_libname[32];
+    /* Basename of the Tcl shared library, e.g., tcl86t.dll */
+    char tcl_shared_library_name[32];
 
-    /* Filename of the Tk shared library, e.g. tk86t.dll */
-    char tk_libname[32];
+    /* Basename of the Tk shared library, e.g. tk86t.dll */
+    char tk_shared_library_name[32];
 
-    /* Tk module library root, e.g. "tk/" */
-    char tk_lib[16];
+    /* Basename of the Tcl module directory, e.g. "tcl/" */
+    char tcl_module_directory_name[16];
+
+    /* Basename of the Tk module directory, e.g. "tk/" */
+    char tk_module_directory_name[16];
 
     /* Splash screen script */
     uint32_t script_len;
@@ -91,11 +94,12 @@ struct SPLASH_CONTEXT
     /* Path to top-level application directory */
     char application_home_dir[PYI_PATH_MAX];
 
-    /* The paths to Tcl/Tk shared libraries and Tk module library directory.
+    /* The paths to Tcl/Tk shared libraries and module directories.
      * These are anchored to application's top-level directory (static
      * or temporary, depending on onedir vs. onefile mode). */
     char tcl_shared_library[PYI_PATH_MAX];
     char tk_shared_library[PYI_PATH_MAX];
+    char tcl_modules_dir[PYI_PATH_MAX];
     char tk_modules_dir[PYI_PATH_MAX];
 
     /* The Tcl script that creates splash screen and the IPC mechanism

--- a/bootloader/src/pyi_splash.h
+++ b/bootloader/src/pyi_splash.h
@@ -88,6 +88,9 @@ struct SPLASH_CONTEXT
      * joinable threads. */
     bool thread_joinable;
 
+    /* Path to top-level application directory */
+    char application_home_dir[PYI_PATH_MAX];
+
     /* The paths to Tcl/Tk shared libraries and Tk module library directory.
      * These are anchored to application's top-level directory (static
      * or temporary, depending on onedir vs. onefile mode). */

--- a/bootloader/src/pyi_splash.h
+++ b/bootloader/src/pyi_splash.h
@@ -94,9 +94,9 @@ struct SPLASH_CONTEXT
     /* The paths to Tcl/Tk shared libraries and Tk module library directory.
      * These are anchored to application's top-level directory (static
      * or temporary, depending on onedir vs. onefile mode). */
-    char tcl_libpath[PYI_PATH_MAX];
-    char tk_libpath[PYI_PATH_MAX];
-    char tk_lib[PYI_PATH_MAX];
+    char tcl_shared_library[PYI_PATH_MAX];
+    char tk_shared_library[PYI_PATH_MAX];
+    char tk_modules_dir[PYI_PATH_MAX];
 
     /* The Tcl script that creates splash screen and the IPC mechanism
      * to communicate with python code. */

--- a/news/9313.feature.rst
+++ b/news/9313.feature.rst
@@ -1,0 +1,1 @@
+Implement support for Tcl/Tk 9 in splash screen.


### PR DESCRIPTION
Fedora 43 ships both Tcl/Tk 8.6 and 9.0, and its main python version (3.14) is built against the latter. Thus, it serves as an "early warning" about issues that need to be addressed in our splash screen implementation, before python.org builds switch to using Tcl/Tk 9.0.

Specifically:
- Tcl 9.0 cannot be built without multi-threading support anymore, so we need to skip the check for it (since the corresponding flag in the `tcl_platform` was also completely removed)
- the size-related arguments in the C API were upgraded from 32-bit to 64-bit, while the symbol names were kept the same. This means that we need to detect Tcl version at run-time, and bind the affected functions to different prototypes.
- the `Tk_Init()` and the modules it loads now seem rely on function auto-loading; so between running Tcl's `init.tcl` to set up auto-loading mechanism and setting up `undefined` handler with static resolver, the former seems to be more sane choice to me (although it seems we need to go to great pains to keep the interpreter's search paths properly isolated). The main issue with static resolver is that it would actually need to cover all potential Tk modules (i.e., the functions they attempt to auto-load), because under some scenarios, all of them are present in the build and are attempted to be loaded (they are attempted to be loaded even if missing, but we suppress those missing-module errors; we could also go for suppression of all other errors, but that would make things trickier to debug when we have real issues at hand).