### PR TITLE
bootloader: fix errors when compiling with gcc 16

### DIFF
--- a/bootloader/src/pyi_utils.c
+++ b/bootloader/src/pyi_utils.c
@@ -49,7 +49,7 @@ int
 pyi_create_parent_directory_tree(const struct PYI_CONTEXT *pyi_ctx, const char *prefix_path, const char *filename)
 {
     char path[PYI_PATH_MAX];
-    char *subpath_cursor;
+    const char *subpath_cursor;
     size_t path_length;
 
     /* Ensure that combined path length does not exceed max path. */

--- a/bootloader/src/pyi_utils_posix.c
+++ b/bootloader/src/pyi_utils_posix.c
@@ -134,7 +134,7 @@ static char *
 _pyi_create_runtime_tmpdir(const char *runtime_tmpdir)
 {
     char directory_tree_path[PYI_PATH_MAX];
-    char *subpath_cursor;
+    const char *subpath_cursor;
 
     /* Ensure runtime_tmpdir (and thus also its sub-path components)
      * do not exceed path limit. */

--- a/news/9371.bootloader.rst
+++ b/news/9371.bootloader.rst
@@ -1,0 +1,2 @@
+Fix errors when compiling with ``glibc`` 2.43 and compiler that defaults
+to using C23 standard.


### PR DESCRIPTION
The new `gcc` 16 appears to be able to pick up attempts at washing the `const` pointer qualifier through function calls (in our case, through `strchr()`). Fix the target pointer type to avoid warnings, which we treat as errors.

Fixes #9371.