### PR TITLE
bootloader: waf: define `_THREAD_SAFE=1` when compiling on/for AIX

### DIFF
--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -555,6 +555,11 @@ def configure(ctx):
         # On macOS, mkdtemp() is available only with _DARWIN_C_SOURCE.
         elif ctx.env.DEST_OS == 'darwin':
             ctx.env.append_value('DEFINES', '_DARWIN_C_SOURCE')
+        # On AIX, -pthread flag sets _THREAD_SAFE=1 instead of _REENTRANT. Having _THREAD_SAFE (or _THREAD_SAFE_ERRNO)
+        # defined enables thread-safe errno. _THREAD_SAFE is automatically defined when <pthread.h> is included, but
+        # we would need to ensure it is included at the top of every compilation unit. It is easier to define it here.
+        elif ctx.env.DEST_OS == 'aix':
+            ctx.env.append_value('DEFINES', '_THREAD_SAFE=1')
 
         # Determine which semaphore API to use for syncing onefile parent and child process on non-Windows platforms;
         # this is required to ensure consistent signal forwarding behavior. We prefer to use POSIX semaphores; however,


### PR DESCRIPTION
When compiling bootloader for AIX, add `_THREAD_SAFE=1` to the list of defines to be passed to compiler. This supplements the `_REENTRANT` define that we seem to be using in-lieu of `-pthread` compiler flag; while on most platforms, `-pthread` defines `_REENTRANT`, on AIX, it defines `_THREAD_SAFE`.

For example, linux:
```
rok@alpha:~$ diff  <(echo | gcc -dM -E -) <(echo | gcc -pthread -dM -E -)
103a104
> #define _REENTRANT 1
```

AIX:
```
-bash-5.2$ diff <(echo | gcc -dM -E -) <(echo | gcc -pthread -dM -E -)
101a102
> #define _THREAD_SAFE 1
```

`_THREAD_SAFE` is also defined (if necessary) when `pthread.h` header is included on AIX, but if we were to rely on this, we would need to ensure  it is the first header included in every compilation unit.

Having `_THREAD_SAFE` (or `_THREAD_SAFE_ERRNO`) defined enables thread-safe `errno`. In the context of bootloader, this might matter only when splash screen is enabled (since that runs in a secondary thread), so this change is done mostly for the sake of consistency (since we also pass `-lpthread` to the linker).