### PR TITLE
bootloader: implement additional security validation

### DIFF
--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -403,6 +403,7 @@ pyi_main(struct PYI_CONTEXT *pyi_ctx)
      * and based on that, determine the application's top-level directory. */
     if (pyi_ctx->is_onefile) {
         bool create_temp_dir;
+        bool is_parent = true;
 
         if (pyi_ctx->process_level == PYI_PROCESS_LEVEL_PARENT_NEEDS_RESTART) {
             /* POSIX build with splash screen enabled; before restart. */
@@ -423,6 +424,7 @@ pyi_main(struct PYI_CONTEXT *pyi_ctx)
                 "main application process" : "spawned subprocess"
             );
             create_temp_dir = false; /* inherit */
+            is_parent = false; /* child process */
         }
 
         if (create_temp_dir) {
@@ -483,11 +485,30 @@ pyi_main(struct PYI_CONTEXT *pyi_ctx)
              * from tricking us into using an arbitrary _PYI_APPLICATION_HOME_DIR
              * via spoofed _PYI_ARCHIVE_FILE and _PYI_PARENT_PROCESS_LEVEL.
              * See: https://github.com/pyinstaller/pyinstaller/security/advisories/GHSA-9fxf-4qw3-ghmr */
-            if (pyi_security_verify_parent_proces(pyi_ctx) < 0) {
-                return -1;
-            }
-            if (pyi_security_verify_application_home_dir(pyi_ctx) < 0) {
-                return -1;
+            if (is_parent) {
+                /* This codepath should be reached only in onefile POSIX
+                 * builds with splash screen, where the parent process
+                 * needs to set LD_LIBRARY_PATH and restart itself before
+                 * running splash screen. In this case, we cannot verify
+                 * the parent process; but we can verify the inherited
+                 * top-level application directory, on the off chance
+                 * that executable has setuid bit set... */
+                if (pyi_security_verify_application_home_dir(pyi_ctx) < 0) {
+                    return -1;
+                }
+            } else {
+                /* This is supposed to be a onefile child process; therefore,
+                 * its parent should be a valid onefile process, and should
+                 * be using the same executable... */
+                if (pyi_security_verify_parent_proces(pyi_ctx) < 0) {
+                    return -1;
+                }
+                /* Check ownership and permissions on the inherited top-level
+                 * application directory (applicable only on POSIX and only
+                 * if setuid bit is set; otherwise, this check is a no-op) */
+                if (pyi_security_verify_application_home_dir(pyi_ctx) < 0) {
+                    return -1;
+                }
             }
         }
     } else {

--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -18,7 +18,7 @@
 #ifdef _WIN32
     #include <windows.h>
     #include <wchar.h>
-    #include <tlhelp32.h> /* CreateToolhelp32Snapshot, Process32FirstW, Process32NextW */
+    #include <process.h> /* _getpid */
 #else
     #include <unistd.h>
     #include <signal.h>  /* raise */
@@ -498,10 +498,17 @@ pyi_main(struct PYI_CONTEXT *pyi_ctx)
                  * builds with splash screen, where the parent process
                  * needs to set LD_LIBRARY_PATH and restart itself before
                  * running splash screen. In this case, we cannot verify
-                 * the parent process; but we can verify the inherited
-                 * top-level application directory, on the off chance
-                 * that executable has setuid bit set... */
-                if (pyi_security_verify_application_home_dir(pyi_ctx) < 0) {
+                 * the parent process, but we can verify the inherited
+                 * top-level application directory; specifically, its
+                 * name should start with _MEI and should include the
+                 * PID of *this* process. If setuid bit is set on the
+                 * executable, also check owner/permissions on the directory. */
+#if defined(_WIN32)
+                unsigned int prefix_pid = _getpid();
+#else
+                unsigned int prefix_pid = getpid();
+#endif
+                if (pyi_security_verify_application_home_dir(pyi_ctx, prefix_pid) < 0) {
                     return -1;
                 }
             } else {
@@ -511,10 +518,15 @@ pyi_main(struct PYI_CONTEXT *pyi_ctx)
                 if (pyi_security_verify_parent_proces(pyi_ctx) < 0) {
                     return -1;
                 }
-                /* Check ownership and permissions on the inherited top-level
-                 * application directory (applicable only on POSIX and only
-                 * if setuid bit is set; otherwise, this check is a no-op) */
-                if (pyi_security_verify_application_home_dir(pyi_ctx) < 0) {
+                /* Verify the name of the application's home directory.
+                 * Its name should start with _MEI prefix; for now, skip
+                 * the PID part of the check (by passing 0), as that
+                 * would require us to find the parent onefile process
+                 * (which might be more than one level up the ancestry
+                 * tree for worker sub-processes). On POSIX, if setuid
+                 * bit is set on the executable, also check owner/permissions
+                 * on the directory. */
+                if (pyi_security_verify_application_home_dir(pyi_ctx, 0) < 0) {
                     return -1;
                 }
             }
@@ -549,10 +561,10 @@ pyi_main(struct PYI_CONTEXT *pyi_ctx)
             }
         }
 
-        /* Check ownership and permissions on the top-level application
-         * directory (applicable only on POSIX and only if setuid bit
-         * is set; otherwise, this check is a no-op) */
-        if (pyi_security_verify_application_home_dir(pyi_ctx) < 0) {
+        /* On POSIX platforms, if setuid bit is set on the executable,
+         * check owner/permissions on the top-level application's directory
+         * to ensure its contents are accessible only to the effective user. */
+        if (pyi_security_verify_application_home_dir(pyi_ctx, 0) < 0) {
             return -1;
         }
     }

--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -1651,6 +1651,7 @@ _pyi_main_onefile_child_security_check_posix(struct PYI_CONTEXT *pyi_ctx)
 {
     /* Try to look up the executable of the parent process - it should
      * be the same as that of the current process. */
+    int has_setuid;
     pid_t ppid;
     ssize_t name_len = -1;
     char proc_path[PYI_PATH_MAX];
@@ -1669,8 +1670,25 @@ _pyi_main_onefile_child_security_check_posix(struct PYI_CONTEXT *pyi_ctx)
     const char *proc_path_fmt = NULL;
 #endif
 
+    /* Check if executable has setuid bit set */
+    if (stat(pyi_ctx->executable_filename, &executable_stat) < 0) {
+        PYI_ERROR("Security validation failure: could not stat() the executable!\n");
+        return -1;
+    }
+    has_setuid = executable_stat.st_mode & S_ISUID;
+    PYI_DEBUG("SECURITY: setuid bit set: %d\n", has_setuid);
+
+    /* Handle unsupported POSIX platforms, where we have no way to look up
+     * the parent executable. Disallow setuid-enabled executables, otherwise
+     * skip the check. */
     if (!proc_path_fmt) {
-        return 0; /* Unsupported POSIX platform - skip the check */
+        if (has_setuid) {
+            PYI_ERROR("Security validation failure: setuid-enabled executables are not supported on this platform!\n");
+            return -1;
+        } else {
+            PYI_DEBUG("SECURITY: unsupported platform - skipping check for non-setuid executable!\n");
+            return 0;
+        }
     }
 
     /* Get parent PID */
@@ -1702,12 +1720,7 @@ _pyi_main_onefile_child_security_check_posix(struct PYI_CONTEXT *pyi_ctx)
     }
 
     /* Additional checks for executables with setuid bit */
-    if (stat(pyi_ctx->executable_filename, &executable_stat) < 0) {
-        PYI_ERROR("Security validation failure: could not stat() the executable!\n");
-        return -1;
-    }
-
-    if (executable_stat.st_mode & S_ISUID) {
+    if (has_setuid) {
         uid_t euid;
         uid_t permissions;
 
@@ -1735,8 +1748,6 @@ _pyi_main_onefile_child_security_check_posix(struct PYI_CONTEXT *pyi_ctx)
             PYI_ERROR("Security validation failure: application's home directory has invalid permissions (0%o)!\n", permissions);
             return -1;
         }
-    } else {
-        PYI_DEBUG("SECURITY: setuid bit is not set.\n");
     }
 
     return 0;

--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -540,6 +540,13 @@ pyi_main(struct PYI_CONTEXT *pyi_ctx)
                 snprintf(pyi_ctx->application_home_dir, PYI_PATH_MAX, "%s", executable_dir);
             }
         }
+
+        /* Check ownership and permissions on the top-level application
+         * directory (applicable only on POSIX and only if setuid bit
+         * is set; otherwise, this check is a no-op) */
+        if (pyi_security_verify_application_home_dir(pyi_ctx) < 0) {
+            return -1;
+        }
     }
 
     PYI_DEBUG("LOADER: application's top-level directory: %s\n", pyi_ctx->application_home_dir);

--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -127,6 +127,23 @@ pyi_main(struct PYI_CONTEXT *pyi_ctx)
     }
     PYI_DEBUG("LOADER: executable file: %s\n", pyi_ctx->executable_filename);
 
