### PR TITLE
bootloader: add --no-cfg option to waf

### DIFF
--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -183,6 +183,16 @@ def options(ctx):
         dest='macos_universal2',
     )
 
+    grp = ctx.add_option_group('Windows-specific options', 'These options have effect only on Windows.')
+    grp.add_option(
+        '--no-cfg',
+        action='store_false',
+        help="When building on Windows with MSVC, do not enable Control Flow Guard (CFG). By default, bootloader "
+        "executables are built with CFG enabled, which might cause issues with certain libraries.",
+        default=True,
+        dest='enable_cfg',
+    )
+
 
 def check_sizeof_pointer(ctx):
     def check(type, expected):
@@ -719,10 +729,12 @@ def configure(ctx):
             # 6.00 (x86, x64) and 6.02 (ARM) should be fine for our purposes.
             ctx.env.append_value('LINKFLAGS', '/SUBSYSTEM:CONSOLE')
 
-            # Enable support for Control Flow Guard
+            # Enable support for Control Flow Guard (CFG)
             # https://docs.microsoft.com/en-us/windows/win32/secbp/control-flow-guard
-            ctx.env.append_value('CFLAGS', '/guard:cf')
-            ctx.env.append_value('LINKFLAGS', '/guard:cf')
+            ctx.msg('Enable Control Flow Guard (CFG)', result='yes' if ctx.options.enable_cfg else 'no')
+            if ctx.options.enable_cfg:
+                ctx.env.append_value('CFLAGS', '/guard:cf')
+                ctx.env.append_value('LINKFLAGS', '/guard:cf')
 
             # Increase the executable's stack size from the default 1 MiB (0x100000) to 2 MB (0x1E8480) to match
             # the stack size under the Python interpreter.

--- a/doc/bootloader-building.rst
+++ b/doc/bootloader-building.rst
@@ -4,37 +4,82 @@
 Building the Bootloader
 =========================
 
-PyInstaller comes with pre-compiled bootloaders for some platforms in
-the ``bootloader`` folder of the distribution folder.
-When there is no pre-compiled bootloader for
-the current platform (operating-system and word-size),
-the pip_ setup will attempt to build one.
+PyInstaller comes with pre-compiled bootloader executables for
+commonly-used platforms. These executables are located in the
+``bootloader`` directory inside the source distribution directory,
+and are updated (rebuild) as necessary before every PyInstaller release.
+When pre-compiled bootloader executables are not available for the
+current platform (w.r.t. operating system and word-size), the package
+installation process (usually pip_ setup) will attempt to build the
+bootloader from source.
 
-If there is no precompiled bootloader for your platform,
-or if you want to modify the bootloader source,
-you need to build the bootloader.
-To do this,
+You might, however, want to build the bootloader yourself, despite the
+pre-compiled version being available for your target platform. There
+are various reasons why one might to do that, including:
 
