### PR TITLE
bootloader: waf: revise handling of (unknown) target CPU architectures

### DIFF
--- a/PyInstaller/_shared_with_waf.py
+++ b/PyInstaller/_shared_with_waf.py
@@ -16,7 +16,6 @@ in here are standard library ones. Within reason, it is preferable that this fil
 many compiler docker images still have only Python 2 installed.
 """
 
-import platform
 import re
 
 
@@ -40,10 +39,6 @@ def _pyi_machine(machine, system):
     differentiation, and trust that anyone mixing armv6l with armv6h knows what they are doing.
     """
     # See the corresponding tests in tests/unit/test_compat.py for examples.
-
-    if platform.machine() == "sw_64" or platform.machine() == "loongarch64":
-        # This explicitly inhibits cross compiling the bootloader for or on SunWay and LoongArch machine.
-        return platform.machine()
 
     if system == "Windows":
         if machine.lower().startswith("arm"):
@@ -89,6 +84,10 @@ def _pyi_machine(machine, system):
         return "mips"
     if machine.startswith("riscv"):
         return "riscv"
+    if machine.startswith(("sw_", "sunway")):
+        return "sunway"
+    if machine.startswith("loongarch"):
+        return "loongarch"
     # Machines with no known aliases :)
     if machine in ("s390x",):
         return machine