+    /* Check if executable set setuid bit set (POSIX platforms only). */
+#if !defined(_WIN32) && !defined(__APPLE__)
+    if (1) {
+        struct stat executable_stat;
+
+        if (stat(pyi_ctx->executable_filename, &executable_stat) < 0) {
+            PYI_ERROR("Security validation failure: could not stat() the executable!\n");
+            return -1;
+        }
+        pyi_ctx->has_setuid = (executable_stat.st_mode & S_ISUID) == S_ISUID;
+
+        if (pyi_ctx->has_setuid) {
+            PYI_DEBUG("SECURITY: executable has setuid bit set.\n");
+        }
+    }
+#endif
+
     /* Resolve main PKG archive - embedded or side-loaded. */
     if (_pyi_main_resolve_pkg_archive(pyi_ctx) < 0) {
         return -1;
@@ -1651,13 +1668,11 @@ _pyi_main_onefile_child_security_check_posix(struct PYI_CONTEXT *pyi_ctx)
 {
     /* Try to look up the executable of the parent process - it should
      * be the same as that of the current process. */
-    int has_setuid;
     pid_t ppid;
     ssize_t name_len = -1;
     char proc_path[PYI_PATH_MAX];
     char parent_executable[PYI_PATH_MAX];
 
-    struct stat executable_stat;
     struct stat application_home_dir_stat;
 
 #if defined(__linux__) || defined(__CYGWIN__)
@@ -1670,19 +1685,11 @@ _pyi_main_onefile_child_security_check_posix(struct PYI_CONTEXT *pyi_ctx)
     const char *proc_path_fmt = NULL;
 #endif
 
-    /* Check if executable has setuid bit set */
-    if (stat(pyi_ctx->executable_filename, &executable_stat) < 0) {
-        PYI_ERROR("Security validation failure: could not stat() the executable!\n");
-        return -1;
-    }
-    has_setuid = executable_stat.st_mode & S_ISUID;
-    PYI_DEBUG("SECURITY: setuid bit set: %d\n", has_setuid);
-
     /* Handle unsupported POSIX platforms, where we have no way to look up
      * the parent executable. Disallow setuid-enabled executables, otherwise
      * skip the check. */
     if (!proc_path_fmt) {
-        if (has_setuid) {
+        if (pyi_ctx->has_setuid) {
             PYI_ERROR("Security validation failure: setuid-enabled executables are not supported on this platform!\n");
             return -1;
         } else {
@@ -1720,7 +1727,7 @@ _pyi_main_onefile_child_security_check_posix(struct PYI_CONTEXT *pyi_ctx)
     }
 
     /* Additional checks for executables with setuid bit */
-    if (has_setuid) {
+    if (pyi_ctx->has_setuid) {
         uid_t euid;
         uid_t permissions;
 

--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -18,6 +18,7 @@
 #ifdef _WIN32
     #include <windows.h>
     #include <wchar.h>
+    #include <tlhelp32.h> /* CreateToolhelp32Snapshot, Process32FirstW, Process32NextW */
 #else
     #include <unistd.h>
     #include <signal.h>  /* raise */
@@ -43,7 +44,10 @@
 
 #if defined(__APPLE__)
     #include <mach-o/dyld.h>  /* _NSGetExecutablePath() */
+    #include <libproc.h> /* proc_pidpath() */
 #endif
+
+#include <sys/stat.h>  /* stat() */
 
 /* PyInstaller headers. */
 #include "pyi_main.h"
@@ -92,6 +96,8 @@ static int _pyi_main_onefile_parent(struct PYI_CONTEXT *pyi_ctx);
 
 static int _pyi_main_resolve_executable(struct PYI_CONTEXT *pyi_context);
 static int _pyi_main_resolve_pkg_archive(struct PYI_CONTEXT *pyi_context);
+
+static int _pyi_main_onefile_child_security_check(struct PYI_CONTEXT *pyi_context);
 
 
 int
@@ -456,6 +462,14 @@ pyi_main(struct PYI_CONTEXT *pyi_ctx)
             }
 
             free(env_var_value);
+
+            /* Perform additional security validation to prevent an attacker
+             * from tricking us into using an arbitrary _PYI_APPLICATION_HOME_DIR
+             * via spoofed _PYI_ARCHIVE_FILE and _PYI_PARENT_PROCESS_LEVEL.
+             * See: https://github.com/pyinstaller/pyinstaller/security/advisories/GHSA-9fxf-4qw3-ghmr */
+            if (_pyi_main_onefile_child_security_check(pyi_ctx) < 0) {
+                return -1;
+            }
         }
     } else {
         char executable_dir[PYI_PATH_MAX];
@@ -1509,4 +1523,238 @@ _pyi_main_resolve_pkg_archive(struct PYI_CONTEXT *pyi_ctx)
     }
 
     return 0;
+}
+
+
+/**********************************************************************\
+ *        Additional security check for onefile child process         *
+\**********************************************************************/
+#ifdef _WIN32
+
+static int
+_pyi_main_onefile_child_security_check_win32(struct PYI_CONTEXT *pyi_ctx)
+{
+    DWORD pid;
+    DWORD ppid;
+
+    HANDLE process_snapshot;
+    PROCESSENTRY32W process_entry;
+    BOOL entry_found;
+
+    HANDLE process_handle;
+    wchar_t parent_executable_w[PYI_PATH_MAX];
+    char parent_executable[PYI_PATH_MAX];
+    DWORD parent_executable_length;
+
+    /* Current process ID, for look-up in the process snapshot */
+    pid = GetCurrentProcessId();
+
+    /* Take the process snapshot */
+    process_snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+    if (process_snapshot == INVALID_HANDLE_VALUE) {
+        PYI_ERROR_W(L"Security validation failure: could not obtain process snapshot!\n");
+        return -1;
+    }
+
+    /* Walk the process snapshot to find entry for our process, and get
+     * parent process ID from it. */
+    process_entry.dwSize = sizeof(PROCESSENTRY32);
+    if (!Process32FirstW(process_snapshot, &process_entry)) {
+        PYI_ERROR_W(L"Security validation failure: could not walk the process snapshot!\n");
+        CloseHandle(process_snapshot);
+        return -1;
+    }
+
+    entry_found = FALSE;
+    do {
+        if (process_entry.th32ProcessID == pid) {
+            ppid = process_entry.th32ParentProcessID;
+            entry_found = TRUE;
+            break;
+        }
+    } while(Process32NextW(process_snapshot, &process_entry));
+
+    CloseHandle(process_snapshot);
+
+    if (!entry_found) {
+        PYI_ERROR_W(L"Security validation failure: could not determine parent process ID!\n");
+        return -1;
+    }
+
+    /* Now try to query process for its executable name.
+     * QueryFullProcessImageNameW() seems to return a fully-resolved
+     * path to the executable, even when the parent process is launched
+     * via symbolic link. */
+    process_handle = OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, FALSE, ppid);
+    if (process_handle == INVALID_HANDLE_VALUE) {
+        PYI_ERROR_W(L"Security validation failure: failed to obtain information about parent proces!\n");
+        return -1;
+    }
+
+    parent_executable_length = PYI_PATH_MAX;
+    if (!QueryFullProcessImageNameW(process_handle, 0, parent_executable_w, &parent_executable_length)) {
+        PYI_ERROR_W(L"Security validation failure: failed to obtain executable path for parent proces!\n");
+        CloseHandle(process_handle);
+        return -1;
+    }
+
+    CloseHandle(process_handle);
+
+    PYI_DEBUG_W(L"SECURITY: parent process executable: %ls\n", parent_executable_w);
+
+    /* Convert to UTF-8 for comparison */
+    if (!pyi_win32_wcs_to_utf8(parent_executable_w, parent_executable, PYI_PATH_MAX)) {
+        PYI_ERROR_W(L"Security validation failure: failed to convert parent process executable path to UTF-8!\n");
+        return -1;
+    }
+
+    /* Ensure that same executable is used */
+    if (strcmp(parent_executable, pyi_ctx->executable_filename) != 0) {
+        PYI_ERROR_W(L"Security validation failure: parent process has different executable!\n");
+        return -1;
+    }
+
+    return 0;
+}
+
+#elif __APPLE__
+
+static int
+_pyi_main_onefile_child_security_check_macos(struct PYI_CONTEXT *pyi_ctx)
+{
+    /* Try to look up the executable of the parent process - it should
+     * be the same as that of the current process. */
+    pid_t ppid;
+    char parent_executable[PYI_PATH_MAX];
+
+    /* Get parent PID and corresponding executable name. proc_pidpath()
+     * seems to return a fully-resolved path to the executable, even
+     * when the parent process was launched via symbolic link. */
+    ppid = getppid();
+    proc_pidpath(ppid, parent_executable, sizeof(parent_executable));
+
+    PYI_DEBUG("SECURITY: parent process executable: %s\n", parent_executable);
+
+    /* Ensure that same executable is used */
+    if (strcmp(parent_executable, pyi_ctx->executable_filename) != 0) {
+        PYI_ERROR("Security validation failure: parent process has different executable!\n");
+        return -1;
+    }
+
+    return 0;
+}
+
+#else
+
+static int
+_pyi_main_onefile_child_security_check_posix(struct PYI_CONTEXT *pyi_ctx)
+{
+    /* Try to look up the executable of the parent process - it should
+     * be the same as that of the current process. */
+    pid_t ppid;
+    ssize_t name_len = -1;
+    char proc_path[PYI_PATH_MAX];
+    char parent_executable[PYI_PATH_MAX];
+
+    struct stat executable_stat;
+    struct stat application_home_dir_stat;
+
+#if defined(__linux__) || defined(__CYGWIN__)
+    const char *proc_path_fmt = "/proc/%d/exe";
+#elif defined(__FreeBSD__)
+    const char *proc_path_fmt = "/proc/%d/file";
+#elif defined(__sun)
+    const char *proc_path_fmt = "/proc/%d/path/a.out";
+#else
+    const char *proc_path_fmt = NULL;
+#endif
+
+    if (!proc_path_fmt) {
+        return 0; /* Unsupported POSIX platform - skip the check */
+    }
+
+    /* Get parent PID */
+    ppid = getppid();
+
+    /* Try to look up the /proc entry. The entry points at "true" file
+     * location, i.e., fully canonicalized and with all symbolic links
+     * resolved. */
+    if (snprintf(proc_path, PYI_PATH_MAX, proc_path_fmt, ppid) >= PYI_PATH_MAX) {
+        PYI_ERROR("Security validation failure: could not format /proc entry path!\n");
+        return -1;
+    }
+
+    name_len = readlink(proc_path, parent_executable, PYI_PATH_MAX - 1);
+    if (name_len == -1) {
+        PYI_ERROR("Security validation failure: could not determine the executable path for parent process!\n");
+        return -1;
+    }
+
+    /* Output is not yet NULL-terminated, so we need to do it using returned byte count. */
+    parent_executable[name_len] = 0;
+
+    PYI_DEBUG("SECURITY: parent process executable: %s\n", parent_executable);
+
+    /* Ensure that same executable is used */
+    if (strcmp(parent_executable, pyi_ctx->executable_filename) != 0) {
+        PYI_ERROR("Security validation failure: parent process has different executable!\n");
+        return -1;
+    }
+
+    /* Additional checks for executables with setuid bit */
+    if (stat(pyi_ctx->executable_filename, &executable_stat) < 0) {
+        PYI_ERROR("Security validation failure: could not stat() the executable!\n");
+        return -1;
+    }
+
+    if (executable_stat.st_mode & S_ISUID) {
+        uid_t euid;
+        uid_t permissions;
+
+        PYI_DEBUG("SECURITY: setuid bit is set - verifying owner and permissions of application's home directory...\n");
+
+        if (stat(pyi_ctx->application_home_dir, &application_home_dir_stat) < 0) {
+            PYI_ERROR("Security validation failure: could not stat() the application's home directory!\n");
+            return -1;
+        }
+
+        /* Ensure that owner ID of application's temporary directory matches the effective user ID */
+        euid = geteuid();
+        if (application_home_dir_stat.st_uid != euid) {
+            PYI_ERROR(
+                "Security validation failure: owner ID of application's home directory (%d) does not match the effective user ID (%d)!\n",
+                application_home_dir_stat.st_uid, euid
+            );
+            return -1;
+        }
+
+        /* Ensure that the application's home directory has permissions used by bootloader when
+         * creating ephemeral application directory (i.e., S_IRWXU = 0700) */
+        permissions = application_home_dir_stat.st_mode & (S_IRWXU | S_IRWXG | S_IRWXO);
+        if (permissions != S_IRWXU) {
+            PYI_ERROR("Security validation failure: application's home directory has invalid permissions (0%o)!\n", permissions);
+            return -1;
+        }
+    } else {
+        PYI_DEBUG("SECURITY: setuid bit is not set.\n");
+    }
+
+    return 0;
+}
+
+#endif
+
+static int
+_pyi_main_onefile_child_security_check(struct PYI_CONTEXT *pyi_ctx)
+{
+    PYI_DEBUG("SECURITY: performing additional security validation for onefile child process...\n");
+
+    /* Use OS-specific implementation */
+#ifdef _WIN32
+    return _pyi_main_onefile_child_security_check_win32(pyi_ctx);
+#elif __APPLE__
+    return _pyi_main_onefile_child_security_check_macos(pyi_ctx);
+#else
+    return _pyi_main_onefile_child_security_check_posix(pyi_ctx);
+#endif
 }

--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -58,6 +58,7 @@
 #include "pyi_launch.h"
 #include "pyi_splash.h"
 #include "pyi_apple_events.h"
+#include "pyi_security.h"
 
 
 /* Global PYI_CONTEXT structure used for bookkeeping of state variables.
@@ -96,8 +97,6 @@ static int _pyi_main_onefile_parent(struct PYI_CONTEXT *pyi_ctx);
 
 static int _pyi_main_resolve_executable(struct PYI_CONTEXT *pyi_context);
 static int _pyi_main_resolve_pkg_archive(struct PYI_CONTEXT *pyi_context);
-
-static int _pyi_main_onefile_child_security_check(struct PYI_CONTEXT *pyi_context);
 
 
 int
@@ -480,11 +479,14 @@ pyi_main(struct PYI_CONTEXT *pyi_ctx)
 
             free(env_var_value);
 
-            /* Perform additional security validation to prevent an attacker
+            /* Perform additional security verification to prevent an attacker
              * from tricking us into using an arbitrary _PYI_APPLICATION_HOME_DIR
              * via spoofed _PYI_ARCHIVE_FILE and _PYI_PARENT_PROCESS_LEVEL.
              * See: https://github.com/pyinstaller/pyinstaller/security/advisories/GHSA-9fxf-4qw3-ghmr */
-            if (_pyi_main_onefile_child_security_check(pyi_ctx) < 0) {
+            if (pyi_security_verify_parent_proces(pyi_ctx) < 0) {
+                return -1;
+            }
+            if (pyi_security_verify_application_home_dir(pyi_ctx) < 0) {
                 return -1;
             }
         }
@@ -1540,239 +1542,4 @@ _pyi_main_resolve_pkg_archive(struct PYI_CONTEXT *pyi_ctx)
     }
 
     return 0;
