### PR TITLE
Support for alternative splash screen centering modes

### DIFF
--- a/PyInstaller/archive/writers.py
+++ b/PyInstaller/archive/writers.py
@@ -349,9 +349,11 @@ class SplashWriter:
     #
     #     uint32_t requirements_len;
     #     uint32_t requirements_offset;
+    #
+    #     uint32_t centering_mode;
     # } SPLASH_DATA_HEADER;
     #
-    _HEADER_FORMAT = '!32s 32s 16s 16s II II II'
+    _HEADER_FORMAT = '!32s 32s 16s 16s II II II I'
     _HEADER_LENGTH = struct.calcsize(_HEADER_FORMAT)
 
     # The created archive is compressed by the CArchive, so no need to compress the data here.
@@ -366,6 +368,7 @@ class SplashWriter:
         tk_module_directory_name,
         image,
         script,
+        centering_mode,
     ):
         """
         Writer for splash screen resources that are bundled into the CArchive as a single archive/entry.
@@ -378,6 +381,7 @@ class SplashWriter:
         :param str tk_module_directory_name: Basename of the Tk module directory (e.g., tk/)
         :param Union[str, bytes] image: Image like object
         :param str script: The tcl/tk script to execute to create the screen.
+        :param str centering_mode: Splash screen centering mode (integer value that matches enum used by bootloader)
         """
 
         # Ensure forward slashes in dependency names are on Windows converted to back slashes '\\', as on Windows the
@@ -452,6 +456,7 @@ class SplashWriter:
                 image_offset,
                 requirements_len,
                 requirements_offset,
+                centering_mode,
             )
 
             fp.seek(0, os.SEEK_SET)

--- a/PyInstaller/archive/writers.py
+++ b/PyInstaller/archive/writers.py
@@ -356,6 +356,12 @@ class SplashWriter:
     _HEADER_FORMAT = '!32s 32s 16s 16s II II II I'
     _HEADER_LENGTH = struct.calcsize(_HEADER_FORMAT)
 
+    # Centering mode values - keep in sync with values defined in `bootloader/src/pyi_splash.h`!
+    _SPLASH_CENTER_DEFAULT = 0
+    _SPLASH_CENTER_VIRTUAL_SCREEN = 1
+    _SPLASH_CENTER_PRIMARY_SCREEN = 2
+    _SPLASH_CENTER_ACTIVE_SCREEN = 3
+
     # The created archive is compressed by the CArchive, so no need to compress the data here.
 
     def __init__(
@@ -368,7 +374,7 @@ class SplashWriter:
         tk_module_directory_name,
         image,
         script,
-        centering_mode,
+        center_mode,
     ):
         """
         Writer for splash screen resources that are bundled into the CArchive as a single archive/entry.
@@ -381,7 +387,7 @@ class SplashWriter:
         :param str tk_module_directory_name: Basename of the Tk module directory (e.g., tk/)
         :param Union[str, bytes] image: Image like object
         :param str script: The tcl/tk script to execute to create the screen.
-        :param str centering_mode: Splash screen centering mode (integer value that matches enum used by bootloader)
+        :param str center_mode: Splash screen centering mode (integer value that matches enum used by bootloader)
         """
 
         # Ensure forward slashes in dependency names are on Windows converted to back slashes '\\', as on Windows the
@@ -456,7 +462,7 @@ class SplashWriter:
                 image_offset,
                 requirements_len,
                 requirements_offset,
-                centering_mode,
+                center_mode,
             )
 
             fp.seek(0, os.SEEK_SET)

--- a/PyInstaller/building/makespec.py
+++ b/PyInstaller/building/makespec.py
@@ -400,6 +400,13 @@ def __add_options(parser):
         help="(EXPERIMENTAL) Add an splash screen with the image IMAGE_FILE to the application. The splash screen can "
         "display progress updates while unpacking.",
     )
+    g.add_argument(
+        '--splash-center',
+        dest='splash_center',
+        default=None,
+        choices={'default', 'primary', 'virtual', 'active'},
+        help="Splash screen centering mode. See the splash screen documentation for details.",
+    )
 
     g = parser.add_argument_group('How to generate')
     g.add_argument(
@@ -703,6 +710,7 @@ def main(
     argv_emulation=False,
     hide_console=None,
     optimize=None,
+    splash_center=None,
     **_kwargs
 ):
     # Default values for onefile and console when not explicitly specified on command-line (indicated by None)
@@ -808,7 +816,13 @@ def main(
     )
 
     if splash:
-        splash_init = splashtmpl % {'splash_image': splash}
+        splash_options = ""
+        if splash_center:
+            splash_options = f"\n    center={splash_center!r},"
+        splash_init = splashtmpl % {
+            'splash_image': splash,
+            'splash_options': splash_options,
+        }
         splash_binaries = "\n    splash.binaries,"
         splash_target = "\n    splash,"
     else:

--- a/PyInstaller/building/splash.py
+++ b/PyInstaller/building/splash.py
@@ -100,6 +100,19 @@ class Splash(Target):
             applications) can cover the splash screen by user bringing them to front. This might be useful for
             frozen applications with long startup times. Default: ``True``
         :type always_on_top: bool
