### PR TITLE
bootloader: remove MSVC-specific version of no-nop debug macros

### DIFF
--- a/bootloader/src/pyi_global.h
+++ b/bootloader/src/pyi_global.h
@@ -161,14 +161,8 @@
         #define PYI_DEBUG(...) pyi_debug_message(__VA_ARGS__)
         #define PYI_DEBUG_W(...) pyi_debug_message_w(__VA_ARGS__)
     #else
-        /* MSVC does not allow empty vararg macro; but clang + MSVC does */
-        #if defined(_MSC_VER) && !defined(__clang__)
-            #define PYI_DEBUG
-            #define PYI_DEBUG_W
-        #else
-            #define PYI_DEBUG(...)
-            #define PYI_DEBUG_W(...)
-        #endif
+        #define PYI_DEBUG(...)
+        #define PYI_DEBUG_W(...)
     #endif /* defined(LAUNCH_DEBUG) */
 #else /* defined(_WIN32) */
     /* POSIX; display error messages to stderr. */

--- a/doc/bootloader-building.rst
+++ b/doc/bootloader-building.rst
@@ -36,7 +36,7 @@ provide details for individual platforms.
 The officially supported platforms are:
 
 * GNU/Linux (using gcc)
-* Windows (using Visual C++ (VS2015 or later) or MinGW's gcc)
+* Windows (using Visual C++ (VS2017 or later) or MinGW's gcc)
 * macOS (using clang)
 
 Contributed platforms are:
@@ -332,7 +332,7 @@ between three options:
    This is why the bootloaders delivered with PyInstaller are build using
    Visual Studio C++ compiler.
 
-   Visual Studio 2015 or later is required.
+   Visual Studio 2017 or later is required.
 
 
 2. Using the `MinGW-w64`_ suite.
@@ -403,11 +403,11 @@ Build using Microsoft Visual C/C++ toolchain
 
 * Useful Links:
 
-  * `Microsoft Visual C++ Build-Tools 2015
-    <https://www.microsoft.com/en-us/download/details.aspx?id=48159>`_
-  * `Microsoft Build-Tools for Visual Studio 2026.
-    <https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2026>`_
-
+  * `Microsoft Build-Tools for Visual Studio 2017 (direct download) <https://aka.ms/vs/15/release/vs_buildtools.exe>`_
+  * `Microsoft Build-Tools for Visual Studio 2019 (direct download) <https://aka.ms/vs/16/release/vs_buildtools.exe>`_
+  * `Microsoft Build-Tools for Visual Studio 2022 (direct download) <https://aka.ms/vs/17/release/vs_buildtools.exe>`_
+  * `Microsoft Build-Tools for Visual Studio 2026 (direct download) <https://aka.ms/vs/stable/vs_BuildTools.exe>`_
+  * `Microsoft Build-Tools for Visual Studio 2026 (main download page) <https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2026>`_
 
 After installing the C++ build-tool
 you can build the bootloader as shown above.


### PR DESCRIPTION
The past versions of MSVC* did not support empty vararg macros, but contemporary versions appear to be fine with them. So remove the old MSVC-specific `#ifdefs` to prevent accumulation of unnecessary cruft.

[*] I added that comment in 2024 during refactoring of the corresponding parts of the code, so I assume that the issue was still present back then. However, when testing with various versions of VS build tools (going back to build tools for VS2017, which seems to be the earliest version that is still available today...), they all seem to work now. So perhaps it was a bug in MSVC that was addressed by updates within each of the VS series...

It seems that nowadays build tools for VS 2015 are difficult to come by; update the docs to specify 2017 as the minimum supported version, and include direct download links for all available versions: 2017, 2019, 2022, and 2026.