### PR TITLE
hooks: platform: exclude `ios_support` for `sys.platform != 'ios'`

### DIFF
--- a/PyInstaller/hooks/hook-platform.py
+++ b/PyInstaller/hooks/hook-platform.py
@@ -10,7 +10,18 @@
 #-----------------------------------------------------------------------------
 import sys
 
+excludedimports = []
+
 # see https://github.com/python/cpython/blob/3.9/Lib/platform.py#L411
 # This will exclude `plistlib` for sys.platform != 'darwin'
 if sys.platform != 'darwin':
-    excludedimports = ["plistlib"]
+    excludedimports += ["plistlib"]
+
+# Avoid collecting `_ios_support`, which in turn triggers unnecessary collection of `libobjc` shared library if the
+# latter happens to be available on the build system.
+# See https://github.com/pyinstaller/pyinstaller/issues/9333, as well as
+# https://github.com/python/cpython/blob/v3.13.0/Lib/platform.py#L508-L521
+# and
+# https://github.com/python/cpython/blob/v3.13.0/Lib/_ios_support.py#L13
+if sys.platform != 'ios':
+    excludedimports += ["_ios_support"]

--- a/news/9333.bugfix.rst
+++ b/news/9333.bugfix.rst
@@ -1,0 +1,4 @@
+Have hook for stdlib ``platform`` module exclude the ``_ios_support``
+module when ``sys.platform != 'ios'``. This prevents unnecessary
+collection of ``ctypes``-imported ``libobjc`` shared library if the
+latter happens to be available on the build system.


### PR DESCRIPTION
Have hook for stdlib `platform` module exclude the `_ios_support` module when `sys.platform != 'ios'`. This prevents unnecessary collection of `ctypes`-imported `libobjc` shared library if the latter happens to be available on the build system.

Fixes #9333.