### PR TITLE
Fix contents_directory escaping in generated .spec file

### DIFF
--- a/PyInstaller/building/makespec.py
+++ b/PyInstaller/building/makespec.py
@@ -761,7 +761,7 @@ def main(
         # The the text value 'None' means - use default icon.
         icon_file = 'None'
     if contents_directory:
-        exe_options += "\n    contents_directory='%s'," % (contents_directory or "_internal")
+        exe_options += "\n    contents_directory=%r," % (contents_directory,)
     if hide_console:
         exe_options += "\n    hide_console='%s'," % hide_console
 

--- a/news/9472.bugfix.rst
+++ b/news/9472.bugfix.rst
@@ -1,0 +1,3 @@
+Fix ``--contents-directory`` values containing backslashes (e.g. Windows-style
+paths) being written to the generated .spec file as unescaped string literals,
+which silently turned escape sequences such as ``\t`` into control characters.

--- a/tests/unit/test_makespec.py
+++ b/tests/unit/test_makespec.py
@@ -80,3 +80,51 @@ def test_add_data(capsys):
     options = parser.parse_args(["--add-data=a:b", "--add-data=c:d", "--add-binary=e:f"])
     assert options.datas == [("a", "b"), ("c", "d")]
     assert options.binaries == [("e", "f")]
+
+
+def test_contents_directory_backslash_escaped(tmp_path):
+    """
+    A Windows-style ``--contents-directory`` must be written to the .spec file as a valid Python
+    string literal; using plain interpolation turned ``env\\test`` into a literal tab character.
+    """
+    script = tmp_path / "app.py"
+    script.write_text("print(1)\n")
+
+    parser = argparse.ArgumentParser()
+    makespec.__add_options(parser)
+    options = vars(parser.parse_args([r"--contents-directory=env\test"]))
+    options["specpath"] = str(tmp_path)
+    options["name"] = "app"
+
+    spec_file = makespec.main([str(script)], **options)
+
+    namespace = {}
+
+    def _EXE(*args, **kwargs):
+        namespace.update(kwargs)
+
+    class _Analysis:
+        def __init__(self, *args, **kwargs):
+            self.pure = []
+            self.binaries = []
+            self.datas = []
+            self.scripts = []
+            self.zipfiles = []
+            self.zipped_data = []
+            self.dependencies = []
+
+    with open(spec_file) as fp:
+        source = fp.read()
+
+    exec(
+        compile(source, spec_file, "exec"),
+        {
+            "EXE": _EXE,
+            "Analysis": _Analysis,
+            "PYZ": lambda *args, **kwargs: None,
+            "COLLECT": lambda *args, **kwargs: None,
+            "BUNDLE": lambda *args, **kwargs: None,
+        },
+    )
+
+    assert namespace["contents_directory"] == r"env\test"


### PR DESCRIPTION
Closes #9472

`--contents-directory` was interpolated into the generated .spec file with plain `'%s'` quoting, so a Windows-style value like `env\test` was written as `contents_directory='env\test'` and Python read the `\t` as a tab. Using `%r` emits a proper string literal, as @bwoodsend diagnosed in the issue.

New unit test round-trips `--contents-directory=env\test` through the generated spec; it fails on the old interpolation and passes with the fix.
