### PR TITLE
Fix binary dependency analysis under Termux

### DIFF
--- a/PyInstaller/building/utils.py
+++ b/PyInstaller/building/utils.py
@@ -26,7 +26,7 @@ import zipfile
 
 from PyInstaller import compat
 from PyInstaller import log as logging
-from PyInstaller.compat import is_aix, is_darwin, is_win, is_linux
+from PyInstaller.compat import is_aix, is_darwin, is_win, is_linux, is_termux
 from PyInstaller.exceptions import InvalidSrcDestTupleError
 from PyInstaller.utils import misc
 
@@ -627,7 +627,14 @@ def _should_include_system_binary(binary_tuple, exceptions):
     src = binary_tuple[1]
     if fnmatch.fnmatch(src, '*python*'):
         return True
-    if not src.startswith('/lib') and not src.startswith('/usr/lib'):
+    if is_termux:
+        # Termux linux; system libraries are in /system/lib{,64} and /data/data/com.termux/files/usr/lib; in addition
+        # /usr is symbolic link pointing at /data/data/com.termux/files/usr
+        SYS_PREFIX = ('/system/lib', '/data/data/com.termux/files/usr/lib', '/usr/lib')
+    else:
+        # Standard linux distributions; system libraries are in /lib{,64} and /usr/lib{,64}
+        SYS_PREFIX = ('/lib', '/usr/lib')
+    if not src.startswith(SYS_PREFIX):
         return True
     for exception in exceptions:
         if fnmatch.fnmatch(dest, exception):

--- a/PyInstaller/depend/bindepend.py
+++ b/PyInstaller/depend/bindepend.py
@@ -369,16 +369,23 @@ def _get_imports_ldd(filename, search_paths):
         LDD_PATTERN = re.compile(r"^\s*(((?P<libarchive>(.*\.a))(?P<objectmember>\(.*\)))|((?P<libshared>(.*\.so))))$")
     elif compat.is_hpux:
         # Match libs of the form
-        #   'sharedlib.so => full-path-to-lib
+        #   sharedlib.so => full-path-to-lib
         # e.g.
-        #   'libpython2.7.so =>      /usr/local/lib/hpux32/libpython2.7.so'
+        #   libpython2.7.so =>      /usr/local/lib/hpux32/libpython2.7.so
         LDD_PATTERN = re.compile(r"^\s+(.*)\s+=>\s+(.*)$")
     elif compat.is_solar:
         # Match libs of the form
-        #   'sharedlib.so => full-path-to-lib
+        #   sharedlib.so => full-path-to-lib
         # e.g.
-        #   'libpython2.7.so.1.0 => /usr/local/lib/libpython2.7.so.1.0'
+        #   libpython2.7.so.1.0 => /usr/local/lib/libpython2.7.so.1.0
         # Will not match the platform specific libs starting with '/platform'
+        LDD_PATTERN = re.compile(r"^\s+(.*)\s+=>\s+(.*)$")
+    elif compat.is_termux:
+        # Match libs of the form
+        #   sharedlib.so => full-path-to-lib
+        # e.g.
+        #   libpython3.13.so => /data/data/com.termux/files/usr/lib/libpython3.13.so
+        # See: https://github.com/termux/termux-packages/blob/adb6efd/packages/ldd/ldd.in#L71-L72
         LDD_PATTERN = re.compile(r"^\s+(.*)\s+=>\s+(.*)$")
     elif compat.is_linux:
         # Match libs of the form
@@ -447,7 +454,7 @@ def _get_imports_ldd(filename, search_paths):
                 name = name or os.path.basename(lib)
                 if compat.is_linux:
                     # Skip all ld variants listed https://sourceware.org/glibc/wiki/ABIList
-                    # plus musl's ld-musl-*.so.*.
+                    # plus musl's ld-musl-*.so.* and Termux' ld-android.so.
                     if re.fullmatch(r"ld(64)?(-linux|-musl)?(-.+)?\.so(\..+)?", os.path.basename(lib)):
                         continue
             if name[:10] in ('linux-gate', 'linux-vdso'):

--- a/PyInstaller/depend/dylib.py
+++ b/PyInstaller/depend/dylib.py
@@ -246,6 +246,14 @@ _cygwin_excludes = {
     r'cygwin1\.dll',
 }
 
+_termux_excludes = {
+    # These libandroid-*.so libraries seem to be part of the base system.
+    r'libandroid-glob\.so',
+    r'libandroid-posix-semaphore\.so',
+    r'libandroid-selinux\.so',
+    r'libandroid-support\.so',
+}
+
 if compat.is_win:
     _includes |= _win_includes
     _excludes |= _win_excludes
@@ -257,6 +265,10 @@ elif compat.is_aix:
 elif compat.is_solar:
     # The exclude list for Solaris differs from other *nix platforms.
     _excludes |= _solaris_excludes