+        :keyword center:
+            Splash screen centering mode: ``'default'``, ``'primary'``, ``'virtual'``, or ``'active'``. In the default
+            mode, the splash screen script computes the position using screen dimensions obtained via Tk's ``winfo``
+            command, which has platform-specific behavior in multi-monitor setups; on Windows, it seems to return the
+            size of the primary monitor, while on other platforms, it seems to return the size of the whole virtual
+            screen. In other modes, the bootloader attempts to query the target screen size (and position) using
+            platform-specific low-level API, and supply the information to splash screen script; in ``primary`` mode,
+            the size of primary screen is queried, and in ``virtual`` mode, the size of whole virtual screen is queried.
+            The ``active`` mode is supported only on Windows; the bootloader attempts to obtain position of mouse cursor
+            at the time when application is launched, and queries the size (and position) of the corresponding screen.
+            If the required information cannot be obtained and exposed by the bootloader, the splash screen script
+            falls back to the information provided by the ``winfo`` command. Default: ``'default'``
+        :type center: str
         """
         from PyInstaller.config import CONF
         from PyInstaller.utils.hooks.tcl_tk import tcltk_info
@@ -136,6 +149,11 @@ class Splash(Target):
         self.script_name = kwargs.get("script_name", None)
         self.minify_script = kwargs.get("minify_script", True)
         self.max_img_size = kwargs.get("max_img_size", (760, 480))
+
+        self.center = kwargs.get("center", "default").lower()
+        if self.center not in self._CENTER_MODES:
+            valid_modes = list(self._CENTER_MODES.keys())
+            raise ValueError(f"Invalid center mode {self.center!r}! Must be one of: {valid_modes!r}")
 
         # text options
         self.text_pos = kwargs.get("text_pos", None)
@@ -262,6 +280,13 @@ class Splash(Target):
 
         self.__postinit__()
 
+    _CENTER_MODES = {
+        'default': SplashWriter._SPLASH_CENTER_DEFAULT,
+        'primary': SplashWriter._SPLASH_CENTER_PRIMARY_SCREEN,
+        'virtual': SplashWriter._SPLASH_CENTER_VIRTUAL_SCREEN,
+        'active': SplashWriter._SPLASH_CENTER_ACTIVE_SCREEN,
+    }
+
     _GUTS = (
         # input parameters
         ('image_file', _check_guts_eq),
@@ -276,6 +301,7 @@ class Splash(Target):
         ('full_tk', _check_guts_eq),
         ('minify_script', _check_guts_eq),
         ('max_img_size', _check_guts_eq),
+        ('center', _check_guts_eq),
         # calculated/analysed values
         ('uses_tkinter', _check_guts_eq),
         ('script', _check_guts_eq),
@@ -394,7 +420,7 @@ class Splash(Target):
             tcltk_info.TK_ROOTNAME,
             image,
             self.script,
-            0  # default centering mode
+            self._CENTER_MODES[self.center],
         )
 
     @staticmethod

--- a/PyInstaller/building/splash.py
+++ b/PyInstaller/building/splash.py
@@ -393,7 +393,8 @@ class Splash(Target):
             tcltk_info.TCL_ROOTNAME,
             tcltk_info.TK_ROOTNAME,
             image,
-            self.script
+            self.script,
+            0  # default centering mode
         )
 
     @staticmethod

--- a/PyInstaller/building/splash_templates.py
+++ b/PyInstaller/building/splash_templates.py
@@ -88,11 +88,25 @@ package require Tk
 
 set image_width [image width splash_image]
 set image_height [image height splash_image]
-set display_width [winfo screenwidth .]
-set display_height [winfo screenheight .]
 
-set x_position [expr {int(0.5*($display_width - $image_width))}]
-set y_position [expr {int(0.5*($display_height - $image_height))}]
+# If bootloader set $_pyi_screen_geometry array (advanced splash-screen
+# centering modes that are available on some platforms), use values from it.
+# Otherwise, try to center splash screen using information obtained via
+# winfo screenwidth and screenheight command.
+if {[info exists _pyi_screen_geometry]} {
+    set display_x $_pyi_screen_geometry(x)
+    set display_y $_pyi_screen_geometry(y)
+    set display_width $_pyi_screen_geometry(width)
+    set display_height $_pyi_screen_geometry(height)
+} else {
+    set display_x 0
+    set display_y 0
+    set display_width [winfo screenwidth .]
+    set display_height [winfo screenheight .]
+}
+
+set x_position [expr {int($display_x + 0.5*($display_width - $image_width))}]
+set y_position [expr {int($display_y + 0.5*($display_height - $image_height))}]
 
 # Toplevel frame in which all widgets should be positioned
 frame .root

--- a/PyInstaller/building/templates.py
+++ b/PyInstaller/building/templates.py
@@ -121,6 +121,6 @@ splashtmpl = """splash = Splash(
     text_pos=None,
     text_size=12,
     minify_script=True,
-    always_on_top=True,
+    always_on_top=True,%(splash_options)s
 )
 """

--- a/bootloader/src/pyi_splash.c
+++ b/bootloader/src/pyi_splash.c
@@ -68,22 +68,6 @@ static Tcl_ThreadCreateProc _splash_init;
 struct Splash_Event;
 
 
-/* Splash screen centering modes */
-enum SPLASH_CENTER_MODE
-{
-    /* No additional bootloader processing; have the splash screen script
-     * fall back to the  `winfo screenwidth` and `winfo screenheight` */
-    SPLASH_CENTER_DEFAULT = 0,
-    /* Center on virtual screen */
-    SPLASH_CENTER_VIRTUAL_SCREEN = 1,
-    /* Center on primary monitor / screen */
-    SPLASH_CENTER_PRIMARY_SCREEN = 2,
-    /* Center on active monitor / screen; i.e., where mouse cursor is at
-     * the time when application is launched. */
-    SPLASH_CENTER_ACTIVE_SCREEN = 3
-};
-
-
 /*
  * Initialize the splash screen context by reading its data and defining
  * the necessary paths and resources.
@@ -718,13 +702,16 @@ pyi_splash_send(struct SPLASH_CONTEXT *splash, bool async, const void *user_data
  */
 static void _pyi_splash_setup_centering_mode (struct SPLASH_CONTEXT *splash)
 {
-    /* This functionality is supported only on Windows. */
-#if defined(_WIN32)
     const struct DYLIB_TCLTK *dylib_tcltk = splash->dylib_tcltk;
 
     char *env_var_value;
     int centering_mode;
-    int x, y, width, height;
+
+    int x = 0;
+    int y = 0;
+    int width = 0;
+    int height= 0;
+    int status = -1;
 
     char var_value[64];
 
@@ -746,69 +733,45 @@ static void _pyi_splash_setup_centering_mode (struct SPLASH_CONTEXT *splash)
         free(env_var_value);
     }
 
+    /* If default centering mode is used, nothing needs to be done here. */
     switch (centering_mode) {
         case SPLASH_CENTER_DEFAULT: {
-            PYI_DEBUG_W(L"SPLASH: 'default' center mode - nothing to do!\n");
+            PYI_DEBUG("SPLASH: 'default' center mode - nothing to do!\n");
             return;
         }
         case SPLASH_CENTER_VIRTUAL_SCREEN: {
-            PYI_DEBUG_W(L"SPLASH: 'virtual' center mode...\n");
-
-            /* NOTE: this is not DPI aware, and will likely give wrong
-             * results with mixed-DPI screens... */
-            x = 0;
-            y = 0;
-            width = GetSystemMetrics(SM_CXVIRTUALSCREEN);
-            height = GetSystemMetrics(SM_CYVIRTUALSCREEN);
+            PYI_DEBUG("SPLASH: 'virtual' center mode...\n");
             break;
         }
-        case SPLASH_CENTER_PRIMARY_SCREEN:
+        case SPLASH_CENTER_PRIMARY_SCREEN: {
+            PYI_DEBUG("SPLASH: 'primary' center mode...\n");
+            break;
+        }
         case SPLASH_CENTER_ACTIVE_SCREEN:  {
-            POINT mouse_pos;
-            HMONITOR monitor;
-            MONITORINFO monitor_info;
-
-            if (centering_mode == SPLASH_CENTER_PRIMARY_SCREEN) {
-                PYI_DEBUG_W(L"SPLASH: 'primary' center mode...\n");
-                mouse_pos.x = 0;
-                mouse_pos.y = 0;
-                monitor = MonitorFromPoint(mouse_pos, MONITOR_DEFAULTTOPRIMARY);
-            } else {
-                PYI_DEBUG_W(L"SPLASH: 'active' center mode...\n");
-                if (!GetCursorPos(&mouse_pos)) {
-                    PYI_DEBUG_W(L"SPLASH: failed to obtain cursor position!\n");
-                    return;
-                }
-                monitor = MonitorFromPoint(mouse_pos, MONITOR_DEFAULTTONEAREST);
-            }
-
-            if (!monitor) {
-                PYI_DEBUG_W(L"SPLASH: failed to obtain monitor handle!\n");
-                return;
-            }
-
-            /* Query monitor info */
-            memset(&monitor_info, 0, sizeof(MONITORINFO));
-            monitor_info.cbSize = sizeof(MONITORINFO);
-            if (!GetMonitorInfoW(monitor, &monitor_info)) {
-                PYI_DEBUG_W(L"SPLASH: failed to query monitor info!\n");
-                return;
-            }
-
-            x = monitor_info.rcMonitor.left;
-            y = monitor_info.rcMonitor.top;
-            width = monitor_info.rcMonitor.right - monitor_info.rcMonitor.left;
-            height = monitor_info.rcMonitor.bottom - monitor_info.rcMonitor.top;
-
+            PYI_DEBUG("SPLASH: 'active' center mode...\n");
             break;
         }
         default: {
-            PYI_DEBUG_W(L"SPLASH: unhandled centering mode: %d\n", centering_mode);
+            PYI_DEBUG("SPLASH: unhandled centering mode: %d\n", centering_mode);
             return;
         }
     }
 
-    PYI_DEBUG_W(L"SPLASH: storing monitor geometry: x=%d, y=%d, width=%d, height=%d\n", x, y, width, height);
+    /* Platform-specific implementation */
+#if defined(_WIN32)
+    status = _pyi_splash_setup_centering_mode_win32(centering_mode, &x, &y, &width, &height);
+#elif !defined(__APPLE__)
+    status = _pyi_splash_setup_centering_mode_x11(centering_mode, &x, &y, &width, &height);
+#else
+    PYI_DEBUG("SPLASH: splash screen centering is not supported on this platform!\n");
+    status = -1;
+#endif
+
+    if (status != 0) {
+        return;
+    }
+
+    PYI_DEBUG("SPLASH: storing monitor geometry: x=%d, y=%d, width=%d, height=%d\n", x, y, width, height);
 
     /* Store values in an array */
     snprintf(var_value, 64, "%d", x);
@@ -822,9 +785,6 @@ static void _pyi_splash_setup_centering_mode (struct SPLASH_CONTEXT *splash)
 
     snprintf(var_value, 64, "%d", height);
     dylib_tcltk->Tcl_SetVar2(splash->interp, "_pyi_screen_geometry", "height", var_value, TCL_GLOBAL_ONLY);
-#else
-    (void)splash; /* unused */
-#endif
 }
 
 /* ----------------------------------------------------------------------------------------- */

--- a/bootloader/src/pyi_splash.c
+++ b/bootloader/src/pyi_splash.c
@@ -159,6 +159,9 @@ pyi_splash_setup(struct SPLASH_CONTEXT *splash, const struct PYI_CONTEXT *pyi_ct
         splash->requirements_len
     );
 
+    /* Copy default centering mode */
+    splash->centering_mode = pyi_be32toh(data_header->centering_mode);
+
     /* Free raw header data */
     free(data_header);
 
@@ -715,8 +718,8 @@ static void _pyi_splash_setup_centering_mode (struct SPLASH_CONTEXT *splash)
 
     char var_value[64];
 
-    /* TODO: use a default that is set at build time. */
-    centering_mode = SPLASH_CENTER_DEFAULT;
+    /* Default centering mode set at build time. */
+    centering_mode = splash->centering_mode;
 
     /* Allow user to override the mode at run-time via environment variable */
     env_var_value = pyi_getenv("PYINSTALLER_SPLASH_SCREEN_CENTER");

--- a/bootloader/src/pyi_splash.c
+++ b/bootloader/src/pyi_splash.c
@@ -68,6 +68,22 @@ static Tcl_ThreadCreateProc _splash_init;
 struct Splash_Event;
 
 
+/* Splash screen centering modes */
+enum SPLASH_CENTER_MODE
+{
+    /* No additional bootloader processing; have the splash screen script
+     * fall back to the  `winfo screenwidth` and `winfo screenheight` */
+    SPLASH_CENTER_DEFAULT = 0,
+    /* Center on virtual screen */
+    SPLASH_CENTER_VIRTUAL_SCREEN = 1,
+    /* Center on primary monitor / screen */
+    SPLASH_CENTER_PRIMARY_SCREEN = 2,
+    /* Center on active monitor / screen; i.e., where mouse cursor is at
+     * the time when application is launched. */
+    SPLASH_CENTER_ACTIVE_SCREEN = 3
+};
+
+
 /*
  * Initialize the splash screen context by reading its data and defining
  * the necessary paths and resources.
@@ -693,6 +709,124 @@ pyi_splash_send(struct SPLASH_CONTEXT *splash, bool async, const void *user_data
     return rc;
 }
 
+/*
+ * Use platform-specific API to determine monitor geometry for advanced
+ * centering modes. Stored the corresponding screen geometry info
+ * (x, y, width, height) into `_pyi_screen_geometry` array variable that
+ * can be used by the splash screen script in lieu of screen dimensions
+ * obtained via `winfo` command.
+ */
+static void _pyi_splash_setup_centering_mode (struct SPLASH_CONTEXT *splash)
+{
+    /* This functionality is supported only on Windows. */
+#if defined(_WIN32)
+    const struct DYLIB_TCLTK *dylib_tcltk = splash->dylib_tcltk;
+
+    char *env_var_value;
+    int centering_mode;
+    int x, y, width, height;
+
+    char var_value[64];
+
+    /* TODO: use a default that is set at build time. */
+    centering_mode = SPLASH_CENTER_DEFAULT;
+
+    /* Allow user to override the mode at run-time via environment variable */
+    env_var_value = pyi_getenv("PYINSTALLER_SPLASH_SCREEN_CENTER");
+    if (env_var_value) {
+        if (strcmp(env_var_value, "default") == 0) {
+            centering_mode = SPLASH_CENTER_DEFAULT;
+        } else if (strcmp(env_var_value, "virtual") == 0) {
+            centering_mode = SPLASH_CENTER_VIRTUAL_SCREEN;
+        } else if (strcmp(env_var_value, "primary") == 0) {
+            centering_mode = SPLASH_CENTER_PRIMARY_SCREEN;
+        } else if (strcmp(env_var_value, "active") == 0) {
+            centering_mode = SPLASH_CENTER_ACTIVE_SCREEN;
+        }
+        free(env_var_value);
+    }
+
+    switch (centering_mode) {
+        case SPLASH_CENTER_DEFAULT: {
+            PYI_DEBUG_W(L"SPLASH: 'default' center mode - nothing to do!\n");
+            return;
+        }
+        case SPLASH_CENTER_VIRTUAL_SCREEN: {
+            PYI_DEBUG_W(L"SPLASH: 'virtual' center mode...\n");
+
+            /* NOTE: this is not DPI aware, and will likely give wrong
+             * results with mixed-DPI screens... */
+            x = 0;
+            y = 0;
+            width = GetSystemMetrics(SM_CXVIRTUALSCREEN);
+            height = GetSystemMetrics(SM_CYVIRTUALSCREEN);
+            break;
+        }
+        case SPLASH_CENTER_PRIMARY_SCREEN:
+        case SPLASH_CENTER_ACTIVE_SCREEN:  {
+            POINT mouse_pos;
+            HMONITOR monitor;
+            MONITORINFO monitor_info;
+
+            if (centering_mode == SPLASH_CENTER_PRIMARY_SCREEN) {
+                PYI_DEBUG_W(L"SPLASH: 'primary' center mode...\n");
+                mouse_pos.x = 0;
+                mouse_pos.y = 0;
+                monitor = MonitorFromPoint(mouse_pos, MONITOR_DEFAULTTOPRIMARY);
+            } else {
+                PYI_DEBUG_W(L"SPLASH: 'active' center mode...\n");
+                if (!GetCursorPos(&mouse_pos)) {
+                    PYI_DEBUG_W(L"SPLASH: failed to obtain cursor position!\n");
+                    return;
+                }
+                monitor = MonitorFromPoint(mouse_pos, MONITOR_DEFAULTTONEAREST);
+            }
+
+            if (!monitor) {
+                PYI_DEBUG_W(L"SPLASH: failed to obtain monitor handle!\n");
+                return;
+            }
+
+            /* Query monitor info */
+            memset(&monitor_info, 0, sizeof(MONITORINFO));
+            monitor_info.cbSize = sizeof(MONITORINFO);
+            if (!GetMonitorInfoW(monitor, &monitor_info)) {
+                PYI_DEBUG_W(L"SPLASH: failed to query monitor info!\n");
+                return;
+            }
+
+            x = monitor_info.rcMonitor.left;
+            y = monitor_info.rcMonitor.top;
+            width = monitor_info.rcMonitor.right - monitor_info.rcMonitor.left;
+            height = monitor_info.rcMonitor.bottom - monitor_info.rcMonitor.top;
+
+            break;
+        }
+        default: {
+            PYI_DEBUG_W(L"SPLASH: unhandled centering mode: %d\n", centering_mode);
+            return;
+        }
+    }
+
+    PYI_DEBUG_W(L"SPLASH: storing monitor geometry: x=%d, y=%d, width=%d, height=%d\n", x, y, width, height);
+
+    /* Store values in an array */
+    snprintf(var_value, 64, "%d", x);
+    dylib_tcltk->Tcl_SetVar2(splash->interp, "_pyi_screen_geometry", "x", var_value, TCL_GLOBAL_ONLY);
+
+    snprintf(var_value, 64, "%d", y);
+    dylib_tcltk->Tcl_SetVar2(splash->interp, "_pyi_screen_geometry", "y", var_value, TCL_GLOBAL_ONLY);
+
+    snprintf(var_value, 64, "%d", width);
+    dylib_tcltk->Tcl_SetVar2(splash->interp, "_pyi_screen_geometry", "width", var_value, TCL_GLOBAL_ONLY);
+
+    snprintf(var_value, 64, "%d", height);
+    dylib_tcltk->Tcl_SetVar2(splash->interp, "_pyi_screen_geometry", "height", var_value, TCL_GLOBAL_ONLY);
+#else
+    (void)splash; /* unused */
+#endif
+}
+
 /* ----------------------------------------------------------------------------------------- */
 
 /*
@@ -1107,6 +1241,11 @@ _splash_init(ClientData client_data)
     free(splash->image);
     splash->image = NULL;
 
+    /* Setup additional variables for different splash-screen centering
+     * modes (if available on the current platform). */
+    _pyi_splash_setup_centering_mode(splash);
+
+    /* Run the splash screen script */
     if (dylib_tcltk->tcl_major >= 9) {
         err = dylib_tcltk->Tcl_EvalEx_9(splash->interp, splash->script, splash->script_len, TCL_GLOBAL_ONLY);
     } else {

--- a/bootloader/src/pyi_splash.h
+++ b/bootloader/src/pyi_splash.h
@@ -66,6 +66,9 @@ struct SPLASH_DATA_HEADER
     uint32_t requirements_len;
     uint32_t requirements_offset;
 
+    /* Centering mode set at build time. */
+    uint32_t centering_mode;
+
     /*
      * Followed by a chunk of data, including the splash screen
      * script, the image, and the required files array.
@@ -139,6 +142,9 @@ struct SPLASH_CONTEXT
     /* Structure that encapsulates loaded Tcl and Tk shared library and
      * pointers to imported functions. */
     struct DYLIB_TCLTK *dylib_tcltk;
+
+    /* Splash screen centering mode; see SPLASH_CENTER_MODE enum. */
+    int centering_mode;
 };
 
 typedef int (pyi_splash_event_proc)(struct SPLASH_CONTEXT *, const void *);

--- a/bootloader/src/pyi_splash.h
+++ b/bootloader/src/pyi_splash.h
@@ -19,6 +19,21 @@
 #include "pyi_archive.h"
 #include "pyi_dylib_tcltk.h"
 
+/* Splash screen centering modes */
+enum SPLASH_CENTER_MODE
+{
+    /* No additional bootloader processing; have the splash screen script
+     * fall back to the  `winfo screenwidth` and `winfo screenheight` */
+    SPLASH_CENTER_DEFAULT = 0,
+    /* Center on virtual screen */
+    SPLASH_CENTER_VIRTUAL_SCREEN = 1,
+    /* Center on primary monitor / screen */
+    SPLASH_CENTER_PRIMARY_SCREEN = 2,
+    /* Center on active monitor / screen; i.e., where mouse cursor is at
+     * the time when application is launched. */
+    SPLASH_CENTER_ACTIVE_SCREEN = 3
+};
+
 /* Archive item header for splash data
  * This struct is a header describing the rest of this archive item */
 struct SPLASH_DATA_HEADER
@@ -130,6 +145,12 @@ typedef int (pyi_splash_event_proc)(struct SPLASH_CONTEXT *, const void *);
 
 struct PYI_CONTEXT;
 
+/* Platform-specific implementation of advanced centering modes */
+#if defined(_WIN32)
+int _pyi_splash_setup_centering_mode_win32(int mode, int *x, int *y, int *width, int *height);
+#elif !defined(__APPLE__)
+int _pyi_splash_setup_centering_mode_x11(int mode, int *x, int *y, int *width, int *height);
+#endif
 
 /**
  * Public API functions for pyi_splash

--- a/bootloader/src/pyi_splash_centering_win32.c
+++ b/bootloader/src/pyi_splash_centering_win32.c
@@ -1,0 +1,76 @@
+/*
+ * ****************************************************************************
+ * Copyright (c) 2026, PyInstaller Development Team.
+ *
+ * Distributed under the terms of the GNU General Public License (version 2
+ * or later) with exception for distributing the bootloader.
+ *
+ * The full license is in the file COPYING.txt, distributed with this software.
+ *
+ * SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+ * ****************************************************************************
+ */
+
+#include "pyi_splash.h"
+
+#if defined(_WIN32)
+
+int _pyi_splash_setup_centering_mode_win32(int mode, int *x, int *y, int *width, int *height)
+{
+    switch (mode) {
+        case SPLASH_CENTER_VIRTUAL_SCREEN: {
+            /* NOTE: this is not DPI aware, and will likely give wrong
+             * results with mixed-DPI screens... */
+            *x = 0;
+            *y = 0;
+            *width = GetSystemMetrics(SM_CXVIRTUALSCREEN);
+            *height = GetSystemMetrics(SM_CYVIRTUALSCREEN);
+            break;
+        }
+        case SPLASH_CENTER_PRIMARY_SCREEN:
+        case SPLASH_CENTER_ACTIVE_SCREEN:  {
+            POINT mouse_pos;
+            HMONITOR monitor;
+            MONITORINFO monitor_info;
+
+            if (mode == SPLASH_CENTER_PRIMARY_SCREEN) {
+                mouse_pos.x = 0;
+                mouse_pos.y = 0;
+                monitor = MonitorFromPoint(mouse_pos, MONITOR_DEFAULTTOPRIMARY);
+            } else {
+                if (!GetCursorPos(&mouse_pos)) {
+                    PYI_DEBUG_W(L"SPLASH: failed to obtain cursor position!\n");
+                    return -1;
+                }
+                monitor = MonitorFromPoint(mouse_pos, MONITOR_DEFAULTTONEAREST);
+            }
+
+            if (!monitor) {
+                PYI_DEBUG_W(L"SPLASH: failed to obtain monitor handle!\n");
+                return -1;
+            }
+
+            /* Query monitor info */
+            memset(&monitor_info, 0, sizeof(MONITORINFO));
+            monitor_info.cbSize = sizeof(MONITORINFO);
+            if (!GetMonitorInfoW(monitor, &monitor_info)) {
+                PYI_DEBUG_W(L"SPLASH: failed to query monitor info!\n");
+                return -1;
+            }
+
+            *x = monitor_info.rcMonitor.left;
+            *y = monitor_info.rcMonitor.top;
+            *width = monitor_info.rcMonitor.right - monitor_info.rcMonitor.left;
+            *height = monitor_info.rcMonitor.bottom - monitor_info.rcMonitor.top;
+
+            break;
+        }
+        default: {
+            return -1; /* Not handled */
+        }
+    }
+
+    return 0;
+}
+
+#endif

--- a/bootloader/src/pyi_splash_centering_x11.c
+++ b/bootloader/src/pyi_splash_centering_x11.c
@@ -11,14 +11,292 @@
  * ****************************************************************************
  */
 
+#include <stdlib.h> /* calloc */
+
 #include "pyi_splash.h"
 
 #if !defined(_WIN32) && !defined(__APPLE__)
 
+/* Dynamic bindings for Xlib: /usr/include/X11/Xlib.h */
+typedef struct Display_ Display;
+#define Bool int
+
+PYI_EXT_FUNC_PROTO(Display *, XOpenDisplay, (char *))
+PYI_EXT_FUNC_PROTO(int, XCloseDisplay, (Display *))
+PYI_EXT_FUNC_PROTO(int, XDefaultScreen, (Display *))
+PYI_EXT_FUNC_PROTO(int, XDisplayWidth, (Display *, int))
+PYI_EXT_FUNC_PROTO(int, XDisplayHeight, (Display *, int))
+PYI_EXT_FUNC_PROTO(void, XFree, (void *))
+
+struct DYLIB_XLIB
+{
+    /* Shared library handles */
+    pyi_dylib_t handle;
+
+    /* Function pointers for imported functions */
+    PYI_EXT_FUNC_ENTRY(XOpenDisplay)
+    PYI_EXT_FUNC_ENTRY(XCloseDisplay)
+    PYI_EXT_FUNC_ENTRY(XDefaultScreen)
+    PYI_EXT_FUNC_ENTRY(XDisplayWidth)
+    PYI_EXT_FUNC_ENTRY(XDisplayHeight)
+    PYI_EXT_FUNC_ENTRY(XFree)
+};
+
+static void pyi_dylib_xlib_cleanup(struct DYLIB_XLIB **dylib_ref)
+{
+    struct DYLIB_XLIB *dylib = *dylib_ref;
+
+    *dylib_ref = NULL;
+
+    if (dylib == NULL) {
+        return;
+    }
+
+    /* Unload the shared library */
+    if (dylib->handle != NULL) {
+        PYI_DEBUG("DYLIB: unloading Xlib shared library...\n");
+
+        if (dlclose(dylib->handle) < 0) {
+            PYI_DEBUG("DYLIB: failed to unload Xlib shared library!\n");
+        } else {
+            PYI_DEBUG("DYLIB: unloaded Xlib shared library.\n");
+        }
+    }
+
+    /* Free the allocated structure */
+    free(dylib);
+}
+
+static struct DYLIB_XLIB *pyi_dylib_xlib_load()
+{
+    struct DYLIB_XLIB *dylib;
+    const char *libname = "libX11.so.6";
+
+    /* Allocate structure */
+    dylib = (struct DYLIB_XLIB *)calloc(1, sizeof(struct DYLIB_XLIB));
+    if (dylib == NULL) {
+        PYI_PERROR("calloc", "Could not allocate memory for DYLIB_XLIB structure.\n");
+        return NULL;
+    }
+
+    /* Load shared library */
+    dylib->handle = dlopen(libname, RTLD_NOW | RTLD_GLOBAL);
+    if (dylib->handle == NULL) {
+        PYI_ERROR("Failed to load Xlib shared library '%s': %s\n", libname, dlerror());
+        goto cleanup;
+    }
+    PYI_DEBUG("DYLIB: loaded Xlib shared library.\n");
+
+    /* Import functions/symbols */
+    #define _IMPORT_FUNCTION(name) \
+        PYI_EXT_FUNC_BIND(dylib->handle, name, dylib->name); \
+        if (!dylib->name) { \
+            PYI_ERROR("Failed to import symbol %s from Xlib shared library: %s\n", #name, dlerror()); \
+            goto cleanup; \
+        }
+
+    _IMPORT_FUNCTION(XOpenDisplay)
+    _IMPORT_FUNCTION(XCloseDisplay)
+    _IMPORT_FUNCTION(XDefaultScreen)
+    _IMPORT_FUNCTION(XDisplayWidth)
+    _IMPORT_FUNCTION(XDisplayHeight)
+    _IMPORT_FUNCTION(XFree)
+
+    #undef _IMPORT_FUNCTION
+
+    PYI_DEBUG("DYLIB: imported symbols from Xlib shared library.\n");
+
+    return dylib;
+
+cleanup:
+    pyi_dylib_xlib_cleanup(&dylib);
+    return dylib;
+}
+
+/* Dynamic bindings for Xinerama extension: /usr/include/X11/extensions/Xinerama.h */
+typedef struct
+{
+   int screen_number;
+   short x_org;
+   short y_org;
+   short width;
+   short height;
+} XineramaScreenInfo;
+
+PYI_EXT_FUNC_PROTO(Bool, XineramaQueryExtension, (Display *, int *, int *))
+PYI_EXT_FUNC_PROTO(XineramaScreenInfo *, XineramaQueryScreens, (Display *, int *))
+
+struct DYLIB_XINERAMA
+{
+    /* Shared library handles */
+    pyi_dylib_t handle;
+
+    /* Function pointers for imported functions */
+    PYI_EXT_FUNC_ENTRY(XineramaQueryExtension)
+    PYI_EXT_FUNC_ENTRY(XineramaQueryScreens)
+};
+
+static void pyi_dylib_xinerama_cleanup(struct DYLIB_XINERAMA **dylib_ref)
+{
+    struct DYLIB_XINERAMA *dylib = *dylib_ref;
+
+    *dylib_ref = NULL;
+
+    if (dylib == NULL) {
+        return;
+    }
+
+    /* Unload the shared library */
+    if (dylib->handle != NULL) {
+        PYI_DEBUG("DYLIB: unloading Xinerama shared library...\n");
+
+        if (dlclose(dylib->handle) < 0) {
+            PYI_DEBUG("DYLIB: failed to unload Xinerama shared library!\n");
+        } else {
+            PYI_DEBUG("DYLIB: unloaded Xinerama shared library.\n");
+        }
+    }
+
+    /* Free the allocated structure */
+    free(dylib);
+}
+
+static struct DYLIB_XINERAMA *pyi_dylib_xinerama_load()
+{
+    struct DYLIB_XINERAMA *dylib;
+    const char *libname = "libXinerama.so.1";
+
+    /* Allocate structure */
+    dylib = (struct DYLIB_XINERAMA *)calloc(1, sizeof(struct DYLIB_XINERAMA));
+    if (dylib == NULL) {
+        PYI_PERROR("calloc", "Could not allocate memory for DYLIB_XINERAMA structure.\n");
+        return NULL;
+    }
+
+    /* Load shared library */
+    dylib->handle = dlopen(libname, RTLD_NOW | RTLD_GLOBAL);
+    if (dylib->handle == NULL) {
+        PYI_ERROR("Failed to load Xinerama shared library '%s': %s\n", libname, dlerror());
+        goto cleanup;
+    }
+    PYI_DEBUG("DYLIB: loaded Xinerama shared library.\n");
+
+    /* Import functions/symbols */
+    #define _IMPORT_FUNCTION(name) \
+        PYI_EXT_FUNC_BIND(dylib->handle, name, dylib->name); \
+        if (!dylib->name) { \
+            PYI_ERROR("Failed to import symbol %s from Xinerama shared library: %s\n", #name, dlerror()); \
+            goto cleanup; \
+        }
+
+    _IMPORT_FUNCTION(XineramaQueryExtension)
+    _IMPORT_FUNCTION(XineramaQueryScreens)
+
+    #undef _IMPORT_FUNCTION
+
+    PYI_DEBUG("DYLIB: imported symbols from Xinerama shared library.\n");
+
+    return dylib;
+
+cleanup:
+    pyi_dylib_xinerama_cleanup(&dylib);
+    return dylib;
+}
+
+/* Splash screen centering implementation for X11 / (X)Wayland */
 int _pyi_splash_setup_centering_mode_x11(int mode, int *x, int *y, int *width, int *height)
 {
-    PYI_DEBUG("SPLASH: TODO - implement splash-screen centering for X11/(X)Wayland!\n");
-    return -1;
+    struct DYLIB_XLIB *xlib = NULL;
+    struct DYLIB_XINERAMA *xinerama = NULL;
+
+    Display *display = NULL;
+    int screen = 0;
+
+    int xinerama_event_base;
+    int xinerama_error_base;
+    XineramaScreenInfo *xinerama_screens = NULL;
+    int num_xinerama_screens = 0;
+
+    int status = -1;
+
+    /* Load Xlib */
+    PYI_DEBUG("SPLASH: loading Xlib shared library...\n");
+    xlib = pyi_dylib_xlib_load();
+    if (xlib == NULL) {
+        PYI_DEBUG("SPLASH: could not dynamically load the Xlib shared library!\n");
+        goto end;
+    }
+
+    /* Connect to display */
+    display = xlib->XOpenDisplay(NULL);
+    if (!display) {
+        PYI_DEBUG("SPLASH: could not connect to display!\n");
+        goto end;
+    }
+
+    /* Get screen number */
+    screen = xlib->XDefaultScreen(display);
+
+    /* We do not support "active screen" mode; we would require to query
+     * mouse cursor position, and while XQueryPointer() exists in Xlib,
+     * it does not work on contemporary (X)Wayland systems. For now,
+     * just fall back to primary screen mode. */
+    if (mode == SPLASH_CENTER_ACTIVE_SCREEN) {
+        PYI_DEBUG("SPLASH: 'active' mode not supported on this platform - falling back to 'primary'!\n");
+        mode = SPLASH_CENTER_PRIMARY_SCREEN;
+    }
+
+    /* For virtual screen, we can use XDisplayWidth() and XDisplayHeight() */
+    if (mode == SPLASH_CENTER_VIRTUAL_SCREEN) {
+        *x = 0;
+        *y = 0;
+        *width = xlib->XDisplayWidth(display, screen);
+        *height = xlib->XDisplayHeight(display, screen);
+        status = 0; /* Succeeded */
+        goto end;
+    }
+
+    /* For primary-screen mode, we need to use Xinerama extension to query
+     * extent of the primary screen/monitor (listed first in the output) */
+    if (mode != SPLASH_CENTER_PRIMARY_SCREEN) {
+        goto end;
+    }
+
+    PYI_DEBUG("SPLASH: loading Xinerama shared library...\n");
+    xinerama = pyi_dylib_xinerama_load();
+    if (!xinerama) {
+        PYI_DEBUG("SPLASH: could not dynamically load the Xinerama shared library!\n");
+        goto end;
+    }
+    if (!xinerama->XineramaQueryExtension(display, &xinerama_event_base, &xinerama_error_base)) {
+        PYI_DEBUG("SPLASH: Xinerama extension is not available!\n");
+        goto end;
+    }
+
+    xinerama_screens = xinerama->XineramaQueryScreens(display, &num_xinerama_screens);
+    if (!num_xinerama_screens) {
+        PYI_DEBUG("SPLASH: could not obtain screen info from Xinerama extension!\n");
+        goto end;
+    }
+
+    *x = xinerama_screens[0].x_org;
+    *y = xinerama_screens[0].y_org;
+    *width = xinerama_screens[0].width;
+    *height = xinerama_screens[0].height;
+    status = 0; /* Succeeded */
+
+    xlib->XFree(xinerama_screens);
+
+end:
+    /* Cleanup */
+    if (display) {
+        xlib->XCloseDisplay(display);
+    }
+
+    pyi_dylib_xlib_cleanup(&xlib);
+    pyi_dylib_xinerama_cleanup(&xinerama);
+
+    return status;
 }
 
 #endif

--- a/bootloader/src/pyi_splash_centering_x11.c
+++ b/bootloader/src/pyi_splash_centering_x11.c
@@ -70,7 +70,18 @@ static void pyi_dylib_xlib_cleanup(struct DYLIB_XLIB **dylib_ref)
 static struct DYLIB_XLIB *pyi_dylib_xlib_load()
 {
     struct DYLIB_XLIB *dylib;
+
+#ifdef AIX
+#ifdef AIX64
+    const char *libname = "libX11.a(shr_64.o)"; /* 64-bit object in .a archive */
+#else
+    const char *libname = "libX11.a(shr4.o)"; /* 32-bit object in .a archive */
+#endif
+    const int dlopen_flags = RTLD_NOW | RTLD_GLOBAL | RTLD_MEMBER;
+#else
     const char *libname = "libX11.so.6";
+    const int dlopen_flags = RTLD_NOW | RTLD_GLOBAL;
+#endif
 
     /* Allocate structure */
     dylib = (struct DYLIB_XLIB *)calloc(1, sizeof(struct DYLIB_XLIB));
@@ -80,7 +91,7 @@ static struct DYLIB_XLIB *pyi_dylib_xlib_load()
     }
 
     /* Load shared library */
-    dylib->handle = dlopen(libname, RTLD_NOW | RTLD_GLOBAL);
+    dylib->handle = dlopen(libname, dlopen_flags);
     if (dylib->handle == NULL) {
         PYI_ERROR("Failed to load Xlib shared library '%s': %s\n", libname, dlerror());
         goto cleanup;
@@ -164,7 +175,20 @@ static void pyi_dylib_xinerama_cleanup(struct DYLIB_XINERAMA **dylib_ref)
 static struct DYLIB_XINERAMA *pyi_dylib_xinerama_load()
 {
     struct DYLIB_XINERAMA *dylib;
+
+#ifdef AIX
+    /* On AIX, the Xinerama extension is part of monolithic Xext
+     * extension library. */
+#ifdef AIX64
+    const char *libname = "libXext.a(shr_64.o)"; /* 64-bit object in .a archive */
+#else
+    const char *libname = "libXext.a(shr.o)"; /* 32-bit object in .a archive */
+#endif
+    const int dlopen_flags = RTLD_NOW | RTLD_GLOBAL | RTLD_MEMBER;
+#else
     const char *libname = "libXinerama.so.1";
+    const int dlopen_flags = RTLD_NOW | RTLD_GLOBAL;
+#endif
 
     /* Allocate structure */
     dylib = (struct DYLIB_XINERAMA *)calloc(1, sizeof(struct DYLIB_XINERAMA));
@@ -174,7 +198,7 @@ static struct DYLIB_XINERAMA *pyi_dylib_xinerama_load()
     }
 
     /* Load shared library */
-    dylib->handle = dlopen(libname, RTLD_NOW | RTLD_GLOBAL);
+    dylib->handle = dlopen(libname, dlopen_flags);
     if (dylib->handle == NULL) {
         PYI_ERROR("Failed to load Xinerama shared library '%s': %s\n", libname, dlerror());
         goto cleanup;

--- a/bootloader/src/pyi_splash_centering_x11.c
+++ b/bootloader/src/pyi_splash_centering_x11.c
@@ -1,0 +1,24 @@
+/*
+ * ****************************************************************************
+ * Copyright (c) 2026, PyInstaller Development Team.
+ *
+ * Distributed under the terms of the GNU General Public License (version 2
+ * or later) with exception for distributing the bootloader.
+ *
+ * The full license is in the file COPYING.txt, distributed with this software.
+ *
+ * SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+ * ****************************************************************************
+ */
+
+#include "pyi_splash.h"
+
+#if !defined(_WIN32) && !defined(__APPLE__)
+
+int _pyi_splash_setup_centering_mode_x11(int mode, int *x, int *y, int *width, int *height)
+{
+    PYI_DEBUG("SPLASH: TODO - implement splash-screen centering for X11/(X)Wayland!\n");
+    return -1;
+}
+
+#endif

--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -624,6 +624,9 @@ def configure(ctx):
 
     elif ctx.env.DEST_OS == 'aix':
         ctx.env.append_value('DEFINES', 'AIX')
+        # Additional macro to distinguish between 32-bit and 64-bit AIX builds.
+        if ctx.env.PYI_ARCH == '64bit':
+            ctx.env.append_value('DEFINES', 'AIX64')
         # On AIX some APIs are restricted if _ALL_SOURCE is not defined. In the case of PyInstaller, we need the AIX
         # specific flag RTLD_MEMBER for dlopen(), which is used to load a shared object from a library archive.
         # We need to load the Python library like this:

--- a/doc/advanced-topics.rst
+++ b/doc/advanced-topics.rst
@@ -235,6 +235,12 @@ the following variables are used:
   not to be shown, and functions of :mod:`pyi_splash` module become no-op
   without raising errors or warnings.
 
+.. envvar:: PYINSTALLER_SPLASH_SCREEN_CENTER
+
+  Setting this environment variable allows user to override the :ref:`splash
+  screen centering mode <splash screen centering>` at run-time. Valid values
+  are: ``default``, ``primary``, ``virtual``, ``active``.
+
 .. envvar:: PYINSTALLER_RESET_ENVIRONMENT
 
   Setting this environment variable to 1 causes the bootloader to reset

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -243,8 +243,49 @@ If the splash screen is configured to show text, it will automatically (as onefi
 display the name of the file that is currently being unpacked, this acts as a progress bar.
 
 
+.. _splash screen centering:
+
+.. _splash screen centering:
+
+Splash screen centering
+-----------------------
+
+By default, the splash screen script attempts to center the splash screen based on screen
+dimensions obtained by the Tk's ``winfo`` command (i.e., ``winfo screenwidth`` and
+``winfo screenheight``). In the case of multi-monitor setups, this may result in a platform-specific
+behavior; on Windows, the size of the primary screen seems to be reported, while on other platforms,
+the size of the whole virtual screen seems to be reported.
+
+Therefore, the splash screen implementation provides additional centering modes, where the target
+screen dimensions are obtained by bootloader using low-level platform-specific API, and passed to
+the splash screen script for centering purposes. The preferred splash screen centering mode can
+be set at build-time via the ``center`` argument passed to :ref:`the Splash target in the spec file
+<splash screen target>`, or via the :option:`--splash-center` command-line option when generating
+the spec file. The centering mode can be overridden at run-time using the :envvar:`PYINSTALLER_SPLASH_SCREEN_CENTER`
+environment variable.
+
+The following modes can be set at either build-time and the run-time:
+
+- **default**: have the splash screen script use Tk's ``winfo`` to obtain platform-specific screen
+  dimensions. No additional information is required from the bootloader.
+
+- **primary**: have the bootloader use low-level API to obtain dimensions of the primary screen,
+  so that splash screen is centered on the primary monitor.
+
+- **virtual**: have the bootloader use low-level API to obtain dimensions of the whole virtual
+  screen, so that splash screen is centered on the virtual screen.
+
+- **active**: have the bootloader use low-level API to obtain mouse cursor position, and obtain the
+  dimensions of corresponding screen. This way, the splash screen is centered on "active" monitor,
+  i.e., the one where the mouse cursor is located at the time when application is started. This mode
+  is currently supported only on Windows - on other platforms, **primary** mode is used instead.
+
+If the bootloader cannot obtain the required information, the splash screen script falls back to
+using the information obtained via the ``winfo`` command.
+
+
 The ``pyi_splash`` Module
-~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------
 
 The splash screen is controlled from within Python by the :mod:`pyi_splash` module, which can
 be imported at runtime. This module **cannot** be installed by a package manager

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -207,7 +207,7 @@ Splash Screen *(Experimental)*
     the Tcl/Tk (or rather, the underlying GUI toolkit) on macOS.
 
 Some applications may require a splash screen as soon as the application
-(bootloader) has been started, because especially in onefile mode large
+(bootloader) has been started, because especially in ``onefile`` mode large
 applications may have long extraction/startup times, while the bootloader
 prepares everything, where the user cannot judge whether the application
 was started successfully or not.
@@ -242,8 +242,11 @@ system, as it is not bundled. If the font is not available, a fallback font is u
 If the splash screen is configured to show text, it will automatically (as onefile archive)
 display the name of the file that is currently being unpacked, this acts as a progress bar.
 
+.. Warning::
+    While splash screen can be enabled in either ``onefile`` or ``onedir`` mode,
+    using it in ``onedir`` mode may cause issues with your application's own UI -
+    see :ref:`splash screen onedir issues`.
 
-.. _splash screen centering:
 
 .. _splash screen centering:
 
@@ -306,6 +309,42 @@ This module must be imported within the Python program. The usage is as follows:
 Of course the import should be in a ``try ... except`` block, in case the program is
 used externally as a normal Python script, without a bootloader.
 For a detailed description see :ref:`pyi_splash Module`.
+
+
+.. _splash screen onedir issues:
+
+Issues caused by splash screen in ``onedir`` applications
+---------------------------------------------------------
+
+Splash screen was primarily designed for ``onefile`` mode, to indicate
+the application activity and progress during extraction to the temporary
+directory. In this mode, the splash screen and your application's own UI
+(if any) run in different processes; the splash screen runs in the parent
+process of the onefile application, while the application's UI runs in
+the child process of the onefile application (which is the main application
+process).
+
+While splash screen can be also used with ``onedir`` applications, be aware
+that in this mode, both the splash screen and the application's own UI run
+in the same process. This might have implications for the application's own
+windows, which are instantiated and shown after the splash screen's window,
+and might manifest in subtle issues, independently of whether your application
+also uses ``tkinter`` or some other UI framework.
+
+So far, the following issues have been observed:
+
+- :issue:`8338` (Windows): using splash screen in ``onedir`` application causes
+  focus issues in windows and dialogs shown by the application; closing the splash
+  screen might send other application windows to the background.
+- :issue:`9394` (Windows): using splash screen in ``onedir`` application that
+  uses ``tkinter`` prevents the default/application-wide window icon from
+  being set via ``Tk.iconphoto()``.
+
+These issues likely stem from the fact that splash screen is the first
+displayed window in the process, and therefore the OS ends up treating it
+as the "main" application window. A proper fix would likely require the
+redesign of splash screen to run in a separate process rather than in
+a secondary thread of the main process.
 
 
 .. _defining the extraction location:

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -222,6 +222,24 @@ image, so non-rectangular splash screens can also be displayed.
     Tcl/Tk platform limitations. The ``-transparentcolor`` and ``-transparent`` wm attributes
     used by PyInstaller are not available to Linux.
 
+.. Note::
+    On Windows, the transparency in splash screen is implemented by marking the
+    ``magenta`` color (``#ff00ff``) as transparent color, and overlaying the
+    splash screen image over magenta background. This has two implications.
+
+    First, any region of splash screen image that uses magenta color will be rendered as
+    transparent; if splash screen originally contains magenta regions, they should
+    be changed to a slightly different color instead (for example, ``#ff00fe``).
+
+    Second, **semi-transparent pixels in the splash screen image are not supported, and
+    will be rendered as a shade of magenta color that depends on transparency of
+    each pixel**, due to image being overlaid on magenta background. For example, if
+    splash screen image contains **feathered edges** (i.e., smooth edges made up of
+    semi-transparent pixels), these will end up manifesting as magenta-colored glow around
+    the opaque part of the splash screen - see :issue:`8579`. To mitigate this problem,
+    use an image processing utility to convert your image into a hard-cut transparent
+    image, where every pixel is either fully transparent or fully opaque.
+
 This splash screen is based on `Tcl/Tk`_, which is the same library used by the Python
 module `tkinter`_. PyInstaller bundles the dynamic libraries of tcl and tk into the
 application at compile time. These are loaded into the bootloader at startup of the

--- a/news/6271.feature.rst
+++ b/news/6271.feature.rst
@@ -1,0 +1,2 @@
+Initial support for setting :ref:`alternative splash screen centering modes
+<splash screen centering>` for multi-monitor setups.

--- a/news/9425.doc.1.rst
+++ b/news/9425.doc.1.rst
@@ -1,0 +1,3 @@
+Document the "glowing magenta border" problem in splash screen when
+splash screen image contains semi-transparent pixels (for example,
+due to feathered edges).

--- a/news/9425.doc.rst
+++ b/news/9425.doc.rst
@@ -1,0 +1,2 @@
+Document known issues with using splash screen in ``onedir`` GUI-based
+applications.


### PR DESCRIPTION
Implement initial support for alternative splash screen centering modes.

The original splash screen centering code uses Tk's ``winfo`` command to query screen dimensions (which are then used, together with image dimensions, to determine the coordinates where the splash screen should be placed). The behavior of ``winfo`` in multi-monitor setups appears to be platform-dependent; in my test setup (VirtualBox VM with two virtual monitors/screens), ``winfo`` on Windows seems to return the dimensions of primary monitor/screen, while on Linux, it seems to return the dimensions of the whole virtual screen.

Therefore, as per #6271, attempt to give users a bit more control over centering behavior. As Tk does not expose enough information, we need bootloader to use platform-specific low-level API to query dimensions ofinterest, and pass that information on to the splash screen script.

The following modes are currently implemented:
- **default**: the original centering codepath, with no additional work required in the bootloader, and with original platform-specific behavior of Tk
- **primary**: explicitly attempt to center on primary monitor/screen
- **virtual**: explicitly attempt to center on whole virtual screen
- **active**: attempt to center on monitor where mouse cursor is located when application is launched. This is supported only on Windows, where the application is able to query absolute cursor position; the X11 API has an equivalent function, but it does not work under XWayland (i.e., modern Linux systems). If there is interest, we can still try to make it work for non-Wayland systems at later time.

The preferred mode can be set at build time (``center`` argument to ``Splash`` target, or equivalent ``--splash-center`` command-line option), but can also be overridden at run-time via ``PYINSTALLER_SPLASH_SCREEN_CENTER`` environment variable (which also makes it easier to test different modes without having to rebuild the application).

If bootloader fails to obtain the required information, the splash screen centering script falls back to using ``winfo``.

Since the splash screen documentation needed to be updated accordingly, two more additions to documentation were made:
- document the issues with using splash screen in ``onedir`` GUI-based applications
- document issues with "glowing magenta edge" in splash images that have semi-transparent pixels (for example, feather edges)