### PR TITLE
hooks: gi: collect platform-specific modules for GLib and Gio

### DIFF
--- a/PyInstaller/hooks/hook-gi.repository.GLib.py
+++ b/PyInstaller/hooks/hook-gi.repository.GLib.py
@@ -24,6 +24,9 @@ def hook(hook_api):
 
     binaries, datas, hiddenimports = module_info.collect_typelib_data()
 
+    # Collect platform-specific module, otherwise it may be opportunistically loaded from the run-time system.
+    hiddenimports += ['gi.repository.GLib' + ('Win32' if is_win else 'Unix')]
+
     # Collect translations
     lang_list = get_hook_config(hook_api, "gi", "languages")
     datas += collect_glib_translations('glib20', lang_list)

--- a/PyInstaller/hooks/hook-gi.repository.GLibUnix.py
+++ b/PyInstaller/hooks/hook-gi.repository.GLibUnix.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2026, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks.gi import GiModuleInfo
+
+module_info = GiModuleInfo('GLibUnix', '2.0')
+if module_info.available:
+    binaries, datas, hiddenimports = module_info.collect_typelib_data()

--- a/PyInstaller/hooks/hook-gi.repository.GLibWin32.py
+++ b/PyInstaller/hooks/hook-gi.repository.GLibWin32.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2026, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks.gi import GiModuleInfo
+
+module_info = GiModuleInfo('GLibWin32', '2.0')
+if module_info.available:
+    binaries, datas, hiddenimports = module_info.collect_typelib_data()

--- a/PyInstaller/hooks/hook-gi.repository.Gio.py
+++ b/PyInstaller/hooks/hook-gi.repository.Gio.py
@@ -22,6 +22,9 @@ module_info = GiModuleInfo('Gio', '2.0')
 if module_info.available:
     binaries, datas, hiddenimports = module_info.collect_typelib_data()
 
+    # Collect platform-specific module, otherwise it may be opportunistically loaded from the run-time system.
+    hiddenimports += ['gi.repository.Gio' + ('Win32' if compat.is_win else 'Unix')]
+
     # Find Gio modules
     libdir = module_info.get_libdir()
     modules_pattern = None

--- a/PyInstaller/hooks/hook-gi.repository.GioUnix.py
+++ b/PyInstaller/hooks/hook-gi.repository.GioUnix.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2026, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks.gi import GiModuleInfo
+
+module_info = GiModuleInfo('GioUnix', '2.0')
+if module_info.available:
+    binaries, datas, hiddenimports = module_info.collect_typelib_data()

--- a/PyInstaller/hooks/hook-gi.repository.GioWin32.py
+++ b/PyInstaller/hooks/hook-gi.repository.GioWin32.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2026, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+from PyInstaller.utils.hooks.gi import GiModuleInfo
+
+module_info = GiModuleInfo('GioWin32', '2.0')
+if module_info.available:
+    binaries, datas, hiddenimports = module_info.collect_typelib_data()

--- a/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GLibUnix.py
+++ b/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GLibUnix.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2026, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+
+def pre_safe_import_module(api):
+    # PyGObject modules loaded through the gi repository are marked as MissingModules by modulegraph, so we convert them
+    # to RuntimeModules in order for their hooks to be loaded and executed.
+    api.add_runtime_module(api.module_name)

--- a/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GLibWin32.py
+++ b/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GLibWin32.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2026, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+
+def pre_safe_import_module(api):
+    # PyGObject modules loaded through the gi repository are marked as MissingModules by modulegraph, so we convert them
+    # to RuntimeModules in order for their hooks to be loaded and executed.
+    api.add_runtime_module(api.module_name)

--- a/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GioUnix.py
+++ b/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GioUnix.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2026, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+
+def pre_safe_import_module(api):
+    # PyGObject modules loaded through the gi repository are marked as MissingModules by modulegraph, so we convert them
+    # to RuntimeModules in order for their hooks to be loaded and executed.
+    api.add_runtime_module(api.module_name)