-}
-
-
-/**********************************************************************\
- *        Additional security check for onefile child process         *
-\**********************************************************************/
-#ifdef _WIN32
-
-static int
-_pyi_main_onefile_child_security_check_win32(struct PYI_CONTEXT *pyi_ctx)
-{
-    DWORD pid;
-    DWORD ppid;
-
-    HANDLE process_snapshot;
-    PROCESSENTRY32W process_entry;
-    BOOL entry_found;
-
-    HANDLE process_handle;
-    wchar_t parent_executable_w[PYI_PATH_MAX];
-    char parent_executable[PYI_PATH_MAX];
-    DWORD parent_executable_length;
-
-    /* Current process ID, for look-up in the process snapshot */
-    pid = GetCurrentProcessId();
-
-    /* Take the process snapshot */
-    process_snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
-    if (process_snapshot == INVALID_HANDLE_VALUE) {
-        PYI_ERROR_W(L"Security validation failure: could not obtain process snapshot!\n");
-        return -1;
-    }
-
-    /* Walk the process snapshot to find entry for our process, and get
-     * parent process ID from it. */
-    process_entry.dwSize = sizeof(PROCESSENTRY32);
-    if (!Process32FirstW(process_snapshot, &process_entry)) {
-        PYI_ERROR_W(L"Security validation failure: could not walk the process snapshot!\n");
-        CloseHandle(process_snapshot);
-        return -1;
-    }
-
-    entry_found = FALSE;
-    do {
-        if (process_entry.th32ProcessID == pid) {
-            ppid = process_entry.th32ParentProcessID;
-            entry_found = TRUE;
-            break;
-        }
-    } while(Process32NextW(process_snapshot, &process_entry));
-
-    CloseHandle(process_snapshot);
-
-    if (!entry_found) {
-        PYI_ERROR_W(L"Security validation failure: could not determine parent process ID!\n");
-        return -1;
-    }
-
-    /* Now try to query process for its executable name.
-     * QueryFullProcessImageNameW() seems to return a fully-resolved
-     * path to the executable, even when the parent process is launched
-     * via symbolic link. */
-    process_handle = OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, FALSE, ppid);
-    if (process_handle == INVALID_HANDLE_VALUE) {
-        PYI_ERROR_W(L"Security validation failure: failed to obtain information about parent proces!\n");
-        return -1;
-    }
-
-    parent_executable_length = PYI_PATH_MAX;
-    if (!QueryFullProcessImageNameW(process_handle, 0, parent_executable_w, &parent_executable_length)) {
-        PYI_ERROR_W(L"Security validation failure: failed to obtain executable path for parent proces!\n");
-        CloseHandle(process_handle);
-        return -1;
-    }
-
-    CloseHandle(process_handle);
-
-    PYI_DEBUG_W(L"SECURITY: parent process executable: %ls\n", parent_executable_w);
-
-    /* Convert to UTF-8 for comparison */
-    if (!pyi_win32_wcs_to_utf8(parent_executable_w, parent_executable, PYI_PATH_MAX)) {
-        PYI_ERROR_W(L"Security validation failure: failed to convert parent process executable path to UTF-8!\n");
-        return -1;
-    }
-
-    /* Ensure that same executable is used */
-    if (strcmp(parent_executable, pyi_ctx->executable_filename) != 0) {
-        PYI_ERROR_W(L"Security validation failure: parent process has different executable!\n");
-        return -1;
-    }
-
-    return 0;
-}
-
-#elif __APPLE__
-
-static int
-_pyi_main_onefile_child_security_check_macos(struct PYI_CONTEXT *pyi_ctx)
-{
-    /* Try to look up the executable of the parent process - it should
-     * be the same as that of the current process. */
-    pid_t ppid;
-    char parent_executable[PYI_PATH_MAX];
-
-    /* Get parent PID and corresponding executable name. proc_pidpath()
-     * seems to return a fully-resolved path to the executable, even
-     * when the parent process was launched via symbolic link. */
-    ppid = getppid();
-    proc_pidpath(ppid, parent_executable, sizeof(parent_executable));
-
-    PYI_DEBUG("SECURITY: parent process executable: %s\n", parent_executable);
-
-    /* Ensure that same executable is used */
-    if (strcmp(parent_executable, pyi_ctx->executable_filename) != 0) {
-        PYI_ERROR("Security validation failure: parent process has different executable!\n");
-        return -1;
-    }
-
-    return 0;
-}
-
-#else
-
-static int
-_pyi_main_onefile_child_security_check_posix(struct PYI_CONTEXT *pyi_ctx)
-{
-    /* Try to look up the executable of the parent process - it should
-     * be the same as that of the current process. */
-    pid_t ppid;
-    ssize_t name_len = -1;
-    char proc_path[PYI_PATH_MAX];
-    char parent_executable[PYI_PATH_MAX];
-
-    struct stat application_home_dir_stat;
-
-#if defined(__linux__) || defined(__CYGWIN__)
-    const char *proc_path_fmt = "/proc/%d/exe";
-#elif defined(__FreeBSD__)
-    const char *proc_path_fmt = "/proc/%d/file";
-#elif defined(__sun)
-    const char *proc_path_fmt = "/proc/%d/path/a.out";
-#else
-    const char *proc_path_fmt = NULL;
-#endif
-
-    /* Handle unsupported POSIX platforms, where we have no way to look up
-     * the parent executable. Disallow setuid-enabled executables, otherwise
-     * skip the check. */
-    if (!proc_path_fmt) {
-        if (pyi_ctx->has_setuid) {
-            PYI_ERROR("Security validation failure: setuid-enabled executables are not supported on this platform!\n");
-            return -1;
-        } else {
-            PYI_DEBUG("SECURITY: unsupported platform - skipping check for non-setuid executable!\n");
-            return 0;
-        }
-    }
-
-    /* Get parent PID */
-    ppid = getppid();
-
-    /* Try to look up the /proc entry. The entry points at "true" file
-     * location, i.e., fully canonicalized and with all symbolic links
-     * resolved. */
-    if (snprintf(proc_path, PYI_PATH_MAX, proc_path_fmt, ppid) >= PYI_PATH_MAX) {
-        PYI_ERROR("Security validation failure: could not format /proc entry path!\n");
-        return -1;
-    }
-
-    name_len = readlink(proc_path, parent_executable, PYI_PATH_MAX - 1);
-    if (name_len == -1) {
-        PYI_ERROR("Security validation failure: could not determine the executable path for parent process!\n");
-        return -1;
-    }
-
-    /* Output is not yet NULL-terminated, so we need to do it using returned byte count. */
-    parent_executable[name_len] = 0;
-
-    PYI_DEBUG("SECURITY: parent process executable: %s\n", parent_executable);
-
-    /* Ensure that same executable is used */
-    if (strcmp(parent_executable, pyi_ctx->executable_filename) != 0) {
-        PYI_ERROR("Security validation failure: parent process has different executable!\n");
-        return -1;
-    }
-
-    /* Additional checks for executables with setuid bit */
-    if (pyi_ctx->has_setuid) {
-        uid_t euid;
-        uid_t permissions;
-
-        PYI_DEBUG("SECURITY: setuid bit is set - verifying owner and permissions of application's home directory...\n");
-
-        if (stat(pyi_ctx->application_home_dir, &application_home_dir_stat) < 0) {
-            PYI_ERROR("Security validation failure: could not stat() the application's home directory!\n");
-            return -1;
-        }
-
-        /* Ensure that owner ID of application's temporary directory matches the effective user ID */
-        euid = geteuid();
-        if (application_home_dir_stat.st_uid != euid) {
-            PYI_ERROR(
-                "Security validation failure: owner ID of application's home directory (%d) does not match the effective user ID (%d)!\n",
-                application_home_dir_stat.st_uid, euid
-            );
-            return -1;
-        }
-
-        /* Ensure that the application's home directory has permissions used by bootloader when
-         * creating ephemeral application directory (i.e., S_IRWXU = 0700) */
-        permissions = application_home_dir_stat.st_mode & (S_IRWXU | S_IRWXG | S_IRWXO);
-        if (permissions != S_IRWXU) {
-            PYI_ERROR("Security validation failure: application's home directory has invalid permissions (0%o)!\n", permissions);
-            return -1;
-        }
-    }
-
-    return 0;
-}
-
-#endif
-
-static int
-_pyi_main_onefile_child_security_check(struct PYI_CONTEXT *pyi_ctx)
-{
-    PYI_DEBUG("SECURITY: performing additional security validation for onefile child process...\n");
-
-    /* Use OS-specific implementation */
-#ifdef _WIN32
-    return _pyi_main_onefile_child_security_check_win32(pyi_ctx);
-#elif __APPLE__
-    return _pyi_main_onefile_child_security_check_macos(pyi_ctx);
-#else
-    return _pyi_main_onefile_child_security_check_posix(pyi_ctx);
-#endif
 }

