### PR TITLE
bootloader: resolve /proc entry using realpath() instead of readlink()

### DIFF
--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -1302,7 +1302,7 @@ _pyi_resolve_executable_posix(const char *argv0, char *executable_filename, char
      * and with all symbolic links resolved. */
     ssize_t name_len = -1;
 
-#if defined(__linux__) || defined(__CYGWIN__)
+#if defined(__linux__) || defined(__CYGWIN__) || defined(__NetBSD__)
     const char *proc_path = "/proc/self/exe";
 #elif defined(__FreeBSD__)
     const char *proc_path = "/proc/curproc/file";

--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -1297,22 +1297,30 @@ _pyi_find_progam_in_search_path(const char *name, char *result_path)
 static int
 _pyi_resolve_executable_posix(const char *argv0, char *executable_filename, char *loader_filename)
 {
-    /* On Linux, Cygwin, FreeBSD, and Solaris, we try /proc entry first.
+    /* On supported platforms, we try the /proc entry first.
      * The entry points at "true" file location, i.e., fully canonicalized
      * and with all symbolic links resolved. */
     ssize_t name_len = -1;
 
 #if defined(__linux__) || defined(__CYGWIN__)
-    name_len = readlink("/proc/self/exe", executable_filename, PYI_PATH_MAX - 1);  /* Linux, Cygwin */
+    const char *proc_path = "/proc/self/exe";
 #elif defined(__FreeBSD__)
-    name_len = readlink("/proc/curproc/file", executable_filename, PYI_PATH_MAX - 1);  /* FreeBSD */
+    const char *proc_path = "/proc/curproc/file";
 #elif defined(__sun)
-    name_len = readlink("/proc/self/path/a.out", executable_filename, PYI_PATH_MAX - 1);  /* Solaris */
+    const char *proc_path = "/proc/self/path/a.out";
+#else
+    const char *proc_path = NULL; /* Unsupported */
 #endif
 
-    if (name_len != -1) {
-        /* Output is not yet NULL-terminated, so we need to do it using returned byte count. */
-        executable_filename[name_len] = 0;
+    if (proc_path) {
+        PYI_DEBUG("LOADER: trying to resolve executable file via /proc entry...\n");
+        name_len = readlink(proc_path, executable_filename, PYI_PATH_MAX - 1);
+        if (name_len != -1) {
+            /* Output is not yet NULL-terminated, so we need to do it using returned byte count. */
+            executable_filename[name_len] = 0;
+        }
+    } else {
+        PYI_DEBUG("LOADER: executable resolution via /proc entry is not supported...\n");
     }
 
     /* On linux, we might have been launched using custom ld.so dynamic loader.
@@ -1327,6 +1335,7 @@ _pyi_resolve_executable_posix(const char *argv0, char *executable_filename, char
 #endif
 
     if (name_len != -1) {
+        PYI_DEBUG("LOADER: executable file resolved via /proc entry\n");
         return 0;
     }
 

--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -1298,10 +1298,11 @@ static int
 _pyi_resolve_executable_posix(const char *argv0, char *executable_filename, char *loader_filename)
 {
     /* On supported platforms, we try the /proc entry first.
-     * The entry points at "true" file location, i.e., fully canonicalized
-     * and with all symbolic links resolved. */
-    ssize_t name_len = -1;
-
+     * On some platforms, the entry points at "true" file location,
+     * i.e., canonical and with all symbolic links resolved; on others
+     * (e.g., NetBSD), the entry is neither canonical nor fully resolved.
+     * So to be safe, always pass the symlink to realpath() for full
+     * resolution. */
 #if defined(__linux__) || defined(__CYGWIN__) || defined(__NetBSD__)
     const char *proc_path = "/proc/self/exe";
 #elif defined(__FreeBSD__)
@@ -1314,27 +1315,26 @@ _pyi_resolve_executable_posix(const char *argv0, char *executable_filename, char
 
     if (proc_path) {
         PYI_DEBUG("LOADER: trying to resolve executable file via /proc entry...\n");
-        name_len = readlink(proc_path, executable_filename, PYI_PATH_MAX - 1);
-        if (name_len != -1) {
-            /* Output is not yet NULL-terminated, so we need to do it using returned byte count. */
-            executable_filename[name_len] = 0;
+        if (realpath(proc_path, executable_filename) == NULL) {
+            executable_filename[0] = 0;
         }
     } else {
         PYI_DEBUG("LOADER: executable resolution via /proc entry is not supported...\n");
+        executable_filename[0] = 0;
     }
 
     /* On linux, we might have been launched using custom ld.so dynamic loader.
      * In that case, /proc/self/exe points to the ld.so executable, and we need
      * to ignore it. */
 #if defined(__linux__)
-    if (name_len != -1 && _pyi_is_ld_linux_so(executable_filename) == true) {
+    if (executable_filename[0] != 0 && _pyi_is_ld_linux_so(executable_filename) == true) {
         PYI_DEBUG("LOADER: resolved executable file %s is ld.so dynamic linker/loader - storing its name.\n", executable_filename);
         strncpy(loader_filename, executable_filename, PYI_PATH_MAX); /* both buffers are guaranteed to be PYI_PATH_MAX-sized */
-        name_len = -1;
+        executable_filename[0] = 0;
     }
 #endif
 
-    if (name_len != -1) {
+    if (executable_filename[0] != 0) {
         PYI_DEBUG("LOADER: executable file resolved via /proc entry\n");
         return 0;
     }

--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -1377,6 +1377,35 @@ _pyi_resolve_executable_posix(const char *argv0, char *executable_filename, char
     return 0;
 }
 
+#if defined(__CYGWIN__)
+
+static int
+_pyi_resolve_executable_cygwin(const char *argv0, char *executable_filename, char *loader_filename)
+{
+    size_t len;
+
+    /* Resolve using POSIX helper */
+    if (_pyi_resolve_executable_posix(argv0, executable_filename, loader_filename) < 0) {
+        return -1;
+    }
+
+    /* Depending on invocation, the executable might be resolved with or
+     * without the .exe suffix. Several places expect the executable name
+     * to be without suffix, so remove it as necessary. */
+    len = strlen(executable_filename);
+    if (len >= 5) {
+        char *suffix_ptr = executable_filename + len - 4;
+        if (strcasecmp(suffix_ptr, ".exe") == 0) {
+            PYI_DEBUG("LOADER: removing .exe suffix from executable name\n");
+            *suffix_ptr = 0;
+        }
+    }
+
+    return 0;
+}
+
+#endif /* defined(__CYGWIN__) */
+
 #endif
 
 
@@ -1388,6 +1417,8 @@ _pyi_main_resolve_executable(struct PYI_CONTEXT *pyi_ctx)
     return _pyi_resolve_executable_win32(pyi_ctx->executable_filename);
 #elif defined(__APPLE__)
     return _pyi_resolve_executable_macos(pyi_ctx->executable_filename);
+#elif defined(__CYGWIN__)
+    return _pyi_resolve_executable_cygwin(pyi_ctx->argv[0], pyi_ctx->executable_filename, pyi_ctx->dynamic_loader_filename);
 #else
     return _pyi_resolve_executable_posix(pyi_ctx->argv[0], pyi_ctx->executable_filename, pyi_ctx->dynamic_loader_filename);
 #endif

--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -1159,7 +1159,7 @@ int pyi_main_onefile_parent_cleanup(struct PYI_CONTEXT *pyi_ctx)
 /**********************************************************************\
  *                     Executable file resolution                     *
 \**********************************************************************/
-#ifdef _WIN32
+#if defined(_WIN32)
 
 static int
 _pyi_resolve_executable_win32(char *executable_filename)
@@ -1207,7 +1207,7 @@ _pyi_resolve_executable_win32(char *executable_filename)
     return 0;
 }
 
-#elif __APPLE__
+#elif defined(__APPLE__)
 
 static int
 _pyi_resolve_executable_macos(char *executable_filename)
@@ -1384,9 +1384,9 @@ static int
 _pyi_main_resolve_executable(struct PYI_CONTEXT *pyi_ctx)
 {
     /* Resolve using OS-specific implementation */
-#ifdef _WIN32
+#if defined(_WIN32)
     return _pyi_resolve_executable_win32(pyi_ctx->executable_filename);
-#elif __APPLE__
+#elif defined(__APPLE__)
     return _pyi_resolve_executable_macos(pyi_ctx->executable_filename);
 #else
     return _pyi_resolve_executable_posix(pyi_ctx->argv[0], pyi_ctx->executable_filename, pyi_ctx->dynamic_loader_filename);


### PR DESCRIPTION
Similarly to Linux, NetBSD also has `/proc/self/exe` that allows us to resolve the executable of the current process. But in contrast to Linux, the target of the symlink is not canonical (it is `/path/to/./executable` when executable is launched as `./executable`) and potential symlinks in the path are not resolved (e.g., in the previous example, `executable` could be a symlink pointing to a real executable in some other location).

The first commit refactors the part of `_pyi_resolve_executable_posix` that handles /proc entries, so that only platform-specific /proc paths are placed under platform-specific `#ifdef`s. It also adds couple of debug messages that improve observability of executable resolution in debug-enabled bootloader.

Second commit adds #ifdef for NetBSD (`__NetBSD__`).

Third commit replaces the use of `readlink()` with `realpath()`, for all platforms; this way, we do not need to concern ourselves with platform-specific behavior of the `/proc/self/exe` (or equivalent) symlink, and always end up with canonical and fully resolved path to executable.