### PR TITLE
doc: update yapf version under Coding conventions

### DIFF
--- a/doc/development/coding-conventions.rst
+++ b/doc/development/coding-conventions.rst
@@ -14,7 +14,7 @@ tools.
 
 To install them run::
 
-    pip install flake8 yapf==0.32.0 toml
+    pip install flake8 yapf==0.43.0 toml
 
 Reformat your code automatically with yapf_::
 


### PR DESCRIPTION
Update `yapf` version documented in Coding conventions section of Development guide to match the version currently used by CI; as per https://github.com/pyinstaller/pyinstaller/pull/9491#issuecomment-5153047096.