### PR TITLE
bootloader: Windows: use QueryFullProcessImageNameW for executable resolution

### DIFF
--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -1245,44 +1245,29 @@ int pyi_main_onefile_parent_cleanup(struct PYI_CONTEXT *pyi_ctx)
 static int
 _pyi_resolve_executable_win32(char *executable_filename)
 {
-    wchar_t modulename_w[PYI_PATH_MAX];
+    HANDLE process_handle;
+    wchar_t executable_filename_w[PYI_PATH_MAX];
+    DWORD executable_filename_length;
 
-    /* GetModuleFileNameW returns an absolute, fully qualified path */
-    if (!GetModuleFileNameW(NULL, modulename_w, PYI_PATH_MAX)) {
-        PYI_WINERROR_W(L"GetModuleFileNameW", L"Failed to obtain executable path.\n");
+    process_handle = GetCurrentProcess(); /* Get pseudo-handle for current process */
+
+    /* Use QueryFullProcessImageNameW(), which fully resolves the executable
+     * (i.e, resolves the symbolic links / junctions). The same function
+     * is used to obtain parent process executable path in
+     * `_pyi_security_verify_parent_proces_win32()` in pyi_security.c */
+    executable_filename_length = PYI_PATH_MAX;
+    if (!QueryFullProcessImageNameW(process_handle, 0, executable_filename_w, &executable_filename_length)) {
+        PYI_WINERROR_W(L"QueryFullProcessImageNameW", L"Failed to obtain executable path.\n");
+        CloseHandle(process_handle);
         return -1;
     }
 
-    /* If path is a symbolic link, resolve it */
-    if (pyi_win32_is_symlink(modulename_w)) {
-        wchar_t executable_filename_w[PYI_PATH_MAX];
-        int offset = 0;
+    CloseHandle(process_handle);
 
-        PYI_DEBUG_W(L"LOADER: executable file %ls is a symbolic link - resolving...\n", modulename_w);
-
-        /* Resolve */
-        if (pyi_win32_realpath(modulename_w, executable_filename_w) < 0) {
-            PYI_ERROR_W(L"Failed to resolve full path to executable %ls.\n", modulename_w);
-            return -1;
-        }
-
-        /* Remove the extended path indicator, to avoid potential issues due
-         * to its appearance in `sys.executable`, `sys._MEIPASS`, etc. */
-        if (wcsncmp(L"\\\\?\\", executable_filename_w, 4) == 0) {
-            offset = 4;
-        }
-
-        /* Convert to UTF-8 */
-        if (!pyi_win32_wcs_to_utf8(executable_filename_w + offset, executable_filename, PYI_PATH_MAX)) {
-            PYI_ERROR_W(L"Failed to convert executable path to UTF-8.\n");
-            return -1;
-        }
-    } else {
-        /* Convert to UTF-8 */
-        if (!pyi_win32_wcs_to_utf8(modulename_w, executable_filename, PYI_PATH_MAX)) {
-            PYI_ERROR_W(L"Failed to convert executable path to UTF-8.\n");
-            return -1;
-        }
+    /* Convert to UTF-8 */
+    if (!pyi_win32_wcs_to_utf8(executable_filename_w, executable_filename, PYI_PATH_MAX)) {
+        PYI_ERROR_W(L"Failed to convert executable path to UTF-8.\n");
+        return -1;
     }
 
     return 0;

--- a/news/9508.bugfix.rst
+++ b/news/9508.bugfix.rst
@@ -1,0 +1,2 @@
+(Windows) Fix spurious security validation error when a ``onefile``
+executable is launched from a symlinked directory or a junction.

--- a/tests/functional/test_security.py
+++ b/tests/functional/test_security.py
@@ -273,3 +273,57 @@ def test_application_home_directory_hijack(pyi_builder, tmp_path, parent_level):
             # due to strict parent process validation requirement).
             assert p.returncode not in {0, 42}
             assert (MSG_PARENT_EXECUTABLE in p.stderr) or (MSG_HOME_DIRECTORY in p.stderr)
+
+
+# Test that parent-process security validation works correctly in case of symlinked executables (i.e., the executable
+# itself being symlinked, or one of its parent directories being symlinked). See #9508.
+def test_security_validation_with_symlinked_executable(pyi_builder, tmp_path):
+    # Ensure that symbolic links can be created
+    try:
+        test_dir = tmp_path / 'sanity-check' / 'test-dir'
+        test_dir.mkdir(parents=True)
+        test_file = tmp_path / 'sanity-check' / 'test-file.txt'
+        test_file.write_text('Test', encoding='utf-8')
+
+        test_dir_symlink = tmp_path / 'sanity-check' / 'test-dir-symlink'
+        test_file_symlink = tmp_path / 'sanity-check' / 'test-file-symlink.txt'
+
+        os.symlink(test_file, test_file_symlink)
+        os.symlink(test_dir, test_dir_symlink, target_is_directory=True)
+    except OSError:
+        if compat.is_win:
+            raise
+            pytest.skip("OS does not support creation of symbolic links.")
+        else:
+            raise
+
+    # Basic test application
+    pyi_builder.test_source("""
+        print("Hello world")
+    """)
+
+    print("\nFinished build and sanity-check tests - preparing the actual test...", file=sys.stdout)
+    print("\nFinished build and sanity-check tests - preparing the actual test...", file=sys.stderr)
+
+    executables = pyi_builder._find_executables('test_source')
+    assert len(executables) == 1
+    executable = executables[0]
+    print(f"Test application's executable: {executable}", file=sys.stdout)
+    print(f"Test application's executable: {executable}", file=sys.stderr)
+
+    # Symlinked executable
+    symlinked_exe = tmp_path / ('symlinked_executable.exe' if compat.is_win else 'symlinked_executable')
+    os.symlink(executable, symlinked_exe)
+
+    print(f"Running symlinked executable: {symlinked_exe}", file=sys.stdout)
+    print(f"Running symlinked executable: {symlinked_exe}", file=sys.stderr)
+    subprocess.run([symlinked_exe], check=True)
+
+    # Symlinked dist directory
+    symlinked_dist = tmp_path / 'symlinked-dist'
+    os.symlink(tmp_path / 'dist', symlinked_dist)
+    symlinked_dist_exe = symlinked_dist / pathlib.Path(executable).relative_to(tmp_path / 'dist')
+
+    print(f"Running executable in symlinked dist directory: {symlinked_dist_exe}", file=sys.stdout)
+    print(f"Running executable in symlinked dist directory: {symlinked_dist_exe}", file=sys.stderr)
+    subprocess.run([symlinked_dist_exe], check=True)


### PR DESCRIPTION
Have `_pyi_resolve_executable_win32()` use `QueryFullProcessImageNameW` to resolve the executable of the current process. This function should automatically resolve symbolic links for cases when the executable itself is linked (a file symlink) and when its parent directories are linked (a directory symlink or a junction).

The previous codepath resolved symlinks only for symlinked files, whereas security validation codepath already resolves the parent-process executable using `QueryFullProcessImageNameW`. The mismatch in behavior results in spurious security validation error when a `onefile` executable is launched from a symlinked directory.

Fixes #9508.