### PR TITLE
depend: use explicit patterns to exclude wayland dynamic libraries

### DIFF
--- a/PyInstaller/depend/dylib.py
+++ b/PyInstaller/depend/dylib.py
@@ -222,7 +222,7 @@ _unix_excludes = {
     r'libxcb-dri.*\.so(\..*)?',
     # system running a Wayland compositor should already have these libraries
     # in versions that should not conflict with system drivers, unlike bundled
-    r'libwayland.*\.so(\..*)?',
+    r'libwayland-(client|cursor|egl|server)\.so(\..*)?',
 }
 
 _aix_excludes = {

--- a/news/9430.bugfix.rst
+++ b/news/9430.bugfix.rst
@@ -1,0 +1,2 @@
+(Linux) Fix regression that prevented automatic collection of wayland
+shared libraries that are bundled with ``pywayland`` binary wheels.


### PR DESCRIPTION
Use explicit patterns to prevent collection of system-installed wayland dynamic libraries (`libwayland-client`, `libwayland-cursor`, `libwayland-egl`, and `libwayland-server`), instead of general `libwayland*` pattern.

Fixes #9430, which is a regression on our part, regardless of whether those wheel-bundled shared libraries make sense or not.

In the grander scheme of things, it might make sense to revise our exclusion codepath(s) so that exclusion patterns are applied strictly to system shared libraries...