+    _excludes |= _unix_excludes
+elif compat.is_termux:
+    # The exclude list for Termux has additional entries.
+    _excludes |= _termux_excludes
     _excludes |= _unix_excludes
 elif compat.is_unix:
     # Common excludes for *nix platforms -- except AIX.

--- a/news/9402.bugfix.rst
+++ b/news/9402.bugfix.rst
@@ -1,0 +1,3 @@
+(Linux) Fix binary dependency analysis in Termux environment; previously,
+no binary dependencies would be reported due to mismatched ``ldd`` output
+pattern.

--- a/tests/unit/test_bindepend.py
+++ b/tests/unit/test_bindepend.py
@@ -9,7 +9,9 @@
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
 
-from PyInstaller.depend.bindepend import _library_matcher
+import sys
+
+from PyInstaller.depend import bindepend
 
 
 def test_library_matcher():
@@ -17,11 +19,34 @@ def test_library_matcher():
     Test that _library_matcher() is tolerant to version numbers both before and after the .so suffix but does not
     allow runaway glob patterns to match anything else.
     """
-    m = _library_matcher("libc")
+    m = bindepend._library_matcher("libc")
     assert m("libc.so")
     assert m("libc.dylib")
     assert m("libc.so.1")
     assert not m("libcrypt.so")
 
-    m = _library_matcher("libpng")
+    m = bindepend._library_matcher("libpng")
     assert m("libpng16.so.16")
+
+
+def test_binary_dependency_analysis():
+    """
+    Test that binary dependency analysis works, by running it on a binary (executable or shared library) and checking
+    that at least one dependency is reported.
+    """
+    # Check both python interpreter executable and python shared library. Often, the python executable is linked against
+    # the python shared library (but now always - for example, Debian-packaged python). The python shared library is
+    # usually linked against the standard C library, but on some platforms (e.g., Alpine linux), this is a symbolic link
+    # to the dynamic program loader binary, which our binary dependency analysis omits from the output.
+    exe = sys.executable
+    print(f"Python executable: {exe}")
+    exe_dependencies = bindepend.get_imports(exe)
+    print(f"Dependencies of Python executable: {exe_dependencies}")
+
+    lib = bindepend.get_python_library_path()
+    print(f"Python shared library: {lib}")
+    lib_dependencies = bindepend.get_imports(lib)
+    print(f"Dependencies of Python shared library: {lib_dependencies}")
+
+    # At least one of these must not be empty.
+    assert exe_dependencies or lib_dependencies

--- a/tests/unit/test_building_utils.py
+++ b/tests/unit/test_building_utils.py
@@ -16,6 +16,7 @@ import pathlib
 import pytest
 
 from PyInstaller.building import utils
+from PyInstaller.compat import is_termux
 
 
 def test_format_binaries_and_datas_not_found_raises_error(tmp_path):
@@ -116,19 +117,71 @@ def test_format_binaries_and_datas_with_bracket(tmp_path):
 
 def test_should_include_system_binary():
     python_dir = f'python{sys.version_info.major}.{sys.version_info.minor}'
-    CASES = [
-        (f'{python_dir}/lib-dynload/any', f'/usr/lib64/{python_dir}/lib-dynload/any', [], True),
-        ('libany', '/lib64/libpython.so', [], True),
-        ('any', '/lib/python/site-packages/any', [], True),
-        ('libany', '/etc/libany', [], True),
-        ('libany', '/usr/lib/libany', ['*any*'], True),
-        ('libany2', '/lib/libany2', ['libnone*', 'libany*'], True),
-        ('libnomatch', '/lib/libnomatch', ['libnone*', 'libany*'], False),
-    ]
+    python_lib = f'libpython{sys.version_info.major}.{sys.version_info.minor}.so'
+    if is_termux:
+        # NOTE: in Termux environment, /usr is symbolic link to /data/data/com.termux/files/usr
+        termux_usr = '/data/data/com.termux/files/usr'
+        CASES = (
+            # Python shared library; should be always included
+            (python_lib, f'{termux_usr}/lib/{python_lib}', [], True),
+            (python_lib, f'/usr/lib/{python_lib}', [], True),
+            # Python stdlib extension from lib-dynload directory; should be always included
+            (f'{python_dir}/lib-dynload/any.so', f'{termux_usr}/lib/{python_dir}/lib-dynload/any.so', [], True),
+            (f'{python_dir}/lib-dynload/any.so', f'/usr/lib/{python_dir}/lib-dynload/any.so', [], True),
+            # Shared library bundled with a package inside system's site-packages directory; should be always included.
+            ('mypackage/any.so', f'{termux_usr}/lib/{python_dir}/site-packages/mypackage/any.so', [], True),
+            ('mypackage/any.so', f'/usr/lib/{python_dir}/site-packages/mypackage/any.so', [], True),
+            # Some other (system) directory
+            ('libany.so', '/etc/libany.so', [], True),
+            ('libany.so', f'{termux_usr}/etc/libany.so', [], True),
+            ('libany.so', '/usr/etc/libany.so', [], True),
+            # Shared library in /data/data/com.termux/files/usr/lib (or /usr/lib), with various exception combinations.
+            ('libany.so', f'{termux_usr}/lib/libany.so', ['*any*'], True),
+            ('libany.so', '/usr/lib/libany.so', ['*any*'], True),
+            ('libany2.so', f'{termux_usr}/lib/libany2.so', ['libnone*', 'libany*'], True),
+            ('libany2.so', '/usr/lib/libany2.so', ['libnone*', 'libany*'], True),
+            ('libnomatch.so', f'{termux_usr}/lib/libnomatch.so', ['libnone*', 'libany*'], False),
+            ('libnomatch.so', '/usr/lib/libnomatch.so', ['libnone*', 'libany*'], False),
+            # Shared library in /system/lib; without and with exclusion exception
+            ('libc++.so', '/system/lib/libc++.so', [], False),
+            ('libc++.so', '/system/lib/libc++.so', ['libc*'], True),
+        )
+    else:
+        # NOTE: nowadays, /lib64 and /lib are symbolic links to their counterparts in /usr. For the sake of
+        # completeness, we explicitly test all four possibilities.
+        CASES = (
+            # Python shared library; should be always included
+            (python_lib, f'/lib64/{python_lib}', [], True),
+            (python_lib, f'/usr/lib64/{python_lib}', [], True),
+            (python_lib, f'/lib/{python_lib}', [], True),
+            (python_lib, f'/usr/lib/{python_lib}', [], True),
+            # Python stdlib extension from lib-dynload directory; should be always included
+            (f'{python_dir}/lib-dynload/any.so', f'/lib64/{python_dir}/lib-dynload/any.so', [], True),
+            (f'{python_dir}/lib-dynload/any.so', f'/usr/lib64/{python_dir}/lib-dynload/any.so', [], True),
+            (f'{python_dir}/lib-dynload/any.so', f'/lib/{python_dir}/lib-dynload/any.so', [], True),
+            (f'{python_dir}/lib-dynload/any.so', f'/usr/lib/{python_dir}/lib-dynload/any.so', [], True),
+            # Shared library bundled with a package inside system's site-packages directory; should be always included.
+            ('mypackage/any.so', f'/lib64/{python_dir}/site-packages/mypackage/any.so', [], True),
+            ('mypackage/any.so', f'/usr/lib64/{python_dir}/site-packages/mypackage/any.so', [], True),
+            ('mypackage/any.so', f'/lib/{python_dir}/site-packages/mypackage/any.so', [], True),
+            ('mypackage/any.so', f'/usr/lib/{python_dir}/site-packages/mypackage/any.so', [], True),
+            # Some other (system) directory
+            ('libany.so', '/etc/libany.so', [], True),
+            # Shared library in system library directory, with various exception combinations.
+            ('libany.so', '/lib64/libany.so', ['*any*'], True),
+            ('libany.so', '/usr/lib64/libany.so', ['*any*'], True),
+            ('libany.so', '/lib/libany.so', ['*any*'], True),
+            ('libany.so', '/usr/lib/libany.so', ['*any*'], True),
+            ('libany2.so', '/lib64/libany2.so', ['libnone*', 'libany*'], True),
+            ('libany2.so', '/usr/lib64/libany2.so', ['libnone*', 'libany*'], True),
+            ('libany2.so', '/lib/libany2.so', ['libnone*', 'libany*'], True),
+            ('libany2.so', '/lib64/libany2.so', ['libnone*', 'libany*'], True),
+            ('libnomatch.so', '/lib64/libnomatch.so', ['libnone*', 'libany*'], False),
+            ('libnomatch.so', '/usr/lib64/libnomatch.so', ['libnone*', 'libany*'], False),
+            ('libnomatch.so', '/lib/libnomatch.so', ['libnone*', 'libany*'], False),
+            ('libnomatch.so', '/usr/lib/libnomatch.so', ['libnone*', 'libany*'], False),
+        )
 
-    for case in CASES:
-        tuple = (case[0], case[1])
-        excepts = case[2]
-        expected = case[3]
-
-        assert utils._should_include_system_binary(tuple, excepts) == expected
+    for dest_path, src_path, exceptions, expected_result in CASES:
+        toc_entry = (dest_path, src_path, 'BINARY')
+        assert utils._should_include_system_binary(toc_entry, exceptions) == expected_result


### PR DESCRIPTION
As mentioned in https://github.com/pyinstaller/pyinstaller/pull/9398, our binary dependency analysis is currently broken/no-op under Termux, because its `ldd` script returns entries without trailing address information. 

Fix the expected pattern, add couple of Termux-specific excludes that seem to be part of the base system (i.e., they are available in a clean `termux-docker` container), and fix the helper used by `Analysis.exclude_system_libraries()` to account for different system-directory paths in the Termux environment.