### PR TITLE
hooks: Install translations for libadwaita

### DIFF
--- a/PyInstaller/hooks/hook-gi.repository.Adw.py
+++ b/PyInstaller/hooks/hook-gi.repository.Adw.py
@@ -9,8 +9,21 @@
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
 
-from PyInstaller.utils.hooks.gi import GiModuleInfo
+from PyInstaller.utils.hooks import get_hook_config
+from PyInstaller.utils.hooks.gi import GiModuleInfo, collect_glib_translations
 
-module_info = GiModuleInfo('Adw', '1')
-if module_info.available:
+
+def hook(hook_api):
+    module_info = GiModuleInfo('Adw', '1', hook_api=hook_api)  # Pass hook_api to read version from hook config
+    if not module_info.available:
+        return
+
     binaries, datas, hiddenimports = module_info.collect_typelib_data()
+
+    # Translations
+    lang_list = get_hook_config(hook_api, "gi", "languages")
+    datas += collect_glib_translations("libadwaita", lang_list)
+
+    hook_api.add_datas(datas)
+    hook_api.add_binaries(binaries)
+    hook_api.add_imports(*hiddenimports)

--- a/news/9444.hooks.rst
+++ b/news/9444.hooks.rst
@@ -1,0 +1,2 @@
+Update the ``gi.repository.Adw`` hook to collect translation files
+for ``libadwaita``.


### PR DESCRIPTION
We lack the translations for libadwaita. As a result the defaults text on things like the about dialog are not localized.

See https://github.com/gaphor/gaphor/issues/4178.


Aside: is there a way to check (or ensure) that the packaged translation files are actually used?