### PR TITLE
Various improvements to test suite and CI, continued

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,11 +254,12 @@ jobs:
         run: |
           echo "PYTEST_DEBUG_TEMPROOT=$RUNNER_TEMP" >> $GITHUB_ENV
 
-      # Attempt to mitigate test failures on x86_64 macOS runners due to lost time slices.
-      - name: Allow single re-run of every failed test
+      # Attempt to mitigate test failures on x86_64 macOS runners due to slow(er) builds. Increase the default
+      # test timeout from 10 minutes to 15 minutes, and allow a single re-run of every failed test.
+      - name: Mitigate issues with slow(er) builds
         if: ${{ startsWith(matrix.os, 'macos') && endsWith(matrix.os, 'intel') }}
         run: |
-          echo "PYTEST_ADDOPTS=--reruns=1 --reruns-delay=30" >> $GITHUB_ENV
+          echo "PYTEST_ADDOPTS=--timeout=900 --reruns=1 --reruns-delay=30" >> $GITHUB_ENV
           # This is necessary to activate re-runs on tests in test_qt.py that have @pytest.mark.flaky() marker
           # with condition argument.
           echo "PYINSTALLER_TEST_FORCE_FLAKY_RERUN=1" >> $GITHUB_ENV

--- a/PyInstaller/building/utils.py
+++ b/PyInstaller/building/utils.py
@@ -16,7 +16,6 @@ import io
 import marshal
 import os
 import pathlib
-import platform
 import shutil
 import struct
 import subprocess
@@ -173,7 +172,7 @@ def process_collected_binary(
 
     # Prepare cache directory path. Cache is tied to python major/minor version, but also to various processing options.
     pyver = f'py{sys.version_info[0]}{sys.version_info[1]}'
-    arch = platform.architecture()[0]
+    arch = compat.architecture
     cache_dir = os.path.join(
         CONF['cachedir'],
         f'bincache{use_strip:d}{use_upx:d}{pyver}{arch}',

--- a/PyInstaller/utils/conftest.py
+++ b/PyInstaller/utils/conftest.py
@@ -230,11 +230,13 @@ class AppBuilder:
         self.script = str(script)  # might be a pathlib.Path at this point!
         assert os.path.exists(self.script), f'Script {self.script!r} not found.'
 
+        start_time = time.time()
         self._display_message('TEST-SCRIPT', 'Starting build...')
         if not self._test_building(args=pyi_args):
             pytest.fail(f'Building of {script} failed.')
 
-        self._display_message('TEST-SCRIPT', 'Build finished, now running executable...')
+        elapsed = time.time() - start_time
+        self._display_message('TEST-SCRIPT', f'Build finished in {elapsed:.1f} seconds, now running executable...')
         self._test_executables(app_name, args=app_args, run_from_path=run_from_path, **kwargs)
         self._display_message('TEST-SCRIPT', 'Running executable finished.')
 

--- a/PyInstaller/utils/conftest.py
+++ b/PyInstaller/utils/conftest.py
@@ -153,8 +153,9 @@ def data_dir(
 
 
 class AppBuilder:
-    def __init__(self, tmp_path, request, bundle_mode):
+    def __init__(self, tmp_path, bincache_path, request, bundle_mode):
         self._tmp_path = tmp_path
+        self._bincache_path = bincache_path
         self._request = request
         self._mode = bundle_mode
         self._spec_dir = tmp_path
@@ -482,8 +483,8 @@ class AppBuilder:
         pyi_args = [self.script, *default_args, *args]
         # TODO: fix return code in running PyInstaller programmatically.
         PYI_CONFIG = configure.get_config()
-        # Override CACHEDIR for PyInstaller; relocate cache into `self._tmp_path`.
-        PYI_CONFIG['cachedir'] = str(self._tmp_path)
+        # Override CACHEDIR for PyInstaller; relocate cache into `self._bincache_path`.
+        PYI_CONFIG['cachedir'] = str(self._bincache_path)
 
         pyi_main.run(pyi_args, PYI_CONFIG)
         retcode = 0
@@ -528,9 +529,15 @@ def pyi_modgraph():
     initialize_modgraph()
 
 
+# Per-session binary cache directory.
+@pytest.fixture(scope='session')
+def pyi_bincache(tmp_path_factory):
+    return tmp_path_factory.mktemp("pyi-bincache-")
+
+
 # Run by default test as onedir and onefile.
 @pytest.fixture(params=['onedir', 'onefile'])
-def pyi_builder(tmp_path, monkeypatch, request, pyi_modgraph):
+def pyi_builder(tmp_path, monkeypatch, request, pyi_modgraph, pyi_bincache):
     # Save/restore environment variable PATH.
     monkeypatch.setenv('PATH', os.environ['PATH'])
     # PyInstaller or a test case might manipulate 'sys.path'. Reset it for every test.
@@ -541,7 +548,7 @@ def pyi_builder(tmp_path, monkeypatch, request, pyi_modgraph):
     # as the original value.
     monkeypatch.setattr('PyInstaller.config.CONF', {'pathex': []})
 
-    yield AppBuilder(tmp_path, request, request.param)
+    yield AppBuilder(tmp_path, pyi_bincache, request, request.param)
 
     # Clean up the temporary directory of a successful test
     if _PYI_BUILDER_CLEANUP and request.node.rep_setup.passed and request.node.rep_call.passed:
@@ -551,7 +558,7 @@ def pyi_builder(tmp_path, monkeypatch, request, pyi_modgraph):
 
 # Fixture for .spec based tests. With .spec it does not make sense to differentiate onefile/onedir mode.
 @pytest.fixture
-def pyi_builder_spec(tmp_path, request, monkeypatch, pyi_modgraph):
+def pyi_builder_spec(tmp_path, request, monkeypatch, pyi_modgraph, pyi_bincache):
     # Save/restore environment variable PATH.
     monkeypatch.setenv('PATH', os.environ['PATH'])
     # Set current working directory to
@@ -562,7 +569,7 @@ def pyi_builder_spec(tmp_path, request, monkeypatch, pyi_modgraph):
     # as the original value.
     monkeypatch.setattr('PyInstaller.config.CONF', {'pathex': []})
 
-    yield AppBuilder(tmp_path, request, None)
+    yield AppBuilder(tmp_path, pyi_bincache, request, None)
 
     # Clean up the temporary directory of a successful test
     if _PYI_BUILDER_CLEANUP and request.node.rep_setup.passed and request.node.rep_call.passed:


### PR DESCRIPTION
A follow-up to #9480, which evidently did not fully resolve timeouts on x86_64 macOS runners.

Up until now, the working assumption was that something goes wrong during test program *execution*, which is where we usually see the 10-minute timeout from `pytest-timeout` to kick in. But the confusing part is - why does our own 2-minute timeout on subprocess kick in before that?

But this is exactly what happens when the *build* part takes up almost 10 minutes, and then lets the execution part race against the remaining time. Which means that the problematic tests are on the verge of exceeding 10 minutes on these x86_64 macOS runners, and the problems could likely be avoided by simply raising the limit to 15 minutes.

This PR does that, but it also attempts to speed up the builds a bit, by introducing per-session binary cache. While we cannot have global binary cache due to parallel test execution, the tests within the same session are executed sequentially, so per-session cache is feasible. The slowest tests on my fork now seem to take ~7 minutes, so the old 10 minute timeout might also do. But still, it's cheaper to potentially have to wait additional 5 minutes than having to rerun the test.