### PR TITLE
hooks: update scipy hook for compatibily with upcoming scipy 1.18.0

### DIFF
--- a/PyInstaller/hooks/hook-scipy.py
+++ b/PyInstaller/hooks/hook-scipy.py
@@ -42,7 +42,10 @@ hiddenimports = ['scipy._lib.%s' % m for m in ['messagestream', "_ccallback_c", 
 
 # In scipy 1.14.0, `scipy._lib.array_api_compat.numpy` added a programmatic import of its `.fft` submodule, which needs
 # to be added to hiddenimports.
-if check_requirement("scipy >= 1.14.0"):
+# In scipy 1.18.0rc1, `scipy._lib.array_api_compat` was renamed to `scipy._external.array_api_compat`.
+if check_requirement("scipy >= 1.18.0rc1"):
+    hiddenimports += ['scipy._external.array_api_compat.numpy.fft']
+elif check_requirement("scipy >= 1.14.0"):
     hiddenimports += ['scipy._lib.array_api_compat.numpy.fft']
 
 # If scipy is provided by Debian's python3-scipy, its scipy.__config__ submodule is renamed to a dynamically imported

--- a/news/9450.hooks.rst
+++ b/news/9450.hooks.rst
@@ -1,0 +1,1 @@
+Update ``scipy`` hook for compatibility with upcoming ``scipy`` v1.18.0.

--- a/tests/functional/test_scipy.py
+++ b/tests/functional/test_scipy.py
@@ -16,7 +16,7 @@ import sys
 
 import pytest
 
-from PyInstaller.utils.tests import importorskip, xfail, onedir_only
+from PyInstaller.utils.tests import importable, importorskip, xfail, onedir_only
 
 pytestmark = [
     importorskip('scipy'),
@@ -35,6 +35,7 @@ pytestmark = [
         'scipy.cluster',
         'scipy.constants',
         'scipy.datasets',
+        'scipy.differentiate',
         'scipy.fft',
         'scipy.fftpack',
         'scipy.integrate',
@@ -54,6 +55,8 @@ pytestmark = [
 )
 @onedir_only
 def test_scipy(pyi_builder, module):
+    if not importable(module):
+        pytest.skip(f"Can't import {module!r}.")
     pyi_builder.test_source(f"""
         import {module}
         """)


### PR DESCRIPTION
As per #9450, update the hiddenimports for `scipy` 1.18.0rc1. Closes #9450.

Also add `scipy.differentiate` to the list of tested `scipy` modules - this one seems to have been introduced in 1.15.0, and we missed it at that time.