### PR TITLE
hooks: update matplotlib hooks to use new matplotlib backends registry

### DIFF
--- a/PyInstaller/hooks/hook-matplotlib.backends.py
+++ b/PyInstaller/hooks/hook-matplotlib.backends.py
@@ -35,8 +35,16 @@ def _list_available_mpl_backends():
     """
     Returns the names of all available matplotlib backends.
     """
-    import matplotlib
-    return matplotlib.rcsetup.all_backends
+    try:
+        # In matplotlib >= 3.9, the lists of all available / built-in backends can be obtained from
+        # `matplotlib.backends.backend_registry`
+        from matplotlib.backends import backend_registry
+        return backend_registry.list_all()
+    except ImportError:
+        # In earlier versions, the list is available in `matplotlib.rcsetup.all_backends`; this was deprecated in
+        # matplotlib 3.9 and removed in 3.11.
+        import matplotlib
+        return matplotlib.rcsetup.all_backends
 
 
 @isolated.decorate
@@ -81,7 +89,8 @@ def _backend_module_name(name):
     """
     Converts matplotlib backend name to its corresponding module name.
 
-    Equivalent to matplotlib.cbook._backend_module_name().
+    Equivalent to `matplotlib.backends.registry.BackendRegistry._backend_module_name()` in matplotlib >= 3.9.0 or
+    `matplotlib.cbook._backend_module_name()` in earlier versions.
     """
     if name.startswith("module://"):
         return name[9:]

--- a/PyInstaller/hooks/hook-matplotlib.backends.py
+++ b/PyInstaller/hooks/hook-matplotlib.backends.py
@@ -10,7 +10,7 @@
 #-----------------------------------------------------------------------------
 
 from PyInstaller.compat import is_darwin
-from PyInstaller.utils.hooks import logger, get_hook_config
+from PyInstaller.utils.hooks import copy_metadata, logger, get_hook_config
 from PyInstaller import isolated
 
 
@@ -211,6 +211,22 @@ def _collect_all_importable_backends():
     return importable_backends
 
 
+def _find_dists_for_backends(backends):
+    """
+    Return list of dist names for backends that are not built into matplotlib.
+    """
+    from PyInstaller.compat import importlib_metadata
+
+    backend_modules = set(backends.values())  # set of backend module names
+
+    backend_dists = set()
+    for entry_point in importlib_metadata.entry_points(group="matplotlib.backend"):
+        if entry_point.module in backend_modules:
+            backend_dists.add(entry_point.dist.name)
+
+    return sorted(backend_dists)
+
+
 def hook(hook_api):
     # Backend collection setting
     backends_method = get_hook_config(hook_api, 'matplotlib', 'backends')
@@ -235,8 +251,16 @@ def hook(hook_api):
         # Resolve backend names into module names
         backends = _resolve_backend_modules(backend_names)
 
+    # Resolve dists for backends that are not built into matplotlib
+    backend_dists = _find_dists_for_backends(backends)
+
     # Display the final list of selected backends
     logger.info("Selected matplotlib backends: %r", sorted(backends.keys()))
+    logger.info("Extra dists for selected matplotlib backends: %r", backend_dists)
 
     # Set module names as hiddenimports
     hook_api.add_imports(*list(backends.values()))
+
+    # Copy metadata for extra dists
+    for dist_name in backend_dists:
+        hook_api.add_datas(copy_metadata(dist_name))

--- a/PyInstaller/hooks/hook-matplotlib.backends.py
+++ b/PyInstaller/hooks/hook-matplotlib.backends.py
@@ -31,20 +31,31 @@ def _get_configured_default_backend():
 
 
 @isolated.decorate
-def _list_available_mpl_backends():
+def _resolve_backend_modules(backends):
     """
-    Returns the names of all available matplotlib backends.
+    Returns the names of all available matplotlib backends and their corresponding module names.
     """
     try:
         # In matplotlib >= 3.9, the lists of all available / built-in backends can be obtained from