--- a/bootloader/waflib/Tools/c_config.py
+++ b/bootloader/waflib/Tools/c_config.py
@@ -38,6 +38,10 @@ MACRO_TO_DESTOS = {
     '__native_client__': 'nacl'
 }
 MACRO_TO_DEST_CPU = {
+    # define __sw_64__ check before __x86_64__, just in case the note in
+    # PyInstaller's bootloader build script about __x86_64__ also being
+    # defined is true...
+    '__sw_64__': 'sunway',
     '__x86_64__': 'x86_64',
     '__amd64__': 'x86_64',
     '__i386__': 'x86',
@@ -59,6 +63,7 @@ MACRO_TO_DEST_CPU = {
     '__xtensa__': 'xtensa',
     '__e2k__': 'e2k',
     '__riscv': 'riscv',
+    '__loongarch__': 'loongarch',
 }
 
 

--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -84,13 +84,6 @@ else:
 is_cross = None
 
 
-def machine(ctx):
-    """
-    Determine path to bootloader based on C compiler target.
-    """
-    return _shared_with_waf._pyi_machine(ctx.env.DEST_CPU, DESTOS_TO_SYSTEM[ctx.env.DEST_OS])
-
-
 def is_msvc_target(ctx):
     """
     clang may be compiled to use either MSVC's headers or mingw's. If it's the former, it inherits some of MSVC's
@@ -227,7 +220,7 @@ def check_sizeof_pointer(ctx):
 @conf
 def detect_arch(ctx):
     """
-    Handle --target-arch options, or use the same architecture as the compiler.
+    Handle --target-arch options, or use the compiler's default architecture.
     """
     try:
         system = DESTOS_TO_SYSTEM[ctx.env.DEST_OS]
@@ -237,7 +230,6 @@ def detect_arch(ctx):
     # Get arch values either from CLI or detect it.
     if ctx.options.target_arch:
         arch = ctx.options.target_arch
-        ctx.msg('Platform', '%s-%s manually chosen' % (system, arch))
         ctx.env.ARCH_FLAGS_REQUIRED = True
         if arch == '64bit-arm':
             arch = '64bit'
@@ -246,19 +238,28 @@ def detect_arch(ctx):
         # PyInstaller uses the result of platform.architecture() to determine the bits and this is testing the pointer
         # size (via module struct). We do the same here.
         arch = "%sbit" % (8 * check_sizeof_pointer(ctx))
-        _machine = machine(ctx)
-        if _machine is not None:
-            plat = '%s-%s-%s detected based on compiler' % (system, arch, _machine)
-        else:
-            plat = '%s-%s detected based on compiler' % (system, arch)
-        ctx.msg('Platform', plat)
         ctx.env.ARCH_FLAGS_REQUIRED = False
     if arch not in ('32bit', '64bit'):
         ctx.fatal('Unrecognized target architecture: %s' % arch)
 
-    # Pass return values as environment variables.
-    ctx.env.PYI_ARCH = arch  # '32bit' or '64bit'
+    # Normalize target CPU architecture into identifiers that PyInstaller uses at run-time to look up bootloader
+    # executable.
+    machine = _shared_with_waf._pyi_machine(ctx.env.DEST_CPU, system)
+
+    # Display full platform info
+    full_platform = f'{system}-{arch}-{machine}' if machine is not None else f'{system}-{arch}'
+    if ctx.options.target_arch:
+        ctx.msg('Platform', f'{full_platform} manually chosen')
+    else:
+        ctx.msg('Platform', f'{full_platform} detected based on compiler')
+
+    # Pass return values as environment variables:
+    #  - PYI_SYSTEM: normalized name of target OS
+    #  - PYI_MACHINE: normalized name of target CPU architecture
+    #  - PYI_ARCH: '32bit' or '64bit'
     ctx.env.PYI_SYSTEM = system
+    ctx.env.PYI_MACHINE = machine
+    ctx.env.PYI_ARCH = arch
 
 
 @conf
@@ -276,7 +277,7 @@ def set_arch_flags(ctx):
 
     if ctx.env.DEST_OS == 'win32' and ctx.env.CC_NAME == 'msvc':
         # Set msvc linkflags based on architecture.
-        if machine(ctx) == 'arm':
+        if ctx.env.PYI_MACHINE == 'arm':
             ctx.env.append_value('LINKFLAGS', '/MACHINE:ARM64')
         elif ctx.env.PYI_ARCH == '32bit':
             ctx.env.append_value('LINKFLAGS', '/MACHINE:X86')
@@ -353,7 +354,7 @@ def set_arch_flags(ctx):
 
     # Other compiler - not msvc.
     else:
-        if machine(ctx) == 'sw_64':
+        if ctx.env.PYI_MACHINE == 'sw_64':
             # The gcc has no '-m64' option under sw64 machine, but the __x86_64__ macro needs to be defined.
             ctx.env.append_value('CCDEFINES', '__x86_64__')
         # This ensures proper compilation with 64-bit gcc and 32-bit Python or vice versa or with manually
@@ -853,8 +854,8 @@ def build(ctx):
     install_path = os.path.join(os.getcwd(), '../PyInstaller/bootloader', ctx.env.PYI_SYSTEM + "-" + ctx.env.PYI_ARCH)
     install_path = os.path.normpath(install_path)
 
-    if machine(ctx) and ctx.env.DEST_OS != 'darwin':
-        install_path += '-' + machine(ctx)
+    if ctx.env.PYI_MACHINE and ctx.env.DEST_OS != 'darwin':
+        install_path += '-' + ctx.env.PYI_MACHINE
 
     if ctx.is_musl():
         install_path += "-musl"
@@ -909,7 +910,7 @@ def build(ctx):
 
     # This warning is deliberately at the end of the build, in the hopes that it will be more visible amongst all the
     # other stuff written to stdout.
-    if machine(ctx) and machine(ctx) == "unknown":
+    if ctx.env.PYI_MACHINE and ctx.env.PYI_MACHINE == "unknown":
         Logs.log.warning(
             "The target architecture reported by the compiler '%s' was not recognised and defaulted to 'unknown'. You "
             "should verify that `PyInstaller.compat.machine` is also 'unknown' on the target machine. If it is not, "

--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -243,8 +243,16 @@ def detect_arch(ctx):
         ctx.fatal('Unrecognized target architecture: %s' % arch)
 
     # Normalize target CPU architecture into identifiers that PyInstaller uses at run-time to look up bootloader
-    # executable.
-    machine = _shared_with_waf._pyi_machine(ctx.env.DEST_CPU, system)
+    # executable. The value in `ctx.env.DEST_CPU` is waf's identifier, based on macro definitions set up by the
+    # compiler. It is empty when identification fails. See `MACRO_TO_DEST_CPU` in `waflib/Tools/c_config.py`.
+    machine = ctx.env.DEST_CPU
+    if not machine:
+        # waf failed to identify target CPU - assume platform that we are building on. This implicitly breaks
+        # cross-compiling for unidentified platforms, as compiled bootloaders will end up being placed in incorrect
+        # directory.
+        machine = platform.machine()
+        ctx.msg("Failed to identify target CPU - assuming", machine)
+    machine = _shared_with_waf._pyi_machine(machine, system)
 
     # Display full platform info
     full_platform = f'{system}-{arch}-{machine}' if machine is not None else f'{system}-{arch}'

--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -362,7 +362,7 @@ def set_arch_flags(ctx):
 
     # Other compiler - not msvc.
     else:
-        if ctx.env.PYI_MACHINE == 'sw_64':
+        if ctx.env.PYI_MACHINE == 'sunway':
             # The gcc has no '-m64' option under sw64 machine, but the __x86_64__ macro needs to be defined.
             ctx.env.append_value('CCDEFINES', '__x86_64__')
         # This ensures proper compilation with 64-bit gcc and 32-bit Python or vice versa or with manually

--- a/news/9403.bootloader.rst
+++ b/news/9403.bootloader.rst
@@ -1,0 +1,6 @@
+Rework the handling of unknown target CPU architectures in the bootloader
+build script, and add identification for ``loongsoon`` and ``sunway`` to
+the bundled copy of ``waflib``. The bootloader directories for these
+platforms now use PyInstaller's normalized platform name (i.e.,
+``Linux-64bit-loongarch`` and ``Linux-64bit-sunway`` instead of
+former ``Linux-64bit-loongarch64`` and``Linux-64bit-sw_64``).

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -45,6 +45,10 @@ def test_exec_command_subprocess_wrong_encoding_reports_nicely(capsys):
         ("s390x", "s390x"),
         ("mips", "mips"),
         ("mips64", "mips"),
+        ("sunway", "sunway"),
+        ("sw_64", "sunway"),
+        ("loongarch", "loongarch"),
+        ("loongarch64", "loongarch"),
         ("something-alien", "unknown"),
     ]
 )


### PR DESCRIPTION
This is based on the core premise of #9377 - have the `_pyi_machine()` in `_shared_with_waf.py` always use the passed `machine` argument and do not try to use `platform.machine()` to accommodate the known platforms where compiler-based platform detection on `waf` side fails.

In contrast to #9377, the handling of unknown platforms is now fully the responsibility of the caller - in this case, the `waf` build script. So revise the latter to display a message when target platform cannot be identified from compiler macros/defines, and fall back to run-time platform (`platform.machine()`). 

Add detection/identification of `loongarch` and `sunway` to the bundled copy of `waflib` so we can avoid falling back to using the run-time platform info (which should enable cross-compiling).

Supersedes and closes #9377.