### PR TITLE
bootloader: call _pyi_is_ld_linux_so() only if preceding readlink() call succeeded

### DIFF
--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -1319,7 +1319,7 @@ _pyi_resolve_executable_posix(const char *argv0, char *executable_filename, char
      * In that case, /proc/self/exe points to the ld.so executable, and we need
      * to ignore it. */
 #if defined(__linux__)
-    if (_pyi_is_ld_linux_so(executable_filename) == true) {
+    if (name_len != -1 && _pyi_is_ld_linux_so(executable_filename) == true) {
         PYI_DEBUG("LOADER: resolved executable file %s is ld.so dynamic linker/loader - storing its name.\n", executable_filename);
         strncpy(loader_filename, executable_filename, PYI_PATH_MAX); /* both buffers are guaranteed to be PYI_PATH_MAX-sized */
         name_len = -1;


### PR DESCRIPTION
Have `_pyi_resolve_executable_posix()` call linux-specific `_pyi_is_ld_linux_so()` helper only if the preceding `readlink()` call succeeded (`name_len` != -1).

This is done mostly for the sake of formality, to avoid impression that the call might end up operating on a buffer with undefined contents. The buffer pointer in question actually points to the `pyi_ctx->executable_filename`, which is zero-initialized when the context structure is allocated (although, at least in theory, a  failed `readlink()` call *could* write some contents into buffer without properly terminating it...)