### PR TITLE
Do not overwrite XDG_DATA_DIRS fallback value

### DIFF
--- a/PyInstaller/hooks/rthooks/pyi_rth_glib.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_glib.py
@@ -25,7 +25,7 @@ def _pyi_rthook():
         if pyi_data_dir not in xdg_data_dirs:
             xdg_data_dirs = pyi_data_dir + os.pathsep + xdg_data_dirs
     else:
-        xdg_data_dirs = pyi_data_dir
+        xdg_data_dirs = pyi_data_dir + os.pathsep + '/usr/local/share/' + os.pathsep + '/usr/share/'
     os.environ['XDG_DATA_DIRS'] = xdg_data_dirs
 
     # Cleanup aux variables

--- a/news/9422.hooks.rst
+++ b/news/9422.hooks.rst
@@ -1,0 +1,4 @@
+Prevent the run-time hook for ``gi.repository.GLib`` from overriding
+the implicit default value of the ``XDG_DATA_DIRS`` environment
+variable (i.e., ``/usr/local/share/:/usr/share/``) when adding the
+frozen application's top-level directory to the list of data directories.


### PR DESCRIPTION
If XDG_DATA_DIRS is empty, a fallback of /usr/local/share/:/usr/share/ is used, according to the XDG Base Directory Specification. By setting this environment variable directly when it is not set, we are implicitly overriding the fallback, rather than prepending to it.