### PR TITLE
Improve *BSD support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -604,3 +604,87 @@ jobs:
             export FORCE_COLOR=1
             python -m pytest -n 4 --maxfail 3 --durations 10 tests/unit tests/functional
           '
+
+  test-misc-platforms:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: ['freebsd', 'openbsd', 'netbsd']
+      fail-fast: false
+    steps:
+      - name: Checkout PyInstaller code
+        uses: actions/checkout@v6
+
+      # The platform-specific VM setup; uses corresponding action from vmactions
+      # (and defines custom "vmsh" shell for use in subsequent steps) and
+      # platform-specific package manager to set up python environment.
+      - name: Setup VM (FreeBSD)
+        if: matrix.platform == 'freebsd'
+        uses: vmactions/freebsd-vm@v1
+        with:
+          custom-shell-name: vmsh
+          copyback: false  # Avoid copying files back to host between steps using vmsh
+          prepare: |
+            pkg update
+            pkg upgrade -y
+            pkg install -y \
+              python py312-pip py312-sqlite3 py312-tkinter \
+              py312-psutil py312-pytest py312-pytest-xdist \
+              py312-numpy py312-pillow
+
+      - name: Setup VM (OpenBSD)
+        if: matrix.platform == 'openbsd'
+        uses: vmactions/openbsd-vm@v1
+        with:
+          custom-shell-name: vmsh
+          copyback: false
+          prepare: |
+            pkg_add \
+              py3-pip python-tkinter \
+              py3-psutil py3-test py3-test-xdist \
+              py3-numpy py3-pillow
+
+      # NOTE: for now, install and python 3.12; with 3.13 and 3.14, we seem to be getting
+      # a segfault at frozen program exit.
+      - name: Setup VM (NetBSD)
+        if: matrix.platform == 'netbsd'
+        uses: vmactions/netbsd-vm@v1
+        with:
+          custom-shell-name: vmsh
+          copyback: false
+          prepare: |
+            export PATH="/usr/pkg/sbin:/usr/pkg/bin:$PATH"
+            export PKG_PATH="https://cdn.netbsd.org/pub/pkgsrc/packages/NetBSD/x86_64/11.0_2026Q2/All/"
+            pkg_add pkgin
+            pkgin -y install \
+              python312 py312-pip py312-Tk \
+              py312-psutil py312-test py312-test-xdist \
+              py312-numpy py312-Pillow
+            ln -s /usr/pkg/bin/python3.12 /usr/pkg/bin/python3
+
+      # The steps below should be common to all platforms
+      - name: Install PyInstaller
+        shell: vmsh {0}
+        run: |
+            cd bootloader
+            python3 waf all
+            cd ..
+            python3 -m pip install --break-system-packages .
+            pyinstaller --version
+
+      - name: Install test requirements
+        shell: vmsh {0}
+        run: |
+            python3 -m pip install --break-system-packages -r tests/requirements-base.txt
+
+      - name: Run tests
+        shell: vmsh {0}
+        run: |
+            export FORCE_COLOR=1
+            export PYINSTALLER_STRICT_UNPACK_MODE=1
+            export PYINSTALLER_STRICT_COLLECT_MODE=1
+            export PYINSTALLER_STRICT_BUNDLE_CODESIGN_ERROR=1
+            export PYINSTALLER_VERIFY_BUNDLE_SIGNATURE=1
+            export PYTHONWARNDEFAULTENCODING=true
+            export PYINSTALLER_ZLIB_COMPRESSION_LEVEL=1
+            python3 -m pytest -n 4 --maxfail 3 --durations 10 tests/unit tests/functional

--- a/PyInstaller/depend/bindepend.py
+++ b/PyInstaller/depend/bindepend.py
@@ -360,6 +360,7 @@ def _get_imports_ldd(filename, search_paths):
     output = set()
 
     # Output of ldd varies between platforms...
+    ldd_extra_args = []
     if compat.is_aix:
         # Match libs of the form
         #   'archivelib.a(objectmember.so/.o)'
@@ -393,13 +394,20 @@ def _get_imports_ldd(filename, search_paths):
         # or
         #   /tmp/python/install/bin/../lib/libpython3.13.so.1.0 (0x00007b9489c82000)
         LDD_PATTERN = re.compile(r"^\s*(?:(.*?)\s+=>\s+)?(.*?)\s+\(.*\)")