--- a/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GioWin32.py
+++ b/PyInstaller/hooks/pre_safe_import_module/hook-gi.repository.GioWin32.py
@@ -1,0 +1,16 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2026, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+
+def pre_safe_import_module(api):
+    # PyGObject modules loaded through the gi repository are marked as MissingModules by modulegraph, so we convert them
+    # to RuntimeModules in order for their hooks to be loaded and executed.
+    api.add_runtime_module(api.module_name)

--- a/news/9410.hooks.1.rst
+++ b/news/9410.hooks.1.rst
@@ -1,0 +1,5 @@
+Update ``gi.repository.Gio`` hook to collect corresponding platform-specific
+typelib (``GioWin32`` or ``GioUnix``), and add hooks for these modules.
+This aims to prevent potential run-time errors, either because the typelib
+is missing, or because it was opportunistically loaded from the run-time
+system and happens to be of incompatible version.

--- a/news/9410.hooks.rst
+++ b/news/9410.hooks.rst
@@ -1,0 +1,5 @@
+Update ``gi.repository.GLib`` hook to collect corresponding platform-specific
+typelib (``GLibWin32`` or ``GLibUnix``), and add hooks for these modules.
+This aims to prevent potential run-time errors, either because the typelib
+is missing, or because it was opportunistically loaded from the run-time
+system and happens to be of incompatible version.

--- a/tests/functional/test_gi.py
+++ b/tests/functional/test_gi.py
@@ -55,19 +55,35 @@ def test_gi_repository(pyi_builder, repository_name, version):
         import gi
 
         # Check that package/namespace can be imported
+        print("Importing module...", file=sys.stderr)
         gi.require_version('{repository_name}', '{version}')
         from gi.repository import {repository_name}
-        print({repository_name})
+        print(f"  Imported: {{{repository_name}}}", file=sys.stderr)
 
         # Check that the typelib is, in fact, loaded from the frozen application (instead of falling back to the copy
         # that is installed on the system).
+        print("Checking that module's typelib is loaded from frozen application...", file=sys.stderr)
         repo = gi.Repository.get_default()
         typelib_path = repo.get_typelib_path('{repository_name}')
-        print("typelib path: ", typelib_path)
+        print(f"  Typelib path: {{typelib_path}}", file=sys.stderr)
 
         typelib_path = pathlib.Path(typelib_path).resolve()
         application_path = pathlib.Path(sys._MEIPASS).resolve()
         if application_path not in typelib_path.parents:
             raise ValueError(f"Typelib {{str(typelib_path)!r}} is not loaded from frozen application's directory!")
+
+        # Similarly, ensure that all gi.repository sub-modules that are now registered in sys.modules (i.e., were loaded
+        # during the above import of the target module) are also loaded from the frozen application. This aims to catch
+        # implicit dependencies that were missed during collection, and are therefore loaded from the system.
+        print("Checking all loaded gi.repository sub-modules...", file=sys.stderr)
+        for module_name, module in sys.modules.items():
+            if not module_name.startswith('gi.repository.'):
+                continue
+            module_path = module.__path__[0]
+            module_path = pathlib.Path(module_path).resolve()
+            print(f"  Module: {{module_name!r}}, path: {{module_path!r}}", file=sys.stderr)
+
+            if application_path not in module_path.parents:
+                raise ValueError(f"Typelib {{str(module_path)!r}} is not loaded from frozen application's directory!")
         """
     )


### PR DESCRIPTION
Update `gi.repository ` hooks to collect platform specific modules and typelibs for `GLib` and `Gio`: `GLibWin32` and `GioWin32` on Windows, or `GLibUnix` and `GioUnix` on other platforms.
    
Failing to do so may result in missing-library errors at run-time, or these typelibs being opportunistically loaded from the system (which may lead to other issues related to system libraries leaking into frozen application).

Fixes #9410.