### PR TITLE
fix: replace 10 bare except clauses with except Exception

### DIFF
--- a/bootloader/waflib/Logs.py
+++ b/bootloader/waflib/Logs.py
@@ -118,7 +118,7 @@ class log_handler(logging.StreamHandler):
             self.flush()
         except (KeyboardInterrupt, SystemExit):
             raise
-        except:
+        except Exception:
             self.handleError(record)
 
     def emit_override(self, record, **kw):

--- a/bootloader/waflib/Scripting.py
+++ b/bootloader/waflib/Scripting.py
@@ -122,7 +122,7 @@ def waf_entry_point(current_directory, version, wafdir):
         try:
             try:
                 run_commands()
-            except:
+            except Exception:
                 if options.pdb:
                     import pdb
                     type, value, tb = sys.exc_info()

--- a/tests/unit/test_modulegraph/testpkg-edgedata/script.py
+++ b/tests/unit/test_modulegraph/testpkg-edgedata/script.py
@@ -13,14 +13,14 @@ if a == b:
     try:
         import toplevel_conditional_import_existing
         import toplevel_conditional_import_nonexisting
-    except:
+    except Exception:
         import toplevel_conditional_import2_existing
         import toplevel_conditional_import2_nonexisting
 
 try:
     import toplevel_import_existing
     import toplevel_import_nonexisting
-except:
+except Exception:
     import toplevel_import2_existing
     import toplevel_import2_nonexisting
 
@@ -39,13 +39,13 @@ def function():
         try:
             import function_conditional_import_existing
             import function_conditional_import_nonexisting
-        except:
+        except Exception:
             import function_conditional_import2_existing
             import function_conditional_import2_nonexisting
 
     try:
         import function_import_existing
         import function_import_nonexisting
-    except:
+    except Exception:
         import function_import2_existing
         import function_import2_nonexisting

--- a/tests/unit/test_modulegraph/testpkg-edgedata/script_from_import.py
+++ b/tests/unit/test_modulegraph/testpkg-edgedata/script_from_import.py
@@ -11,13 +11,13 @@ if a == b:
 
     try:
         from pkg import toplevel_conditional_import_existing, toplevel_conditional_import_nonexisting
-    except:
+    except Exception:
         from pkg import toplevel_conditional_import2_existing
         from pkg import toplevel_conditional_import2_nonexisting
 
 try:
     from pkg import toplevel_import_existing, toplevel_import_nonexisting
-except:
+except Exception:
     from pkg import toplevel_import2_existing
     from pkg import toplevel_import2_nonexisting
 
@@ -34,13 +34,13 @@ def function():
         try:
             from pkg import function_conditional_import_existing
             from pkg import function_conditional_import_nonexisting
-        except:
+        except Exception:
             from pkg import function_conditional_import2_existing
             from pkg import function_conditional_import2_nonexisting
 
     try:
         from pkg import function_import_existing
         from pkg import function_import_nonexisting
-    except:
+    except Exception:
         from pkg import function_import2_existing
         from pkg import function_import2_nonexisting


### PR DESCRIPTION
Replace bare `except:` clauses with `except Exception:` for PEP 8 compliance.