### PR TITLE
building: update warnfile header

### DIFF
--- a/PyInstaller/building/build_main.py
+++ b/PyInstaller/building/build_main.py
@@ -66,12 +66,12 @@ IMPORT_TYPES = [
 WARNFILE_HEADER = """\
 
 This file lists modules PyInstaller was not able to find. This does not
-necessarily mean this module is required for running your program. Python and
-Python 3rd-party packages include a lot of conditional or optional modules. For
-example the module 'ntpath' only exists on Windows, whereas the module
-'posixpath' only exists on Posix systems.
+necessarily mean these modules are required for running your program. Both
+Python's standard library and 3rd-party Python packages often conditionally
+import optional modules, some of which may be available only on certain
+platforms.
 
-Types if import:
+Types of import:
 * top-level: imported at the top-level - look at these first
 * conditional: imported within an if-statement
 * delayed: imported within a function


### PR DESCRIPTION
Update the header of `warnfile` (i.e., the file with warnings about missing modules). Fix the typo reported in #9344: "Types if import:" -> "Types of import:". Remove mentions of `posixpath` and `ntpath` modules, which are (nowadays?) both available on both Windows and POSIX platforms.

Fixes #9344.