+    elif compat.is_netbsd:
+        # The default output format used by NetBSD ldd is `\t-l%o.%m => %p\n'. This would give us entries of form
+        #    -lpython3.11.1.0 => /usr/pkg/lib/libpython3.11.so.1.0
+        # Instead, override the format to give us entries of the form
+        #    libpython3.11.so.1.0 => /usr/pkg/lib/libpython3.11.so.1.0
+        ldd_extra_args = ['-f', '\tlib%o.so.%m => %p\n']
+        LDD_PATTERN = re.compile(r"\s*(.*?)\s+=>\s+(.*?)$")
     else:
         LDD_PATTERN = re.compile(r"\s*(.*?)\s+=>\s+(.*?)\s+\(.*\)")
 
     # Resolve symlinks since GNU ldd contains a bug in processing a symlink to a binary
     # using $ORIGIN: https://sourceware.org/bugzilla/show_bug.cgi?id=25263
     p = subprocess.run(
-        ['ldd', os.path.realpath(filename)],
+        ['ldd', *ldd_extra_args, os.path.realpath(filename)],
         stdin=subprocess.DEVNULL,
         stderr=subprocess.PIPE,
         stdout=subprocess.PIPE,
@@ -457,6 +465,10 @@ def _get_imports_ldd(filename, search_paths):
                     # plus musl's ld-musl-*.so.* and Termux' ld-android.so.
                     if re.fullmatch(r"ld(64)?(-linux|-musl)?(-.+)?\.so(\..+)?", os.path.basename(lib)):
                         continue
+                elif compat.is_netbsd:
+                    # libsomething.so without soversion has .(null) in displayed name (the .%m part of the ldd format).
+                    if name.endswith('.(null)'):
+                        name = name[:-7]
             if name[:10] in ('linux-gate', 'linux-vdso'):
                 # linux-gate is a fake library which does not exist and should be ignored. See also:
                 # http://www.trilithium.com/johan/2005/08/linux-gate/

--- a/PyInstaller/depend/bindepend.py
+++ b/PyInstaller/depend/bindepend.py
@@ -401,6 +401,23 @@ def _get_imports_ldd(filename, search_paths):
         #    libpython3.11.so.1.0 => /usr/pkg/lib/libpython3.11.so.1.0
         ldd_extra_args = ['-f', '\tlib%o.so.%m => %p\n']
         LDD_PATTERN = re.compile(r"\s*(.*?)\s+=>\s+(.*?)$")
+    elif compat.is_openbsd:
+        # $ ldd /usr/local/bin/python3.13
+        # /usr/local/bin/python3.13:
+        #   Start            End              Type  Open Ref GrpRef Name
+        #   000001b19dcf5000 000001b19dcf9000 exe   2    0   0      /usr/local/bin/python3.13
+        #   000001b48652e000 000001b486bb6000 rlib  0    1   0      /usr/local/lib/libpython3.13.so.0.0
+        #   000001b3b8ced000 000001b3b8d25000 rlib  0    2   0      /usr/local/lib/libintl.so.8.2
+        #   ...
+        #
+        # Note that `ldd` on OpenBSD explicitly disallows unresolved libraries, and exits with signal 9 if any are
+        # encountered.
+        #
+        # The pattern implicitly ignores the first two lines (input path and the header).
+        LDD_PATTERN = re.compile(
+            r"^\s+(?P<start>\S+)\s+(?P<end>\S+)\s+(?P<type>\S+)\s+(?P<open>\d+)\s+(?P<ref>\d+)\s+(?P<grp_ref>\d+)"
+            r"\s+(?P<name>.*)$"
+        )
     else:
         LDD_PATTERN = re.compile(r"\s*(.*?)\s+=>\s+(.*?)\s+\(.*\)")
 
@@ -455,6 +472,19 @@ def _get_imports_ldd(filename, search_paths):
                     #   'sharedlib.so'
                     lib = m.group('libshared')
                     name = os.path.basename(lib)
+            elif compat.is_openbsd:
+                # Ignore 'exe', 'dlib', and 'ld.so' types.
+                if m['type'] != 'rlib':
+                    continue
+
+                # Ignore the entry with ref=0, which appears to be the scanned binary itself; should be already
+                # discarded by type check above (due to being 'exe' or 'dlib'), but just in case...
+                ref = int(m['ref'])
+                if ref == 0:
+                    continue
+
+                lib = m['name']
+                name = os.path.basename(lib)
             elif compat.is_hpux:
                 name, lib = m.group(1), m.group(2)
             else:

--- a/PyInstaller/utils/hooks/tcl_tk.py
+++ b/PyInstaller/utils/hooks/tcl_tk.py
@@ -78,6 +78,29 @@ def _get_tcl_tk_info():
     }
 
 
+def _check_tkinter_fully_usable():
+    """
+    Check that tkinter is fully usable by instantiating a window in a subprocess.
+    This check should cover the following scenarios:
+     - tkinter missing
+     - import of tkinter crashes python interpreter
+     - tkinter.Tk() fails due to DISPLAY not being set on linux
+     - tkinter.Tk() fails due to faulty build (e.g., due to Tcl/Tk version mix-up, as seen with python <= 3.10 builds on
+       macos-12 GHA runners; https://github.com/actions/setup-python/issues/649#issuecomment-1745056485)
+    """
+    @isolated.decorate
+    def _create_tkinter_window():
+        import tkinter
+        tkinter.Tk()
+
+    try:
+        _create_tkinter_window()
+    except Exception:
+        return False
+
+    return True
+
+
 class TclTkInfo:
     # Root directory names of Tcl and Tk library/data directories in the frozen application. These directories are
     # originally fully versioned (e.g., tcl8.6 and tk8.6); we want to remap them to unversioned variants, so that our
