### PR TITLE
Add NetBSD support to the bootloader build and platform detection

### DIFF
--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -89,11 +89,12 @@ is_solar = sys.platform.startswith('sun')  # Solaris
 is_aix = sys.platform.startswith('aix')
 is_freebsd = sys.platform.startswith('freebsd')
 is_openbsd = sys.platform.startswith('openbsd')
+is_netbsd = sys.platform.startswith('netbsd')
 is_hpux = sys.platform.startswith('hp-ux')
 
 # Some code parts are similar to several unix platforms (e.g. Linux, Solaris, AIX).
 # macOS is not considered as unix since there are many platform-specific details for Mac in PyInstaller.
-is_unix = is_linux or is_solar or is_aix or is_freebsd or is_hpux or is_openbsd
+is_unix = is_linux or is_solar or is_aix or is_freebsd or is_hpux or is_openbsd or is_netbsd
 
 # Linux distributions such as Alpine or OpenWRT use musl as their libc implementation and resultantly need specially
 # compiled bootloaders. On musl systems, ldd with no arguments prints 'musl' and its version.

--- a/PyInstaller/depend/bindepend.py
+++ b/PyInstaller/depend/bindepend.py
@@ -818,7 +818,7 @@ def _resolve_library_path_unix(name):
                 paths.append('/usr/local/lib/hpux32')
             else:
                 paths.append('/usr/local/lib/hpux64')
-        elif compat.is_freebsd or compat.is_openbsd:
+        elif compat.is_freebsd or compat.is_openbsd or compat.is_netbsd:
             paths.append('/usr/local/lib')
         lib = lib_search_func(name, paths)
 

