### PR TITLE
_pyi_machine: Avoid using platform.machine() directly

### DIFF
--- a/PyInstaller/_shared_with_waf.py
+++ b/PyInstaller/_shared_with_waf.py
@@ -41,9 +41,9 @@ def _pyi_machine(machine, system):
     """
     # See the corresponding tests in tests/unit/test_compat.py for examples.
 
-    if platform.machine() == "sw_64" or platform.machine() == "loongarch64":
+    if machine == "sw_64" or machine == "loongarch64":
         # This explicitly inhibits cross compiling the bootloader for or on SunWay and LoongArch machine.
-        return platform.machine()
+        return machine
 
     if system == "Windows":
         if machine.lower().startswith("arm"):

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -38,6 +38,7 @@ def test_exec_command_subprocess_wrong_encoding_reports_nicely(capsys):
         ("armv7a", "arm"),
         ("arm", "arm"),
         ("aarch64", "arm"),
+        ("loongarch64", "loongarch64"),
         ("ppc64le", "ppc"),
         ("ppc64", "ppc"),
         ("ppc32le", "ppc"),


### PR DESCRIPTION
The `machine` argument sould be used on all platforms. This change fixes _pyi_machine tests on loongarch64.

Fixes: b194152ceeab572bd879057748b3ecd064b16724
Fixes: 018fa3fe39cba357aaa636b75f1320a4c4ca3464