@@ -98,6 +121,12 @@ class TclTkInfo:
 
     # Delay initialization of Tcl/Tk information until until the corresponding attributes are first requested.
     def __getattr__(self, name):
+        # tkinter_fully_usable is initialized and cached independently of other properties.
+        if name == 'tkinter_fully_usable':
+            if 'tkinter_fully_usable' not in self.__dict__:
+                self.tkinter_fully_usable = _check_tkinter_fully_usable()
+            return getattr(self, name)
+
         if 'available' in self.__dict__:
             # Initialization was already done, but requested attribute is not available.
             raise AttributeError(name)

--- a/news/9505.bugfix.1.rst
+++ b/news/9505.bugfix.1.rst
@@ -1,0 +1,1 @@
+(OpenBSD) Fix binary dependency analysis.

--- a/news/9505.bugfix.rst
+++ b/news/9505.bugfix.rst
@@ -1,0 +1,1 @@
+(NetBSD) Fix binary dependency analysis.

--- a/tests/functional/test_libraries.py
+++ b/tests/functional/test_libraries.py
@@ -13,7 +13,7 @@ import pytest
 
 from PyInstaller.compat import is_win, is_linux
 from PyInstaller.utils.tests import importorskip, skipif, requires
-from PyInstaller.utils.hooks import can_import_module
+from PyInstaller.utils.hooks import can_import_module, tcl_tk
 
 
 @importorskip('gevent')
@@ -96,31 +96,9 @@ def test_tkinter_tcl_library_dir(pyi_builder):
 # button, and register a timer to shut down the application. Doing so verifies that all Tcl/Tk files (e.g., .tcl
 # scripts from library directories) are properly collected.
 #
-# The prerequisite for this test is that tkinter can be used unfrozen, so try instantiating a window in a subprocess
-# to verify that this is the case. This check should cover the following scenarios:
-#  - tkinter missing
-#  - import of tkinter crashes python interpreter
-#  - tkinter.Tk() fails due to DISPLAY not being set on linux
-#  - tkinter.Tk() fails due to faulty build (e.g., due to Tcl/Tk version mix-up, as seen with python <= 3.10 builds on
-#    macos-12 GHA runners; https://github.com/actions/setup-python/issues/649#issuecomment-1745056485)
-def _tkinter_fully_usable():
-    from PyInstaller import isolated
-
-    @isolated.decorate
-    def _create_tkinter_window():
-        import tkinter
-        tkinter.Tk()
-
-    try:
-        _create_tkinter_window()
-    except Exception:
-        return False
-
-    return True
-
-
+# The prerequisite for this test is that tkinter can be used unfrozen, so check that this is indeed the case.
 def test_tkinter_functional(pyi_builder):
-    if not _tkinter_fully_usable():
+    if not tcl_tk.tcltk_info.tkinter_fully_usable:
         pytest.skip("tkinter is not fully usable.")
 
     pyi_builder.test_source(

--- a/tests/functional/test_splash.py
+++ b/tests/functional/test_splash.py
@@ -17,14 +17,11 @@ NOTE: splash screen is not supported on macOS due to incompatible design.
 import pytest
 
 from PyInstaller.compat import is_darwin, is_musl
-from PyInstaller.utils.hooks import can_import_module
+from PyInstaller.utils.hooks.tcl_tk import tcltk_info
 
 pytestmark = [
-    # PyInstaller.utils.tests.importorskip('tkinter') ends up checking if the module's spec exists, but does not
-    # actually try to import the module. So we need to use `can_import_module()` hook utility function instead, which
-    # does try to import the module, and catches errors when _tkinter is unavailable or cannot be loaded due to broken
-    # dependencies.
-    pytest.mark.skipif(not can_import_module('tkinter'), reason="tkinter cannot be imported."),
+    # Splash screen tests require Tcl/Tk (and, by extension, `tkinter`) to be fully functional.
+    pytest.mark.skipif(not tcltk_info.tkinter_fully_usable, reason="tkinter is not fully usable."),
     pytest.mark.skipif(is_darwin, reason="Splash screen is not supported on macOS."),
     pytest.mark.xfail(is_musl, reason="musl + tkinter is known to cause mysterious segfaults."),
 ]

--- a/tests/unit/test_isolation.py
+++ b/tests/unit/test_isolation.py
@@ -168,6 +168,7 @@ def test_decorator():
 
 
 @requires("psutil")
+@pytest.mark.xfail(compat.is_netbsd, reason="more file descriptors used than expected.")
 def test_pipe_leakage():
     """
     There is a finite number of open pipes/file handles/file descriptors allowed per process. Ensure that all


### PR DESCRIPTION
Add basic CI workflows for FreeBSD, OpenBSD and NetBSD, using VMs from https://github.com/vmactions. 

Fix binary dependency analysis on NetBSD and OpenBSD, each with its own `ldd` output format.

Skip splash-screen tests unless `tkinter` is fully functional (as opposed to being present and importable). 

xfail the `test_pipe_leakage` on NetBSD, because it seems that pipes take more file descriptors that anticipated (three or four instead of two) - needs to be investigated further.