### PR TITLE
test/ci: Use minimal zlib compression level

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ env:
   PYINSTALLER_VERIFY_BUNDLE_SIGNATURE: 1
   # Enable PEP 597 EncodingWarnings
   PYTHONWARNDEFAULTENCODING: true
+  # Use minimal compression for speed
+  PYINSTALLER_ZLIB_COMPRESSION_LEVEL: 1
 
 permissions:
   contents: read # to fetch code (actions/checkout)

--- a/PyInstaller/archive/writers.py
+++ b/PyInstaller/archive/writers.py
@@ -31,7 +31,7 @@ class ZlibArchiveWriter:
     """
     _PYZ_MAGIC_PATTERN = b'PYZ\0'
     _HEADER_LENGTH = 12 + 5
-    _COMPRESSION_LEVEL = 6  # zlib compression level
+    _COMPRESSION_LEVEL = int(os.environ.get("PYINSTALLER_ZLIB_COMPRESSION_LEVEL", 6))  # zlib compression level
 
     def __init__(self, filename, entries, code_dict=None):
         """
@@ -129,7 +129,7 @@ class CArchiveWriter:
     _TOC_ENTRY_FORMAT = '!IIIIBc'
     _TOC_ENTRY_LENGTH = struct.calcsize(_TOC_ENTRY_FORMAT)
 
-    _COMPRESSION_LEVEL = 9  # zlib compression level
+    _COMPRESSION_LEVEL = int(os.environ.get("PYINSTALLER_ZLIB_COMPRESSION_LEVEL", 9))  # zlib compression level
 
     def __init__(self, filename, entries, pylib_name):
         """


### PR DESCRIPTION
On the theme of trying to speed CI up a bit, give ourselves a way to reduce the time spent zlib compressing everything over and over. CI timings aren't very predictable but I think we're down from about 1 day 4-6 hours to 1 day 0-2 hours summed execution time.