--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -65,9 +65,6 @@ SYSTEM_TO_BUILDOS = {
     # Android is also folded back into 'linux', to avoid a message about "cross-compiling for Linux".
     'Android': 'linux',
     'FreeBSD': 'freebsd',
-    # Without these, BUILD_OS falls back to platform.system() ('OpenBSD' /
-    # 'NetBSD'), which never equals waf's DEST_OS ('openbsd' / 'netbsd'), so a
-    # native build is misreported as a cross-compilation.
     'OpenBSD': 'openbsd',
     'NetBSD': 'netbsd',
     'Windows': 'win32',

--- a/bootloader/wscript
+++ b/bootloader/wscript
@@ -48,6 +48,7 @@ DESTOS_TO_SYSTEM = {
     'linux': 'Linux',
     'freebsd': 'FreeBSD',
     'openbsd': 'OpenBSD',
+    'netbsd': 'NetBSD',
     'win32': 'Windows',
     'darwin': 'Darwin',
     'sunos': platform.system(),  # FIXME: inhibits cross-compile
@@ -64,6 +65,11 @@ SYSTEM_TO_BUILDOS = {
     # Android is also folded back into 'linux', to avoid a message about "cross-compiling for Linux".
     'Android': 'linux',
     'FreeBSD': 'freebsd',
+    # Without these, BUILD_OS falls back to platform.system() ('OpenBSD' /
+    # 'NetBSD'), which never equals waf's DEST_OS ('openbsd' / 'netbsd'), so a
+    # native build is misreported as a cross-compilation.
+    'OpenBSD': 'openbsd',
+    'NetBSD': 'netbsd',
     'Windows': 'win32',
     'Darwin': 'darwin',
     'Solaris': 'sunos',

--- a/news/9496.bugfix.rst
+++ b/news/9496.bugfix.rst
@@ -1,3 +1,3 @@
-(NetBSD) Add the ``is_netbsd`` platform flag, treat NetBSD as a Unix platform,
-and search ``/usr/local/lib`` for shared libraries, as is already done for
-FreeBSD and OpenBSD.
+(NetBSD) Fix/improve NetBSD support: add the ``is_netbsd`` platform
+flag, treat NetBSD as a Unix platform, and search ``/usr/local/lib`` for
+shared libraries, as is already done for FreeBSD and OpenBSD.

--- a/news/9496.bugfix.rst
+++ b/news/9496.bugfix.rst
@@ -1,0 +1,3 @@
+(NetBSD) Add the ``is_netbsd`` platform flag, treat NetBSD as a Unix platform,
+and search ``/usr/local/lib`` for shared libraries, as is already done for
+FreeBSD and OpenBSD.

--- a/news/9496.build.1.rst
+++ b/news/9496.build.1.rst
@@ -1,0 +1,2 @@
+(OpenBSD) Fix misreport of cross-compilation when compiling bootloader
+on an OpenBSD system.

--- a/news/9496.build.rst
+++ b/news/9496.build.rst
@@ -1,0 +1,5 @@
+(NetBSD) Fix ``KeyError: 'netbsd'`` when compiling the bootloader, by adding
+NetBSD to the ``DESTOS_TO_SYSTEM`` and ``SYSTEM_TO_BUILDOS`` tables.
+Also add the missing ``OpenBSD`` entry to ``SYSTEM_TO_BUILDOS``, so that a
+native build on either system is no longer misreported as a
+cross-compilation.

--- a/news/9496.build.rst
+++ b/news/9496.build.rst
@@ -1,5 +1,1 @@
-(NetBSD) Fix ``KeyError: 'netbsd'`` when compiling the bootloader, by adding
-NetBSD to the ``DESTOS_TO_SYSTEM`` and ``SYSTEM_TO_BUILDOS`` tables.
-Also add the missing ``OpenBSD`` entry to ``SYSTEM_TO_BUILDOS``, so that a
-native build on either system is no longer misreported as a
-cross-compilation.
+(NetBSD) Fix ``KeyError: 'netbsd'`` when compiling the bootloader.


### PR DESCRIPTION
Building the bootloader on NetBSD fails outright:

```
No precompiled bootloader found or compile forced. Trying to compile the bootloader for you ...
  File ".../bootloader/wscript", line 456, in configure
KeyError: 'netbsd'
ERROR: Failed compiling the bootloader. Please compile manually and rerun
```

waf resolves `DEST_OS` to `netbsd` (`MACRO_TO_DESTOS` maps `__NetBSD__`), but `DESTOS_TO_SYSTEM` has no such key, so the lookup raises and PyInstaller cannot be installed from sdist on NetBSD at all.

### Why that lookup is reached at all

It sits inside the `if is_cross:` branch, which should never run on a native build. `SYSTEM_TO_BUILDOS` has no `NetBSD` entry, so `BUILD_OS` falls back to `platform.system()` — `NetBSD` — which never equals waf's `netbsd`, making `is_cross` true natively.

**`OpenBSD` is missing from that same table and is misdetected identically today.** It survives only because `DESTOS_TO_SYSTEM` happens to have an `openbsd` key, so rather than raising it prints `Assuming cross-compilation for OpenBSD` during an ordinary native build. Simulating the two tables:

| `platform.system()` | `BUILD_OS` | `DEST_OS` | `is_cross` | before |
|---|---|---|---|---|
| Linux | linux | linux | False | ok |
| FreeBSD | freebsd | freebsd | False | ok |
| OpenBSD | **OpenBSD** | openbsd | **True** | spurious cross-compile |
| NetBSD | **NetBSD** | netbsd | **True** | **KeyError** |

After this change all four are `False`.

### Changes

- `bootloader/wscript`: add `netbsd` to `DESTOS_TO_SYSTEM`; add `NetBSD` **and `OpenBSD`** to `SYSTEM_TO_BUILDOS`.
- `PyInstaller/compat.py`: add `is_netbsd`, fold into `is_unix`.
- `PyInstaller/depend/bindepend.py`: append `/usr/local/lib` for NetBSD as well (pkgsrc installs there).

### Deliberately not changed

The `is_freebsd or is_openbsd` branches in `depend/utils.py` that select ldconfig's output format. NetBSD ships **no ldconfig at all**, so `_load_ldconfig_cache` does not find one and correctly falls back to an empty cache. I probed a live NetBSD 10.1 host to confirm rather than assume:

```
sys.platform      = netbsd10      # so startswith('netbsd') is the right test
platform.system() = NetBSD
ldconfig          MISSING
```

### Verification

On **NetBSD 10.1 / amd64, CPython 3.13**: the bootloader compiles from source, and a `--onefile` build of a non-trivial CLI (~18 MB, ~1500 bundled data files) starts, reports its version, and reads data files bundled via `--add-data` out of `sys._MEIPASS`. Regression-checked on **linux-x86_64** that a `--onefile` build still runs.

I am happy to add a news fragment once this has a PR number, and to adjust anything to taste.