### PR TITLE
Fix: Preserve STARTUPINFO wShowWindow and dwFlags in bootloader

### DIFF
--- a/bootloader/src/pyi_utils_win32.c
+++ b/bootloader/src/pyi_utils_win32.c
@@ -618,8 +618,7 @@ pyi_utils_create_child(struct PYI_CONTEXT *pyi_ctx)
     startup_info.lpReserved = NULL;
     startup_info.lpDesktop = NULL;
     startup_info.lpTitle = NULL;
-    startup_info.dwFlags = STARTF_USESTDHANDLES | STARTF_USESHOWWINDOW;
-    startup_info.wShowWindow = SW_NORMAL;
+    startup_info.dwFlags |= STARTF_USESTDHANDLES;
     startup_info.hStdInput = _pyi_get_stream_handle(stdin);
     startup_info.hStdOutput = _pyi_get_stream_handle(stdout);
     startup_info.hStdError = _pyi_get_stream_handle(stderr);

--- a/news/9342.bootloader.rst
+++ b/news/9342.bootloader.rst
@@ -1,0 +1,4 @@
+(Windows) When spawning ``onefile`` child process, preserve the values of
+``dwFlags` and ``wShowWindow`` in ``STARTUPINFO`` structure as inherited
+from the parent process, instead of forcing them to ``STARTF_USESHOWWINDOW``
+and ``SW_NORMAL``.


### PR DESCRIPTION
Previously, the bootloader forces wShowWindow = SW_NORMAL, so the PyInstaller-outputted exe program didn't know if it was created hidden or not.

My company has many python scripts that should run hidden. I'd like to be able to know startup_info (retrieved with ctypes.windll.kernel32.GetStartupInfo) if the program was started hidden or not, but the bootloader stomps wShowWindow with a startup_info.wShowWindow = SW_NORMAL;

Also the dwFlags should be a bitwise OR "good citizenship" operation (so we don't accidentally delete other flags).

See dwFlags in https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/ns-processthreadsapi-startupinfoa

**To reproduce:**

1. Place check_flags.py and test_check_flags.py into a folder:
[check_flags.py](https://github.com/user-attachments/files/24300703/check_flags.py)
[test_check_flags.py](https://github.com/user-attachments/files/24300704/test_check_flags.py)

2. Run pyinstaller.exe --onefile check_flags.py

3. Run python.exe test_check_flags.py, which launches check_flags.exe shown and launches check_flags.exe hidden.

**Before fix:**
Launching with SW_SHOW...
dwFlags: 0x00000101
wShowWindow: 1
Has STARTF_USESHOWWINDOW: True
PASS

Launching with hidden arg and SW_HIDE...
dwFlags: 0x00000101
wShowWindow: 1
Has STARTF_USESHOWWINDOW: True
FAIL: hidden passed as arg, but startup info indicates not hidden. wShowWindow=1

**After fix:**
Launching with SW_SHOW...
dwFlags: 0x00000101
wShowWindow: 1
Has STARTF_USESHOWWINDOW: True
PASS

Launching with hidden arg and SW_HIDE...
dwFlags: 0x00000101
wShowWindow: 0
Has STARTF_USESHOWWINDOW: True
PASS