-        # `matplotlib.backends.backend_registry`
+        # `matplotlib.backends.backend_registry`.
+        #
+        # NOTE: `backend_registry.list_all()` loads entry-points, and therefore we need to call it even if we already
+        # have a list of backend names to resolve; otherwise, `_backend_module_name()` fails to resolve modules for
+        # backends that are loaded via entry-points.
         from matplotlib.backends import backend_registry
-        return backend_registry.list_all()
+        all_backends = backend_registry.list_all()
+        _backend_module_name = backend_registry._backend_module_name
     except ImportError:
-        # In earlier versions, the list is available in `matplotlib.rcsetup.all_backends`; this was deprecated in
-        # matplotlib 3.9 and removed in 3.11.
+        # In earlier versions, the list of all backends available in `matplotlib.rcsetup.all_backends`; this was
+        # deprecated in matplotlib 3.9 and removed in 3.11.
         import matplotlib
-        return matplotlib.rcsetup.all_backends
+        all_backends = matplotlib.rcsetup.all_backends
+        from matplotlib.cbook import _backend_module_name
+
+    if not backends:
+        backends = all_backends
+
+    return {backend: _backend_module_name(backend) for backend in backends}
 
 
 @isolated.decorate
@@ -54,7 +65,8 @@ def _check_mpl_backend_importable(module_name):
 
     Exceptions are propagated to caller.
     """
-    __import__(module_name)
+    import importlib
+    importlib.import_module(module_name)
 
 
 # Bytecode scanning
@@ -85,22 +97,14 @@ def _recursive_scan_code_objects_for_mpl_use(co):
     return backends
 
 
-def _backend_module_name(name):
-    """
-    Converts matplotlib backend name to its corresponding module name.
-
-    Equivalent to `matplotlib.backends.registry.BackendRegistry._backend_module_name()` in matplotlib >= 3.9.0 or
-    `matplotlib.cbook._backend_module_name()` in earlier versions.
-    """
-    if name.startswith("module://"):
-        return name[9:]
-    return f"matplotlib.backends.backend_{name.lower()}"
-
-
 def _autodetect_used_backends(hook_api):
     """
-    Returns a list of automatically-discovered matplotlib backends in use, or the name of the default matplotlib
-    backend. Implements the 'auto' backend selection method.
+    Tries to auto-select matplotlib backend(s) to collect into frozen application (the 'auto' backend selection method),
+    using the following semantics:
+     - scan the code for use of matplotlib.use() to auto-discover used backend(s)
+     - try to determine the configured default backend
+     - try to select first importable backend from hard-coded list of platform-specific defaults
+    Returns dictionary of backend names and their corresponding module names.
     """
     # Scan the code for matplotlib.use()
     modulegraph = hook_api.analysis.graph
@@ -124,7 +128,7 @@ def _autodetect_used_backends(hook_api):
             "backend of choice is not in this list, either add a `matplotlib.use()` call to your code, or configure "
             "the backend collection via hook options (see: %s).", used_backends, HOOK_CONFIG_DOCS
         )
-        return used_backends
+        return _resolve_backend_modules(used_backends)
 
     # Determine the default matplotlib backend.
     #
@@ -142,7 +146,7 @@ def _autodetect_used_backends(hook_api):
     default_backend = _get_configured_default_backend()  # isolated sub-process
     if default_backend:
         logger.info("Found configured default matplotlib backend: %s", default_backend)
-        return [default_backend]
+        return _resolve_backend_modules([default_backend])
 
     # `QtAgg` supersedes `Qt5Agg`; however, we keep `Qt5Agg` in the candidate list to support older versions of
     # matplotlib that do not have `QtAgg`.
@@ -151,29 +155,30 @@ def _autodetect_used_backends(hook_api):
         candidates = ["MacOSX"] + candidates
     logger.info("Trying determine the default backend as first importable candidate from the list: %r", candidates)
 
-    for candidate in candidates:
+    candidates = _resolve_backend_modules(candidates)  # [name] -> {name: module_name}
+    for name, module_name in candidates.items():
         try:
-            module_name = _backend_module_name(candidate)
             _check_mpl_backend_importable(module_name)  # NOTE: uses an isolated sub-process.
         except Exception:
             continue
-        return [candidate]
+        return {name: module_name}
 
     # Fall back to headless Agg backend
     logger.info("None of the backend candidates could be imported; falling back to headless Agg!")
-    return ['Agg']
+    return _resolve_backend_modules(['Agg'])
 
 
-def _collect_all_importable_backends(hook_api):
+def _collect_all_importable_backends():
     """
