### PR TITLE
Support Matplotlib backend registry API

### DIFF
--- a/PyInstaller/hooks/hook-matplotlib.backends.py
+++ b/PyInstaller/hooks/hook-matplotlib.backends.py
@@ -35,8 +35,14 @@ def _list_available_mpl_backends():
     """
     Returns the names of all available matplotlib backends.
     """
-    import matplotlib
-    return matplotlib.rcsetup.all_backends
+    try:
+        from matplotlib.backends import backend_registry
+    except ImportError:
+        import matplotlib
+
+        return matplotlib.rcsetup.all_backends
+
+    return backend_registry.list_all()
 
 
 @isolated.decorate

--- a/news/9467.hooks.rst
+++ b/news/9467.hooks.rst
@@ -1,0 +1,2 @@
+Update the Matplotlib backends hook to use the backend registry API when
+listing all available backends, fixing compatibility with Matplotlib 3.11.

--- a/tests/unit/test_hook_matplotlib_backends.py
+++ b/tests/unit/test_hook_matplotlib_backends.py
@@ -1,0 +1,40 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+
+def _load_hook_module():
+    hook_path = (
+        Path(__file__).parents[2]
+        / "PyInstaller"
+        / "hooks"
+        / "hook-matplotlib.backends.py"
+    )
+    spec = importlib.util.spec_from_file_location("hook_matplotlib_backends", hook_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_list_available_mpl_backends_uses_backend_registry(monkeypatch):
+    hook = _load_hook_module()
+    backends = ModuleType("matplotlib.backends")
+    backends.backend_registry = SimpleNamespace(list_all=lambda: ["Agg", "TkAgg"])
+
+    monkeypatch.setitem(sys.modules, "matplotlib", ModuleType("matplotlib"))
+    monkeypatch.setitem(sys.modules, "matplotlib.backends", backends)
+
+    assert hook._list_available_mpl_backends.__wrapped__() == ["Agg", "TkAgg"]
+
+
+def test_list_available_mpl_backends_falls_back_to_rcsetup(monkeypatch):
+    hook = _load_hook_module()
+    matplotlib = ModuleType("matplotlib")
+    matplotlib.rcsetup = SimpleNamespace(all_backends=["Agg", "QtAgg"])
+
+    monkeypatch.setitem(sys.modules, "matplotlib", matplotlib)
+    monkeypatch.delitem(sys.modules, "matplotlib.backends", raising=False)
+
+    assert hook._list_available_mpl_backends.__wrapped__() == ["Agg", "QtAgg"]


### PR DESCRIPTION
Fixes #9467.

## Summary

Matplotlib 3.11 removed the deprecated `matplotlib.rcsetup.all_backends` attribute. The `matplotlib.backends` hook still used that attribute for `hooksconfig={"matplotlib": {"backends": "all"}}`, so backend collection failed before it could test/import any backends.

This updates `_list_available_mpl_backends()` to prefer the Matplotlib backend registry API and fall back to `rcsetup.all_backends` for older Matplotlib versions.

## Verification

```text
python -m pytest tests/unit/test_hook_matplotlib_backends.py -q
python -m pytest tests/functional/test_matplotlib.py --collect-only -q
python -m ruff check PyInstaller/hooks/hook-matplotlib.backends.py tests/unit/test_hook_matplotlib_backends.py
python scripts/verify-news-fragments.py
git diff --check
```