### PR TITLE
Fix version number in changelog

### DIFF
--- a/doc/CHANGES.rst
+++ b/doc/CHANGES.rst
@@ -15,7 +15,7 @@ Changelog for PyInstaller
 
 .. towncrier release notes start
 
-6.16.0 (2026-06-13)
+6.21.0 (2026-06-13)
 -------------------
 
 Features


### PR DESCRIPTION
The version number of the latest release in `docs/CHANGES.rst` and on [the website](https://pyinstaller.org/en/stable/CHANGES.html) was wrong, so I fixed it.