### PR TITLE
Deprecation towards making UPX opt-in

### DIFF
--- a/PyInstaller/building/makespec.py
+++ b/PyInstaller/building/makespec.py
@@ -17,6 +17,7 @@ import os
 import re
 import sys
 import pathlib
+import shutil
 
 from PyInstaller import DEFAULT_SPECPATH
 from PyInstaller import log as logging
@@ -436,9 +437,16 @@ def __add_options(parser):
         help="Apply a symbol-table strip to the executable and shared libs (not recommended for Windows)",
     )
     g.add_argument(
-        "--noupx",
+        "--upx",
         action="store_true",
-        default=False,
+        default="unset",
+        help=
+        "Use UPX (if available) to compress collected binaries. This is the default but will stop being so in v7.0.0",
+    )
+    g.add_argument(
+        "--noupx",
+        dest="upx",
+        action="store_false",
         help="Do not use UPX even if it is available (works differently between Windows and *nix)",
     )
     g.add_argument(
@@ -637,7 +645,7 @@ def main(
     debug=[],
     python_options=[],
     strip=False,
-    noupx=False,
+    upx=False,
     upx_exclude=None,
     runtime_tmpdir=None,
     contents_directory=None,
@@ -674,6 +682,14 @@ def main(
     splash_center=None,
     **_kwargs
 ):
+    if upx == "unset":
+        upx = True
+        if shutil.which("upx"):
+            logger.log(
+                logging.DEPRECATION,
+                "Implicitly enabling UPX. In PyInstaller 7.0.0, UPX will become opt-in rather than opt-out. Pass --upx if you wish to keep using UPX"
+            )
+
     # Default values for onefile and console when not explicitly specified on command-line (indicated by None)
     if onefile is None:
         onefile = False
@@ -827,7 +843,7 @@ def main(
         'debug_bootloader': 'bootloader' in debug,
         'bootloader_ignore_signals': bootloader_ignore_signals,
         'strip': strip,
-        'upx': not noupx,
+        'upx': upx,
         'upx_exclude': [portable_filepath(i) for i in upx_exclude],
         'runtime_tmpdir': portable_filepath(runtime_tmpdir) if runtime_tmpdir else None,
         'exe_options': exe_options,

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -152,6 +152,10 @@ command-line option.
     fail the validation check of the ``codesign`` utility, and therefore
     cannot be code-signed (which is a requirement on the Apple M1 platform).
 
+.. note::
+  UPX will become opt-in via the :option:`--upx` option rather than opt-out via
+  :option:`--noupx` in PyInstaller v7.0.0.
+
 
 Excluding problematic files from UPX processing
 -----------------------------------------------

--- a/news/9497.deprecation.rst
+++ b/news/9497.deprecation.rst
@@ -1,0 +1,3 @@
+UPX compression will become opt-in rather that implicitly enabled if installed
+in v7.0.0. Supply :option:`--upx` to keep UPX compression. The :option:`--noupx`
+will be kept for backwards compatibility but eventually become a no-op.


### PR DESCRIPTION
To avoid the situation where UPX implicitly runs on a file it doesn't support without the user knowing because they just happened to have UPX installed...

* Add a new (currently benign) --upx option as a counterpart to --noupx with the intention that we'll flip the default in v7.0.0.

* Add a deprecation warning during spec generation if the above switch would cause a silent behaviour change (UPX is available but neither --upx nor --noupx is set).