### PR TITLE
Fix the remaining tests that are failing on Termux pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -568,6 +568,9 @@ jobs:
         run: |
           docker run -v"$PWD:/io" termux/termux-docker:x86_64 bash -ec '
             echo "*** Installing system dependencies ***"
+            ln -sf ${PREFIX}/etc/termux/mirrors/default ${PREFIX}/etc/termux/chosen_mirrors
+            pkg update
+            pkg upgrade -y
             pkg install -y python ldd binutils
             export CC=clang
             echo "*** Installing PyInstaller ***"

--- a/tests/functional/test_misc.py
+++ b/tests/functional/test_misc.py
@@ -256,7 +256,13 @@ def test_program_importing_module_with_invalid_encoding2(pyi_builder):
 def test_bundled_shell_script(pyi_builder, tmp_path):
     script_file = tmp_path / "test_script.sh"
     with open(script_file, "w", encoding="utf-8") as fp:
-        print('#!/bin/sh', file=fp)
+        if compat.is_termux:
+            # In Termux environment, /usr is usually a symbolic link to ${PREFIX}; but it may also not exist. So use
+            # ${PREFIX} directly...
+            prefix = os.environ.get('PREFIX', '/usr')
+            print(f'#!{prefix}/bin/env sh', file=fp)
+        else:
+            print('#!/usr/bin/env sh', file=fp)
         print('echo "Hello world!"', file=fp)
     script_file.chmod(0o755)
 

--- a/tests/functional/test_path_encodings.py
+++ b/tests/functional/test_path_encodings.py
@@ -35,6 +35,8 @@ def test_linux_non_unicode_path(pyi_builder, monkeypatch):
     pyi_builder._dist_dir = pyi_builder._dist_dir / unicode_filename
 
     tmp = pyi_builder._tmp_path / f"{unicode_filename}_TMP"
+    tmp.mkdir()
+
     monkeypatch.setenv('LC_ALL', 'C')
     monkeypatch.setenv('TMPDIR', str(tmp))
     monkeypatch.setenv('TMP', str(tmp))
@@ -51,6 +53,8 @@ def test_osx_linux_unicode_path(pyi_builder, monkeypatch):
     pyi_builder._dist_dir = pyi_builder._dist_dir / unicode_filename
 
     tmp = pyi_builder._tmp_path / f"{unicode_filename}_TMP"
+    tmp.mkdir()
+
     monkeypatch.setenv('TMPDIR', str(tmp))
     monkeypatch.setenv('TMP', str(tmp))
 
@@ -66,6 +70,8 @@ def test_win_codepage_path(pyi_builder, monkeypatch):
     pyi_builder._dist_dir = pyi_builder._dist_dir / cp_filename
 
     tmp = pyi_builder._tmp_path / f"{cp_filename}_TMP"
+    tmp.mkdir()
+
     monkeypatch.setenv('TMPDIR', str(tmp))
     monkeypatch.setenv('TMP', str(tmp))
 
@@ -87,6 +93,8 @@ def test_win_codepage_path_disabled_shortfilename(pyi_builder, monkeypatch):
         pytest.xfail("Administrator privileges required to strip ShortFileName.")
 
     tmp = pyi_builder._tmp_path / f"{cp_filename}_TMP"
+    tmp.mkdir()
+
     monkeypatch.setenv('TMPDIR', str(tmp))
     monkeypatch.setenv('TMP', str(tmp))
 
@@ -103,6 +111,8 @@ def test_win_non_codepage_path(pyi_builder, monkeypatch):
 
     # To test what happens with a non-ANSI tempdir, we will also need to pass the TMP environ as wide chars.
     tmp = pyi_builder._tmp_path / f"{non_cp_filename}_TMP"
+    tmp.mkdir()
+
     monkeypatch.setenv('TMPDIR', str(tmp))
     monkeypatch.setenv('TMP', str(tmp))
 


### PR DESCRIPTION
Turns out that the remaining failing tests on the Termux pipeline (after Termux folks fixed the issue with `_multiprocessing` extension in their new python 3.13.13 build) are due to `/usr` symlink not being present in the current instance of the `termux` docker container. Which took me embarrassingly long to figure out, because my local copy *does* have the symlink present (EDIT: ... because it was not up-to-date).

In `test_bundled_shell_script`, the lack of `/usr` means that the shell given in the shebang of the bundled script cannot be found; to side-step the issue, we should use `/data/data/com.termux/files/usr` prefix on Termux (which is available in `PREFIX` environment variable).

The `onefile` variant of `test_linux_non_unicode_path` is also affected by lack of `/usr` (and `/tmp`), although in this case, the test itself is subtly broken - since we forgot to create the custom temporary directory (that contains various non-ascii characters), the bootloader could not create _MEI temporary directory under it, and fell back to pre-defined standard locations (`/tmp`, `/var/tmp`, `/usr/tmp`) - and with `/usr` and `/tmp` missing, this ended up failing as well. EDIT: this actually applies to all tests in `test_path_encodings.py`, not just `test_linux_non_unicode_path`...

The first commit sets Termux to use their primary mirror (as per https://github.com/pyinstaller/pyinstaller/pull/9423#issuecomment-4225235062); this should let us receive the updates faster, but hopefully also minimize the amount of pipeline failures due to incomplete mirror syncs. Just in case, we now also upgrade all packages before proceeding with installing PyInstaller-specific dependencies.