-    Returns a list of all importable matplotlib backends. Implements the 'all' backend selection method.
+    Return a dictionary of all importable matplotlib backends and their corresponding module names.
+    Implements the 'all' backend selection method.
     """
-    # List of the human-readable names of all available backends.
-    backend_names = _list_available_mpl_backends()  # NOTE: retrieved in an isolated sub-process.
-    logger.info("All available matplotlib backends: %r", backend_names)
+    # Get names and corresponding module names for all available backends.
+    available_backends = _resolve_backend_modules(None)  # NOTE: retrieved in an isolated sub-process.
+    logger.info("All available matplotlib backends: %r", list(available_backends.keys()))
 
     # Try to import the module(s).
-    importable_backends = []
+    importable_backends = {}
 
     # List of backends to exclude; Qt4 is not supported by PyInstaller anymore.
     exclude_backends = {'Qt4Agg', 'Qt4Cairo'}
@@ -188,13 +193,12 @@ def _collect_all_importable_backends(hook_api):
     exclude_backends = {backend.lower() for backend in exclude_backends}
 
     # For safety, attempt to import each backend in an isolated sub-process.
-    for backend_name in backend_names:
+    for backend_name, module_name in available_backends.items():
         if backend_name.lower() in exclude_backends:
             logger.info('  Matplotlib backend %r: excluded', backend_name)
             continue
 
         try:
-            module_name = _backend_module_name(backend_name)
             _check_mpl_backend_importable(module_name)  # NOTE: uses an isolated sub-process.
         except Exception:
             # Backend is not importable, for whatever reason.
@@ -202,7 +206,7 @@ def _collect_all_importable_backends(hook_api):
             continue
 
         logger.info('  Matplotlib backend %r: added', backend_name)
-        importable_backends.append(backend_name)
+        importable_backends[backend_name] = module_name
 
     return importable_backends
 
@@ -216,10 +220,10 @@ def hook(hook_api):
     # Select backend(s)
     if backends_method == 'auto':
         logger.info("Matplotlib backend selection method: automatic discovery of used backends")
-        backend_names = _autodetect_used_backends(hook_api)
+        backends = _autodetect_used_backends(hook_api)
     elif backends_method == 'all':
         logger.info("Matplotlib backend selection method: collection of all importable backends")
-        backend_names = _collect_all_importable_backends(hook_api)
+        backends = _collect_all_importable_backends()
     else:
         logger.info("Matplotlib backend selection method: user-provided name(s)")
         if isinstance(backends_method, str):
@@ -228,11 +232,11 @@ def hook(hook_api):
             assert isinstance(backends_method, list), "User-provided backend name(s) must be either a string or a list!"
             backend_names = backends_method
 
-    # Deduplicate and sort the list of selected backends before displaying it.
-    backend_names = sorted(set(backend_names))
+        # Resolve backend names into module names
+        backends = _resolve_backend_modules(backend_names)
 
-    logger.info("Selected matplotlib backends: %r", backend_names)
+    # Display the final list of selected backends
+    logger.info("Selected matplotlib backends: %r", sorted(backends.keys()))
 
     # Set module names as hiddenimports
-    module_names = [_backend_module_name(backend) for backend in backend_names]  # backend name -> module name
-    hook_api.add_imports(*module_names)
+    hook_api.add_imports(*list(backends.values()))

--- a/PyInstaller/hooks/hook-matplotlib.backends.py
+++ b/PyInstaller/hooks/hook-matplotlib.backends.py
@@ -175,9 +175,12 @@ def _collect_all_importable_backends(hook_api):
     if not is_darwin:
         exclude_backends |= {'CocoaAgg', 'MacOSX'}
 
+    # Starting with matplotlib 3.9, the backend names are lower-case...
+    exclude_backends = {backend.lower() for backend in exclude_backends}
+
     # For safety, attempt to import each backend in an isolated sub-process.
     for backend_name in backend_names:
-        if backend_name in exclude_backends:
+        if backend_name.lower() in exclude_backends:
             logger.info('  Matplotlib backend %r: excluded', backend_name)
             continue
 

--- a/PyInstaller/hooks/hook-matplotlib.figure.py
+++ b/PyInstaller/hooks/hook-matplotlib.figure.py
@@ -1,0 +1,14 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2026, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+# This backend is imported in a conditional block that can be entered only if the backend is actually in use (i.e.,
+# collected through a different import chaing).
+excludedimports = ['matplotlib.backends.backend_webagg']

--- a/news/9467.hooks.rst
+++ b/news/9467.hooks.rst
@@ -1,0 +1,5 @@
+Update the ``matplotlib.backends`` hook to obtain the list of available
+Matplotlib backends from the new backends registry, if available
+(Matplotlib >= 3.9). Fixes compatibility with Matplotlib >= 3.11, which
+removed the old list of available backends that was superseded by the
+backends registry.

--- a/news/9469.hooks.rst
+++ b/news/9469.hooks.rst
@@ -1,0 +1,3 @@
+Update the ``matplotlib.backends`` hook to automatically collect dist
+metadata for backends that are discovered via ``matplotlib.backend``
+entry point (Matplotlib >= 3.9).

--- a/tests/functional/test_matplotlib.py
+++ b/tests/functional/test_matplotlib.py
@@ -130,9 +130,14 @@ def test_matplotlib_all_backends(pyi_builder, monkeypatch, tmp_path):
         import json
         import importlib.util
 
-        import matplotlib
-
-        backends = matplotlib.rcsetup.all_backends
+        try:
+            # matplotlib >= 3.9
+            from matplotlib.backends import backend_registry
+            backends = backend_registry.list_all()
+        except ImportError:
+            # matplotlib < 3.9
+            import matplotlib
+            backends = matplotlib.rcsetup.all_backends
 
         def _backend_module_name(name):
             if name.startswith("module://"):
@@ -173,9 +178,14 @@ def test_matplotlib_all_backends(pyi_builder, monkeypatch, tmp_path):
     def _get_unfrozen_backends():
         import importlib
 
-        import matplotlib
-
-        backends = matplotlib.rcsetup.all_backends
+        try:
+            # matplotlib >= 3.9
+            from matplotlib.backends import backend_registry
+            backends = backend_registry.list_all()
+        except ImportError:
+            # matplotlib < 3.9
+            import matplotlib
+            backends = matplotlib.rcsetup.all_backends
 
         def _backend_module_name(name):
             if name.startswith("module://"):

--- a/tests/functional/test_matplotlib.py
+++ b/tests/functional/test_matplotlib.py
@@ -133,16 +133,15 @@ def test_matplotlib_all_backends(pyi_builder, monkeypatch, tmp_path):
         try:
             # matplotlib >= 3.9
             from matplotlib.backends import backend_registry
+
             backends = backend_registry.list_all()
+            _backend_module_name = backend_registry._backend_module_name
         except ImportError:
             # matplotlib < 3.9
             import matplotlib
-            backends = matplotlib.rcsetup.all_backends
 
-        def _backend_module_name(name):
-            if name.startswith("module://"):
-                return name[9:]
-            return f"matplotlib.backends.backend_{name.lower()}"
+            backends = matplotlib.rcsetup.all_backends
+            from matplotlib.cbook import _backend_module_name
 
         backend_info = []
         for backend in backends:
@@ -181,16 +180,15 @@ def test_matplotlib_all_backends(pyi_builder, monkeypatch, tmp_path):
         try:
             # matplotlib >= 3.9
             from matplotlib.backends import backend_registry
+
             backends = backend_registry.list_all()
+            _backend_module_name = backend_registry._backend_module_name
         except ImportError:
             # matplotlib < 3.9
             import matplotlib
-            backends = matplotlib.rcsetup.all_backends
 
-        def _backend_module_name(name):
-            if name.startswith("module://"):
-                return name[9:]
-            return f"matplotlib.backends.backend_{name.lower()}"
+            backends = matplotlib.rcsetup.all_backends
+            from matplotlib.cbook import _backend_module_name
 
         backend_info = []
         for backend in backends:

--- a/tests/functional/test_matplotlib.py
+++ b/tests/functional/test_matplotlib.py
@@ -12,9 +12,13 @@
 Functional tests for Matplotlib.
 """
 
