### PR TITLE
Adjust CI for recent updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -423,23 +423,23 @@ jobs:
             mingw-w64-${{matrix.env}}-python
             mingw-w64-${{matrix.env}}-python-pip
             mingw-w64-${{matrix.env}}-python-setuptools
-            mingw-w64-${{matrix.env}}-python-pywin32-ctypes
             mingw-w64-${{matrix.env}}-python-packaging
             mingw-w64-${{matrix.env}}-python-pytest
             mingw-w64-${{matrix.env}}-python-pytest-xdist
             mingw-w64-${{matrix.env}}-python-pytest-timeout
-            mingw-w64-${{matrix.env}}-python-pywin32
-            mingw-w64-${{matrix.env}}-python-gobject
 
       # Some msys2 python packages are not available for i686 anymore:
       #  - numpy
       #  - pefile
       #  - psutil (removed with update to psutil 6.1.1; see https://github.com/msys2/MINGW-packages/commit/7f1c75b33a5aebb89899f99f5fa656c623eeb9ed)
       #  - pillow (see https://github.com/msys2/MINGW-packages/commit/a7d88c34aa36adce78ba71633711412a24d8792c)
+      #  - pywin32-ctypes (see https://github.com/msys2/MINGW-packages/commit/a8bba24b7d3abf45c8d5b3c67af5058c754f6f11)
+      #  - pywin32 (see https://github.com/msys2/MINGW-packages/commit/a8bba24b7d3abf45c8d5b3c67af5058c754f6f11)
+      #  - pygobject (see https://github.com/msys2/MINGW-packages/commit/a8bba24b7d3abf45c8d5b3c67af5058c754f6f11)
       # If running in 64-bit environment, install the said packages here.
       # Otherwise, we will run tests without these packages (note that
-      # if not installed here, `pefile` will end up installed via `pip`
-      # as part of PyInstaller's dependencies).
+      # if not installed here, `pefile` and `pywin32-ctypes` will end
+      # up installed via `pip` as part of PyInstaller's dependencies).
       - name: Install extra msys2 packages (64-bit only)
         if: matrix.env != 'i686'
         run: >
@@ -448,6 +448,9 @@ jobs:
           mingw-w64-${{matrix.env}}-python-pefile
           mingw-w64-${{matrix.env}}-python-psutil
           mingw-w64-${{matrix.env}}-python-pillow
+          mingw-w64-${{matrix.env}}-python-pywin32-ctypes
+          mingw-w64-${{matrix.env}}-python-pywin32
+          mingw-w64-${{matrix.env}}-python-gobject
 
       - name: Checkout PyInstaller code
         uses: actions/checkout@v6

--- a/tests/functional/test_libraries.py
+++ b/tests/functional/test_libraries.py
@@ -11,7 +11,7 @@
 
 import pytest
 
-from PyInstaller.compat import is_win, is_linux
+from PyInstaller import compat
 from PyInstaller.utils.tests import importorskip, skipif, requires
 from PyInstaller.utils.hooks import can_import_module
 
@@ -35,6 +35,7 @@ def test_gevent_monkey(pyi_builder):
 # The tkinter module may be available for import, but not actually importable due to missing shared libraries.
 # Therefore, we need to use `can_import_module`-based skip decorator instead of `@importorskip`.
 @pytest.mark.skipif(not can_import_module("tkinter"), reason="tkinter cannot be imported.")
+@pytest.mark.skipif(compat.is_py315 and compat.is_win, reason="tkinter is broken in python 3.15.0b2.")
 def test_tkinter(pyi_builder):
     pyi_builder.test_script('pyi_lib_tkinter.py')
 
@@ -153,6 +154,7 @@ def test_zope_interface(pyi_builder):
 # Therefore, we need to use `can_import_module`-based skip decorator instead of `@importorskip`.
 @importorskip('idlelib')
 @pytest.mark.skipif(not can_import_module("tkinter"), reason="tkinter cannot be imported.")
