### PR TITLE
hooks: numpy: relax installer-type check for delvewheel codepath

### DIFF
--- a/PyInstaller/hooks/hook-numpy.py
+++ b/PyInstaller/hooks/hook-numpy.py
@@ -62,7 +62,14 @@ if numpy_installer == 'conda':
 # automatically pick up DLLs from external `numpy.libs` directory, this does not work on Anaconda python 3.8 and 3.9
 # due to defunct `os.add_dll_directory`, which forces `delvewheel` to use the old load-order file approach. So we need
 # to explicitly ensure that load-order file as well as DLLs are collected.
-if compat.is_win and numpy_version >= (1, 26) and numpy_installer == 'pip':
+#
+# Under contemporary python versions, we might still need to explicitly collect the DLLs from `numpy.libs` directory
+# to accommodate the cases when some other package's `.lib` directory (for example, `pandas.libs`) contains a DLL
+# with the same name, and binary dependency analysis ends up resolving that one.
+#
+# The installer check compares against 'conda', because PyPI wheels might be installed by installers other than 'pip'
+# (for example, 'uv' - see #9360).
+if compat.is_win and numpy_version >= (1, 26) and numpy_installer != 'conda':
     from PyInstaller.utils.hooks import collect_delvewheel_libs_directory
     datas, binaries = collect_delvewheel_libs_directory("numpy", datas=datas, binaries=binaries)
 

--- a/PyInstaller/hooks/hook-pandas.py
+++ b/PyInstaller/hooks/hook-pandas.py
@@ -9,12 +9,28 @@
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
 
-from PyInstaller.utils.hooks import collect_submodules, check_requirement
+from PyInstaller import compat
+from PyInstaller.utils.hooks import collect_submodules, get_installer
+
+from packaging.version import Version
+
+pandas_version = Version(compat.importlib_metadata.version("pandas")).release
+pandas_installer = get_installer('pandas')
+
+datas = []
+binaries = []
 
 # Pandas keeps Python extensions loaded with dynamic imports here.
 hiddenimports = collect_submodules('pandas._libs')
 
 # Pandas 1.2.0 and later require cmath hidden import on linux and macOS. On Windows, this is not strictly required, but
 # we add it anyway to keep things simple (and future-proof).
-if check_requirement('pandas >= 1.2.0'):
+if pandas_version >= (1, 2, 0):
     hiddenimports += ['cmath']
+
+# Pandas 2.1.0 started using `delvewheel` for its Windows PyPI wheels. Ensure that DLLs from `pandas.libs` directory are
+# collected regardless of whether binary dependency analysis manages to pick them up or not. See a similar block in the
+# `numpy` hook for additional explanation.
+if compat.is_win and pandas_version >= (2, 1, 0) and pandas_installer != 'conda':
+    from PyInstaller.utils.hooks import collect_delvewheel_libs_directory
+    datas, binaries = collect_delvewheel_libs_directory("pandas", datas=datas, binaries=binaries)

--- a/news/9360.bugfix.rst
+++ b/news/9360.bugfix.rst
@@ -1,0 +1,2 @@
+(Windows) Fix collection of ``numpy`` DLLs when ``numpy`` PyPI wheel is
+installed using ``uv`` instead of ``pip``.

--- a/news/9365.hooks.1.rst
+++ b/news/9365.hooks.1.rst
@@ -1,0 +1,3 @@
+(Windows) Update the ``pandas`` hook to explicitly collect the DLLs
+from ``pandas.libs`` directory that has been used in Windows PyPI wheels
+since ``pandas`` 2.1.0.

--- a/news/9365.hooks.rst
+++ b/news/9365.hooks.rst
@@ -1,0 +1,3 @@
+(Windows) Fix installer check in ``numpy`` hook to enable explicit collection
+of DLLs from ``numpy.libs`` directory when ``numpy`` PyPI wheels are installed
+through an installer other than `pip` - for example, `uv`.


### PR DESCRIPTION
Relax the installer-type check in `numpy` hook to execute the `delvewheel` codepath for installers other than `pip`, such as `uv`. Fixes #9360. FWIW, we could also completely forego the installer check, because the `collect_delvewheel_libs_directory` helper checks for presence of the external .libs directory and becomes no-op if it does not exist.

Update `pandas` hook to explicitly collect DLLs from `pandas.libs` using `collect_delvewheel_libs_directory`; `pandas` seem to have been using `delvewheel` for their Windows PyPI wheels since v2.1.0, and while so far we have picked the DLL through binary dependency analysis*, this should add a bit of future-proofing (for example, if there was a third package that shipped the DLL whose name matched the `pandas` copy but not the `numpy` one...)

(\* Or the binary dependency analysis happened to pick up eponymous `numpy`-bundled copy, and it did not matter because `numpy` ends up being imported first at run-time...)