### PR TITLE
loader: clean up the bootstrap script

### DIFF
--- a/PyInstaller/loader/pyiboot01_bootstrap.py
+++ b/PyInstaller/loader/pyiboot01_bootstrap.py
@@ -12,34 +12,23 @@
 
 def _pyi_bootstrap():
     #-- Start bootstrap process
-    # Only python built-in modules can be used.
+    # Only python built-in modules and modules from base_library.zip can be used at this point.
 
-    import sys
+    import sys  # built-in
+    import os  # base_library.zip
 
+    # Extend Python import machinery with our importer(s).
     import pyimod02_importers
-
-    # Extend Python import machinery by adding PEP302 importers to sys.meta_path.
     pyimod02_importers.install()
 
     #-- Bootstrap process is complete.
-    # We can use other python modules (e.g. os)
-
-    import os  # noqa: E402
+    # We can now use python modules that were collected into PYZ archive.
 
     # Let other python modules know that the code is running in frozen mode.
     if not hasattr(sys, 'frozen'):
         sys.frozen = True
 
-    # sys._MEIPASS is now set in the bootloader. Hooray.
-
-    # Python 3 C-API function Py_SetPath() resets sys.prefix to empty string. Python 2 was using PYTHONHOME for
-    # sys.prefix. Let's do the same for Python 3.
-    sys.prefix = sys._MEIPASS
-    sys.exec_prefix = sys.prefix
-
-    # Python 3.3+ defines also sys.base_prefix. Let's set them too.
-    sys.base_prefix = sys.prefix
-    sys.base_exec_prefix = sys.exec_prefix
+    # NOTE: sys._MEIPASS is set by the bootloader.
 
     # Some packages behave differently when running inside virtual environment. E.g., IPython tries to append path
     # VIRTUAL_ENV to sys.path. For the frozen app we want to prevent this behavior.
@@ -49,13 +38,6 @@ def _pyi_bootstrap():
         # delete it from the environment.
         os.environ[VIRTENV] = ''
         del os.environ[VIRTENV]
-
-    # Ensure sys.path contains absolute paths. Otherwise, import of other python modules will fail when current working
-    # directory is changed by the frozen application.
-    python_path = []
-    for pth in sys.path:
-        python_path.append(os.path.abspath(pth))
-        sys.path = python_path
 
     # At least on Windows, Python seems to hook up the codecs on this import, so it is not enough to just package up all
     # the encodings.
@@ -72,11 +54,13 @@ def _pyi_bootstrap():
 
     # In the Python interpreter 'warnings' module is imported when 'sys.warnoptions' is not empty. Mimic this behavior.
     if sys.warnoptions:
-        import warnings  # noqa: F401
+        try:
+            import warnings  # noqa: F401
+        except ImportError:
+            pass
 
     # Install the hooks for ctypes
     import pyimod03_ctypes  # noqa: E402
-
     pyimod03_ctypes.install()
 
     # Install the hooks for pywin32 (Windows only)

--- a/PyInstaller/loader/pyiboot01_bootstrap.py
+++ b/PyInstaller/loader/pyiboot01_bootstrap.py
@@ -9,87 +9,93 @@
 # SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
 #-----------------------------------------------------------------------------
 
-#-- Start bootstrap process
-# Only python built-in modules can be used.
 
-import sys
+def _pyi_bootstrap():
+    #-- Start bootstrap process
+    # Only python built-in modules can be used.
 
-import pyimod02_importers
+    import sys
 
-# Extend Python import machinery by adding PEP302 importers to sys.meta_path.
-pyimod02_importers.install()
+    import pyimod02_importers
 
-#-- Bootstrap process is complete.
-# We can use other python modules (e.g. os)
+    # Extend Python import machinery by adding PEP302 importers to sys.meta_path.
+    pyimod02_importers.install()
 
-import os  # noqa: E402
+    #-- Bootstrap process is complete.
+    # We can use other python modules (e.g. os)
 