+import json
+import sys
+
 import pytest
 
-from PyInstaller.utils.tests import importorskip
+from PyInstaller import isolated
+from PyInstaller.utils.tests import importorskip, onedir_only
 from PyInstaller.utils.hooks import check_requirement
 
 # List of tuples "(backend_name, qt_bindings)", where:
@@ -98,3 +102,104 @@ def test_matplotlib(pyi_builder, monkeypatch, backend_name, qt_bindings):
         """,
         pyi_args=pyi_args,
     )
+
+
+# Check that "all backends" collection mode in fact collects all available backends.
+@importorskip('matplotlib')
+@onedir_only
+def test_matplotlib_all_backends(pyi_builder, monkeypatch, tmp_path):
+    # Patch Analysis to set backend collection mode via hooksconfig
+    import PyInstaller.building.build_main
+
+    class _Analysis(PyInstaller.building.build_main.Analysis):
+        def __init__(self, *args, **kwargs):
+            kwargs['hooksconfig'] = {
+                "matplotlib": {
+                    "backends": "all",
+                }
+            }
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr('PyInstaller.building.build_main.Analysis', _Analysis)
+
+    # Test program; retrieve backends in frozen matplotlib
+    result_file = tmp_path / 'results.txt'
+    pyi_builder.test_source(
+        """
+        import sys
+        import json
+        import importlib.util
+
+        import matplotlib
+
+        backends = matplotlib.rcsetup.all_backends
+
+        def _backend_module_name(name):
+            if name.startswith("module://"):
+                return name[9:]
+            return f"matplotlib.backends.backend_{name.lower()}"
+
+        backend_info = []
+        for backend in backends:
+            backend_module = _backend_module_name(backend)
+
+            # Check that module is available (but not that it is actually importable)
+            spec = importlib.util.find_spec(backend_module)
+            exists = spec is not None
+
+            backend_info.append((backend, backend_module, exists))
+
+        print("Matplotlib backends:", file=sys.stderr)
+        for name, module, exists in backend_info:
+            print(f"  name={name}, module={module}, exists={exists}", file=sys.stderr)
+
+        if len(sys.argv) > 1:
+            with open(sys.argv[1], "w") as fp:
+                json.dump(backend_info, fp)
+        """,
+        app_args=[str(result_file)],
+    )
+
+    with open(result_file, "r", encoding="utf-8") as fp:
+        frozen_backends_info = json.load(fp)
+
+    frozen_backends_info = sorted(frozen_backends_info)
+    print("Backends in frozen matplotlib:", file=sys.stderr)
+    for name, module, exists in frozen_backends_info:
+        print(f"  name={name}, module={module}, exists={exists}", file=sys.stderr)
+
+    # Importable backends in unfrozen matplotlib
+    @isolated.decorate
+    def _get_unfrozen_backends():
+        import importlib
+
+        import matplotlib
+
+        backends = matplotlib.rcsetup.all_backends
+
+        def _backend_module_name(name):
+            if name.startswith("module://"):
+                return name[9:]
+            return f"matplotlib.backends.backend_{name.lower()}"
+
+        backend_info = []
+        for backend in backends:
+            backend_module = _backend_module_name(backend)
+
+            try:
+                importlib.import_module(backend_module)
+                importable = True
+            except Exception:
+                importable = False
+
+            backend_info.append([backend, backend_module, importable])
+
+        return backend_info
+
+    unfrozen_backends_info = sorted(_get_unfrozen_backends())
+    print("Importable backends in unfrozen matplotlib:", file=sys.stderr)
+    for name, module, importable in unfrozen_backends_info:
+        print(f"  name={name}, module={module}, importable={importable}", file=sys.stderr)
+
+    # The available backends in frozen matplotlib should be the ones that are importable in unfrozen matplotlib.
+    assert frozen_backends_info == unfrozen_backends_info


### PR DESCRIPTION
Matplotlib 3.9 introduced new backend registry, which largely flew under our radar due to changes not directly affecting our tests (and the covered subset of Matplotlib functionality).

Matplotlib 3.11 removed the parts that were deprecated in 3.9, such as the old list of available backends (`matplotlib.rcsetup.all_backends`) that our hook was using. This leads to error when user tries to collect all importable backends via hook configuration (#9467), but again went unnoticed due to lack of test for this codepath.

This PR updates the hook to use the new backend registry when available (Matplotlib >= 3.9), and also addresses couple of other issues that I noticed while looking at the changes:

- first, there is a new test (`test_matplotlib_all_backends`) that covers the "collect all importable backends" mode. This is both to catch potential (though unlikely) changes on Matplotlib side, and  to ensure that the mode is actually working as intended - the test checks that the backends that are available in the frozen application are the ones that are importable in unfrozen Matplotlib.

- the new test indicated that we end up collecting `webagg` backend even when it is not importable. This is due to a conditional import in `matplotlib.figure`; so there's now a hook that suppresses this particular reference to avoid unnecessary collection.

- starting with Matplotlib 3.9, the backend names are all lower-cased, so the code for preemptively excluding platform-specific backends (e.g., `MacOSX` / `macosx` backend on non-macOS platforms) needs to be adjusted to perform case-normalized matching.

- if the new backend registry is available (Matplotlib >= 3.9), use it to obtain list of all available backends; otherwise continue using the old list (`matplotlib.rcsetup.all_backends`). Fixes #9467.

- up until now, we converted backend name into module name using our own equivalent of [`matplotlib.cbook._backend_module_name()`](https://github.com/matplotlib/matplotlib/blob/v3.8.x/lib/matplotlib/cbook.py#L2175-L2181). With 3.9 and backend registry, the mapping is not necessarily as straight-forward; for example, the former `NbAgg` backend is now listed as `notebook`, but `nbagg` is still used for the module name. Therefore, switch to using Matplotlib's [`matplotlib.cbook._backend_module_name()`](https://github.com/matplotlib/matplotlib/blob/v3.8.x/lib/matplotlib/cbook.py#L2175-L2181) or [`BackendRegistry._backend_module_name()`](https://github.com/matplotlib/matplotlib/blob/v3.9.x/lib/matplotlib/backends/registry.py#L95-L107) to ensure that mapping is always consistent with what Matplotlib uses internally. This resolution happens in an isolated sub-process, so the code had to be reshuffled a bit to minimize the amounts of calls (i.e., a single call with list of backend names of interest).

- lastly, the new backend registry allows additional backends to be registered via `matplotlib.backend` entry point. For example, `inline` backend is now registered through entry point of `matplotlib-inline` dist. Therefore, we also need to collect metadata for dists that correspond to collected backend modules (if any), in order for these backends to be discoverable at run-time.