### PR TITLE
Fix multiprocessing with forkserver in python 3.13.13 and 3.14.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
+          check-latest: true
 
       - name: Install apt packages
         if: startsWith(matrix.os, 'ubuntu')
@@ -345,6 +346,7 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
+          check-latest: true
 
       - name: Update pip
         run: python -m pip install --upgrade pip

--- a/PyInstaller/hooks/rthooks/pyi_rth_multiprocessing.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_multiprocessing.py
@@ -21,7 +21,7 @@ def _pyi_rthook():
     # Prevent `spawn` from trying to read `__main__` in from the main script
     multiprocessing.process.ORIGINAL_DIR = None
 
-    def _freeze_support():
+    def _divert_multiprocessing_helper():
         # We want to catch the two processes that are spawned by the multiprocessing code:
         # - the semaphore tracker, which cleans up named semaphores in the `spawn` multiprocessing mode
         # - the fork server, which keeps track of worker processes in the `forkserver` mode.
@@ -29,14 +29,47 @@ def _pyi_rthook():
         # from `_args_from_interpreter_flags` and then "-c" and an import statement.
         # Look for those flags and the import statement, then `exec()` the code ourselves.
 
-        if (
-            len(sys.argv) >= 2 and sys.argv[-2] == '-c' and sys.argv[-1].startswith(
-                ('from multiprocessing.resource_tracker import main', 'from multiprocessing.forkserver import main')
-            ) and set(sys.argv[1:-2]) == set(_args_from_interpreter_flags())
-        ):
-            exec(sys.argv[-1])
-            sys.exit()
+        # First, look for the -c argument; this should come after executable path and arguments obtained from
+        # `_args_from_interpreter_flags()` (which should be treated as variable due to their dependence on interpreter
+        # flags, some of which may change with different PyInstaller build settings).
+        try:
+            command_switch_idx = sys.argv.index("-c")
+        except ValueError:
+            return
 
+        # Check that -c switch is preceded by `_args_from_interpreter_flags()`.
+        if set(sys.argv[1:command_switch_idx]) != set(_args_from_interpreter_flags()):
+            return
+
+        # "-c" switch should be followed by at least one more argument - the command to execute. Additional arguments
+        # may follow, but they are of no concern here (i.e., the executed command will read them from `sys.argv` as
+        # necessary).
+        if len(sys.argv) <= command_switch_idx + 1:
+            return
+        command = sys.argv[command_switch_idx + 1]
+
+        COMMAND_PREFIXES = (
+            # semaphore/resource tracker
+            'from multiprocessing.resource_tracker import main',
+            # forkserver
+            'from multiprocessing.forkserver import main',
+            # forkserver in python >= 3.15.0a8 (backported to 3.13.13 and 3.14.4)
+            # See: https://github.com/python/cpython/pull/148194
+            'import sys; from multiprocessing.forkserver import main',
+        )
+        if not command.startswith(COMMAND_PREFIXES):
+            return
+
+        # Execute the given command and exit
+        exec(command)
+        sys.exit()
+
+    def _freeze_support():
+        # Check the arguments for known `multiprocessing` helper sub-processes; on match, execute its code and exit the
+        # process by calling sys.exit()
+        _divert_multiprocessing_helper()
+
+        # Check the arguments for attempt at spawning a worker sub-process, and divert program flow on match.
         if multiprocessing.spawn.is_forking(sys.argv):
             kwds = {}
             for arg in sys.argv[2:]:

--- a/news/9423.bugfix.rst
+++ b/news/9423.bugfix.rst
@@ -1,0 +1,2 @@
+Fix the ``forkserver`` spawn mode of ``multiprocessing`` under python
+3.13.13, 3.14.4, and the upcoming 3.15.


### PR DESCRIPTION
Python 3.15.0a8 introduced a change to `forkserver` spawn mode of `multiprocessing`, and that change was also back-ported to python 3.13.13 and 3.14.4.

See: https://github.com/python/cpython/pull/148194
    
In the modified version, the `sys.argv` elements passed to the `forkserver` process have been moved from the command string (that follows `-c` switch) itself into additional command-line arguments.
    
This breaks our current argument-matching implementation in `multiprocessing` run-time hook, which assumes that the command string is the last passed argument. In addition, the command string itself changed a bit (there is an added `import sys; ` at the beginning).
    
Therefore, revise the argument matching to find the index of `-c` argument, and use the following argument (if available) as the command string to match. Add the pattern for the new forkserver command to ensure match under these new python versions.