-# Let other python modules know that the code is running in frozen mode.
-if not hasattr(sys, 'frozen'):
-    sys.frozen = True
+    import os  # noqa: E402
 
-# sys._MEIPASS is now set in the bootloader. Hooray.
+    # Let other python modules know that the code is running in frozen mode.
+    if not hasattr(sys, 'frozen'):
+        sys.frozen = True
 
-# Python 3 C-API function Py_SetPath() resets sys.prefix to empty string. Python 2 was using PYTHONHOME for sys.prefix.
-# Let's do the same for Python 3.
-sys.prefix = sys._MEIPASS
-sys.exec_prefix = sys.prefix
+    # sys._MEIPASS is now set in the bootloader. Hooray.
 
-# Python 3.3+ defines also sys.base_prefix. Let's set them too.
-sys.base_prefix = sys.prefix
-sys.base_exec_prefix = sys.exec_prefix
+    # Python 3 C-API function Py_SetPath() resets sys.prefix to empty string. Python 2 was using PYTHONHOME for
+    # sys.prefix. Let's do the same for Python 3.
+    sys.prefix = sys._MEIPASS
+    sys.exec_prefix = sys.prefix
 
-# Some packages behave differently when running inside virtual environment. E.g., IPython tries to append path
-# VIRTUAL_ENV to sys.path. For the frozen app we want to prevent this behavior.
-VIRTENV = 'VIRTUAL_ENV'
-if VIRTENV in os.environ:
-    # On some platforms (e.g., AIX) 'os.unsetenv()' is unavailable and deleting the var from os.environ does not
-    # delete it from the environment.
-    os.environ[VIRTENV] = ''
-    del os.environ[VIRTENV]
+    # Python 3.3+ defines also sys.base_prefix. Let's set them too.
+    sys.base_prefix = sys.prefix
+    sys.base_exec_prefix = sys.exec_prefix
 
-# Ensure sys.path contains absolute paths. Otherwise, import of other python modules will fail when current working
-# directory is changed by the frozen application.
-python_path = []
-for pth in sys.path:
-    python_path.append(os.path.abspath(pth))
-    sys.path = python_path
+    # Some packages behave differently when running inside virtual environment. E.g., IPython tries to append path
+    # VIRTUAL_ENV to sys.path. For the frozen app we want to prevent this behavior.
+    VIRTENV = 'VIRTUAL_ENV'
+    if VIRTENV in os.environ:
+        # On some platforms (e.g., AIX) 'os.unsetenv()' is unavailable and deleting the var from os.environ does not
+        # delete it from the environment.
+        os.environ[VIRTENV] = ''
+        del os.environ[VIRTENV]
 
-# At least on Windows, Python seems to hook up the codecs on this import, so it is not enough to just package up all
-# the encodings.
-#
-# It was also reported that without 'encodings' module, the frozen executable fails to load in some configurations:
-# http://www.pyinstaller.org/ticket/651
-#
-# Importing 'encodings' module in a run-time hook is not enough, since some run-time hooks require this module, and the
-# order of running the code from the run-time hooks is not defined.
-try:
-    import encodings  # noqa: F401
-except ImportError:
-    pass
+    # Ensure sys.path contains absolute paths. Otherwise, import of other python modules will fail when current working
+    # directory is changed by the frozen application.
+    python_path = []
+    for pth in sys.path:
+        python_path.append(os.path.abspath(pth))
+        sys.path = python_path
 
-# In the Python interpreter 'warnings' module is imported when 'sys.warnoptions' is not empty. Mimic this behavior.
-if sys.warnoptions:
-    import warnings  # noqa: F401
+    # At least on Windows, Python seems to hook up the codecs on this import, so it is not enough to just package up all
+    # the encodings.
+    #
+    # It was also reported that without 'encodings' module, the frozen executable fails to load in some configurations:
+    # http://www.pyinstaller.org/ticket/651
+    #
+    # Importing 'encodings' module in a run-time hook is not enough, since some run-time hooks require this module, and
+    # the order of running the code from the run-time hooks is not defined.
+    try:
+        import encodings  # noqa: F401
+    except ImportError:
+        pass
 