--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -313,6 +313,14 @@ pyi_main(struct PYI_CONTEXT *pyi_ctx)
              * splash-screen-enabled onefile application after restart.
              * Applicable only to POSIX systems other than macOS and Cygwin. */
             if (pyi_ctx->is_onefile) {
+                /* Check that build has splash screen enabled; otherwise,
+                 * we might be dealing with a spoofed environment that is
+                 * trying to trick us into executing this particular
+                 * codepath... */
+                if (!pyi_ctx->has_splash) {
+                    PYI_ERROR("Security validation failure: unexpected process level!\n");
+                    return -1;
+                }
                 pyi_ctx->process_level = PYI_PROCESS_LEVEL_PARENT;
             } else {
                 pyi_ctx->process_level = PYI_PROCESS_LEVEL_MAIN;

--- a/bootloader/src/pyi_main.h
+++ b/bootloader/src/pyi_main.h
@@ -148,6 +148,12 @@ struct PYI_CONTEXT
      * environment variable. */
     unsigned char suppress_splash;
 
+    /* Flag indicating whether the executable has `setuid` bit set or
+     * not. Applicable only to POSIX platforms, where it is used to
+     * toggle additional security checks. On other platforms, the value
+     * is left at 0. */
+    unsigned char has_setuid;
+
     /* Splash screen context structure. */
     struct SPLASH_CONTEXT *splash;
 

--- a/bootloader/src/pyi_security.c
+++ b/bootloader/src/pyi_security.c
@@ -324,13 +324,16 @@ pyi_security_verify_application_home_dir_permissions(const struct PYI_CONTEXT *p
 
 
 int
-pyi_security_verify_application_home_dir(const struct PYI_CONTEXT *pyi_ctx)
+pyi_security_verify_application_home_dir(const struct PYI_CONTEXT *pyi_ctx, unsigned int prefix_pid)
 {
     /* In onefile mode, the application home directory name should have
      * distrinct, PyInstaller-specific format: _MEIXXXXXX */
     if (pyi_ctx->is_onefile) {
         char basename[PYI_PATH_MAX];
         size_t name_len;
+
+        char expected_prefix[32];
+        int expected_prefix_len;
 
         if (!pyi_path_basename(basename, pyi_ctx->application_home_dir)) {
             PYI_ERROR("Security validation failure: failed to obtain name of application's home directory!\n");
@@ -340,27 +343,40 @@ pyi_security_verify_application_home_dir(const struct PYI_CONTEXT *pyi_ctx)
         PYI_DEBUG("SECURITY: verifying the name of application's home directory (%s)...\n", basename);
 
         /* Verify the length of the name:
-         *  - Windows: _MEI + process ID number (in decimal format) + suffix
-         *    added by _wtempnam(); so we check that the name is longer than
-         *    four characters...
-         *  - other platforms: _MEI + six random characters added by mkdtemp();
-         *    so we check that the name is exactly ten characters long... */
+         *  - Windows: _MEI + process ID number (%08x format) + suffix
+         *    added by _wtempnam(); so we check that the name is at least
+         *    12 characters long...
+         *  - other platforms: _MEI + process ID number (%08x format) +
+         *    six random characters added by mkdtemp(); so we check that
+         *    the name is exactly 18 characters long... */
         name_len = strlen(basename);
 
 #ifdef _WIN32
-        if (name_len < 4) {
+        if (name_len < 12) {
             PYI_ERROR("Security validation failure: unexpected name of application's home directory!\n");
             return -1;
         }
 #else
-        if (name_len != 10) {
+        if (name_len != 18) {
             PYI_ERROR("Security validation failure: unexpected name of application's home directory!\n");
             return -1;
         }
 #endif
 
         /* Verify the prefix */
-        if (strncmp("_MEI", basename, 4) != 0) {
+        if (prefix_pid > 0) {
+            expected_prefix_len = snprintf(expected_prefix, 32, "_MEI%08x", prefix_pid);
+        } else {
+            expected_prefix_len = snprintf(expected_prefix, 32, "_MEI");
+        }
+        if (expected_prefix_len < 0 || expected_prefix_len >= 32) {
+            PYI_ERROR("Security validation failure: failed to format expected name prefix!\n");
+            return -1;
+        }
+
+        PYI_DEBUG("SECURITY: expected prefix: %s\n", expected_prefix);
+
+        if (strncmp(basename, expected_prefix, expected_prefix_len) != 0) {
             PYI_ERROR("Security validation failure: unexpected name of application's home directory!\n");
             return -1;
         }

--- a/bootloader/src/pyi_security.c
+++ b/bootloader/src/pyi_security.c
@@ -209,16 +209,18 @@ _pyi_security_verify_parent_proces_posix(const struct PYI_CONTEXT *pyi_ctx)
     }
 
     if (realpath(proc_path, parent_executable) == NULL) {
-        /* On FreeBSD, the /proc filesystem is not available by default (i.e., needs
-         * to be explicitly mounted). So allow this to fail for non-setuid executables. */
-#if defined(__FreeBSD__)
-        if (!pyi_ctx->has_setuid) {
-            PYI_DEBUG("SECURITY: could not access %s - assuming missing procfs (allowed for non-setuid executable on FreeBSD)!\n");
+        /* The access to /proc entry might be blocked due to security policy,
+         * or by proc filesystem not being mounted (as is the case on FreeBSD
+         * by default). Allow this to be the case for a non-setuid executable
+         * (and skip the parent-process verification), but fail in the case of
+         * a setuid executable. */
+        if (pyi_ctx->has_setuid) {
+            PYI_ERROR("Security validation failure: could not determine the executable path for parent process!\n");
+            return -1;
+        } else {
+            PYI_DEBUG("SECURITY: could not access %s - skipping check for non-setuid executable!\n", proc_path);
             return 0;
         }
-#endif
-        PYI_ERROR("Security validation failure: could not determine the executable path for parent process!\n");
-        return -1;
     }
 
     /* Exclude the .exe suffix from the resolved executable path, in order to

--- a/bootloader/src/pyi_security.c
+++ b/bootloader/src/pyi_security.c
@@ -1,0 +1,327 @@
+/*
+ * ****************************************************************************
+ * Copyright (c) 2026, PyInstaller Development Team.
+ *
+ * Distributed under the terms of the GNU General Public License (version 2
+ * or later) with exception for distributing the bootloader.
+ *
+ * The full license is in the file COPYING.txt, distributed with this software.
+ *
+ * SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+ * ****************************************************************************
+ */
+
+/*
+ * Additional security verification of inherited run-time environment.
+ */
+
+#ifdef _WIN32
+    #include <windows.h>
+    #include <tlhelp32.h> /* CreateToolhelp32Snapshot(), Process32FirstW(), Process32NextW() */
+#else
+    #include <sys/stat.h> /* struct stat */
+    #include <unistd.h> /* readlink() */
+#endif
+
+#include <stdio.h>  /* snprintf() */
+#include <string.h>  /* strcmp() */
+
+#if defined(__APPLE__)
+    #include <libproc.h> /* proc_pidpath() */
+#endif
+
+#include "pyi_global.h"
+#include "pyi_main.h"
+#include "pyi_utils.h"
+
+
+/**********************************************************************\
+ *                   Verification of parent process                   *
+\**********************************************************************/
+/* Verify that parent process uses same executable as current process.
+ * This aims to ensure that the run-time environment was indeed inherited
+ * from a parent process of a onefile application, rather than being
+ * spoofed by malicious user. */
+
+#if defined(_WIN32)
+
+static int
+_pyi_security_verify_parent_proces_win32(const struct PYI_CONTEXT *pyi_ctx)
+{
+    DWORD pid;
+    DWORD ppid;
+
+    HANDLE process_snapshot;
+    PROCESSENTRY32W process_entry;
+    BOOL entry_found;
+
+    HANDLE process_handle;
+    wchar_t parent_executable_w[PYI_PATH_MAX];
+    char parent_executable[PYI_PATH_MAX];
+    DWORD parent_executable_length;
+
+    /* Current process ID, for look-up in the process snapshot */
+    pid = GetCurrentProcessId();
+
+    /* Take the process snapshot */
+    process_snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+    if (process_snapshot == INVALID_HANDLE_VALUE) {
+        PYI_ERROR_W(L"Security validation failure: could not obtain process snapshot!\n");
+        return -1;
+    }
+
+    /* Walk the process snapshot to find entry for our process, and get
+     * parent process ID from it. */
+    process_entry.dwSize = sizeof(PROCESSENTRY32);
+    if (!Process32FirstW(process_snapshot, &process_entry)) {
+        PYI_ERROR_W(L"Security validation failure: could not walk the process snapshot!\n");
+        CloseHandle(process_snapshot);
+        return -1;
+    }
+
+    entry_found = FALSE;
+    do {
+        if (process_entry.th32ProcessID == pid) {
+            ppid = process_entry.th32ParentProcessID;
+            entry_found = TRUE;
+            break;
+        }
+    } while(Process32NextW(process_snapshot, &process_entry));
+
+    CloseHandle(process_snapshot);
+
+    if (!entry_found) {
+        PYI_ERROR_W(L"Security validation failure: could not determine parent process ID!\n");
+        return -1;
+    }
+
+    /* Now try to query process for its executable name.
+     * QueryFullProcessImageNameW() seems to return a fully-resolved
+     * path to the executable, even when the parent process is launched
+     * via symbolic link. */
+    process_handle = OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, FALSE, ppid);
+    if (process_handle == INVALID_HANDLE_VALUE) {
+        PYI_ERROR_W(L"Security validation failure: failed to obtain information about parent proces!\n");
+        return -1;
+    }
+
+    parent_executable_length = PYI_PATH_MAX;
+    if (!QueryFullProcessImageNameW(process_handle, 0, parent_executable_w, &parent_executable_length)) {
+        PYI_ERROR_W(L"Security validation failure: failed to obtain executable path for parent proces!\n");
+        CloseHandle(process_handle);
+        return -1;
+    }
+
+    CloseHandle(process_handle);
+
+    PYI_DEBUG_W(L"SECURITY: parent process executable: %ls\n", parent_executable_w);
+
+    /* Convert to UTF-8 for comparison */
+    if (!pyi_win32_wcs_to_utf8(parent_executable_w, parent_executable, PYI_PATH_MAX)) {
+        PYI_ERROR_W(L"Security validation failure: failed to convert parent process executable path to UTF-8!\n");
+        return -1;
+    }
+
+    /* Ensure that same executable is used */
+    if (strcmp(parent_executable, pyi_ctx->executable_filename) != 0) {
+        PYI_ERROR_W(L"Security validation failure: parent process has different executable!\n");
+        return -1;
+    }
+
+    return 0;
+}
+
+#elif defined(__APPLE__)
+
+static int
+_pyi_security_verify_parent_proces_macos(const struct PYI_CONTEXT *pyi_ctx)
+{
+    /* Try to look up the executable of the parent process - it should
+     * be the same as that of the current process. */
+    pid_t ppid;
+    char parent_executable[PYI_PATH_MAX];
+
+    /* Get parent PID and corresponding executable name. proc_pidpath()
+     * seems to return a fully-resolved path to the executable, even
+     * when the parent process was launched via symbolic link. */
+    ppid = getppid();
+    proc_pidpath(ppid, parent_executable, sizeof(parent_executable));
+
+    PYI_DEBUG("SECURITY: parent process executable: %s\n", parent_executable);
+
+    /* Ensure that same executable is used */
+    if (strcmp(parent_executable, pyi_ctx->executable_filename) != 0) {
+        PYI_ERROR("Security validation failure: parent process has different executable!\n");
+        return -1;
+    }
+
+    return 0;
+}
+
+#else
+
+static int
+_pyi_security_verify_parent_proces_posix(const struct PYI_CONTEXT *pyi_ctx)
+{
+    /* Try to look up the executable of the parent process - it should
+     * be the same as that of the current process. */
+    pid_t ppid;
+    ssize_t name_len = -1;
+    char proc_path[PYI_PATH_MAX];
+    char parent_executable[PYI_PATH_MAX];
+
+#if defined(__linux__) || defined(__CYGWIN__)
+    const char *proc_path_fmt = "/proc/%d/exe";
+#elif defined(__FreeBSD__)
+    const char *proc_path_fmt = "/proc/%d/file";
+#elif defined(__sun)
+    const char *proc_path_fmt = "/proc/%d/path/a.out";
+#else
+    const char *proc_path_fmt = NULL;
+#endif
+
+    /* Handle unsupported POSIX platforms, where we have no way to look up
+     * the parent executable. Disallow setuid-enabled executables, otherwise
+     * skip the check. */
+    if (!proc_path_fmt) {
+        if (pyi_ctx->has_setuid) {
+            PYI_ERROR("Security validation failure: setuid-enabled executables are not supported on this platform!\n");
+            return -1;
+        } else {
+            PYI_DEBUG("SECURITY: unsupported platform - skipping check for non-setuid executable!\n");
+            return 0;
+        }
+    }
+
+    /* Get parent PID */
+    ppid = getppid();
+
+    /* Try to look up the /proc entry. The entry points at "true" file
+     * location, i.e., fully canonicalized and with all symbolic links
+     * resolved. */
+    if (snprintf(proc_path, PYI_PATH_MAX, proc_path_fmt, ppid) >= PYI_PATH_MAX) {
+        PYI_ERROR("Security validation failure: could not format /proc entry path!\n");
+        return -1;
+    }
+
+    name_len = readlink(proc_path, parent_executable, PYI_PATH_MAX - 1);
+    if (name_len == -1) {
+        PYI_ERROR("Security validation failure: could not determine the executable path for parent process!\n");
+        return -1;
+    }
+
+    /* Output is not yet NULL-terminated, so we need to do it using returned byte count. */
+    parent_executable[name_len] = 0;
+
+    PYI_DEBUG("SECURITY: parent process executable: %s\n", parent_executable);
+
+    /* Ensure that same executable is used */
+    if (strcmp(parent_executable, pyi_ctx->executable_filename) != 0) {
+        PYI_ERROR("Security validation failure: parent process has different executable!\n");
+        return -1;
+    }
+
+    return 0;
+}
+
+#endif
+
+
+int
+pyi_security_verify_parent_proces(const struct PYI_CONTEXT *pyi_ctx)
+{
+    PYI_DEBUG("SECURITY: verifying parent process...\n");
+
+    /* Use OS-specific implementation */
+#if defined(_WIN32)
+    return _pyi_security_verify_parent_proces_win32(pyi_ctx);
+#elif defined(__APPLE__)
+    return _pyi_security_verify_parent_proces_macos(pyi_ctx);
+#else
+    return _pyi_security_verify_parent_proces_posix(pyi_ctx);
+#endif
+}
+
+
+/**********************************************************************\
+ *            Verification of application's home directory            *
+\**********************************************************************/
+/* Verify that application's top-level / home directory has correct owner
+ * and permissions. Currently implemented only on POSIX platforms, where,
+ * if the executable has setuid bit set, we require:
+ *  - the owner ID of the top-level application directory to match the
+ *    effective user ID
+ *  - permissions on the top-level application directory to be set to
+ *    0700
+ *
+ * This should be ensure that the onefile child processes are inheriting
+ * temporary application directory that was set up by the onefile parent
+ * process (instead of being passed an arbitrary directory as top-level
+ * application directory via spoofed environment variables). Similarly,
+ * it should ensure that setuid-enabled onedir executable has an
+ * accompanying contents directory that cannot be modified by a
+ * non-privileged user. */
+#if defined(_WIN32) || defined(__APPLE__)
+
+int
+pyi_security_verify_application_home_dir(const struct PYI_CONTEXT *pyi_ctx)
+{
+    (void)pyi_ctx;
+    return 0;
+}
+
+#else
+
+int
+pyi_security_verify_application_home_dir(const struct PYI_CONTEXT *pyi_ctx)
+{
+    uid_t euid;
+    uid_t permissions;
+    struct stat application_home_dir_stat;
+
+    /* Applicable only to executables with setuid bit set. */
+    if (!pyi_ctx->has_setuid) {
+        PYI_DEBUG("SECURITY: setuid bit is not set - skipping verification of application's home directory.\n");
+        return 0;
+    }
+
+    PYI_DEBUG("SECURITY: setuid bit is set - verifying application's home directory...\n");
+
+    if (stat(pyi_ctx->application_home_dir, &application_home_dir_stat) < 0) {
+        PYI_ERROR("Security validation failure: could not stat() the application's home directory!\n");
+        return -1;
+    }
+
+    /* Ensure that owner ID of application's temporary directory matches
+     * the effective user ID. By comparing effective user ID instead of
+     * executable's owner ID, we attempt to accommodate scenario where a
+     * setuid-enabled application drops its privileges and attempts to
+     * spawn a worker subprocess. Note that this requires that the
+     * application transfers the ownership of its temporary directory
+     * prior to privilege drop; but this is the case anyway, otherwise
+     * it would end up locking both itself and its worker subprocesses
+     * out of the temporary directory... */
+    euid = geteuid();
+    if (application_home_dir_stat.st_uid != euid) {
+        PYI_ERROR(
+            "Security validation failure: owner ID of application's home directory (%d) does not match the effective user ID (%d)!\n",
+            application_home_dir_stat.st_uid, euid
+        );
+        return -1;
+    }
+
+    /* Ensure that the application's home directory has permissions used
+     * by bootloader when creating ephemeral application directory
+     * (i.e., S_IRWXU = 0700). In case of onedir application, it ensures
+     * that the contents directory cannot be modified by unprivileged
+     * user. */
+    permissions = application_home_dir_stat.st_mode & (S_IRWXU | S_IRWXG | S_IRWXO);
+    if (permissions != S_IRWXU) {
+        PYI_ERROR("Security validation failure: application's home directory has invalid permissions (0%o)!\n", permissions);
+        return -1;
+    }
+
+    return 0;
+}
+
+#endif

--- a/bootloader/src/pyi_security.c
+++ b/bootloader/src/pyi_security.c
@@ -20,11 +20,12 @@
     #include <tlhelp32.h> /* CreateToolhelp32Snapshot(), Process32FirstW(), Process32NextW() */
 #else
     #include <sys/stat.h> /* struct stat */
-    #include <unistd.h> /* readlink() */
+    #include <unistd.h> /* getppid(), geteuid() */
 #endif
 
 #include <stdio.h>  /* snprintf() */
 #include <string.h>  /* strcmp() */
+#include <stdlib.h>  /* realpath() */
 
 #if defined(__APPLE__)
     #include <libproc.h> /* proc_pidpath() */
@@ -167,11 +168,10 @@ _pyi_security_verify_parent_proces_posix(const struct PYI_CONTEXT *pyi_ctx)
     /* Try to look up the executable of the parent process - it should
      * be the same as that of the current process. */
     pid_t ppid;
-    ssize_t name_len = -1;
     char proc_path[PYI_PATH_MAX];
     char parent_executable[PYI_PATH_MAX];
 
-#if defined(__linux__) || defined(__CYGWIN__)
+#if defined(__linux__) || defined(__CYGWIN__) || defined(__NetBSD__)
     const char *proc_path_fmt = "/proc/%d/exe";
 #elif defined(__FreeBSD__)
     const char *proc_path_fmt = "/proc/%d/file";
@@ -197,22 +197,36 @@ _pyi_security_verify_parent_proces_posix(const struct PYI_CONTEXT *pyi_ctx)
     /* Get parent PID */
     ppid = getppid();
 
-    /* Try to look up the /proc entry. The entry points at "true" file
-     * location, i.e., fully canonicalized and with all symbolic links
-     * resolved. */
+    /* Try to look up the /proc entry. On some platforms, the entry points
+     * at "true" file location, i.e., canonical and with all symbolic links
+     * resolved; on others (e.g., NetBSD), the entry is neither canonical
+     * nor fully resolved. So to be safe, always pass the symlink to realpath()
+     * for full resolution. This matches the behavior of _pyi_resolve_executable_posix()
+     * in pyi_main.c */
     if (snprintf(proc_path, PYI_PATH_MAX, proc_path_fmt, ppid) >= PYI_PATH_MAX) {
         PYI_ERROR("Security validation failure: could not format /proc entry path!\n");
         return -1;
     }
 
-    name_len = readlink(proc_path, parent_executable, PYI_PATH_MAX - 1);
-    if (name_len == -1) {
+    if (realpath(proc_path, parent_executable) == NULL) {
         PYI_ERROR("Security validation failure: could not determine the executable path for parent process!\n");
         return -1;
     }
 
-    /* Output is not yet NULL-terminated, so we need to do it using returned byte count. */
-    parent_executable[name_len] = 0;
+    /* Exclude the .exe suffix from the resolved executable path, in order to
+     * match the behavior of _pyi_resolve_executable_cygwin() in pyi_main.c */
+#if defined(__CYGWIN__)
+    if (1) {
+        size_t len = strlen(parent_executable);
+        if (len >= 5) {
+            char *suffix_ptr = parent_executable + len - 4;
+            if (strcasecmp(suffix_ptr, ".exe") == 0) {
+                PYI_DEBUG("SECURITY: removing .exe suffix from parent executable name\n");
+                *suffix_ptr = 0;
+            }
+        }
+    }
+#endif
 
     PYI_DEBUG("SECURITY: parent process executable: %s\n", parent_executable);
 

--- a/bootloader/src/pyi_security.c
+++ b/bootloader/src/pyi_security.c
@@ -32,6 +32,7 @@
 
 #include "pyi_global.h"
 #include "pyi_main.h"
+#include "pyi_path.h"
 #include "pyi_utils.h"
 
 
@@ -246,9 +247,13 @@ pyi_security_verify_parent_proces(const struct PYI_CONTEXT *pyi_ctx)
 /**********************************************************************\
  *            Verification of application's home directory            *
 \**********************************************************************/
-/* Verify that application's top-level / home directory has correct owner
- * and permissions. Currently implemented only on POSIX platforms, where,
- * if the executable has setuid bit set, we require:
+/* Verify the application's top-level / home directory.
+ *
+ * In onefile mode, check that the directory's name matches the format
+ * used by PyInstaller's bootloader.
+ *
+ * On POSIX platforms, perform additional check for executables with
+ * setuid bit set; in that case, we require:
  *  - the owner ID of the top-level application directory to match the
  *    effective user ID
  *  - permissions on the top-level application directory to be set to
@@ -261,19 +266,10 @@ pyi_security_verify_parent_proces(const struct PYI_CONTEXT *pyi_ctx)
  * it should ensure that setuid-enabled onedir executable has an
  * accompanying contents directory that cannot be modified by a
  * non-privileged user. */
-#if defined(_WIN32) || defined(__APPLE__)
+#if !defined(_WIN32) && !defined(__APPLE__)
 
-int
-pyi_security_verify_application_home_dir(const struct PYI_CONTEXT *pyi_ctx)
-{
-    (void)pyi_ctx;
-    return 0;
-}
-
-#else
-
-int
-pyi_security_verify_application_home_dir(const struct PYI_CONTEXT *pyi_ctx)
+static int
+pyi_security_verify_application_home_dir_permissions(const struct PYI_CONTEXT *pyi_ctx)
 {
     uid_t euid;
     uid_t permissions;
@@ -281,11 +277,11 @@ pyi_security_verify_application_home_dir(const struct PYI_CONTEXT *pyi_ctx)
 
     /* Applicable only to executables with setuid bit set. */
     if (!pyi_ctx->has_setuid) {
-        PYI_DEBUG("SECURITY: setuid bit is not set - skipping verification of application's home directory.\n");
+        PYI_DEBUG("SECURITY: setuid bit is not set - skipping verification of owner/permissions of application's home directory.\n");
         return 0;
     }
 
-    PYI_DEBUG("SECURITY: setuid bit is set - verifying application's home directory...\n");
+    PYI_DEBUG("SECURITY: setuid bit is set - verifying owner/permissions of application's home directory...\n");
 
     if (stat(pyi_ctx->application_home_dir, &application_home_dir_stat) < 0) {
         PYI_ERROR("Security validation failure: could not stat() the application's home directory!\n");
@@ -325,3 +321,58 @@ pyi_security_verify_application_home_dir(const struct PYI_CONTEXT *pyi_ctx)
 }
 
 #endif
+
+
+int
+pyi_security_verify_application_home_dir(const struct PYI_CONTEXT *pyi_ctx)
+{
+    /* In onefile mode, the application home directory name should have
+     * distrinct, PyInstaller-specific format: _MEIXXXXXX */
+    if (pyi_ctx->is_onefile) {
+        char basename[PYI_PATH_MAX];
+        size_t name_len;
+
+        if (!pyi_path_basename(basename, pyi_ctx->application_home_dir)) {
+            PYI_ERROR("Security validation failure: failed to obtain name of application's home directory!\n");
+            return -1;
+        }
+
+        PYI_DEBUG("SECURITY: verifying the name of application's home directory (%s)...\n", basename);
+
+        /* Verify the length of the name:
+         *  - Windows: _MEI + process ID number (in decimal format) + suffix
+         *    added by _wtempnam(); so we check that the name is longer than
+         *    four characters...
+         *  - other platforms: _MEI + six random characters added by mkdtemp();
+         *    so we check that the name is exactly ten characters long... */
+        name_len = strlen(basename);
+
+#ifdef _WIN32
+        if (name_len < 4) {
+            PYI_ERROR("Security validation failure: unexpected name of application's home directory!\n");
+            return -1;
+        }
+#else
+        if (name_len != 10) {
+            PYI_ERROR("Security validation failure: unexpected name of application's home directory!\n");
+            return -1;
+        }
+#endif
+
+        /* Verify the prefix */
+        if (strncmp("_MEI", basename, 4) != 0) {
+            PYI_ERROR("Security validation failure: unexpected name of application's home directory!\n");
+            return -1;
+        }
+    }
+
+    /* POSIX: additional owner/permissions validation when setuid bit is
+     * set on the executable */
+#if !defined(_WIN32) && !defined(__APPLE__)
+    if (pyi_security_verify_application_home_dir_permissions(pyi_ctx) < 0) {
+        return -1;
+    }
+#endif
+
+    return 0;
+}

--- a/bootloader/src/pyi_security.c
+++ b/bootloader/src/pyi_security.c
@@ -209,6 +209,14 @@ _pyi_security_verify_parent_proces_posix(const struct PYI_CONTEXT *pyi_ctx)
     }
 
     if (realpath(proc_path, parent_executable) == NULL) {
+        /* On FreeBSD, the /proc filesystem is not available by default (i.e., needs
+         * to be explicitly mounted). So allow this to fail for non-setuid executables. */
+#if defined(__FreeBSD__)
+        if (!pyi_ctx->has_setuid) {
+            PYI_DEBUG("SECURITY: could not access %s - assuming missing procfs (allowed for non-setuid executable on FreeBSD)!\n");
+            return 0;
+        }
+#endif
         PYI_ERROR("Security validation failure: could not determine the executable path for parent process!\n");
         return -1;
     }

--- a/bootloader/src/pyi_security.h
+++ b/bootloader/src/pyi_security.h
@@ -1,0 +1,27 @@
+/*
+ * ****************************************************************************
+ * Copyright (c) 2026, PyInstaller Development Team.
+ *
+ * Distributed under the terms of the GNU General Public License (version 2
+ * or later) with exception for distributing the bootloader.
+ *
+ * The full license is in the file COPYING.txt, distributed with this software.
+ *
+ * SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+ * ****************************************************************************
+ */
+
+/*
+ * Additional security verification of inherited run-time environment.
+ */
+
+
+#ifndef PYI_SECURITY_H
+#define PYI_SECURITY_H
+
+struct PYI_CONTEXT;
+
+int pyi_security_verify_parent_proces(const struct PYI_CONTEXT *pyi_ctx);
+int pyi_security_verify_application_home_dir(const struct PYI_CONTEXT *pyi_ctx);
+
+#endif /* PYI_SECURITY_H */

--- a/bootloader/src/pyi_security.h
+++ b/bootloader/src/pyi_security.h
@@ -22,6 +22,6 @@
 struct PYI_CONTEXT;
 
 int pyi_security_verify_parent_proces(const struct PYI_CONTEXT *pyi_ctx);
-int pyi_security_verify_application_home_dir(const struct PYI_CONTEXT *pyi_ctx);
+int pyi_security_verify_application_home_dir(const struct PYI_CONTEXT *pyi_ctx, unsigned int prefix_pid);
 
 #endif /* PYI_SECURITY_H */

--- a/bootloader/src/pyi_utils_posix.c
+++ b/bootloader/src/pyi_utils_posix.c
@@ -184,6 +184,8 @@ _pyi_format_and_create_tmpdir(char *tmpdir_path)
 {
     size_t path_len;
     unsigned char needs_separator;
+    char prefix[32];
+    int prefix_len;
 
     /* Compute length of the given temporary directory path - to ensure
      * that strcat operations below do not exceed buffer length. */
@@ -193,16 +195,18 @@ _pyi_format_and_create_tmpdir(char *tmpdir_path)
      * it should not, but on macOS, the value from $TMPDIR does. */
     needs_separator = tmpdir_path[path_len - 1] != PYI_SEP;
 
-    /* Add separator , _MEI, and six X characters required by mkdtemp */
-    path_len += needs_separator + 4 + 6;
-    if (path_len >= PYI_PATH_MAX) {
+    /* Add separator, "_MEI", PID in %08x format, and six X characters
+     * required by mkdtemp() */
+    prefix_len = snprintf(prefix, 32, "%s" "_MEI" "%08x" "XXXXXX", needs_separator ? PYI_SEPSTR : "", getpid());
+    if (prefix_len < 0 || prefix_len >= 32) {
         return -1;
     }
 
-    if (needs_separator) {
-        strcat(tmpdir_path, PYI_SEPSTR);
+    if (path_len + prefix_len + 1 >= PYI_PATH_MAX) {
+        return -1;
     }
-    strcat(tmpdir_path, "_MEIXXXXXX");
+
+    strcat(tmpdir_path, prefix);
 
     /* Try creating the directory */
     if (mkdtemp(tmpdir_path) == NULL) {

--- a/bootloader/src/pyi_utils_win32.c
+++ b/bootloader/src/pyi_utils_win32.c
@@ -271,7 +271,7 @@ pyi_create_temporary_application_directory(struct PYI_CONTEXT *pyi_ctx)
     PYI_DEBUG_W(L"LOADER: attempting to create temporary application directory under %ls\n", tempdir_path);
 
     /* Create _MEI + PID prefix */
-    swprintf(prefix, 16, L"_MEI%d", _getpid());
+    swprintf(prefix, 16, L"_MEI%08x", _getpid());
 
     /* Windows does not have a race-free function to create a temporary
      * directory. Thus, we rely on _tempnam, and simply try several times

--- a/doc/advanced-topics.rst
+++ b/doc/advanced-topics.rst
@@ -399,12 +399,18 @@ executables is still supported, but due to lack of validation, it may be
 subject to environment manipulation.
 
 On POSIX platforms where look-up via ``procfs`` is nominally supported
-(i.e., Linux, Cygwin, FreeBSD, NetBSD, and SunOS), it is strictly enforced.
+(i.e., Linux, Cygwin, NetBSD, and SunOS), it is strictly enforced.
 If the corresponding entry under ``/proc/<ppid>`` cannot be accessed for
 whatever reason (e.g., additional security constraints), the validation
 will fail and prevent the ``onefile`` application from running. This
 currently applies regardless of whether the executable has ``setuid``
 bit set or not.
+
+On FreeBSD systems, the ``procfs`` fileystem is not mounted by default;
+therefore, the parent-process validation is skipped if ``/proc`` entry
+is inaccessible, but only if ``setuid`` bit is not set on the executable.
+If ``setuid`` bit is set, the executable will fail to run unless parent
+process can be validated (i.e., ``procfs`` filesystem is mounted).
 
 
 .. _bootloader security validation onedir:

--- a/doc/advanced-topics.rst
+++ b/doc/advanced-topics.rst
@@ -399,18 +399,21 @@ executables is still supported, but due to lack of validation, it may be
 subject to environment manipulation.
 
 On POSIX platforms where look-up via ``procfs`` is nominally supported
-(i.e., Linux, Cygwin, NetBSD, and SunOS), it is strictly enforced.
-If the corresponding entry under ``/proc/<ppid>`` cannot be accessed for
-whatever reason (e.g., additional security constraints), the validation
-will fail and prevent the ``onefile`` application from running. This
-currently applies regardless of whether the executable has ``setuid``
-bit set or not.
+(i.e., Linux, Cygwin, FreeBSD, NetBSD, and SunOS), the behavior depends
+on whether the executable has ``setuid`` bit set and whether the
+corresponding entry under ``/proc/<ppid>`` is accessible or not.
 
-On FreeBSD systems, the ``procfs`` fileystem is not mounted by default;
-therefore, the parent-process validation is skipped if ``/proc`` entry
-is inaccessible, but only if ``setuid`` bit is not set on the executable.
-If ``setuid`` bit is set, the executable will fail to run unless parent
-process can be validated (i.e., ``procfs`` filesystem is mounted).
+For executables with ``setuid`` bit set, the parent-process validation
+is mandatory. If the corresponding entry under ``/proc/<ppid>`` is
+inaccessible for whatever reason (for example, due to ``procfs`` not
+being mounted, as is the case on FreeBSD by default, or due to access
+being blocked by local security policy), security validation will
+automatically fail and the process will exit with security validation
+error message.
+
+For regular executables (without ``setuid`` bit set), the parent-process
+check is enforced when the relevant ``procfs`` entry is accessible, and
+skipped when it happens to be inaccessible.
 
 
 .. _bootloader security validation onedir:

--- a/doc/advanced-topics.rst
+++ b/doc/advanced-topics.rst
@@ -339,6 +339,93 @@ result in endless process spawn loop).
    suppressed via the public :envvar:`PYINSTALLER_SUPPRESS_SPLASH_SCREEN`
    environment variable.
 
+.. _bootloader security validation onefile:
+
+Security Validation in ``onefile`` Mode
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Starting with PyInstaller v6.22.1, additional security validation has been
+implemented in the child process codepath of a frozen application built
+in ``onefile`` mode - i.e., the main application process and worker
+sub-processes spawned by the main application process via ``sys.executable``.
+The process attempts to look up the path to the executable of its parent
+process, and verifies that it matches its own executable, in order to
+ensure that the run-time environment it is supposed to inherit was indeed
+set up by a parent process of a ``onefile`` application.
+
+This validation aims to prevent the ``onefile`` executable from being
+tricked, via a crafted set of :ref:`environment variables <bootloader environment variables>`,
+into running a child process codepath with an arbitrary top-level application directory.
+Depending on the content of the spoofed top-level application directory,
+this may result in execution with altered behavior, or even local privilege
+escalation (e.g., POSIX executable with ``setuid`` bit set).
+
+Windows
+-------
+
+On Windows, the parent process ID is obtained by walking the current
+process snapshot (``CreateToolhelp32Snapshot``, ``Process32First``,
+``Process32Next``), and the path to corresponding executable is retrieved
+using ``QueryFullProcessImageName``.
+
+macOS
+-----
+
+On macOS, the parent process ID is obtained via standard POSIX
+``getppid()`` system call, and the path to corresponding executable is
+retrieved using ``proc_pidpath()``.
+
+
+POSIX platforms
+---------------
+
+On other POSIX platforms, the parent process ID is obtained via
+standard POSIX ``getppid()`` system call, followed by the look-up of
+the platform-specific entry on the ``procfs`` filesystem
+(i.e., inside the ``/proc/<ppid>`` directory).
+
+If the executable has ``setuid`` bit set, additional validation is
+performed on the inherited (temporary) top-level application directory.
+The owner ID of the said directory must match the owner ID of the
+executable, and its permissions must be ``0700`` (i.e., permissions
+that the bootloader uses when creating a temporary application directory).
+
+Some of otherwise supported POSIX platforms do not implement ``procfs``
+at all (for example, OpenBSD), or do not provide the information about the
+executable path (for example, AIX). On such platforms, setting ``setuid``
+bit on ``onefile`` executables is not supported anymore - the implemented
+security validation will automatically fail. Running regular ``onefile``
+executables is still supported, but due to lack of validation, it may be
+subject to environment manipulation.
+
+On POSIX platforms where look-up via ``procfs`` is nominally supported
+(i.e., Linux, Cygwin, FreeBSD, NetBSD, and SunOS), it is strictly enforced.
+If the corresponding entry under ``/proc/<ppid>`` cannot be accessed for
+whatever reason (e.g., additional security constraints), the validation
+will fail and prevent the ``onefile`` application from running. This
+currently applies regardless of whether the executable has ``setuid``
+bit set or not.
+
+
+.. _bootloader security validation onedir:
+
+
+Security Validation in ``onedir`` Mode
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Starting with PyInstaller v6.22.1, an additional security requirement has
+been imposed on POSIX onedir executables that have ``setuid`` bit set.
+Such executables now validate the owner and permissions on their contents
+directory (typically the ``_internal`` directory); the owner ID must match
+the effective user ID under which the process is running, and the
+permissions on the directory need to be ``0700``.
+
+The above restriction aims to prevent unprivileged users from modifying
+contents of an application that runs in privileged mode. However, it
+also prevents an application from starting in privileged mode and later
+dropping the privileges (for example, via the ``os.setuid()`` call), as
+this would prevent further access to the content directory.
+
 
 .. _pyi_splash Module:
 

--- a/doc/common-issues-and-pitfalls.rst
+++ b/doc/common-issues-and-pitfalls.rst
@@ -561,3 +561,23 @@ environment variable (if using ``pip install`` in combination with
 ``PYINSTALLER_COMPILE_BOOTLOADER`` environment variable).
 
 For details, see :ref:`building the bootloader`.
+
+
+Security Validation Failure Errors
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Starting with PyInstaller v6.22.1, the bootloader implements additional
+validation of its run-time environment. This validation aims to prevent
+execution with a spoofed set of :ref:`internal environment variables <bootloader environment variables>`
+that could trick the executable into using arbitrary application directory;
+this could lead to arbitrary code execution and, if executable is running
+in privileged mode (e.g., POSIX executable with ``setsuid`` bit set), to
+local privilege escalation.
+
+The error messages pertaining the new security validation in bootloader
+follow the ``Security validation failure: <details>`` format; if you
+encounter such a error message, consult either
+:ref:`bootloader security validation onefile`
+or
+:ref:`bootloader security validation onedir`
+for possible causes.

--- a/doc/operating-mode.rst
+++ b/doc/operating-mode.rst
@@ -155,8 +155,8 @@ to execute your script.
 Everything follows normally from there, provided
 that all the necessary support files were included.
 
-(This is an overview.
-For more detail, see :ref:`The Bootstrap Process in Detail` below.)
+This is an overview. For more details, see :ref:`The Bootstrap Process in Detail`.
+For details on restrictions due to built-in security validation, see :ref:`bootloader security validation onedir`.
 
 
 .. _Bundling to One File:
@@ -249,12 +249,11 @@ stored in the executable, and the bootloader will create the
     escalate privileges by modifying them.
 
 .. Note::
-    Applications that use `os.setuid()` may encounter permissions errors.
-    The temporary folder where the bundled app runs may not being readable
-    after `setuid` is called. If your script needs to
-    call `setuid`, it may be better to use one-folder mode
-    so as to have more control over the permissions on its files.
+    Applications that use ``os.setuid()`` may encounter permissions errors.
+    The temporary folder where the bundled app runs will likely not be accessible
+    after ``os.setuid()`` is called.
 
+For details on restrictions due to built-in security validation, see :ref:`bootloader security validation onefile`.
 
 Using a Console Window
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/news/9492.bootloader.rst
+++ b/news/9492.bootloader.rst
@@ -1,0 +1,12 @@
+Implement additional validation of inherited environment for ``onefile``
+execution codepaths, in order to prevent execution with spoofed environment;
+see `GHSA-9fxf-4qw3-ghmr <https://github.com/pyinstaller/pyinstaller/security/advisories/GHSA-9fxf-4qw3-ghmr>`_.
+When running as a child ``onefile`` process (i.e., the main application
+process or worker sub-process spawned via ``sys.excutable``), the bootloader
+now attempts to look up the parent process ID, and resolve its executable.
+The path to the parent process' executable must match that of the current
+process' executable, otherwise an error is raised. This check is
+implemented on Windows, macOS, and POSIX platforms where the look-up
+is possible through ``procfs`` filesystem; this includes Linux, Cygwin,
+FreeBSD, and Solaris, but not OpenBSD nor AIX. For additional
+compatibility implications, see the **Breaking changes** section.

--- a/news/9492.breaking.1.rst
+++ b/news/9492.breaking.1.rst
@@ -1,9 +1,11 @@
 (POSIX) When running as a ``onefile`` child process (on POSIX platforms
 other than OpenBSD and AIX), the bootloader now attempts to verify
 the parent process executable via ``procfs`` lookup. This check is
-currently enabled for all ``onefile`` executables, regardless of
-whether the ``setuid`` bit is set on the executable or not. If this
-happens to break a use case with a *non-privileged* ``onefile`` executable
-(for example, due to hardened environment disallowing access to relevant
-``procfs`` entries), let us know, and we might reconsider making the
-check mandatory only for executables with ``setuid`` bit set.
+mandatory for ``onefile`` executables with ``setuid`` bit set; if the
+relevant ``procfs`` entry is inaccessible (for example, due to ``procfs``
+not being mounted, as is the case on FreeBSD by default, or due to access
+being blocked by local security policy), the process will exit with
+security validation error message. For regular ``onefile`` executables
+(without ``setuid`` bit set), the parent-process check is enforced when the
+relevant ``procfs`` entry is accessible, and skipped when it happens to be
+inaccessible.

--- a/news/9492.breaking.1.rst
+++ b/news/9492.breaking.1.rst
@@ -1,0 +1,9 @@
+(POSIX) When running as a ``onefile`` child process (on POSIX platforms
+other than OpenBSD and AIX), the bootloader now attempts to verify
+the parent process executable via ``procfs`` lookup. This check is
+currently enabled for all ``onefile`` executables, regardless of
+whether the ``setuid`` bit is set on the executable or not. If this
+happens to break a use case with a *non-privileged* ``onefile`` executable
+(for example, due to hardened environment disallowing access to relevant
+``procfs`` entries), let us know, and we might reconsider making the
+check mandatory only for executables with ``setuid`` bit set.

--- a/news/9492.breaking.2.rst
+++ b/news/9492.breaking.2.rst
@@ -1,0 +1,3 @@
+(OpenBSD, AIX) Running ``onefile`` executables with ``setuid`` bit set
+is explicitly disallowed, due to lack of support for verifying the
+executable of the parent process and security implications.

--- a/news/9492.breaking.3.rst
+++ b/news/9492.breaking.3.rst
@@ -1,0 +1,13 @@
+(POSIX) When running as a ``onefile`` child process and the executable
+has ``setuid`` bit set, the bootloader now validates the owner and
+permissions on the (inherited) temporary directory. The owner ID of the
+temporary directory must match the effective user ID under which the
+process is running, and permissions on the temporary directory are need
+to be `0700`. This might (further) break applications that start in
+privileged mode and then attempt to drop privileges without transferring
+the ownership of the temporary directory to the unprivileged user;
+while formerly this would result in the main application process locking
+itself (as well as any sub-processes spawned by it via ``sys.executable``)
+from the temporary directory, it will now also cause any subprocess
+spawned via ``sys.excutable`` to fail the security validation the
+bootloader.

--- a/news/9492.breaking.4.rst
+++ b/news/9492.breaking.4.rst
@@ -1,0 +1,7 @@
+(POSIX) Executables built in ``onedir`` mode with ``setuid`` bit set
+now validate the owner and permissions on their contents directory
+(typically the ``_internal`` directory); the owner ID must match the
+effective user ID under which the process is running, and the
+permissions on the directory need to be `0700`. This aims to prevent
+unprivileged users from modifying contents of an application that
+runs in privileged mode.

--- a/news/9492.doc.rst
+++ b/news/9492.doc.rst
@@ -1,0 +1,2 @@
+Document the new security validation in bootloader and its implications
+for users.

--- a/tests/functional/test_security.py
+++ b/tests/functional/test_security.py
@@ -28,6 +28,74 @@ PYI_PROCESS_LEVEL_MAIN = 1
 PYI_PROCESS_LEVEL_SUBPROCESS = 2
 
 
+def _ensure_long_path(path):
+    if not compat.is_win and not compat.is_cygwin:
+        return path
+
+    # Bind GetLongPathNameW from kernel32.dll
+    import ctypes
+    import ctypes.wintypes
+
+    kernel32 = ctypes.cdll.LoadLibrary("kernel32.dll")
+
+    kernel32.GetLongPathNameW.restype = ctypes.wintypes.DWORD
+    kernel32.GetLongPathNameW.argtypes = [
+        ctypes.wintypes.LPCWSTR,  # LPCWSTR lpszShortPath
+        ctypes.wintypes.LPWSTR,  # LPWSTR lpszLongPath
+        ctypes.wintypes.DWORD,  # DWORD cchBuffer
+    ]
+
+    # Bind cygwin_conv_path from cygwin1.dll
+    if compat.is_cygwin:
+        cygwin = ctypes.cdll.LoadLibrary("cygwin1.dll")
+
+        cygwin.cygwin_create_path.restype = ctypes.c_size_t
+        cygwin.cygwin_create_path.argtypes = [
+            ctypes.c_int32,  # cygwin_conv_path_t what
+            ctypes.c_void_p,  # const void * from
+            ctypes.c_void_p,  # void * to
+            ctypes.c_size_t,  # size_t size
+        ]
+
+        CCP_POSIX_TO_WIN_W = 1
+        CCP_WIN_W_TO_POSIX = 3
+
+    path_len = 4096
+
+    # Convert cygwin path to Windows path (long or short)
+    if compat.is_cygwin:
+        winpath_w = ctypes.create_unicode_buffer(path_len)
+        ret = cygwin.cygwin_conv_path(
+            CCP_POSIX_TO_WIN_W,
+            ctypes.c_char_p(path.encode('utf-8')),
+            winpath_w,
+            path_len,
+        )
+        assert ret == 0, "Failed to convert POSIX path to Windows path!"
+    else:
+        winpath_w = ctypes.c_wchar_p(path)
+
+    # Convert Windows path to long Windows path
+    winpath_long_w = ctypes.create_unicode_buffer(path_len)
+    ret = kernel32.GetLongPathNameW(winpath_w, winpath_long_w, path_len)
+
+    # Convert long windows path to cygwin path
+    if compat.is_cygwin:
+        long_path = ctypes.create_string_buffer(path_len)
+        ret = cygwin.cygwin_conv_path(
+            CCP_WIN_W_TO_POSIX,
+            winpath_long_w,
+            long_path,
+            path_len,
+        )
+        assert ret == 0, "Failed to convert POSIX path to Windows path!"
+        long_path = long_path.value.decode('utf-8')
+    else:
+        long_path = winpath_long_w.value
+
+    return long_path
+
+
 # Check whether application's top level directory can be hijacked via manipulation of _PYI_ environment variables.
 # See: https://github.com/pyinstaller/pyinstaller/security/advisories/GHSA-9fxf-4qw3-ghmr
 @skipif(compat.is_aix or compat.is_openbsd or compat.is_hpux, reason="Mitigation is not available on this platform.")
@@ -130,6 +198,13 @@ def test_application_home_directory_hijack(pyi_builder, tmp_path, parent_level):
         # In an msys2 Windows environment, replace POSIX-style separators with Windows-style ones, which are used
         # within the bootloader...
         archive_path = archive_path.replace('/', '\\')
+    # On Windows and Cygwin, ensure that we have long path instead of 8.3 short path. Bootloader determines archive
+    # path from executable path, and that is resolved to long path.
+    archive_path = _ensure_long_path(archive_path)
+    if compat.is_cygwin and archive_path.lower().endswith('.exe'):
+        archive_path = archive_path[:-4]  # Under Cygwin, bootloader resolves executable/archive without .exe suffix
+    print(f"Setting _PYI_ARCHIVE_FILE to: {archive_path!r}", file=sys.stdout)
+    print(f"Setting _PYI_ARCHIVE_FILE to: {archive_path!r}", file=sys.stderr)
     fake_env['_PYI_ARCHIVE_FILE'] = archive_path
     # Try to trick process into running a specific codepath by manipulating its parent level.
     fake_env['_PYI_PARENT_PROCESS_LEVEL'] = str(parent_level)

--- a/tests/functional/test_security.py
+++ b/tests/functional/test_security.py
@@ -18,7 +18,6 @@ import sys
 import pytest
 
 from PyInstaller import compat
-from PyInstaller.utils.tests import skipif
 
 # PYI_PROCESS_LEVEL enum values from bootloader/src/pyi_main.h
 PYI_PROCESS_LEVEL_UNKNOWN = -2
@@ -98,7 +97,6 @@ def _ensure_long_path(path):
 
 # Check whether application's top level directory can be hijacked via manipulation of _PYI_ environment variables.
 # See: https://github.com/pyinstaller/pyinstaller/security/advisories/GHSA-9fxf-4qw3-ghmr
-@skipif(compat.is_aix or compat.is_openbsd or compat.is_hpux, reason="Mitigation is not available on this platform.")
 @pytest.mark.parametrize(
     'parent_level',
     [
@@ -248,6 +246,10 @@ def test_application_home_directory_hijack(pyi_builder, tmp_path, parent_level):
         assert p.returncode == 0
     else:
         # Onefile mode
+        MSG_PROCESS_LEVEL = "Security validation failure: unexpected process level!"
+        MSG_HOME_DIRECTORY = "Security validation failure: unexpected name of application's home directory!"
+        MSG_PARENT_EXECUTABLE = "Security validation failure: parent process has different executable!"
+
         if parent_level == PYI_PROCESS_LEVEL_UNKNOWN:
             # This is same as _PYI_PARENT_PROCESS_LEVEL not being set at all; the process should run as parent process
             # of onefile application and set up new environment. Thus, the test application should run normally.
@@ -258,9 +260,18 @@ def test_application_home_directory_hijack(pyi_builder, tmp_path, parent_level):
             # should similarly exit with message about unexpected level, since splash screen is not enabled on the
             # build; if it were enabled, the validation of directory name would fail instead.
             assert p.returncode not in {0, 42}
-            assert "Security validation failure: unexpected process level!" in p.stderr or \
-                "Security validation failure: unexpected name of application's home directory!" in p.stderr
+            assert (MSG_PROCESS_LEVEL in p.stderr) or (MSG_HOME_DIRECTORY in p.stderr)
         else:  # PYI_PROCESS_LEVEL_PARENT, PYI_PROCESS_LEVEL_MAIN
             # The process is supposed to be either These should fail the parent process verification in the bootloader.
+            #
+            # On platforms where procfs-based look-up of parent executable is not supported (AIX, OpenBSD; but also
+            # FreeBSD without /proc mounted), we cannot validate the parent process. In these cases, we expect the
+            # validation of home directory name to fail (since executable in this test does not have setuid bit set,
+            # which would fail due to strict parent process validation requirement).
+            no_procfs = (
+                compat.is_aix or compat.is_openbsd or compat.is_hpux
+                or (compat.is_freebsd and not os.path.isdir('/proc/curproc'))
+            )
+
             assert p.returncode not in {0, 42}
-            assert "Security validation failure: parent process has different executable!" in p.stderr
+            assert (MSG_PARENT_EXECUTABLE in p.stderr) or (no_procfs and MSG_HOME_DIRECTORY in p.stderr)

--- a/tests/functional/test_security.py
+++ b/tests/functional/test_security.py
@@ -262,16 +262,14 @@ def test_application_home_directory_hijack(pyi_builder, tmp_path, parent_level):
             assert p.returncode not in {0, 42}
             assert (MSG_PROCESS_LEVEL in p.stderr) or (MSG_HOME_DIRECTORY in p.stderr)
         else:  # PYI_PROCESS_LEVEL_PARENT, PYI_PROCESS_LEVEL_MAIN
-            # The process is supposed to be either These should fail the parent process verification in the bootloader.
+            # The process is supposed to be either main application process, or worker sub-process spawned via
+            # `sys.executable`. These should fail the parent process verification in the bootloader.
             #
-            # On platforms where procfs-based look-up of parent executable is not supported (AIX, OpenBSD; but also
-            # FreeBSD without /proc mounted), we cannot validate the parent process. In these cases, we expect the
-            # validation of home directory name to fail (since executable in this test does not have setuid bit set,
-            # which would fail due to strict parent process validation requirement).
-            no_procfs = (
-                compat.is_aix or compat.is_openbsd or compat.is_hpux
-                or (compat.is_freebsd and not os.path.isdir('/proc/curproc'))
-            )
-
+            # On platforms where procfs-based look-up of parent executable is not supported (AIX, OpenBSD) or the
+            # relevant entry under /proc/<ppid> is inaccessible (e.g., FreeBSD without /proc mounted, or any other
+            # supported POSIX platform where local security policy blocks access to /proc/<ppid> directory for other
+            # processes), we cannot validate the parent process. In these cases, we expect the validation of home
+            # directory name to fail (since executable in this test does not have setuid bit set, which would fail
+            # due to strict parent process validation requirement).
             assert p.returncode not in {0, 42}
-            assert (MSG_PARENT_EXECUTABLE in p.stderr) or (no_procfs and MSG_HOME_DIRECTORY in p.stderr)
+            assert (MSG_PARENT_EXECUTABLE in p.stderr) or (MSG_HOME_DIRECTORY in p.stderr)

--- a/tests/functional/test_security.py
+++ b/tests/functional/test_security.py
@@ -16,10 +16,12 @@ import subprocess
 import sys
 
 from PyInstaller import compat
+from PyInstaller.utils.tests import skipif
 
 
 # Check whether application's top level directory can be hijacked via manipulation of _PYI_ environment variables.
 # See: https://github.com/pyinstaller/pyinstaller/security/advisories/GHSA-9fxf-4qw3-ghmr
+@skipif(compat.is_aix or compat.is_openbsd or compat.is_hpux, reason="Mitigation is not available on this platform.")
 def test_application_home_directory_hijack(pyi_builder, tmp_path):
     mode = pyi_builder._mode  # Original mode
 

--- a/tests/functional/test_security.py
+++ b/tests/functional/test_security.py
@@ -15,14 +15,40 @@ import pathlib
 import subprocess
 import sys
 
+import pytest
+
 from PyInstaller import compat
 from PyInstaller.utils.tests import skipif
+
+# PYI_PROCESS_LEVEL enum values from bootloader/src/pyi_main.h
+PYI_PROCESS_LEVEL_UNKNOWN = -2
+PYI_PROCESS_LEVEL_PARENT_NEEDS_RESTART = -1
+PYI_PROCESS_LEVEL_PARENT = 0
+PYI_PROCESS_LEVEL_MAIN = 1
+PYI_PROCESS_LEVEL_SUBPROCESS = 2
 
 
 # Check whether application's top level directory can be hijacked via manipulation of _PYI_ environment variables.
 # See: https://github.com/pyinstaller/pyinstaller/security/advisories/GHSA-9fxf-4qw3-ghmr
 @skipif(compat.is_aix or compat.is_openbsd or compat.is_hpux, reason="Mitigation is not available on this platform.")
-def test_application_home_directory_hijack(pyi_builder, tmp_path):
+@pytest.mark.parametrize(
+    'parent_level',
+    [
+        PYI_PROCESS_LEVEL_UNKNOWN,
+        PYI_PROCESS_LEVEL_PARENT_NEEDS_RESTART,
+        PYI_PROCESS_LEVEL_PARENT,
+        PYI_PROCESS_LEVEL_MAIN,
+        PYI_PROCESS_LEVEL_SUBPROCESS,
+    ],
+    ids=[
+        'UNKNOWN',
+        'PARENT_NEEDS_RESTART',
+        'PARENT',
+        'MAIN',
+        'SUBPROCESS',
+    ],
+)
+def test_application_home_directory_hijack(pyi_builder, tmp_path, parent_level):
     mode = pyi_builder._mode  # Original mode
 
     # Create files with secrets
@@ -103,11 +129,8 @@ def test_application_home_directory_hijack(pyi_builder, tmp_path):
         # within the bootloader...
         archive_path = archive_path.replace('/', '\\')
     fake_env['_PYI_ARCHIVE_FILE'] = archive_path
-    # Make the process believe it already has a parent. In onedir build, this would mean that the process is a worker
-    # sub-process spawned from the main application process. In onefile build, this would mean that the process is the
-    # main application process, and should use the ephemeral top-level application directory that was prepared by its
-    # parent.
-    fake_env['_PYI_PARENT_PROCESS_LEVEL'] = '0'
+    # Try to trick process into running a specific codepath by manipulating its parent level.
+    fake_env['_PYI_PARENT_PROCESS_LEVEL'] = str(parent_level)
     # Try to hijack the top-level application directory
     fake_env['_PYI_APPLICATION_HOME_DIR'] = str(fake_app_dir)
 
@@ -127,16 +150,39 @@ def test_application_home_directory_hijack(pyi_builder, tmp_path):
     else:
         print("Captured stderr: N/A")
 
+    # PYI_PROCESS_LEVEL_SUBPROCESS should be an invalid *parent* process level, regardless of mode.
+    if parent_level == PYI_PROCESS_LEVEL_SUBPROCESS:
+        assert p.returncode not in {0, 42}
+        assert f"Invalid parent process level: {parent_level}" in p.stderr
+        return
+
+    # PYI_PROCESS_LEVEL_PARENT_NEEDS_RESTART should be invalid on Windows, macOS, and Cygwin, regardless of mode.
+    non_posix = compat.is_win or compat.is_darwin or compat.is_cygwin
+    if non_posix and parent_level == PYI_PROCESS_LEVEL_PARENT_NEEDS_RESTART:
+        assert p.returncode not in {0, 42}
+        assert f"Invalid parent process level: {parent_level}" in p.stderr
+        return
+
     if mode == 'onedir':
         # In onedir build, the _PYI_APPLICATION_HOME_DIR environment variable should not be used at all - so the test
-        # application should run normally - even if it is tricked into believing to be a sub-process of a onedir main
+        # application should run normally, even if it is tricked into believing to be a sub-process of a onedir main
         # application process...
         assert p.returncode == 0
     else:
-        # Onefile mode - the test application should exit with non-zero return code. However, the error code should
-        # also not be 42, which is used by the test program to indicate that it read the secret file in top-level
-        # application directory and found it to be different from the expected one.
-        assert p.returncode not in {0, 42}
-        # Check for specific error message, which indicates that the process exited due to failed security validation
-        # in the bootloader.
-        assert "Security validation failure: parent process has different executable!" in p.stderr
+        # Onefile mode
+        if parent_level == PYI_PROCESS_LEVEL_UNKNOWN:
+            # This is same as _PYI_PARENT_PROCESS_LEVEL not being set at all; the process should run as parent process
+            # of onefile application and set up new environment. Thus, the test application should run normally.
+            assert p.returncode == 0
+        elif parent_level == PYI_PROCESS_LEVEL_PARENT_NEEDS_RESTART:
+            # This level is valid only in POSIX onefile builds with splash screen enabled. On non-POSIX systems, it
+            # should exit with message about unrecognized level (handled by an earlier check). On POSIX systems, it
+            # should similarly exit with message about unexpected level, since splash screen is not enabled on the
+            # build; if it were enabled, the validation of directory name would fail instead.
+            assert p.returncode not in {0, 42}
+            assert "Security validation failure: unexpected process level!" in p.stderr or \
+                "Security validation failure: unexpected name of application's home directory!" in p.stderr
+        else:  # PYI_PROCESS_LEVEL_PARENT, PYI_PROCESS_LEVEL_MAIN
+            # The process is supposed to be either These should fail the parent process verification in the bootloader.
+            assert p.returncode not in {0, 42}
+            assert "Security validation failure: parent process has different executable!" in p.stderr

--- a/tests/functional/test_security.py
+++ b/tests/functional/test_security.py
@@ -112,12 +112,14 @@ def test_application_home_directory_hijack(pyi_builder, tmp_path, parent_level):
     executables = pyi_builder._find_executables('app_real')
     assert len(executables) == 1
     executable = executables[0]
-    print(f"Test application's executable: {executable}")
+    print(f"Test application's executable: {executable}", file=sys.stdout)
+    print(f"Test application's executable: {executable}", file=sys.stderr)
 
     executables = pyi_builder._find_executables('app_fake')
     assert len(executables) == 1
     fake_app_dir = pathlib.Path(executables[0]).parent / '_internal'
-    print(f"Fake application's directory: {str(fake_app_dir)!r}")
+    print(f"Fake application's directory: {str(fake_app_dir)!r}", file=sys.stdout)
+    print(f"Fake application's directory: {str(fake_app_dir)!r}", file=sys.stderr)
     assert fake_app_dir.is_dir()
 
     # The cloak & dagger part...
@@ -138,17 +140,18 @@ def test_application_home_directory_hijack(pyi_builder, tmp_path, parent_level):
     print(f"Running executable: {executable}", file=sys.stderr)
     p = subprocess.run([executable, SECRET_REAL], env=fake_env, capture_output=True, encoding='utf-8')
 
-    print(f"Return code: {p.returncode}")
+    print(f"Return code: {p.returncode}", file=sys.stdout)
+    print(f"Return code: {p.returncode}", file=sys.stderr)
 
     if p.stdout:
-        print(f"Captured stdout:\n----------------\n{p.stdout}\n----------------")
+        print(f"Captured stdout:\n----------------\n{p.stdout}\n----------------", file=sys.stderr)
     else:
-        print("Captured stdout: N/A")
+        print("Captured stdout: N/A", file=sys.stderr)
 
     if p.stderr:
-        print(f"Captured stderr:\n----------------\n{p.stderr}\n----------------")
+        print(f"Captured stderr:\n----------------\n{p.stderr}\n----------------", file=sys.stderr)
     else:
-        print("Captured stderr: N/A")
+        print("Captured stderr: N/A", file=sys.stderr)
 
     # PYI_PROCESS_LEVEL_SUBPROCESS should be an invalid *parent* process level, regardless of mode.
     if parent_level == PYI_PROCESS_LEVEL_SUBPROCESS:

--- a/tests/functional/test_security.py
+++ b/tests/functional/test_security.py
@@ -1,0 +1,140 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2026, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License (version 2
+# or later) with exception for distributing the bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#
+# SPDX-License-Identifier: (GPL-2.0-or-later WITH Bootloader-exception)
+#-----------------------------------------------------------------------------
+
+import copy
+import os
+import pathlib
+import subprocess
+import sys
+
+from PyInstaller import compat
+
+
+# Check whether application's top level directory can be hijacked via manipulation of _PYI_ environment variables.
+# See: https://github.com/pyinstaller/pyinstaller/security/advisories/GHSA-9fxf-4qw3-ghmr
+def test_application_home_directory_hijack(pyi_builder, tmp_path):
+    mode = pyi_builder._mode  # Original mode
+
+    # Create files with secrets
+    SECRET_REAL = "REAL"
+    SECRET_FAKE = "FAKE"
+
+    real_secret_dir = tmp_path / 'real'
+    real_secret_dir.mkdir()
+
+    real_secret_file = real_secret_dir / 'secret.txt'
+    real_secret_file.write_text(SECRET_REAL, encoding='utf-8')
+
+    fake_secret_dir = tmp_path / 'fake'
+    fake_secret_dir.mkdir()
+
+    fake_secret_file = fake_secret_dir / 'secret.txt'
+    fake_secret_file.write_text(SECRET_FAKE, encoding='utf-8')
+
+    # Test script to use in both builds
+    test_script = """
+        import sys
+        import os
+
+        expected_secret = sys.argv[1]
+
+        secret_file = os.path.join(sys._MEIPASS, 'secret.txt')
+        with open(secret_file, 'r', encoding='utf-8') as fp:
+            secret = fp.read().strip()
+
+        print(f"Read secret: {secret}", file=sys.stderr)
+        print(f"Expected secret: {expected_secret}", file=sys.stderr)
+
+        if secret != expected_secret:
+            print(f"Secret mismatch! {secret!r} vs {expected_secret!r}", file=sys.stderr)
+            sys.exit(42)
+    """
+
+    # Build the test application
+    pyi_builder.test_source(
+        test_script,
+        pyi_args=['--add-data', f'{str(real_secret_file)}:.'],
+        app_name='app_real',
+        app_args=[SECRET_REAL],
+    )
+
+    # Build the fake application - in onedir mode
+    pyi_builder._mode = 'onedir'
+
+    pyi_builder.test_source(
+        test_script,
+        pyi_args=['--add-data', f'{str(fake_secret_file)}:.'],
+        app_name='app_fake',
+        app_args=[SECRET_FAKE],
+    )
+
+    # The actual test - try to pass the fake application's contents
+    # directory as top-level directory for the real test application.
+    print("\nFinished build and sanity-check tests - preparing the actual test...", file=sys.stdout)
+    print("\nFinished build and sanity-check tests - preparing the actual test...", file=sys.stderr)
+
+    executables = pyi_builder._find_executables('app_real')
+    assert len(executables) == 1
+    executable = executables[0]
+    print(f"Test application's executable: {executable}")
+
+    executables = pyi_builder._find_executables('app_fake')
+    assert len(executables) == 1
+    fake_app_dir = pathlib.Path(executables[0]).parent / '_internal'
+    print(f"Fake application's directory: {str(fake_app_dir)!r}")
+    assert fake_app_dir.is_dir()
+
+    # The cloak & dagger part...
+    fake_env = copy.deepcopy(os.environ)
+    # Prevent reset of _PYI_ environment variables
+    archive_path = str(executable)
+    if compat.is_win:
+        # In an msys2 Windows environment, replace POSIX-style separators with Windows-style ones, which are used
+        # within the bootloader...
+        archive_path = archive_path.replace('/', '\\')
+    fake_env['_PYI_ARCHIVE_FILE'] = archive_path
+    # Make the process believe it already has a parent. In onedir build, this would mean that the process is a worker
+    # sub-process spawned from the main application process. In onefile build, this would mean that the process is the
+    # main application process, and should use the ephemeral top-level application directory that was prepared by its
+    # parent.
+    fake_env['_PYI_PARENT_PROCESS_LEVEL'] = '0'
+    # Try to hijack the top-level application directory
+    fake_env['_PYI_APPLICATION_HOME_DIR'] = str(fake_app_dir)
+
+    print(f"Running executable: {executable}", file=sys.stdout)
+    print(f"Running executable: {executable}", file=sys.stderr)
+    p = subprocess.run([executable, SECRET_REAL], env=fake_env, capture_output=True, encoding='utf-8')
+
+    print(f"Return code: {p.returncode}")
+
+    if p.stdout:
+        print(f"Captured stdout:\n----------------\n{p.stdout}\n----------------")
+    else:
+        print("Captured stdout: N/A")
+
+    if p.stderr:
+        print(f"Captured stderr:\n----------------\n{p.stderr}\n----------------")
+    else:
+        print("Captured stderr: N/A")
+
+    if mode == 'onedir':
+        # In onedir build, the _PYI_APPLICATION_HOME_DIR environment variable should not be used at all - so the test
+        # application should run normally - even if it is tricked into believing to be a sub-process of a onedir main
+        # application process...
+        assert p.returncode == 0
+    else:
+        # Onefile mode - the test application should exit with non-zero return code. However, the error code should
+        # also not be 42, which is used by the test program to indicate that it read the secret file in top-level
+        # application directory and found it to be different from the expected one.
+        assert p.returncode not in {0, 42}
+        # Check for specific error message, which indicates that the process exited due to failed security validation
+        # in the bootloader.
+        assert "Security validation failure: parent process has different executable!" in p.stderr


### PR DESCRIPTION
Implement additional security validation in bootloader to prevent `onefile` executables from being tricked into running with custom top-level application directory via spoofed environment variables (see https://github.com/pyinstaller/pyinstaller/security/advisories/GHSA-9fxf-4qw3-ghmr).

Onefile mode:

- when the bootloader is running as a `onefile` child process (either main application process or worker sub-process spawned via `sys.executable`), it looks up the path to the executable of the parent process (presumably a `onefile` parent process) and ensures that it matches its own. This check is implemented on Windows, macOS, and POSIX platforms where look-up is possible via `procfs` (Linux, Cygwin, FreeBSD, NetBSD, Solaris).

- on POSIX platforms where `procfs` look-up is (nominally) supported (see list above), it is currently strictly enforced - regardless whether executable has `setuid` bit set or not.

- on POSIX platforms where `procfs` look-up is not possible (AIX and OpenBSD), it is not possible to run onefile executables with `setuid` bit set anymore.

- when running as `onefile` child process, the bootloader now verifies the name of the inherited temporary directory, to ensure that it starts with `_MEI` prefix and consists of expected (platform-specific) amount of characters.

- when `onefile` executable has `setuid` bit set (POSIX platforms), the bootloader now checks that the owner ID of the inherited temporary directory matches the effective user ID of the running process, and that permissions on the temporary directory match `0700` (i.e., what bootloader uses in `onefile` parent process when creating the temporary directory)

Onedir mode:

 - on POSIX platforms (excluding macOS), `onedir` executables with `setuid` bit set now validate owner and permissions of the application's content directory (e.g., `_internal`); the owner ID must match the effective user ID of the running process, and permissions must match `0700`, to ensure that unprivileged users cannot modify contents of an application that runs in privileged mode.
   