### PR TITLE
ci: remove upstreamed work-around for macos-15-intel runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,14 +50,6 @@ jobs:
             os: 'macos-15-intel'
       fail-fast: false
     steps:
-      # https://github.com/actions/runner-images/issues/12545
-      # https://github.com/actions/runner-images/issues/13358
-      - name: Work around x86 macOS 15 bug for multiple CPU cores
-        if: matrix.os == 'macos-15-intel'
-        run: |
-          sudo defaults -currentHost write /Library/Preferences/com.apple.powerlogd SMCMonitorCadence 0
-          sudo killall PerfPowerServices || true
-
       - name: Checkout PyInstaller code
         uses: actions/checkout@v4
 


### PR DESCRIPTION
Revert commit 5d741807d62a30a5c91d7f8b4ab211004b257ccb - the same work-around has been implemented upstream, and the updated `macos-15-intel` runner images have been rolled out.