### PR TITLE
utils/hooks: remove warning on optional tcl_module_dir

### DIFF
--- a/PyInstaller/utils/hooks/tcl_tk.py
+++ b/PyInstaller/utils/hooks/tcl_tk.py
@@ -200,11 +200,18 @@ class TclTkInfo:
             )
 
         # Infer location of Tcl module directory. The modules directory is separate from the library/data one, and
-        # is located at $tcl_root/../tclX, where X is the major Tcl version.
-        self.tcl_module_dir = os.path.join(
-            os.path.dirname(self.tcl_data_dir),
-            f"tcl{self.tcl_version[0]}",
-        )
+        # is located at $tcl_root/../tclX, where X is the version.
+        for i in 1, 2:
+            tcl_name = f"tcl{'.'.join(str(v) for v in self.tcl_version[:i])}"
+            temp = os.path.join(os.path.dirname(self.tcl_data_dir), tcl_name)
+            if os.path.isdir(temp):
+                self.tcl_module_dir = temp
+                break
+        else:
+            self.tcl_module_dir = os.path.join(
+                os.path.dirname(self.tcl_data_dir),
+                f"tcl{self.tcl_version[0]}"
+            )
 
         # Find all data files
         if self.is_macos_system_framework:

--- a/PyInstaller/utils/hooks/tcl_tk.py
+++ b/PyInstaller/utils/hooks/tcl_tk.py
@@ -200,7 +200,9 @@ class TclTkInfo:
             )
 
         # Infer location of Tcl module directory. The modules directory is separate from the library/data one, and
-        # is located at $tcl_root/../tclX, where X is the major Tcl version.
+        # is located at $tcl_root/../tclX, where X is the major Tcl version. In some Tcl distributions (for example,
+        # Debian-packaged Tcl), this directory is located under library/data directory ($tcl_root); in such cases,
+        # we do not need to worry about it.
         self.tcl_module_dir = os.path.join(
             os.path.dirname(self.tcl_data_dir),
             f"tcl{self.tcl_version[0]}",
@@ -230,7 +232,7 @@ class TclTkInfo:
             else:
                 logger.warning("%s: Tk library/data directory %r does not exist!", self, self.tk_data_dir)
 
-            # Collect Tcl modules from modules directory
+            # Collect Tcl modules from optional modules directory
             if os.path.isdir(self.tcl_module_dir):
                 self.data_files += self._collect_files_from_directory(
                     self.tcl_module_dir,

--- a/PyInstaller/utils/hooks/tcl_tk.py
+++ b/PyInstaller/utils/hooks/tcl_tk.py
@@ -200,18 +200,11 @@ class TclTkInfo:
             )
 
         # Infer location of Tcl module directory. The modules directory is separate from the library/data one, and
-        # is located at $tcl_root/../tclX, where X is the version.
-        for i in 1, 2:
-            tcl_name = f"tcl{'.'.join(str(v) for v in self.tcl_version[:i])}"
-            temp = os.path.join(os.path.dirname(self.tcl_data_dir), tcl_name)
-            if os.path.isdir(temp):
-                self.tcl_module_dir = temp
-                break
-        else:
-            self.tcl_module_dir = os.path.join(
-                os.path.dirname(self.tcl_data_dir),
-                f"tcl{self.tcl_version[0]}"
-            )
+        # is located at $tcl_root/../tclX, where X is the major Tcl version.
+        self.tcl_module_dir = os.path.join(
+            os.path.dirname(self.tcl_data_dir),
+            f"tcl{self.tcl_version[0]}",
+        )
 
         # Find all data files
         if self.is_macos_system_framework:

--- a/PyInstaller/utils/hooks/tcl_tk.py
+++ b/PyInstaller/utils/hooks/tcl_tk.py
@@ -236,8 +236,6 @@ class TclTkInfo:
                     self.tcl_module_dir,
                     prefix=os.path.basename(self.tcl_module_dir),
                 )
-            else:
-                logger.warning("%s: Tcl module directory %r does not exist!", self, self.tcl_module_dir)
 
     @staticmethod
     def _collect_files_from_directory(root, prefix=None, excludes=None):

--- a/news/9401.bugfix.rst
+++ b/news/9401.bugfix.rst
@@ -1,0 +1,4 @@
+Remove warning about non-existing ``tclX`` module directory; in some Tcl
+distributions (e.g., Debian-packaged Tcl), this directory is located
+under the main library/data directory, and therefore the stand-alone
+directory neither exists nor needs to be explicitly collected.


### PR DESCRIPTION
attempt to fix #9400