### PR TITLE
Attempt to restore compatibility with Termux python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -576,6 +576,7 @@ jobs:
             cd ..
             python -m pip install .
             echo "*** Installing test requirements ***"
+            pkg install -y python-psutil
             python -m pip install -r tests/requirements-base.txt
             echo "*** Running tests ***"
             export FORCE_COLOR=1

--- a/PyInstaller/_shared_with_waf.py
+++ b/PyInstaller/_shared_with_waf.py
@@ -57,6 +57,13 @@ def _pyi_machine(machine, system):
         else:
             return "sparc"
 
+    # Fold Android back into Linux. Currently, Termux environment is the only way to run PyInstaller on Android.
+    # Starting with python 3.13, `platform.system()` reports 'Android' (see PEP-738); earlier versions reported 'Linux'.
+    # The compiler-based target platform identification in `waf`, however, identifies target platform as Linux on all
+    # python versions.
+    if system == "Android":
+        system = "Linux"
+
     if system != "Linux":
         # No architecture specifier for anything par Linux.
         # - macOS is on two 64 bit architectures, but they are merged into one "universal2" bootloader.

--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -214,6 +214,9 @@ else:
 # Cygwin needs special handling, because platform.system() contains identifiers such as MSYS_NT-10.0-19042 and
 # CYGWIN_NT-10.0-19042 that do not fit PyInstaller's OS naming scheme. Explicitly set `system` to 'Cygwin'.
 system = 'Cygwin' if is_cygwin else platform.system()
+# Similarly, fold Android (reported by python >= 3.13 in Termux environment) back into Linux.
+if system == 'Android':
+    system = 'Linux'
 
 # Machine suffix for bootloader.
 if is_win:

--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -83,7 +83,7 @@ is_darwin = sys.platform == 'darwin'  # macOS
 
 # Unix platforms
 is_android = sys.platform.startswith('android')
-is_linux = sys.platform.startswith('linux')
+is_linux = sys.platform.startswith('linux') or is_android  # For our intents and purposes, Android is also Linux.
 is_solar = sys.platform.startswith('sun')  # Solaris
 is_aix = sys.platform.startswith('aix')
 is_freebsd = sys.platform.startswith('freebsd')
@@ -99,6 +99,9 @@ is_unix = is_linux or is_solar or is_aix or is_freebsd or is_hpux or is_openbsd
 is_musl = is_linux and "musl" in subprocess.run(["ldd"], capture_output=True, encoding="utf-8").stderr
 
 # Termux - terminal emulator and Linux environment app for Android.
+# With python >= 3.13, this could also be directly inferred from `sys.platform` or `platform.system()` (see PEP-738),
+# and `is_android` will also be set to True; this is not the case with earlier python versions (that people might still
+# have installed in their Termux environments), so for now, we keep the legacy check.
 is_termux = is_linux and hasattr(sys, 'getandroidapilevel')
 
 # macOS version

--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -82,6 +82,7 @@ is_cygwin = sys.platform == 'cygwin'
 is_darwin = sys.platform == 'darwin'  # macOS
 
 # Unix platforms
+is_android = sys.platform.startswith('android')
 is_linux = sys.platform.startswith('linux')
 is_solar = sys.platform.startswith('sun')  # Solaris
 is_aix = sys.platform.startswith('aix')
