### PR TITLE
utils: macOS: additional entry filtering in .framework-bundle-fixing helper

### DIFF
--- a/PyInstaller/building/build_main.py
+++ b/PyInstaller/building/build_main.py
@@ -1009,9 +1009,12 @@ class Analysis(Target):
         combined_toc = normalize_toc(self.datas + self.binaries)
         combined_toc = toc_process_symbolic_links(combined_toc)
 
-        # On macOS, look for binaries collected from .framework bundles, and collect their Info.plist files.
+        # On macOS, look for binaries collected from .framework bundles, collect their Info.plist files, and fix the
+        # structure to conform to code-signing requirements (i.e., Versions/Current symbolic link and symbolic links
+        # for top-level directories).
         if is_darwin:
-            combined_toc += osxutils.collect_files_from_framework_bundles(combined_toc)
+            combined_toc = osxutils.collect_files_from_framework_bundles(combined_toc)
+            combined_toc = normalize_toc(combined_toc)
 
         self.datas = []
         self.binaries = []

--- a/PyInstaller/utils/osx.py
+++ b/PyInstaller/utils/osx.py
@@ -695,7 +695,7 @@ def collect_files_from_framework_bundles(collected_files):
     # 2nd pass: scan for additional collected directories from .framework bundles, and create symlinks to the top-level
     # application directory. Make the outer loop go over the registered framework paths, so it becomes no-op if no
     # framework paths are registered.
-    VALID_SUBDIRS = {'Helpers', 'Resources'}
+    VALID_SUBDIRS = {'Documentation', 'Frameworks', 'Headers', 'Helpers', 'Libraries', 'Resources'}
 
     for dest_framework_path in framework_paths:
         for dest_name, src_name, typecode in collected_files:

--- a/PyInstaller/utils/osx.py
+++ b/PyInstaller/utils/osx.py
@@ -609,19 +609,18 @@ def is_framework_bundle_lib(lib_path):
 def collect_files_from_framework_bundles(collected_files):
     """
     Scan the given TOC list of collected files for shared libraries that are collected from macOS .framework bundles,
-    and collect the bundles' Info.plist files. Additionally, the following symbolic links:
+    and collect the bundles' Info.plist files. Additionally, create/restore the following symbolic links:
       - `Versions/Current` pointing to the `Versions/<version>` directory containing the binary
       - `<name>` in the top-level .framework directory, pointing to `Versions/Current/<name>`
       - `Resources` in the top-level .framework directory, pointing to `Versions/Current/Resources`
       - additional directories in top-level .framework directory, pointing to their counterparts in `Versions/Current`
         directory.
 
-    Returns TOC list for the discovered Info.plist files and generated symbolic links. The list does not contain
-    duplicated entries.
+    Returns updated TOC list with added entries for the discovered Info.plist files and generated symbolic links.
     """
     invalid_framework_found = False
 
-    framework_files = set()  # Additional entries for collected files. Use set for de-duplication.
+    framework_entries = set()  # Additional TOC entries for collected files. Use set for de-duplication.
     framework_paths = set()  # Registered framework paths for 2nd pass.
 
     # 1st pass: discover binaries from .framework bundles, and for each such binary:
@@ -666,24 +665,24 @@ def collect_files_from_framework_bundles(collected_files):
                     continue
             info_plist_src = info_plist_src_top
         info_plist_dest = dest_path.parent / "Resources" / "Info.plist"
-        framework_files.add((str(info_plist_dest), str(info_plist_src), "DATA"))
+        framework_entries.add((str(info_plist_dest), str(info_plist_src), "DATA"))
 
         # Reconstruct the symlink Versions/Current -> Versions/<version>.
         # This one seems to be necessary for code signing, but might be absent from .framework bundles shipped with
         # python packages. So we always create it ourselves.
-        framework_files.add((str(dest_path.parent.parent / "Current"), str(dest_path.parent.name), "SYMLINK"))
+        framework_entries.add((str(dest_path.parent.parent / "Current"), str(dest_path.parent.name), "SYMLINK"))
 
         dest_framework_path = dest_path.parent.parent.parent  # Top-level .framework directory path.
 
         # Symlink the binary in the `Current` directory to the top-level .framework directory.
