### PR TITLE
Fix tests/CI for compatibility with setuptools 82.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,14 +174,17 @@ jobs:
         run: |
           python -m pip install --progress-bar=off --upgrade --requirement tests/requirements-libraries.txt
 
-            # On (macos-14, python 3.10), (macos-13, python 3.11) and (macos-14, python 3.11)
-      # combinations the initial `setuptools` installation seems to contain `.opt-1.pyc`
-      # files in `__pycache__` directories. During the upgrade, `pip` fails to remove
-      # those directories (https://github.com/pypa/pip/issues/11835).
+      # Some python versions come with initial `setuptools` installation that seems to contain `.opt-1.pyc`
+      # files in `__pycache__` directories. During the upgrade, `pip` fails to remove those directories
+      # (see: https://github.com/pypa/pip/issues/11835).
       #
       # `setuptools` 75.4 removed its vendored copy of `importlib_resources`, but due to
       # the above issue, the effectively empty directory remains, turning `importlib_resources`
-      # into defunct namespace package, which causes some of our tests to fail.
+      # into a defunct namespace package, which causes some of our tests to fail.
+      #
+      # Similar issue arises when upgrading to `setuptools` 82.0.0, which removed `pkg_resources` package;
+      # the defunct namespace package arising from the left-over directory causes error in our `pkg_resources`
+      # run-time hook (which would otherwise not be collected at all).
       - name: Work around potentially broken setuptools upgrade
         shell: python
         run: |
@@ -190,36 +193,46 @@ jobs:
           import shutil
           import importlib.util
 
-          try:
-            spec = importlib.util.find_spec('setuptools._vendor.importlib_resources')
-          except ImportError:
-            spec = None  # setuptools or setuptools._vendor does not exist
-          if spec is None:
-            print("Did not find setuptools-vendored copy of importlib_resources.")
-            sys.exit(0)
-          elif spec.loader is not None:
-            print("Found a valid setuptools-vendored copy of importlib_resources.")
-            sys.exit(0)
+          PACKAGES = [
+            'setuptools._vendor.importlib_resources',
+            'pkg_resources',
+          ]
 
-          print("Found a defunct setuptools-vendored copy of importlib_resources!")
+          def fix_package(package_name):
+            try:
+              spec = importlib.util.find_spec(package_name)
+            except ImportError:
+              spec = None  # parent package (e.g., setuptools or setuptools._vendor) does not exist
+            if spec is None:
+              print(f"Did not find {package_name}.")
+              return
+            elif spec.loader is not None:
+              # Not a namespace package (i.e., directory with just __pycache__ sub-directory)
+              print(f"Found a valid copy of {package_name}.")
+              return
 
-          # List the contents of importlib_resources package directory for debug purposes
-          def list_directory(path, pad=""):
-            for child in path.iterdir():
-              if child.is_dir():
-                print(f"{pad} + {child.name}")
-                list_directory(child, pad + " ")
-              else:
-                print(f"{pad} - {child.name} ({child.stat().st_size} bytes)")
+            print(f"Found a defunct copy of {package_name}!")
 
-          for path in spec.submodule_search_locations:
-            print(f"Listing contents of {path}")
-            list_directory(pathlib.Path(path))
+            # List the contents of package directory for debug purposes
+            def list_directory(path, pad=""):
+              for child in path.iterdir():
+                if child.is_dir():
+                  print(f"{pad} + {child.name}")
+                  list_directory(child, pad + " ")
+                else:
+                  print(f"{pad} - {child.name} ({child.stat().st_size} bytes)")
 
-          # Remove
-          for path in spec.submodule_search_locations:
-            print(f"Removing {path}...")
-            shutil.rmtree(path)
+            for path in spec.submodule_search_locations:
+              print(f"Listing contents of {path}")
+              list_directory(pathlib.Path(path))
+
+            # Remove
+            for path in spec.submodule_search_locations:
+              print(f"Removing {path}...")
+              shutil.rmtree(path)
+
+          for package in PACKAGES:
+            fix_package(package)
 
       - name: Start display server
         if: startsWith(matrix.os, 'ubuntu')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -501,7 +501,6 @@ jobs:
             python39-pip
             python39-tkinter
 
-
       - name: Disable CRLF line endings in git checkout
         run: git config --global core.autocrlf input
 
@@ -533,6 +532,17 @@ jobs:
         run: |
           Xvfb :99 &
           echo "DISPLAY=:99" >> $GITHUB_ENV
+
+      # See the equivalent step in the "tests" job.
+      # This is a simplified version that targets pnly issue with `pkg_resources`,
+      # which arose with update to `setuptools` 82.0.0. It can be removed once
+      # the cygwin python environment comes with `setuptools` 82.0.0 or newer
+      # installed by default.
+      # NOTE: we cannot use "python" shell here, because that resolves to
+      # python in C:\hostedtoolcache\windows\Python instead of cygwin one!
+      - name: Work around potentially broken setuptools upgrade
+        run: |
+          python -c 'import importlib.util; import shutil; spec = importlib.util.find_spec("pkg_resources"); spec and spec.loader is None and shutil.rmtree(spec.submodule_search_locations[0])'
 
       - name: Run tests
         # Keep the number of pytest workers below the number of available