-* Download and install Python, which is required for running :command:`waf`,
-* `git clone` or download the source from our `GitHub repository`_,
-* ``cd`` into the folder where you cloned or unpacked the source to,
+* you need to modify the bootloader's behavior in some way that
+  is specific to your application
+
+* you want to avoid anti-virus false positives that result from the
+  wide-spread use of pre-compiled bootloaders
+
+* you want to enable (or disable) a particular option exposed via the
+  bootloader's build system
+
+* you want to build with specific compiler toolchain
+
+The first two sub-sections below provide steps for **building and installing
+the bootloader from source distribution** and for **forcing bootloader
+to be rebuild as part of package installation**. The rest of sub-sections
+provide details for individual platforms.
+
+The officially supported platforms are:
+
+* GNU/Linux (using gcc)
+* Windows (using Visual C++ (VS2015 or later) or MinGW's gcc)
+* macOS (using clang)
+
+Contributed platforms are:
+
+* AIX (using gcc or xlc)
+* HP-UX  (using gcc or xlc)
+* Solaris
+
+For more information about cross-building, please read on
+and mind the section about the virtual machines
+provided in the Vagrantfile.
+
+
+Building and installing bootloader from source distribution or repository checkout
+==================================================================================
+
+To build (and install) bootloader from source distribution or repository
+checkout, follow these steps:
+
+* download and install Python, which is required for running :command:`waf`,
+
+* ``git clone`` or download the source from our `GitHub repository`_,
+* ``cd`` into the directory where you cloned the repository or unpacked the source,
 * ``cd bootloader``, and
-* make the bootloader with: ``python ./waf all``,
-* test the build by ref:`running (parts of) the test-suite
+* build the bootloader by running: ``python ./waf all``,
+* install the PyInstaller with rebuilt bootloader; first, change back
+  to the parent (top-level) directory: ``cd ..``, and
+* run ``pip install .`` or ``pip install -e .`` (for editable install)
+* test the build by :ref:`running (parts of) the test-suite
   <running-the-test-suite>`.
 
 This will produce the bootloader executables for your current platform
-(of course, for Windows these files will have the ``.exe`` extension):
+(on Windows, these files will have the ``.exe`` extension):
 
-* :file:`../PyInstaller/bootloader/{OS_ARCH}/run`,
-* :file:`../PyInstaller/bootloader/{OS_ARCH}/run_d`,
-* :file:`../PyInstaller/bootloader/{OS_ARCH}/runw` (macOS and Windows only), and
-* :file:`../PyInstaller/bootloader/{OS_ARCH}/runw_d` (macOS and Windows only).
+* :file:`PyInstaller/bootloader/{OS_ARCH}/run`,
+* :file:`PyInstaller/bootloader/{OS_ARCH}/run_d`,
+* :file:`PyInstaller/bootloader/{OS_ARCH}/runw` (macOS and Windows only), and
+* :file:`PyInstaller/bootloader/{OS_ARCH}/runw_d` (macOS and Windows only).
 
-The bootloaders architecture defaults to the machine's one, but can be changed
-using the :option:`--target-arch` option – given the appropriate compiler and
-development files are installed. E.g. to build a 32-bit bootloader on a 64-bit
-machine, run::
+The bootloader's architecture defaults to the machine's one, but can be changed
+using the ``--target-arch`` option – given the appropriate compiler and
+development files are installed. For example, to build a 32-bit bootloader on
+a 64-bit machine, run::
 
   python ./waf all --target-arch=32bit
 
@@ -42,25 +87,69 @@ machine, run::
 If this reports an error, read the detailed notes that follow,
 then ask for technical help.
 
-By setting the environment variable ``PYINSTALLER_COMPILE_BOOTLOADER``
-the pip_ setup will attempt to build the bootloader for your platform, even
-if it is already present. Doing so would execute the command ``python ./waf configure all`` upon installation. You can also pass additional arguments to the build process by setting the ``PYINSTALLER_BOOTLOADER_WAF_ARGS`` environment variable.
 
-Supported platforms are
+Forcing bootloader rebuild as part of package installation
+==========================================================
 
-* GNU/Linux (using gcc)
-* Windows (using Visual C++ (VS2015 or later) or MinGW's gcc)
-* Mac OX X (using clang)
+Instead of performing manual steps from the previous section, it is also
+possible to force bootloader to be rebuild when installing PyInstaller
+directly through `pip`_. This alternative might prove especially useful
+in setting up automated build pipelines.
 
-Contributed platforms are
+To force bootloader to be rebuilt during PyInstaller package installation, set the
+``PYINSTALLER_COMPILE_BOOTLOADER`` environment variable (to any value)
+before running `pip`_. This will cause the installation process to (re)build
+the bootloader via the equivalent of running the ``python ./waf configure all``
+command. You can pass additional arguments to the build process by setting
+the ``PYINSTALLER_BOOTLOADER_WAF_ARGS`` environment variable.
 
-* AIX (using gcc or xlc)
-* HP-UX  (using gcc or xlc)
-* Solaris
+For the above to work, you also need to ensure that:
 
-For more information about cross-building please read on
-and mind the section about the virtual machines
-provided in the Vagrantfile.
+* prior installation of PyInstaller (if present) is removed: ``pip uninstall PyInstaller``
+* any cached wheels from previous PyInstaller installation attempts are
+  removed, to prevent ``pip`` from re-using them: ``pip cache remove PyInstaller``
+* when running the ``pip install`` command, ``--no-binary=pyinstaller`` is
+  added, to ensure PyInstaller is installed from source distribution
+  (sdist), rather from a binary wheel
+
+It is also recommended to use ``--verbose`` option with ``pip install``
+command, so you can observe the bootloader's build log and verify that
+it was, in fact, rebuild (as opposed, for example, to ``pip`` simply
+re-using and installing a pre-built wheel).
+
+Therefore, the complete list of steps is as follows:
+
+.. tab:: Windows (command prompt)
+
+   .. code-block:: batch
+
+      set PYINSTALLER_COMPILE_BOOTLOADER=1
+      set "PYINSTALLER_BOOTLOADER_WAF_ARGS=--example-option=example-value --example-flag"
+      python -m pip uninstall PyInstaller
+      python -m pip cache remove PyInstaller
+      python -m pip install --verbose --no-binary=PyInstaller PyInstaller
+
+
+.. tab:: Windows (PowerShell)
+
+   .. code-block:: powershell
+
+      $env:PYINSTALLER_COMPILE_BOOTLOADER=1
+      $env:PYINSTALLER_BOOTLOADER_WAF_ARGS="--example-option=example-value --example-flag"
+      python -m pip uninstall PyInstaller
+      python -m pip cache remove PyInstaller
+      python -m pip install --verbose --no-binary=PyInstaller PyInstaller
+
+
+.. tab:: Other
+
+   .. code-block:: shell
+
+      export PYINSTALLER_COMPILE_BOOTLOADER=1
+      export PYINSTALLER_BOOTLOADER_WAF_ARGS="--example-option=example-value --example-flag"
+      python -m pip uninstall PyInstaller
+      python -m pip cache remove PyInstaller
+      python -m pip install --verbose --no-binary=PyInstaller PyInstaller
 
 
 Building for GNU/Linux

--- a/doc/bootloader-building.rst
+++ b/doc/bootloader-building.rst
@@ -369,8 +369,8 @@ In all cases you may want
 You can also build the bootloaders for cygwin.
 
 
-Build using Visual Studio C++
----------------------------------
+Build using Microsoft Visual C/C++ toolchain
+--------------------------------------------
 
 * With our `wscript` file, you don't need to run ``vcvarsall.bat`` to ’switch’
   the environment between VC++ installations and target architecture. The
@@ -387,17 +387,26 @@ Build using Visual Studio C++
      `chocolatey <https://chocolatey.org/>`_ package manager.
      While at a first glance it looks like overdose, this is the easiest
      way to install the C++ build-tools. It comes down to two lines in an
-     administrative powershell::
+     administrative powershell; the `one-line-install as written on the chocolatey
+     homepage <https://chocolatey.org/install>`_ to install `chocolatey`
+     itself, followed by::
 
-       … one-line-install as written on the chocolatey homepage
        choco install -y python3 visualstudio2019-workload-vctools
+
+  .. note::
+     When building bootloader with MSVC toolchain, the Control Flow Guard
+     (CFG) feature is enabled by default. This might cause crashes in
+     libraries that need to manipulate control flow (see :ref:`here
+     <control flow guard>`). In order to build application that uses such
+     library, bootloader needs to be (re)built with CFG disabled, using
+     the ``--no-cfg`` option.
 
 * Useful Links:
 
   * `Microsoft Visual C++ Build-Tools 2015
-    <http://landinghub.visualstudio.com/visual-cpp-build-tools>`_
-  * `Microsoft Build-Tools for Visual Studio 2017.
-    <https://www.visualstudio.com/downloads/#build-tools-for-visual-studio-2017>`_
+    <https://www.microsoft.com/en-us/download/details.aspx?id=48159>`_
+  * `Microsoft Build-Tools for Visual Studio 2026.
+    <https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2026>`_
 
 
 After installing the C++ build-tool

--- a/doc/common-issues-and-pitfalls.rst
+++ b/doc/common-issues-and-pitfalls.rst
@@ -534,3 +534,30 @@ win32 API function via :mod:`ctypes`, passing ``SHCNE_ASSOCCHANGED``
     shell32 = ctypes.OleDLL('shell32')
     shell32.SHChangeNotify.restype = None
     shell32.SHChangeNotify(0x08000000, 0x0000, None, None)
+
+
+.. _control flow guard:
+
+Windows executables and Control Flow Guard (CFG)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When PyInstaller's bootloader is compiled on Windows with Microsoft Visual
+C (MSVC) toolchain, the `Control Flow Guard (CFG) <https://learn.microsoft.com/en-us/windows/win32/secbp/control-flow-guard>`_
+feature is enabled by default. Therefore, the pre-compiled bootloader
+executables for Windows that are shipped with PyInstaller also have CFG
+enabled, and so do the Windows executables made with said bootloader
+executables.
+
+Control Flow Guard may interfere with libraries that need to manipulate
+control flow for whatever reason (for example, the `unicorn package from Unicorn project <https://www.unicorn-engine.org>`_),
+and cause the application to crash.
+
+In order to build an application using such library, you need to rebuild
+the bootloader with Control Flow Guard explicitly disabled. To do so,
+pass the ``--no-cfg`` option to the bootloader build script, either on
+the command-line (if building manually from unpacked source archive or
+repository checkout) or via the ``PYINSTALLER_BOOTLOADER_WAF_ARGS``
+environment variable (if using ``pip install`` in combination with
+``PYINSTALLER_COMPILE_BOOTLOADER`` environment variable).
+
+For details, see :ref:`building the bootloader`.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -69,6 +69,7 @@ extensions = ['sphinx.ext.intersphinx',
               'sphinx.ext.napoleon',
               'sphinx_autodoc_typehints',
               'sphinxcontrib.towncrier',
+              'sphinx_copybutton',
               'sphinx_inline_tabs',
               'sphinx_issues']
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -69,6 +69,7 @@ extensions = ['sphinx.ext.intersphinx',
               'sphinx.ext.napoleon',
               'sphinx_autodoc_typehints',
               'sphinxcontrib.towncrier',
+              'sphinx_inline_tabs',
               'sphinx_issues']
 
 issues_github_path = "pyinstaller/pyinstaller"

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -15,6 +15,7 @@ requests==2.32.3
 snowballstemmer==2.2.0
 Sphinx==7.3.7
 sphinx-autodoc-typehints==2.2.2
+sphinx-copybutton==0.5.2
 sphinx-inline-tabs==2025.12.21.14
 sphinxcontrib-applehelp==1.0.8
 sphinxcontrib-devhelp==1.0.6

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -15,6 +15,7 @@ requests==2.32.3
 snowballstemmer==2.2.0
 Sphinx==7.3.7
 sphinx-autodoc-typehints==2.2.2
+sphinx-inline-tabs==2025.12.21.14
 sphinxcontrib-applehelp==1.0.8
 sphinxcontrib-devhelp==1.0.6
 sphinxcontrib-htmlhelp==2.0.5

--- a/news/9352.bootloader.rst
+++ b/news/9352.bootloader.rst
@@ -1,0 +1,3 @@
+(Windows) Add new option to the ``waf`` build script, ``--no-cfg``,
+that allows bootloader to be built without Control Flow Guard (CFG)
+enabled. Applicable only when building with MSVC toolchain.


### PR DESCRIPTION
Allow users to build bootloader executables without Control Flow Guard (CFG) enabled. Applicable only when building on Windows with MSVC toolchain. 

Add a short section on CFG under Common Issues and Pitfalls, and update the introductory part of the Building the Bootloader section.

Closes #9352.