-        framework_files.add((
+        framework_entries.add((
             str(dest_framework_path / dest_path.name),
             str(pathlib.PurePath("Versions/Current") / dest_path.name),
             "SYMLINK",
         ))
 
         # Ditto for the `Resources` directory.
-        framework_files.add((
+        framework_entries.add((
             str(dest_framework_path / "Resources"),
             "Versions/Current/Resources",
             "SYMLINK",
@@ -718,7 +717,7 @@ def collect_files_from_framework_bundles(collected_files):
             if dir_name not in VALID_SUBDIRS:
                 continue
 
-            framework_files.add((
+            framework_entries.add((
                 str(dest_framework_path / dir_name),
                 str(pathlib.PurePath("Versions/Current") / dir_name),
                 "SYMLINK",
@@ -732,4 +731,4 @@ def collect_files_from_framework_bundles(collected_files):
             "bundle, you will most likely not be able to code-sign it."
         )
 
-    return sorted(framework_files)
+    return collected_files + sorted(framework_entries)

--- a/PyInstaller/utils/osx.py
+++ b/PyInstaller/utils/osx.py
@@ -622,6 +622,7 @@ def collect_files_from_framework_bundles(collected_files):
 
     framework_entries = set()  # Additional TOC entries for collected files. Use set for de-duplication.
     framework_paths = set()  # Registered framework paths for 2nd pass.
+    framework_symlinked_dirs = set()  # Symlinked directories for filtering in 3rd pass.
 
     # 1st pass: discover binaries from .framework bundles, and for each such binary:
     #   - collect `Info.plist`
@@ -669,12 +670,15 @@ def collect_files_from_framework_bundles(collected_files):
 
         # Reconstruct the symlink Versions/Current -> Versions/<version>.
         # This one seems to be necessary for code signing, but might be absent from .framework bundles shipped with
-        # python packages. So we always create it ourselves.
+        # python packages (i.e., PyPI wheels that do not support symlinks). So we always create it ourselves.
         framework_entries.add((str(dest_path.parent.parent / "Current"), str(dest_path.parent.name), "SYMLINK"))
+        framework_symlinked_dirs.add(dest_path.parent.parent / "Current")  # Cleanup in 3rd pass
 
         dest_framework_path = dest_path.parent.parent.parent  # Top-level .framework directory path.
 
         # Symlink the binary in the `Current` directory to the top-level .framework directory.
+        # If TOC also contains an entry for a hard-copy entry in the top-level directory, it will be replaced by this
+        # symlink entry due to how our TOC normalization works.
         framework_entries.add((
             str(dest_framework_path / dest_path.name),
             str(pathlib.PurePath("Versions/Current") / dest_path.name),
@@ -687,6 +691,7 @@ def collect_files_from_framework_bundles(collected_files):
             "Versions/Current/Resources",
             "SYMLINK",
         ))
+        framework_symlinked_dirs.add(dest_framework_path / "Resources")  # Cleanup in 3rd pass
 
         # Register the framework parent path to use in additional directories scan in subsequent pass.
         framework_paths.add(dest_framework_path)
@@ -722,6 +727,24 @@ def collect_files_from_framework_bundles(collected_files):
                 str(pathlib.PurePath("Versions/Current") / dir_name),
                 "SYMLINK",
             ))
+            framework_symlinked_dirs.add(dest_framework_path / dir_name)  # Cleanup in 3rd pass
+
+    # 3rd pass: remove TOC entries under directories for which we are trying to restore symbolic links. These may be
+    # present when a python package (i.e., a PyPI wheel) ships a .framework bundle where symlinks were mangled into hard
+    # copies (due to lack of support for symlinks in wheels) AND these hard copies are collected through use of
+    # `collect_data` / `collect_binaries` / `collect_all` (either by user or by a hook).
+    if framework_symlinked_dirs:
+        filtered_toc = []
+
+        for dest_name, src_name, typecode in collected_files:
+            dest_path = pathlib.PurePath(dest_name)
+
+            if any(dest_parent in framework_symlinked_dirs for dest_parent in dest_path.parents):
+                continue  # Inside symlinked directory; remove
+
+            filtered_toc.append((dest_name, src_name, typecode))
+    else:
+        filtered_toc = collected_files
 
     # If we encountered an invalid .framework bundle without Info.plist, warn the user that code-signing will most
     # likely fail.
@@ -731,4 +754,4 @@ def collect_files_from_framework_bundles(collected_files):
             "bundle, you will most likely not be able to code-sign it."
         )
 
-    return collected_files + sorted(framework_entries)
+    return filtered_toc + sorted(framework_entries)

--- a/news/9335.bugfix.rst
+++ b/news/9335.bugfix.rst
@@ -1,0 +1,6 @@
+(macOS) Improve the .framework bundle fix-up code to remove file entries
+that would be placed under restored symlinked directories. This fixes
+file-already-exists errors at build time (onedir) or run-time (onefile)
+when user or a hook tries to collect (all) files from a package that
+ships a .framework bundle with symlinks mangled into hard-copies
+(for example, due to lack of symlink support in PyPI wheels).


### PR DESCRIPTION
Have the macOS-specific `collect_files_from_framework_bundles` helper keep track of symlinked directories it restores during its 1st and 2nd processing pass, and then perform a 3rd pass that removes all entries that are supposed to be placed under these symlinked directories.
    
Such entries will cause file-already-exists errors during file collection at build-time (onedir) or application unpacking at run-time (onefile).
    
This filtering attempts to mitigate situations when a PyPI wheel for macOS ships a .framework bundle with symlinks mangled into hard copies (e.g., `pymeshlab`) AND all these hard-copies are collected because either user or a hook used `collect_data`, `collect_binaries` or `collect_all` hook utility function on the package.

Fixes #9335.