### PR TITLE
Doc: clarify macOS Finder working directory

### DIFF
--- a/doc/common-issues-and-pitfalls.rst
+++ b/doc/common-issues-and-pitfalls.rst
@@ -189,7 +189,16 @@ the external program.
 .. Note::
     If you are building a `macOS .app bundle <macOS app bundles>`_, you
     should be aware that when launched from Finder, the app process runs
-    in an environment with reduced set of environment variables.
+    with a launch context that differs from a Terminal session.
+    In particular, its current working directory is not the directory that
+    contains the app bundle and is commonly ``/``.
+    Therefore, a relative file path can resolve to a different location between
+    a Terminal launch and a Finder launch.
+    For portable bundled-resource location, anchor paths to ``__file__``; see
+    :ref:`run-time information`.
+
+    The process also runs in an environment with a reduced set of environment
+    variables.
     Most notably, the ``PATH`` environment variable is set to only
     ``/usr/bin:/bin:/usr/sbin:/sbin``. Therefore, programs installed in
     locations that are typically in ``PATH`` when running a Terminal

--- a/news/9485.doc.rst
+++ b/news/9485.doc.rst
@@ -1,0 +1,1 @@
+(macOS) Document Finder's working-directory behavior.


### PR DESCRIPTION
## Summary

- document that an app launched from Finder does not run with the app bundle directory as its current working directory
- note that Finder commonly supplies `/` as the working directory
- link to the existing runtime-information guidance for locating bundled resources instead of duplicating it
- retain the existing warning about Finder’s reduced environment and `PATH`

## Why

#5109 combines several unrelated reports, including py2app-specific behavior. The PyInstaller documentation already explains how to locate bundled resources with `__file__`; the missing macOS-specific detail is that Finder and Terminal provide different launch contexts.

This keeps the fix focused on that distinction without changing bootloader behavior or repeating the existing resource-path documentation.

## Validation

- built the complete Sphinx documentation with warnings treated as errors
- built and signed a windowed app with PyInstaller 6.21 on macOS 26.5
- launched it through LaunchServices from `/` and confirmed its bundled resource remained accessible

Closes #5109