### PR TITLE
rthooks: gstreamer: fix plugin directory name in GST_PLUGIN_PATH

### DIFF
--- a/PyInstaller/hooks/rthooks/pyi_rth_gstreamer.py
+++ b/PyInstaller/hooks/rthooks/pyi_rth_gstreamer.py
@@ -17,7 +17,7 @@ def _pyi_rthook():
     # Without this environment variable set to 'no' importing 'gst' causes 100% CPU load. (Tested on macOS.)
     os.environ['GST_REGISTRY_FORK'] = 'no'
 
-    gst_plugin_paths = [sys._MEIPASS, os.path.join(sys._MEIPASS, 'gst-plugins')]
+    gst_plugin_paths = [sys._MEIPASS, os.path.join(sys._MEIPASS, 'gst_plugins')]
     os.environ['GST_PLUGIN_PATH'] = os.pathsep.join(gst_plugin_paths)
 
     # Prevent permission issues on Windows

--- a/tests/functional/test_gi.py
+++ b/tests/functional/test_gi.py
@@ -87,3 +87,29 @@ def test_gi_repository(pyi_builder, repository_name, version):
                 raise ValueError(f"Typelib {{str(module_path)!r}} is not loaded from frozen application's directory!")
         """
     )
+
+
+# GST_PLUGIN_PATH must point at the directory where the gi.repository.Gst hook puts the plugins.
+@importorskip('gi.repository.Gst')
+def test_gi_gst_plugin_path(pyi_builder):
+    pyi_builder.test_source(
+        """
+        import os
+        import sys
+
+        import gi
+        gi.require_version('Gst', '1.0')
+        from gi.repository import Gst
+
+        search_paths = os.environ['GST_PLUGIN_PATH'].split(os.pathsep)
+        print(f"GST_PLUGIN_PATH entries: {search_paths}", file=sys.stderr)
+
+        plugin_dir = os.path.join(sys._MEIPASS, 'gst_plugins')
+        if plugin_dir not in search_paths:
+            raise ValueError(f"Plugin directory {plugin_dir!r} is not in GST_PLUGIN_PATH: {search_paths}")
+
+        missing = [path for path in search_paths if not os.path.isdir(path)]
+        if missing:
+            raise ValueError(f"GST_PLUGIN_PATH contains non-existent directories: {missing}")
+        """
+    )


### PR DESCRIPTION
The run-time hook pointed at 'gst-plugins', while the gi.repository.Gst hook collects plugins into 'gst_plugins'. Broken since 9d9e7a790, but never noticed: sys._MEIPASS is on the search path too and GStreamer scans it recursively, so the plugins were found anyway.

sys._MEIPASS stays on the path, so the whole-bundle scan is unchanged and the corrected entry is for now redundant with it.

Add a regression test.