--- a/tests/functional/scripts/list_pytest11_entry_point.py
+++ b/tests/functional/scripts/list_pytest11_entry_point.py
@@ -12,8 +12,16 @@
 Print all modules exporting the entry point 'pytest11'.
 """
 
-import pkg_resources
+import sys
 
-plugins = sorted(i.module_name for i in pkg_resources.iter_entry_points("pytest11"))
+# entry_points() with group keyword argument is available in stdlib's importlib.metadata starting with python 3.10; on
+# older versions we require importlib-metadata backport (which should be available and of sufficient version due to
+# being part of PyInstaller's requirements).
+if sys.version_info >= (3, 10):
+    import importlib.metadata as importlib_metadata
+else:
+    import importlib_metadata
+
+plugins = sorted(i.module for i in importlib_metadata.entry_points(group="pytest11"))
 
 print("\n".join(plugins))

--- a/tests/functional/test_import.py
+++ b/tests/functional/test_import.py
@@ -271,6 +271,7 @@ def test_import_pyi_splash(pyi_builder):
 #--- unzipped .egg support ----
 
 
+@importorskip('pkg_resources')
 def test_egg_unzipped(pyi_builder):
     pathex = _MODULES_DIR / 'pyi_test_egg' / 'pyi_egg_unzipped.egg'
     hooks_dir = _MODULES_DIR / 'pyi_test_egg' / 'hooks'
@@ -298,6 +299,7 @@ def test_egg_unzipped(pyi_builder):
     )  # yapf: disable
 
 
+@importorskip('pkg_resources')
 def test_egg_unzipped_metadata_pkg_resources(pyi_builder):
     pathex = _MODULES_DIR / 'pyi_test_egg' / 'pyi_egg_unzipped.egg'
     hooks_dir = _MODULES_DIR / 'pyi_test_egg' / 'hooks'
@@ -354,6 +356,7 @@ def test_egg_unzipped_metadata_importlib_metadata(pyi_builder):
 #--- namespaces ---
 
 
+@importorskip('pkg_resources')
 def test_nspkg1(pyi_builder):
     # Test inclusion of namespace packages implemented using pkg_resources.declare_namespace
     extra_paths = (_MODULES_DIR / 'nspkg1-pkg').glob('*.egg')
@@ -368,6 +371,7 @@ def test_nspkg1(pyi_builder):
     )
 
 
+@importorskip('pkg_resources')
 def test_nspkg1_empty(pyi_builder):
     # Test inclusion of a namespace-only packages in an zipped egg. This package only defines the namespace, nothing is
     # contained there.
@@ -382,6 +386,7 @@ def test_nspkg1_empty(pyi_builder):
     )
 
 
+@importorskip('pkg_resources')
 def test_nspkg1_bbb_zzz(pyi_builder):
     # Test inclusion of a namespace packages in an zipped egg
     extra_paths = (_MODULES_DIR / 'nspkg1-pkg').glob('*.egg')
@@ -488,6 +493,7 @@ def test_nspkg_pep420(pyi_builder):
     )
 
 
+@importorskip('pkg_resources')
 def test_nspkg_attributes(pyi_builder):
     # Test that non-PEP-420 namespace packages (e.g., the ones using
     # pkg_resources.declare_namespace) have proper attributes:

--- a/tests/functional/test_misc.py
+++ b/tests/functional/test_misc.py
@@ -197,16 +197,20 @@ def test_single_file_metadata(pyi_builder):
 
     pyi_builder.test_source(
         """
-        import pkg_resources
+        import sys
+        if sys.version_info >= (3, 10):
+            import importlib.metadata as importlib_metadata
+        else:
+            import importlib_metadata
 
-        # The pkg_resources.get_distribution() call automatically triggers collection of the metadata. While it does not
-        # raise an error if metadata is not found while freezing, the calls below will fall at run-time in that case.
-        dist = pkg_resources.get_distribution('my-test-package')
+        # The `importlib_metadata.distribution()` call automatically triggers collection of the metadata.
+        # While it does not raise an error if metadata is not found while freezing, the calls below will fall at
+        # run-time in that case.
+        dist = importlib_metadata.distribution('my-test-package')
 
         # Sanity check
-        assert dist.project_name == 'my-test-package'
+        assert dist.name == 'my-test-package'
         assert dist.version == '1.0'
-        assert dist.egg_name() == f'my_test_package-{dist.version}-py{sys.version_info[0]}.{sys.version_info[1]}'
         """,
         pyi_args=['--paths', str(extra_path)]
     )

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -75,7 +75,7 @@ sphinx==9.1.0; python_version >= "3.12"
 sqlalchemy==2.0.46
 zope.interface==8.2; python_version >= "3.10"
 Pillow==12.1.0; python_version >= "3.10"
-setuptools==81.0.0; python_version >= "3.9"
+setuptools==82.0.0; python_version >= "3.9"
 
 
 # Python versions not supported / supported for older package versions


### PR DESCRIPTION
`setuptools` 82.0.0 was released on Feb 8th, apparently just in time to have missed our weekly dependency update on Sunday. But it was picked up yesterday by the weekly update in `pyinstaller-hooks-contrib`, so here were are...

This is the first release that removed `pkg_resources`, which gives rise to several different issues with our test suite and CI:
1. we have couple of tests for namespace packages created using `pkg_resources.declare_namespace()`, which were missing the `importorskip('pkg_resources')` decorator
2. couple of tests were still using `pkg_resources` for metadata-related functionality; these are now ported to `importlib.metadata` / `importlib_metadata`
3. the issue with `pip` not removing `__pycache__` directories due to presence of `.opt-1.pyc` files from original installation now results in presence of defunct namespace `pkg_resources` package, which breaks our run-time hook for it. So we need to extend the work-around that we already have in place to cover `pkg_resources` (in addition to `setuptools._vendor.importlib_resources`. The updated version of the work-around has also been copied over to https://github.com/pyinstaller/pyinstaller-hooks-contrib/pull/986.
4. the above issue with defunct `pkg_resources` now also seems to affect `cygwin`, at least for the time being. So we need to implement the cleanup/work-around there as well. I've implemented a simpler version, mostly because I did not figure out how to use `cygwin` python as shell for the work-around step.