-# Install the hooks for ctypes
-import pyimod03_ctypes  # noqa: E402
+    # In the Python interpreter 'warnings' module is imported when 'sys.warnoptions' is not empty. Mimic this behavior.
+    if sys.warnoptions:
+        import warnings  # noqa: F401
 
-pyimod03_ctypes.install()
+    # Install the hooks for ctypes
+    import pyimod03_ctypes  # noqa: E402
 
-# Install the hooks for pywin32 (Windows only)
-if sys.platform.startswith('win'):
-    import pyimod04_pywin32
-    pyimod04_pywin32.install()
+    pyimod03_ctypes.install()
 
-# Apply a hack for metadata that was collected from (unzipped) python eggs; the EGG-INFO directories are collected into
-# their parent directories (my_package-version.egg/EGG-INFO), and for metadata to be discoverable by
-# `importlib.metadata`, the .egg directory needs to be in `sys.path`. The deprecated `pkg_resources` does not have this
-# limitation, and seems to work as long as the .egg directory's parent directory (in our case `sys._MEIPASS` is in
-# `sys.path`.
-for entry in os.listdir(sys._MEIPASS):
-    entry = os.path.join(sys._MEIPASS, entry)
-    if not os.path.isdir(entry):
-        continue
-    if entry.endswith('.egg'):
-        sys.path.append(entry)
+    # Install the hooks for pywin32 (Windows only)
+    if sys.platform.startswith('win'):
+        import pyimod04_pywin32
+        pyimod04_pywin32.install()
+
+    # Apply a hack for metadata that was collected from (unzipped) python eggs; the EGG-INFO directories are collected
+    # into their parent directories (my_package-version.egg/EGG-INFO), and for metadata to be discoverable by
+    # `importlib.metadata`, the .egg directory needs to be in `sys.path`. The deprecated `pkg_resources` does not have
+    # this limitation, and seems to work as long as the .egg directory's parent directory (in our case `sys._MEIPASS`
+    # is in `sys.path`).
+    for entry in os.listdir(sys._MEIPASS):
+        entry = os.path.join(sys._MEIPASS, entry)
+        if not os.path.isdir(entry):
+            continue
+        if entry.endswith('.egg'):
+            sys.path.append(entry)
+
+
+_pyi_bootstrap()
+del _pyi_bootstrap

--- a/tests/functional/scripts/pyi_module__file__attribute.py
+++ b/tests/functional/scripts/pyi_module__file__attribute.py
@@ -20,17 +20,19 @@ import sys
 import shutil as module
 import xml.sax as package
 
-correct_mod = os.path.join(sys.prefix, 'shutil.py')
-correct_pkg = os.path.join(sys.prefix, 'xml', 'sax', '__init__.py')
+expected_mod = os.path.join(sys.prefix, 'shutil.py')
+expected_pkg = os.path.join(sys.prefix, 'xml', 'sax', '__init__.py')
 
 # Print.
-print(('Actual   mod.__file__: %s' % module.__file__))
-print(('Expected mod.__file__: %s' % correct_mod))
-print(('Actual   pkg.__file__: %s' % package.__file__))
-print(('Expected pkg.__file__: %s' % correct_pkg))
+print(f'Actual   mod.__file__: {module.__file__}', file=sys.stderr)
+print(f'Expected mod.__file__: {expected_mod}', file=sys.stderr)
+print(f'Actual   pkg.__file__: {package.__file__}', file=sys.stderr)
+print(f'Expected pkg.__file__: {expected_pkg}', file=sys.stderr)
 