@@ -602,6 +603,10 @@ PY3_BASE_MODULES = {
 
 if not is_py310:
     PY3_BASE_MODULES.add('_bootlocale')
+
+if is_android and is_py313:
+    PY3_BASE_MODULES.add('_android_support')
+    PY3_BASE_MODULES.add('threading')  # dependency of _android_support
 
 # Object types of Pure Python modules in modulegraph dependency graph.
 # Pure Python modules have code object (attribute co_code).

--- a/PyInstaller/depend/bindepend.py
+++ b/PyInstaller/depend/bindepend.py
@@ -286,14 +286,22 @@ def get_imports(filename, search_paths=None):
     Additional list of search paths may be specified via `search_paths`, to be used as a fall-back when the
     platform-specific resolution mechanism fails to resolve a library fullpath.
     """
-    if compat.is_win:
-        if str(filename).lower().endswith(".manifest"):
-            return []
-        return _get_imports_pefile(filename, search_paths)
-    elif compat.is_darwin:
-        return _get_imports_macholib(filename, search_paths)
-    else:
-        return _get_imports_ldd(filename, search_paths)
+    # Ensure search_paths is immutable, so that it can be hashed for the purposes of caching.
+    if search_paths is not None:
+        search_paths = tuple(search_paths)
+
+    @functools.lru_cache
+    def _get_imports(filename, search_paths):
+        if compat.is_win:
+            if str(filename).lower().endswith(".manifest"):
+                return []
+            return _get_imports_pefile(filename, search_paths)
+        elif compat.is_darwin:
+            return _get_imports_macholib(filename, search_paths)
+        else:
+            return _get_imports_ldd(filename, search_paths)
+
+    return _get_imports(filename, search_paths)
 
 
 def _get_imports_pefile(filename, search_paths):
@@ -337,7 +345,7 @@ def _get_imports_pefile(filename, search_paths):
 
     # Attempt to resolve full paths to referenced DLLs. Always add the input binary's parent directory to the search
     # paths.
-    search_paths = [os.path.dirname(filename)] + (search_paths or [])
+    search_paths = (os.path.dirname(filename), *(search_paths or []))
     output = {(lib, resolve_library_path(lib, search_paths)) for lib in output}
 
     return output

--- a/PyInstaller/utils/conftest.py
+++ b/PyInstaller/utils/conftest.py
@@ -65,6 +65,8 @@ def pytest_runtest_setup(item):
     """
     supported_platforms = SUPPORTED_OSES.intersection(mark.name for mark in item.iter_markers())
     plat = sys.platform
+    if plat == 'android':
+        plat = 'linux'
     if supported_platforms and plat not in supported_platforms:
         pytest.skip(f"does not run on {plat}")
 

--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -59,6 +59,10 @@ DESTOS_TO_SYSTEM = {
 # Map from platform.system() to waf's DEST_OS
 SYSTEM_TO_BUILDOS = {
     'Linux': 'linux',
+    # In Termux environment, `platform.system()` reports 'Android' under python >= 3.13 (PEP-738), and 'Linux' under
+    # older python versions. Compiler-based identification currently always resolves to 'linux', so we need to ensure
+    # Android is also folded back into 'linux', to avoid a message about "cross-compiling for Linux".
+    'Android': 'linux',
     'FreeBSD': 'freebsd',
     'Windows': 'win32',
     'Darwin': 'darwin',

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -76,4 +76,5 @@ class CustomBuildHook(BuildHookInterface):
         )
         self.compile_bootloader()
         if not self.bootloader_exists():
-            raise SystemExit("ERROR: Bootloaders have been compiled for the wrong platform")
+            from PyInstaller import PLATFORM
+            raise SystemExit(f"ERROR: Bootloaders have been compiled for the wrong platform (expected: {PLATFORM!r})")

--- a/news/9398.bugfix.rst
+++ b/news/9398.bugfix.rst
@@ -1,0 +1,2 @@
+(Linux) Fix compatibility issues with Termux python 3.13, caused by
+platform being now reported as "android" instead of "linux" (PEP 738).


### PR DESCRIPTION
Termux seems to have updated their python to 3.13, which implements [PEP 738](https://peps.python.org/pep-0738) and therefore `sys.platform` reports `android` instead of `linux` (and `platform.system()` reports `Android` instead of `Linux`). This causes mismatches across different parts of PyInstaller; expected bootloader directory w.r.t. run-time platform name vs. compiler-derived platform name, various parts of building pipeline that are relying on `compat.is_linux`, and linux-specific test cases.

This PR attempts to mitigate these issues by folding "android" platform back into "linux", since for our intents and purposes, the two are the same (and where they are not, we can use `compat.is_android` and `compat.is_termux` to account for differences). This should restore the old, pre-3.13 behavior.

The Termux CI should pass now, but there are two caveats:
1. my preliminary tests indicate a considerable slowdown; previously the Termux run took ~40 minutes to complete (e.g., [here](https://github.com/pyinstaller/pyinstaller/actions/runs/22641732049/job/65619280621)), now it takes ~2 hours (e.g., [here](https://github.com/rokm/pyinstaller/actions/runs/22978790111)). It seems the slow-down is coming from binary dependency analysis stage, and I highly suspect that this is related to Termux' switch from GNU binutils to LLVM binutils that also happened last week (https://github.com/termux/termux-packages/pull/28586); since Termux does not keep old packages available, I'll try to compile GNU `readelf` for side-by-side speed comparison in a local Docker container...
2. while looking into above issue, I discovered that `ldd` on Termux lists dependencies in `libpython3.13.so => /data/data/com.termux/files/usr/lib/libpython3.13.so` format (without address at the end), so we never matched any entries. Which means that our binary dependency analysis on Termux is no-op (and has always been, since the output format of the `ldd` script did not change with underlying `binutils` switch).

This PR aims to restore the baseline state from two weeks ago, so I'll tackle 2. separately. (Although I am somewhat tempted to simply skip the binary dependency analysis on Termux, since nobody seems to have noticed that it was no-op...)