### PR TITLE
tests: add a test for preservation of dwFlags and wShowWindow in STARTUPINFO

### DIFF
--- a/tests/functional/scripts/pyi_get_startupinfo_flags.py
+++ b/tests/functional/scripts/pyi_get_startupinfo_flags.py
@@ -1,0 +1,43 @@
+import ctypes
+from ctypes import wintypes
+import json
+import sys
+
+
+class STARTUPINFOW(ctypes.Structure):
+    _fields_ = [
+        ("cb", wintypes.DWORD),
+        ("lpReserved", wintypes.LPWSTR),
+        ("lpDesktop", wintypes.LPWSTR),
+        ("lpTitle", wintypes.LPWSTR),
+        ("dwX", wintypes.DWORD),
+        ("dwY", wintypes.DWORD),
+        ("dwXSize", wintypes.DWORD),
+        ("dwYSize", wintypes.DWORD),
+        ("dwXCountChars", wintypes.DWORD),
+        ("dwYCountChars", wintypes.DWORD),
+        ("dwFillAttribute", wintypes.DWORD),
+        ("dwFlags", wintypes.DWORD),
+        ("wShowWindow", wintypes.WORD),
+        ("cbReserved2", wintypes.WORD),
+        ("lpReserved2", wintypes.LPBYTE),
+        ("hStdInput", wintypes.HANDLE),
+        ("hStdOutput", wintypes.HANDLE),
+        ("hStdError", wintypes.HANDLE),
+    ]
+
+
+# Get process' startup info...
+si = STARTUPINFOW()
+si.cb = ctypes.sizeof(STARTUPINFOW)
+ctypes.windll.kernel32.GetStartupInfoW(ctypes.byref(si))
+
+# ... and dump fields-of-interest into JSON
+FIELDS = {"dwFlags", "wShowWindow"}
+result = {field: getattr(si, field) for field in FIELDS}
+
+if len(sys.argv) > 1:
+    with open(sys.argv[1], 'w') as fp:
+        json.dump(result, fp)
+else:
+    print(json.dumps(result))

--- a/tests/functional/test_misc.py
+++ b/tests/functional/test_misc.py
@@ -12,6 +12,7 @@
 import os
 import pathlib
 import sys
+import subprocess
 import json
 
 import pytest
@@ -518,3 +519,55 @@ def test_time_sleep(pyi_builder, windowed):
         """,
         pyi_args=['--windowed'] if windowed else [],
     )
+
+
+# Test that on Windows, values of dwFlags and wShowWindow fields in STATRTUPINFO structure are propagated into onefile
+# child process. Onedir variant serves as sanity check. See #9342.
+@pytest.mark.win32
+@pytest.mark.parametrize('windowed', [False, True], ids=['console', 'windowed'])
+def test_startupinfo_flags(pyi_builder, tmp_path, windowed):
+    pyi_builder.test_script(
+        'pyi_get_startupinfo_flags.py',
+        pyi_args=['--windowed'] if windowed else [],
+    )
+
+    # Find executable
+    exes = pyi_builder._find_executables('pyi_get_startupinfo_flags')
+    assert len(exes) == 1
+    program_exe = exes[0]
+
+    # Re-run with various flag combinations
+    TEST_FLAGS = (
+        (False, 0),
+        (True, 0),  # SW_HIDE
+        (True, 1),  # SW_NORMAL
+        (True, 6),  # SW_MINIMIZE
+    )
+
+    for i in range(len(TEST_FLAGS)):
+        enabled, value = TEST_FLAGS[i]
+        print(
+            f"=== running test variant #{i + 1}: STARTF_USESHOWWINDOW={enabled}, wShowWindow={value} ===",
+            file=sys.stderr,
+        )
+
+        output_file = tmp_path / f'output{i}.json'
+
+        si = subprocess.STARTUPINFO()
+        if enabled:
+            si.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+            si.wShowWindow = value
+
+        subprocess.run([program_exe, output_file], check=True, startupinfo=si)
+
+        with open(output_file, 'r') as fp:
+            results = json.load(fp)
+
+        if enabled:
+            assert (results['dwFlags'] & subprocess.STARTF_USESHOWWINDOW) != 0, \
+                'dwFlags does not contain STARTF_USESHOWWINDOW, but it should!'
+            assert results['wShowWindow'] == value, \
+                f"Unexpected wShowWindow value - expected {value}, found {results['wShowWindow']}!"
+        else:
+            assert (results['dwFlags'] & subprocess.STARTF_USESHOWWINDOW) == 0, \
+                'dwFlags contains STARTF_USESHOWWINDOW, but it should not!'


### PR DESCRIPTION
Add a test that formalizes behavior that was introduced in #9342, i.e., the preservation of `dwFlags` and `wShowWindow` fields in `STARTUPINFOW` structure when spawning `onefile` child process on Windows.