-# Test correct values.
-if not module.__file__ == correct_mod:
+# Compare.
+# NOTE: use os.path.normpath() to ensure invariance w.r.t. separator, which may differ between what is used by
+# bootloader and python itself - for example, under msys2/mingw python on Windows.
+if os.path.normpath(module.__file__) != os.path.normpath(expected_mod):
     raise SystemExit('MODULE.__file__ attribute is wrong.')
-if not package.__file__ == correct_pkg:
+if os.path.normpath(package.__file__) != os.path.normpath(expected_pkg):
     raise SystemExit('PACKAGE.__file__ attribute is wrong.')

--- a/tests/functional/scripts/pyi_python_home.py
+++ b/tests/functional/scripts/pyi_python_home.py
@@ -13,11 +13,14 @@
 
 import sys
 
-print(('sys._MEIPASS: ' + sys._MEIPASS))
-print(('sys.prefix: ' + sys.prefix))
-print(('sys.exec_prefix: ' + sys.exec_prefix))
+PATHS_TO_TEST = ['prefix', 'exec_prefix', 'base_prefix', 'base_exec_prefix']
 
-if not sys.prefix == sys._MEIPASS:
-    raise SystemExit('sys.prefix is not set to path as in sys._MEIPASS.')
-if not sys.exec_prefix == sys._MEIPASS:
-    raise SystemExit('sys.exec_prefix is not set to path as in sys._MEIPASS.')
+# Display all paths before doing actual comparison
+print(f"sys._MEIPASS: {sys._MEIPASS!r}", file=sys.stderr)
+for name in PATHS_TO_TEST:
+    print(f"sys.{name}: {getattr(sys, name)!r}", file=sys.stderr)
+
+for name in PATHS_TO_TEST:
+    path = getattr(sys, name)
+    if path != sys._MEIPASS:
+        raise SystemExit(f"sys.{name} ({path!r}) != sys._MEIPASS ({sys._MEIPASS!r})")

--- a/tests/functional/scripts/pyi_python_home.py
+++ b/tests/functional/scripts/pyi_python_home.py
@@ -11,6 +11,7 @@
 
 # PYTHONHOME (sys.prefix) has to be same as sys._MEIPASS.
 
+import os
 import sys
 
 PATHS_TO_TEST = ['prefix', 'exec_prefix', 'base_prefix', 'base_exec_prefix']
@@ -20,7 +21,9 @@ print(f"sys._MEIPASS: {sys._MEIPASS!r}", file=sys.stderr)
 for name in PATHS_TO_TEST:
     print(f"sys.{name}: {getattr(sys, name)!r}", file=sys.stderr)
 
+# NOTE: use os.path.normpath() to ensure invariance w.r.t. separator, which may differ between what is used by
+# bootloader and python itself - for example, under msys2/mingw python on Windows.
 for name in PATHS_TO_TEST:
-    path = getattr(sys, name)
-    if path != sys._MEIPASS:
+    path = os.path.normpath(getattr(sys, name))
+    if path != os.path.normpath(sys._MEIPASS):
         raise SystemExit(f"sys.{name} ({path!r}) != sys._MEIPASS ({sys._MEIPASS!r})")


### PR DESCRIPTION
Wrap the bootstrap script steps into a function, which we execute and then delete (similar to the run-time hooks). This prevents variables used during bootstrap from ending up in the global namespace, making the behavior more consistent with unfrozen python.

Remove unnecessary steps from the bootstrap script:
- explicit setting of `sys.prefix`, `sys.exec_prefix`, `sys.base_prefix` and `sys.base_exec_prefix`; this is a remnant of the old interpreter initialization (as implied by the accompanying comments), and should be unnecessary with contemporary approach that uses PEP-587 or PEP-741.
- explicit conversion of `sys.path` elements to absolute paths; we are setting these in the bootloader, so they should already be absolute.

Since we do not overwrite `sys.prefix` with `sys._MEIPASS` anymore, it might end up using different separator (i.e., msys2/mingw python on Windows). We have couple of tests that need to be fixed to account for that, by normalizing the paths using `os.path.normpath()` before comparing them.