### PR TITLE
hooks: matplotlib: skip MPLCONFIGDIR override on matplotlib >= 3.0

### DIFF
--- a/PyInstaller/hooks/rthooks/pyi_rth_mplconfig.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_mplconfig.py
@@ -9,21 +9,46 @@
 # SPDX-License-Identifier: Apache-2.0
 #-----------------------------------------------------------------------------
 
-# matplotlib will create $HOME/.matplotlib folder in user's home directory. In this directory there is fontList.cache
-# file which lists paths to matplotlib fonts.
-#
-# When you run your onefile exe for the first time it's extracted to for example "_MEIxxxxx" temp directory and
-# fontList.cache file is created with fonts paths pointing to this directory.
-#
-# Second time you run your exe new directory is created "_MEIyyyyy" but fontList.cache file still points to previous
-# directory which was deleted. And then you will get error like:
+# Historically, matplotlib stored absolute paths to font files in its on-disk font cache. For frozen onefile
+# applications, those paths pointed into the `_MEIxxxxx` extraction directory, which changes on every run; the next
+# run would then fail to open the cached font files with errors such as:
 #
 #     RuntimeError: Could not open facefile
 #
-# We need to force matplotlib to recreate config directory every time you run your app.
+# As a workaround, this run-time hook forced matplotlib to use a fresh, temporary config directory (via the
+# `MPLCONFIGDIR` environment variable) on every launch, rebuilding the font cache from scratch.
+#
+# Since matplotlib 3.0, font-cache entries are stored as paths relative to matplotlib's data directory, so the
+# stale-path problem no longer exists. Keeping the workaround on modern matplotlib is actively harmful, because
+# pointing `MPLCONFIGDIR` at a fresh empty directory on every launch forces matplotlib to rebuild its font cache
+# every single time the frozen app starts, which noticeably slows startup.
+#
+# Therefore, this hook now applies the workaround only for matplotlib < 3.0. For matplotlib >= 3.0, we leave
+# `MPLCONFIGDIR` alone, so matplotlib uses its default persistent user cache directory.
 
 
 def _pyi_rthook():
+    # Determine the installed matplotlib version without importing matplotlib itself (importing matplotlib is
+    # expensive and has side effects we would rather avoid in a run-time hook that might end up being a no-op).
+    use_legacy_workaround = True
+    try:
+        from importlib.metadata import version as _pkg_version
+
+        _mpl_version = _pkg_version("matplotlib")
+        # Parse the leading numeric components (major[, minor, ...]). We only care about the major version.
+        _major_str = _mpl_version.split('.', 1)[0]
+        # Strip any non-digit suffix (e.g. dev/rc markers that might sneak into the first component).
+        _major_digits = ''.join(ch for ch in _major_str if ch.isdigit())
+        if _major_digits and int(_major_digits) >= 3:
+            use_legacy_workaround = False
+    except Exception:
+        # If we cannot determine the version for any reason, fall through to the legacy workaround. It is safer
+        # to pay the font-cache-rebuild cost than to risk broken font loading on an old matplotlib.
+        pass
+
+    if not use_legacy_workaround:
+        return
+
     import atexit
     import os
     import shutil

--- a/news/3959.hooks.rst
+++ b/news/3959.hooks.rst
@@ -1,0 +1,5 @@
+Skip the ``MPLCONFIGDIR`` override in the ``matplotlib`` run-time hook when
+``matplotlib`` >= 3.0 is installed.
+The override was a workaround for a limitation in older ``matplotlib``
+versions, and its unconditional use caused the font cache to be rebuilt on
+every application start, noticeably slowing startup.

--- a/tests/functional/test_matplotlib.py
+++ b/tests/functional/test_matplotlib.py
@@ -82,12 +82,19 @@ def test_matplotlib(pyi_builder, monkeypatch, backend_name, qt_bindings):
         # Enable the desired backend *BEFORE* plotting with this backend.
         matplotlib.use({backend_name!r})
 
-        # A runtime hook should force Matplotlib to create its configuration directory in a temporary directory
-        # rather than in $HOME/.matplotlib.
-        configdir = os.environ['MPLCONFIGDIR']
+        # For Matplotlib < 3.0, a runtime hook should force Matplotlib to create its configuration directory in
+        # a temporary directory rather than in $HOME/.matplotlib. For Matplotlib >= 3.0, the runtime hook leaves
+        # MPLCONFIGDIR alone, so that Matplotlib can reuse its font cache across application runs.
+        mpl_version = tuple(int(x) for x in matplotlib.__version__.split('.')[:2] if x.isdigit())
+        configdir = os.environ.get('MPLCONFIGDIR')
         print(f'MPLCONFIGDIR: {{configdir}}')
-        if not configdir.startswith(tempfile.gettempdir()):
-            raise SystemExit('MPLCONFIGDIR not pointing to temp directory.')
+        if mpl_version and mpl_version[0] < 3:
+            if not configdir or not configdir.startswith(tempfile.gettempdir()):
+                raise SystemExit('MPLCONFIGDIR not pointing to temp directory.')
+        else:
+            # The PyInstaller rthook must not have redirected MPLCONFIGDIR into a throwaway temp directory.
+            if configdir and configdir.startswith(tempfile.gettempdir()):
+                raise SystemExit('MPLCONFIGDIR unexpectedly overridden to a temp directory.')
 
         # Test access to the standard 'mpl_toolkits' namespace package installed with Matplotlib.
         # Note that this import was reported to fail under Matplotlib 1.3.0.


### PR DESCRIPTION
## Summary
- The `pyi_rth_mplconfig` run-time hook unconditionally redirected `MPLCONFIGDIR` to a fresh temp directory on every launch, as a workaround for matplotlib < 3.0 storing absolute font paths (pointing inside the onefile `_MEIxxxxx` extraction dir) in its font cache.
- Since matplotlib 3.0 the workaround is obsolete, and unconditionally using a throwaway config dir forces matplotlib to rebuild its font cache on every startup — noticeably slowing frozen-app launch.
- The rthook now checks the installed matplotlib version via `importlib.metadata` (without importing matplotlib) and skips the override for matplotlib >= 3.0, so matplotlib's default persistent user cache directory is used. Legacy behavior is preserved for matplotlib < 3.0 and as a fallback on detection failure.

Fixes #3959.

## Test plan
- [ ] `pytest tests/functional/test_matplotlib.py -v` passes with matplotlib >= 3.0; `MPLCONFIGDIR` diagnostic output is not a PyInstaller temp dir.
- [ ] Manually build a minimal frozen matplotlib app and run it twice; second run imports matplotlib without rebuilding the font cache.
- [ ] (Optional) With matplotlib < 3.0 installed, rthook still points `MPLCONFIGDIR` into the system temp dir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)