### PR TITLE
building: BUNDLE: fix relocation of collected symbolic links

### DIFF
--- a/PyInstaller/building/api.py
+++ b/PyInstaller/building/api.py
@@ -1144,6 +1144,9 @@ class COLLECT(Target):
         # Normalize TOC
         self.toc = normalize_toc(self.toc)
 
+        # Alphabetically sort the TOC to ensure that order of processing is predictable and reproducible.
+        self.toc.sort()
+
         self.__postinit__()
 
     _GUTS = (

--- a/PyInstaller/building/osx.py
+++ b/PyInstaller/building/osx.py
@@ -333,6 +333,8 @@ class BUNDLE(Target):
         _BINARY_DIR_TYPE = 'BINARY-DIR'
         _FRAMEWORK_DIR_TYPE = 'FRAMEWORK-DIR'
 
+        _UNKNOWN_DIR_TYPE = 'UNKNOWN-DIR'  # used only in this step
+
         _TOP_LEVEL_DIR = pathlib.PurePath('.')
 
         for dest_name, src_name, typecode in toc:
@@ -351,22 +353,43 @@ class BUNDLE(Target):
                 if typecode == 'EXTENSION':
                     typecode = 'BINARY'
 
+            # Directory type as per this entry's typecode. Symbolic links are "neutral". On the off chance that a
+            # directory contains only symbolic link(s), we will override the type of "unknown" directories after this
+            # loop finishes.
+            if typecode == 'SYMLINK':
+                entry_type = _UNKNOWN_DIR_TYPE
+            elif typecode == 'BINARY':
+                entry_type = _BINARY_DIR_TYPE
+            else:
+                entry_type = _DATA_DIR_TYPE
+
             # (Re)classify parent directories
             for parent_dir in parent_dirs:
                 # Skip the top-level `.` dir. This is also the only directory that can contain EXECUTABLE and PKG
-                # entries, so we do not have to worry about.
+                # entries, so we do not have to worry about them.
                 if parent_dir == _TOP_LEVEL_DIR:
                     continue
 
-                directory_type = _BINARY_DIR_TYPE if typecode == 'BINARY' else _DATA_DIR_TYPE  # default
-                directory_type = directory_types.get(parent_dir, directory_type)
+                directory_type = directory_types.get(parent_dir, entry_type)
 
-                if directory_type == _DATA_DIR_TYPE and typecode == 'BINARY':
+                # If directory was previously marked as unknown, overwrite its type with the new one.
+                if directory_type == _UNKNOWN_DIR_TYPE:
+                    directory_type = entry_type
+
+                # Update type into mixed-content, if necessary.
+                if directory_type == _DATA_DIR_TYPE and entry_type == _BINARY_DIR_TYPE:
                     directory_type = _MIXED_DIR_TYPE
-                if directory_type == _BINARY_DIR_TYPE and typecode == 'DATA':
+                if directory_type == _BINARY_DIR_TYPE and entry_type == _DATA_DIR_TYPE:
                     directory_type = _MIXED_DIR_TYPE
 
                 directory_types[parent_dir] = directory_type
+
+        # Reclassify all "unknown" directories into "data-only"; these are directories that contain only one or more
+        # symbolic links.
+        directory_types = {
+            directory: directory_type if directory_type != _UNKNOWN_DIR_TYPE else _DATA_DIR_TYPE
+            for directory, directory_type in directory_types.items()
+        }
 
         logger.debug("Directory classification: %r", directory_types)
 

--- a/PyInstaller/building/osx.py
+++ b/PyInstaller/building/osx.py
@@ -473,6 +473,27 @@ class BUNDLE(Target):
                 # mechanism.
                 file_base_dir = 'Contents/Frameworks'
                 crosslink_base_dir = None
+            elif typecode == 'SYMLINK':
+                # Symbolic links
+                parent_dir = orig_dest_path.parent
+                if parent_dir == _TOP_LEVEL_DIR or directory_types.get(parent_dir) == _MIXED_DIR_TYPE:
+                    # Symbolic links that need to be cross-linked (because they are located in top-level directory or
+                    # in a mixed-content directory) are instead created in both locations, and point to the (relative)
+                    # resource in the same directory; so one of the targets will likely be a file, and the other will
+                    # be a symlink due to cross-linking.
+                    bundle_toc.append((os.path.join('Contents/Frameworks', orig_dest_name), src_name, typecode))
+                    bundle_toc.append((os.path.join('Contents/Resources', orig_dest_name), src_name, typecode))
+                    continue
+                elif directory_types.get(parent_dir) == _DATA_DIR_TYPE:
+                    # Symbolic link in a data-only directory; relocate to 'Contents/Resources' and do NOT cross-link
+                    # (since the whole directory will be cross-linked).
+                    file_base_dir = 'Contents/Resources'
+                    crosslink_base_dir = None
+                else:
+                    # Symbolic link in a binary-only directory; similar to data-only directory, except we relocate to
+                    # 'Contents/Frameworks'.
+                    file_base_dir = 'Contents/Frameworks'
+                    crosslink_base_dir = None
             elif typecode == 'DATA':
                 # Data file; relocate to `Contents/Resources` and cross-link it back into `Contents/Frameworks`.
                 file_base_dir = 'Contents/Resources'
@@ -488,14 +509,6 @@ class BUNDLE(Target):
             if crosslink_base_dir is not None:
                 parent_dir = orig_dest_path.parent
                 requires_crosslink = parent_dir == _TOP_LEVEL_DIR or directory_types.get(parent_dir) == _MIXED_DIR_TYPE
-
-            # Special handling for SYMLINK entries in original TOC; if we need to cross-link a symlink entry, we create
-            # it in both locations, and have each point to the (relative) resource in the same directory (so one of the
-            # targets will likely be a file, and the other will be a symlink due to cross-linking).
-            if typecode == 'SYMLINK' and requires_crosslink:
-                bundle_toc.append((os.path.join(file_base_dir, orig_dest_name), src_name, typecode))
-                bundle_toc.append((os.path.join(crosslink_base_dir, orig_dest_name), src_name, typecode))
-                continue
 
             # The file itself.
             file_dest = os.path.join(file_base_dir, orig_dest_name)

--- a/PyInstaller/building/osx.py
+++ b/PyInstaller/building/osx.py
@@ -132,6 +132,9 @@ class BUNDLE(Target):
         # Normalize TOC
         self.toc = normalize_toc(self.toc)
 
+        # Alphabetically sort the TOC to ensure that order of processing is predictable and reproducible.
+        self.toc.sort()
+
         self.__postinit__()
 
     _GUTS = (

--- a/news/9375.bugfix.rst
+++ b/news/9375.bugfix.rst
@@ -1,0 +1,2 @@
+(macOS) Fix built-time error when trying to create an .app bundle with
+data collected from a directory that contains symlinked elements.

--- a/tests/functional/test_macos_bundle_structure.py
+++ b/tests/functional/test_macos_bundle_structure.py
@@ -1215,3 +1215,189 @@ def test_macos_bundle_layout_framework_in_mixed_dir(pyi_builder, monkeypatch, tm
     assert check_path.is_file()
     assert check_path.is_symlink()
     assert os.readlink(check_path) == 'mixed_dir/Dummy.framework/Versions/A/Dummy'
+
+
+# Test with symlink in a data-only directory pointing to a data file in the same directory.
+# Reproduces #9375.
+@pytest.mark.darwin
+@onedir_only
+def test_macos_bundle_layout_symlink_inside_data_dir(pyi_builder, monkeypatch, tmp_path):
+    datas = []
+
+    # + data_dir: (1)
+    #    - data_file.txt (2)
+    #    - link_to_data.txt -> data_file.txt (3)
+    src_path = tmp_path / 'data_dir' / 'data_file.txt'
+    _create_test_data_file(src_path)
+    datas.append((src_path, 'data_dir'))
+
+    src_path = tmp_path / 'data_dir' / 'link_to_data_file.txt'
+    src_path.symlink_to('data_file.txt')
+    datas.append((src_path, 'data_dir'))
+
+    bundle_path = _create_app_bundle(pyi_builder, monkeypatch, tmp_path, datas=datas)
+
+    # (1) The whole data directory is placed into `Contents/Resources`...
+    check_path = bundle_path / 'Contents' / 'Resources' / 'data_dir'
+    assert check_path.is_dir()
+    assert not check_path.is_symlink()
+
+    # ... and symlinked (at directory level) into `Contents/Frameworks`.
+    check_path = bundle_path / 'Contents' / 'Frameworks' / 'data_dir'
+    assert check_path.is_dir()
+    assert check_path.is_symlink()
+    assert os.readlink(check_path) == '../Resources/data_dir'
+
+    # (2) The data file is placed into directory in `Contents/Resources`...
+    check_path = bundle_path / 'Contents' / 'Resources' / 'data_dir' / 'data_file.txt'
+    assert check_path.is_file()
+    assert not check_path.is_symlink()
+
+    # ... but it is also reachable from `Contents/Frameworks`. The linking is done at the parent directory level,
+    # so the file itself is NOT seen as a symlink.
+    check_path = bundle_path / 'Contents' / 'Frameworks' / 'data_dir' / 'data_file.txt'
+    assert check_path.is_file()
+    assert not check_path.is_symlink()
+
+    # (3) The symlink is created in the `Contents/Resources` directory, and points to the file in the same directory.
+    # There is no cross-linking involved, as the parent directory is cross-linked (which we verified above).
+    check_path = bundle_path / 'Contents' / 'Resources' / 'data_dir' / 'link_to_data_file.txt'
+    assert check_path.is_file()
+    assert check_path.is_symlink()
+    assert os.readlink(check_path) == 'data_file.txt'
+
+
+# Test with symlink in a binary-only directory pointing to a binary file in the same directory.
+@pytest.mark.darwin
+@onedir_only
+def test_macos_bundle_layout_symlink_inside_binary_dir(pyi_builder, monkeypatch, tmp_path):
+    binaries = []
+
+    # + binary_dir: (1)
+    #    - binary.dylib (2)
+    #    - link_to_binary.dylib -> binary.dylib (3)
+    src_path = tmp_path / 'binary_dir' / 'binary.dylib'
+    _create_test_binary(src_path)
+    binaries.append((src_path, 'binary_dir'))
+
+    src_path = tmp_path / 'binary_dir' / 'link_to_binary.dylib'
+    src_path.symlink_to('binary.dylib')
+    binaries.append((src_path, 'binary_dir'))
+
+    bundle_path = _create_app_bundle(pyi_builder, monkeypatch, tmp_path, binaries=binaries)
+
+    # (1) The whole binary directory is placed into `Contents/Frameworks`...
+    check_path = bundle_path / 'Contents' / 'Frameworks' / 'binary_dir'
+    assert check_path.is_dir()
+    assert not check_path.is_symlink()
+
+    # ... and symlinked (at directory level) into Contents/Resources.
+    check_path = bundle_path / 'Contents' / 'Resources' / 'binary_dir'
+    assert check_path.is_dir()
+    assert check_path.is_symlink()
+    assert os.readlink(check_path) == '../Frameworks/binary_dir'
+
+    # (2) The binary file is placed into directory in `Contents/Frameworks`...
+    check_path = bundle_path / 'Contents' / 'Frameworks' / 'binary_dir' / 'binary.dylib'
+    assert check_path.is_file()
+    assert not check_path.is_symlink()
+
+    # ... but it is also reachable from `Contents/Resources`. The linking is done at the parent directory level,
+    # so the file itself is NOT seen as a symlink.
+    check_path = bundle_path / 'Contents' / 'Resources' / 'binary_dir' / 'binary.dylib'
+    assert check_path.is_file()
+    assert not check_path.is_symlink()
+
+    # (3) The symlink is created in the `Contents/Frameworks` directory, and points to the file in the same directory.
+    # There is no cross-linking involved, as the parent directory is cross-linked (which we verified above).
+    check_path = bundle_path / 'Contents' / 'Frameworks' / 'binary_dir' / 'link_to_binary.dylib'
+    assert check_path.is_file()
+    assert check_path.is_symlink()
+    assert os.readlink(check_path) == 'binary.dylib'
+
+
+# Test with symlinks in mixed-content directory pointing to files in the same directory.
+@pytest.mark.darwin
+@onedir_only
+def test_macos_bundle_layout_symlink_inside_mixed_dir(pyi_builder, monkeypatch, tmp_path):
+    datas = []
+    binaries = []
+
+    # + mixed_dir: (1)
+    #    - data_file.txt (2)
+    #    - binary.dylib (3)
+    #    - link_to_data_file.txt -> data_file.txt (4)
+    #    - link_to_binary.dylib -> link_to_binary.dylib (5)
+    src_path = tmp_path / 'mixed_dir' / 'data_file.txt'
+    _create_test_data_file(src_path)
+    datas.append((src_path, 'mixed_dir'))
+
+    src_path = tmp_path / 'mixed_dir' / 'binary.dylib'
+    _create_test_binary(src_path)
+    binaries.append((src_path, 'mixed_dir'))
+
+    src_path = tmp_path / 'mixed_dir' / 'link_to_data_file.txt'
+    src_path.symlink_to('data_file.txt')
+    datas.append((src_path, 'mixed_dir'))
+
+    src_path = tmp_path / 'mixed_dir' / 'link_to_binary.dylib'
+    src_path.symlink_to('binary.dylib')
+    binaries.append((src_path, 'mixed_dir'))
+
+    bundle_path = _create_app_bundle(pyi_builder, monkeypatch, tmp_path, datas=datas, binaries=binaries)
+
+    # (1) The mixed-content directory is created in both `Contents/Frameworks` and `Contents/Resources` (i.e., no
+    # linking at the directory level).
+    check_path = bundle_path / 'Contents' / 'Frameworks' / 'mixed_dir'
+    assert check_path.is_dir()
+    assert not check_path.is_symlink()
+
+    check_path = bundle_path / 'Contents' / 'Resources' / 'mixed_dir'
+    assert check_path.is_dir()
+    assert not check_path.is_symlink()
+
+    # (2) The data file is placed into directory in `Contents/Resources`...
+    check_path = bundle_path / 'Contents' / 'Resources' / 'mixed_dir' / 'data_file.txt'
+    assert check_path.is_file()
+    assert not check_path.is_symlink()
+
+    # ... and symlinked into directory in `Contents/Frameworks`.
+    check_path = bundle_path / 'Contents' / 'Frameworks' / 'mixed_dir' / 'data_file.txt'
+    assert check_path.is_file()
+    assert check_path.is_symlink()
+    assert os.readlink(check_path) == '../../Resources/mixed_dir/data_file.txt'
+
+    # (3) The binary is placed into directory in `Contents/Frameworks`...
+    check_path = bundle_path / 'Contents' / 'Frameworks' / 'mixed_dir' / 'binary.dylib'
+    assert check_path.is_file()
+    assert not check_path.is_symlink()
+
+    # ... and symlinked into directory in `Contents/Resources`.
+    check_path = bundle_path / 'Contents' / 'Resources' / 'mixed_dir' / 'binary.dylib'
+    assert check_path.is_file()
+    assert check_path.is_symlink()
+    assert os.readlink(check_path) == '../../Frameworks/mixed_dir/binary.dylib'
+
+    # (4) The symlink is replicated in both `Contents/Frameworks` and `Contents/Resources`, and points to the resource
+    # (file or symlink) in the same directory.
+    check_path = bundle_path / 'Contents' / 'Frameworks' / 'mixed_dir' / 'link_to_data_file.txt'
+    assert check_path.is_file()
+    assert check_path.is_symlink()
+    assert os.readlink(check_path) == 'data_file.txt'
+
+    check_path = bundle_path / 'Contents' / 'Resources' / 'mixed_dir' / 'link_to_data_file.txt'
+    assert check_path.is_file()
+    assert check_path.is_symlink()
+    assert os.readlink(check_path) == 'data_file.txt'
+
+    # (5) The symlink is replicated in both `Contents/Frameworks` and `Contents/Resources`, and points to the resource
+    # (file or symlink) in the same directory.
+    check_path = bundle_path / 'Contents' / 'Frameworks' / 'mixed_dir' / 'link_to_binary.dylib'
+    assert check_path.is_file()
+    assert check_path.is_symlink()
+    assert os.readlink(check_path) == 'binary.dylib'
+
+    check_path = bundle_path / 'Contents' / 'Resources' / 'mixed_dir' / 'link_to_binary.dylib'
+    assert check_path.is_file()
+    assert check_path.is_symlink()
+    assert os.readlink(check_path) == 'binary.dylib'

--- a/tests/functional/test_macos_bundle_structure.py
+++ b/tests/functional/test_macos_bundle_structure.py
@@ -1410,3 +1410,67 @@ def test_macos_bundle_layout_symlink_inside_mixed_dir(pyi_builder, monkeypatch, 
     assert check_path.is_file()
     assert check_path.is_symlink()
     assert os.readlink(check_path) == 'binary.dylib'
+
+
+# Test that a directory that contains only a symbolic link is classified as data-only directory, and is placed/relocated
+# under the Contents/Resources directory structure.
+@pytest.mark.darwin
+@onedir_only
+def test_macos_bundle_layout_directory_with_only_a_symlink(pyi_builder, monkeypatch, tmp_path):
+    binaries = []
+
+    # + binary_dir: (1)
+    #    - binary.dylib (2)
+    # + symlink_dir: (3)
+    #    - link_to_binary.dylib -> ../binary.dylib (4)
+    src_path = tmp_path / 'binary_dir' / 'binary.dylib'
+    _create_test_binary(src_path)
+    binaries.append((src_path, 'binary_dir'))
+
+    (tmp_path / 'symlink_dir').mkdir(parents=True, exist_ok=False)
+
+    src_path = tmp_path / 'symlink_dir' / 'link_to_binary.dylib'
+    src_path.symlink_to('../binary_dir/binary.dylib')
+    binaries.append((src_path, 'symlink_dir'))
+
+    bundle_path = _create_app_bundle(pyi_builder, monkeypatch, tmp_path, binaries=binaries)
+
+    # (1) The whole binary directory is placed into `Contents/Frameworks`...
+    check_path = bundle_path / 'Contents' / 'Frameworks' / 'binary_dir'
+    assert check_path.is_dir()
+    assert not check_path.is_symlink()
+
+    # ... and symlinked (at directory level) into Contents/Resources.
+    check_path = bundle_path / 'Contents' / 'Resources' / 'binary_dir'
+    assert check_path.is_dir()
+    assert check_path.is_symlink()
+    assert os.readlink(check_path) == '../Frameworks/binary_dir'
+
+    # (2) The binary file is placed into directory in `Contents/Frameworks`...
+    check_path = bundle_path / 'Contents' / 'Frameworks' / 'binary_dir' / 'binary.dylib'
+    assert check_path.is_file()
+    assert not check_path.is_symlink()
+
+    # ... but it is also reachable from `Contents/Resources`. The linking is done at the parent directory level,
+    # so the file itself is NOT seen as a symlink.
+    check_path = bundle_path / 'Contents' / 'Resources' / 'binary_dir' / 'binary.dylib'
+    assert check_path.is_file()
+    assert not check_path.is_symlink()
+
+    # (3) The directory with symbolic link is placed into `Contents/Resources`...
+    check_path = bundle_path / 'Contents' / 'Resources' / 'symlink_dir'
+    assert check_path.is_dir()
+    assert not check_path.is_symlink()
+
+    # ... and symlinked (at directory level) into Contents/Frameworks.
+    check_path = bundle_path / 'Contents' / 'Frameworks' / 'symlink_dir'
+    assert check_path.is_dir()
+    assert check_path.is_symlink()
+    assert os.readlink(check_path) == '../Resources/symlink_dir'
+
+    # (4) The symlink is created in the `Contents/Resources` directory.
+    # There is no cross-linking involved, as the parent directory is cross-linked (which we verified above).
+    check_path = bundle_path / 'Contents' / 'Frameworks' / 'symlink_dir' / 'link_to_binary.dylib'
+    assert check_path.is_file()
+    assert check_path.is_symlink()
+    assert os.readlink(check_path) == '../binary_dir/binary.dylib'

--- a/tests/functional/test_macos_bundle_structure.py
+++ b/tests/functional/test_macos_bundle_structure.py
@@ -1217,11 +1217,14 @@ def test_macos_bundle_layout_framework_in_mixed_dir(pyi_builder, monkeypatch, tm
     assert os.readlink(check_path) == 'mixed_dir/Dummy.framework/Versions/A/Dummy'
 
 
-# Test with symlink in a data-only directory pointing to a data file in the same directory.
-# Reproduces #9375.
+# Test with symlink in a data-only directory pointing to a data file in the same directory. Reproduces #9375.
+# This test comes in two sub-variants, with different (name-based) ordering of the file and the symbolic link; this aims
+# to verify that symbolic link does not affect classification of the parent directory type (for example, causes it to be
+# mis-classified as a mixed-content directory).
 @pytest.mark.darwin
 @onedir_only
-def test_macos_bundle_layout_symlink_inside_data_dir(pyi_builder, monkeypatch, tmp_path):
+@pytest.mark.parametrize('symlink_first', [False, True], ids=['file_first', 'symlink_first'])
+def test_macos_bundle_layout_symlink_inside_data_dir(pyi_builder, monkeypatch, tmp_path, symlink_first):
     datas = []
 
     # + data_dir: (1)
@@ -1231,7 +1234,8 @@ def test_macos_bundle_layout_symlink_inside_data_dir(pyi_builder, monkeypatch, t
     _create_test_data_file(src_path)
     datas.append((src_path, 'data_dir'))
 
-    src_path = tmp_path / 'data_dir' / 'link_to_data_file.txt'
+    SYMLINK_BASENAME = 'a_link_to_data_file.txt' if symlink_first else 'link_to_data_file.txt'
+    src_path = tmp_path / 'data_dir' / SYMLINK_BASENAME
     src_path.symlink_to('data_file.txt')
     datas.append((src_path, 'data_dir'))
 
@@ -1261,16 +1265,20 @@ def test_macos_bundle_layout_symlink_inside_data_dir(pyi_builder, monkeypatch, t
 
     # (3) The symlink is created in the `Contents/Resources` directory, and points to the file in the same directory.
     # There is no cross-linking involved, as the parent directory is cross-linked (which we verified above).
-    check_path = bundle_path / 'Contents' / 'Resources' / 'data_dir' / 'link_to_data_file.txt'
+    check_path = bundle_path / 'Contents' / 'Resources' / 'data_dir' / SYMLINK_BASENAME
     assert check_path.is_file()
     assert check_path.is_symlink()
     assert os.readlink(check_path) == 'data_file.txt'
 
 
 # Test with symlink in a binary-only directory pointing to a binary file in the same directory.
+# This test comes in two sub-variants, with different (name-based) ordering of the file and the symbolic link; this aims
+# to verify that symbolic link does not affect classification of the parent directory type (for example, causes it to be
+# mis-classified as a mixed-content directory).
 @pytest.mark.darwin
 @onedir_only
-def test_macos_bundle_layout_symlink_inside_binary_dir(pyi_builder, monkeypatch, tmp_path):
+@pytest.mark.parametrize('symlink_first', [False, True], ids=['file_first', 'symlink_first'])
+def test_macos_bundle_layout_symlink_inside_binary_dir(pyi_builder, monkeypatch, tmp_path, symlink_first):
     binaries = []
 
     # + binary_dir: (1)
@@ -1280,7 +1288,8 @@ def test_macos_bundle_layout_symlink_inside_binary_dir(pyi_builder, monkeypatch,
     _create_test_binary(src_path)
     binaries.append((src_path, 'binary_dir'))
 
-    src_path = tmp_path / 'binary_dir' / 'link_to_binary.dylib'
+    SYMLINK_BASENAME = 'a_link_to_binary.dylib' if symlink_first else 'link_to_binary.dylib'
+    src_path = tmp_path / 'binary_dir' / SYMLINK_BASENAME
     src_path.symlink_to('binary.dylib')
     binaries.append((src_path, 'binary_dir'))
 
@@ -1310,7 +1319,7 @@ def test_macos_bundle_layout_symlink_inside_binary_dir(pyi_builder, monkeypatch,
 
     # (3) The symlink is created in the `Contents/Frameworks` directory, and points to the file in the same directory.
     # There is no cross-linking involved, as the parent directory is cross-linked (which we verified above).
-    check_path = bundle_path / 'Contents' / 'Frameworks' / 'binary_dir' / 'link_to_binary.dylib'
+    check_path = bundle_path / 'Contents' / 'Frameworks' / 'binary_dir' / SYMLINK_BASENAME
     assert check_path.is_file()
     assert check_path.is_symlink()
     assert os.readlink(check_path) == 'binary.dylib'

--- a/tests/functional/test_macos_bundle_structure.py
+++ b/tests/functional/test_macos_bundle_structure.py
@@ -280,7 +280,7 @@ def test_macos_bundle_layout_binary_only_dir(pyi_builder, monkeypatch, tmp_path)
     assert check_path.is_file()
     assert not check_path.is_symlink()
 
-    # ... but it is also reachable from `Resources/Frameworks`. The linking is done at the parent directory level,
+    # ... but it is also reachable from `Contents/Resources`. The linking is done at the parent directory level,
     # so the file itself is NOT seen as a symlink.
     check_path = bundle_path / 'Contents' / 'Resources' / 'binary_dir' / 'binary1.dylib'
     assert check_path.is_file()
@@ -432,7 +432,7 @@ def test_macos_bundle_layout_mixed_dir_with_subdirs(pyi_builder, monkeypatch, tm
     assert check_path.is_file()
     assert not check_path.is_symlink()
 
-    # ... but it is also reachable from `Resources/Frameworks`. The linking is done at the parent directory level,
+    # ... but it is also reachable from `Contents/Resources`. The linking is done at the parent directory level,
     # so the file itself is NOT seen as a symlink.
     check_path = bundle_path / 'Contents' / 'Resources' / 'mixed_dir' / 'binary_subdir' / 'binary.dylib'
     assert check_path.is_file()
@@ -581,7 +581,7 @@ def test_macos_bundle_layout_mixed_dir_with_subdirs_and_dots(pyi_builder, monkey
     assert check_path.is_file()
     assert not check_path.is_symlink()
 
-    # ... but it is also reachable from `Resources/Frameworks`. The linking is done at the parent directory level,
+    # ... but it is also reachable from `Contents/Resources`. The linking is done at the parent directory level,
     # so the file itself is NOT seen as a symlink.
     check_path = bundle_path / 'Contents' / 'Resources' / 'mixed.dir' / '.binary_subdir' / 'binary.dylib'
     assert check_path.is_file()
@@ -719,7 +719,7 @@ def test_macos_bundle_layout_symlink_into_binary_dir(pyi_builder, monkeypatch, t
     assert check_path.is_file()
     assert not check_path.is_symlink()
 
-    # ... but it is also reachable from `Resources/Frameworks`. The linking is done at the parent directory level,
+    # ... but it is also reachable from `Contents/Resources`. The linking is done at the parent directory level,
     # so the file itself is NOT seen as a symlink.
     check_path = bundle_path / 'Contents' / 'Resources' / 'binary_dir' / 'binary.dylib'
     assert check_path.is_file()
@@ -870,7 +870,7 @@ def test_macos_bundle_layout_framework_in_top_level(pyi_builder, monkeypatch, tm
     assert check_path.is_dir()
     assert not check_path.is_symlink()
 
-    # ... but are also reachable from `Resources/Frameworks`. The linking is done at the parent directory level, so the
+    # ... but are also reachable from `Contents/Resources`. The linking is done at the parent directory level, so the
     # files/directories themselves are NOT seen as symlinks.
     check_path = bundle_path / 'Contents' / 'Resources' / 'Dummy.framework' / 'Versions'
     assert check_path.is_dir()
@@ -987,7 +987,7 @@ def test_macos_bundle_layout_framework_in_binary_dir(pyi_builder, monkeypatch, t
     assert check_path.is_file()
     assert not check_path.is_symlink()
 
-    # ... but it is also reachable from `Resources/Frameworks`. The linking is done at the parent directory level,
+    # ... but it is also reachable from `Contents/Resources`. The linking is done at the parent directory level,
     # so the file itself is NOT seen as a symlink.
     check_path = bundle_path / 'Contents' / 'Resources' / 'binary_dir' / 'binary.dylib'
     assert check_path.is_file()
@@ -1136,7 +1136,7 @@ def test_macos_bundle_layout_framework_in_mixed_dir(pyi_builder, monkeypatch, tm
     assert check_path.is_dir()
     assert not check_path.is_symlink()
 
-    # ... and symlinked into `Resources/Frameworks`.
+    # ... and symlinked into `Contents/Resources`.
     check_path = bundle_path / 'Contents' / 'Resources' / 'mixed_dir' / 'Dummy.framework'
     assert check_path.is_dir()
     assert check_path.is_symlink()


### PR DESCRIPTION
This is an attempt to fix #9375, which I initially mistook for an ordering issue. A more thorough investigation revealed that the true cause was the fact that when building an .app bundle, we always relocate collected symbolic links to the `Contents/Frameworks` directory structure.

Most of the time, this works out OK because we typically encounter symlinks to binaries, either in binary-only directories (or .framework bundles) or in mixed-content directories. With #9375, the symlink was in the data-only directory, and should therefore be relocated to the `Contents/Resources` directory structure.

I've reworked the offending part to explicitly handle symlinks for all three cases, so that:
- symlinks in data-only directories are relocated to directory structure under `Contents/Resources`
- symlinks in binary-only directories are relocated to directory structure under `Contents/Frameworks`
- symlinks in mixed-content directories are created under both directory structures

This fixes #9375.

There are new tests for all three cases; the data-only variant reproduces #9375, and the other two are there for the sake of completeness and to codify the desired behavior.

While dealing with the above issue, I came across another corner case, where a directory containing only binaries and symbolic links might be erroneously classified as mixed-content instead of binary-only IF a symbolic link from the directory is encountered first. I've revised the directory classification code so that symlinks are now "neutral" and do not affect directory classification; and if a directory contains only symlinks (e.g., to elements outside of the directory), the directory is considered to be data-only. There's an additional test for that, mostly to codify the behavior.

This PR also contains a commit that changes behavior of `COLLECT` and `BUNDLE`; these targets now alphabetically sort their TOC after merging the input TOCs and normalizing (de-duplicating) the result of the merging. This aims to make the order of processing fully deterministic (and therefore repeatable), and should also make it easier to read the .toc files for these targets, as the elements will now be in alphabetic order.