### PR TITLE
doc: document the issue with icon seemingly not updating on Windows [skip ci]

### DIFF
--- a/doc/common-issues-and-pitfalls.rst
+++ b/doc/common-issues-and-pitfalls.rst
@@ -508,3 +508,29 @@ by setting dummy file handles at the very start of your program::
     mode, we recommend that you first try running your unfrozen script
     using the ``pythonw.exe`` interpreter to ensure that it works correctly
     when console is unavailable.
+
+
+Icon seemingly not being updated on rebuilt Windows executables
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+On Windows, the OS keeps an icon cache that seems to be based on the
+executable's full path, and does not update when an executable at
+an already-cached location is modified (for example, is replaced by a
+different executable with the same name).
+
+Therefore, if you try to rebuild your application with a different icon,
+it might seem that the icon on the executable has not changed. However,
+if you rename the executable or copy/move it to a different location,
+the icon will be updated accordingly.
+
+There are different ways of forcing the icon cache update; since you
+have a python interpreter at your disposal, perhaps the most robust
+way (aside from restarting the system) is to open an interactive
+python shell, and call `SHChangeNotify <https://learn.microsoft.com/en-us/windows/win32/api/shlobj_core/nf-shlobj_core-shchangenotify>`_
+win32 API function via :mod:`ctypes`, passing ``SHCNE_ASSOCCHANGED``
+(0x08000000) and ``SHCNF_IDLIST`` (0x0000) as its first two arguments::
+
+    import ctypes
+    shell32 = ctypes.OleDLL('shell32')
+    shell32.SHChangeNotify.restype = None
+    shell32.SHChangeNotify(0x08000000, 0x0000, None, None)

--- a/doc/help2rst.py
+++ b/doc/help2rst.py
@@ -34,6 +34,9 @@ def parser_to_rst(parser: ArgumentParser, cross_references=True):
     """
     Extract the ``--help`` output from an argparse parser and convert it to restructured text.
     """
+    # On python >= 3.14, disable colored output, as injected color codes interfere with the parser. On earlier python
+    # versions, this is no-op (we are setting a non-existent property).
+    parser.color = False
     help = parser.format_help()
     return help_to_rst(help, cross_references)
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -22,7 +22,7 @@ sphinxcontrib-jquery==4.1
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.7
 sphinxcontrib-serializinghtml==1.1.10
-sphinxcontrib-towncrier==0.4.0a0
+sphinxcontrib-towncrier==0.5.0a0
 sphinx-issues==4.1.0
 sphinx-rtd-theme==2.0.0
 towncrier==25.8.0


### PR DESCRIPTION
Add a new section under "Common Issues and Pitfalls" to document the issue with icon on the rebuilt executable seemingly not updating on Windows due to OS-level caching of icons.

Closes #8784.

Update `sphinxcontrib-towncrier` to fix compatibility with recently re-pinned `towncrier`. And have `help2rst` disable colored `argparse` output (python >= 3.14), since that interferes with help-message parser.