+@pytest.mark.skipif(compat.is_py315 and compat.is_win, reason="tkinter is broken in python 3.15.0b2.")
 def test_idlelib(pyi_builder):
     pyi_builder.test_source(
         """
@@ -164,7 +166,7 @@ def test_idlelib(pyi_builder):
 
 @importorskip('keyring')
 @skipif(
-    is_linux,
+    compat.is_linux,
     reason="SecretStorage backend on linux requires active D-BUS session and initialized keyring, and may "
     "need to unlock the keyring via UI prompt."
 )
@@ -336,7 +338,7 @@ def test_pyexcelerate(pyi_builder):
 
 
 @importorskip('usb')
-@pytest.mark.skipif(is_linux, reason='libusb_exit segfaults on some linuxes')
+@pytest.mark.skipif(compat.is_linux, reason='libusb_exit segfaults on some linuxes')
 def test_usb(pyi_builder):
     # See if the usb package is supported on this platform.
     try:
@@ -407,7 +409,7 @@ def test_pandas_plotting_matplotlib(pyi_builder):
 
 
 @importorskip('win32ctypes')
-@pytest.mark.skipif(not is_win, reason='pywin32-ctypes is supported only on Windows')
+@pytest.mark.skipif(not compat.is_win, reason='pywin32-ctypes is supported only on Windows')
 @pytest.mark.parametrize('submodule', ['win32api', 'win32cred', 'pywintypes'])
 def test_pywin32ctypes(pyi_builder, submodule):
     pyi_builder.test_source(f"""

--- a/tests/functional/test_splash.py
+++ b/tests/functional/test_splash.py
@@ -16,7 +16,7 @@ NOTE: splash screen is not supported on macOS due to incompatible design.
 
 import pytest
 
-from PyInstaller.compat import is_darwin, is_musl
+from PyInstaller import compat
 from PyInstaller.utils.hooks import can_import_module
 
 pytestmark = [
@@ -25,8 +25,9 @@ pytestmark = [
     # does try to import the module, and catches errors when _tkinter is unavailable or cannot be loaded due to broken
     # dependencies.
     pytest.mark.skipif(not can_import_module('tkinter'), reason="tkinter cannot be imported."),
-    pytest.mark.skipif(is_darwin, reason="Splash screen is not supported on macOS."),
-    pytest.mark.xfail(is_musl, reason="musl + tkinter is known to cause mysterious segfaults."),
+    pytest.mark.skipif(compat.is_darwin, reason="Splash screen is not supported on macOS."),
+    pytest.mark.xfail(compat.is_musl, reason="musl + tkinter is known to cause mysterious segfaults."),
+    pytest.mark.skipif(compat.is_py315 and compat.is_win, reason="tkinter and Tcl/Tk are broken in python 3.15.0b2."),
 ]
 
 

--- a/tests/requirements-base.txt
+++ b/tests/requirements-base.txt
@@ -9,7 +9,7 @@
 execnet>=1.5.0
 
 # Testing framework.
-pytest>=2.7.3
+pytest>=2.7.3,!=9.1.0
 
 # Plugin allowing running tests in parallel.
 pytest-xdist


### PR DESCRIPTION
A small subset of changes from my current WIP CI/tests update branch, with changes relevant to tonight's dependency update:
- `pytest` 9.1.0 contains a regression that breaks our attempts to override parameters of `pyi_builder` fixture via `indirect=True`, so we need to avoid it - https://github.com/pytest-dev/pytest/issues/14591
- msys2 seems to have dropped more mingw32/i686 packages
- skip tkinter / splash screen tests under python 3.15 + Windows due to broken Tcl/Tk in Windows builds of 3.15.0b2; in https://github.com/pyinstaller/pyinstaller/pull/9456 I argued that we can live with the pipeline failure until 3.15.0b3 is released, but I've already been bitten by these failures masking a different test failure, so here we are...