### PR TITLE
bootloader: revise earlier fix for #9508

### DIFF
--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -1245,29 +1245,57 @@ int pyi_main_onefile_parent_cleanup(struct PYI_CONTEXT *pyi_ctx)
 static int
 _pyi_resolve_executable_win32(char *executable_filename)
 {
-    HANDLE process_handle;
-    wchar_t executable_filename_w[PYI_PATH_MAX];
-    DWORD executable_filename_length;
+    wchar_t modulename_w[PYI_PATH_MAX];
 
-    process_handle = GetCurrentProcess(); /* Get pseudo-handle for current process */
-
-    /* Use QueryFullProcessImageNameW(), which fully resolves the executable
-     * (i.e, resolves the symbolic links / junctions). The same function
-     * is used to obtain parent process executable path in
-     * `_pyi_security_verify_parent_proces_win32()` in pyi_security.c */
-    executable_filename_length = PYI_PATH_MAX;
-    if (!QueryFullProcessImageNameW(process_handle, 0, executable_filename_w, &executable_filename_length)) {
-        PYI_WINERROR_W(L"QueryFullProcessImageNameW", L"Failed to obtain executable path.\n");
-        CloseHandle(process_handle);
+    /* GetModuleFileNameW() returns an absolute, fully qualified path.
+     * Symbolic links (at either file or directory/junction level) are
+     * NOT resolved!
+     *
+     * While we could use QueryFullProcessImageNameW() to obtain a
+     * fully resolved path (including all symlinks), that seems to
+     * be mis-behaving in certain corner cases, such as ImDisk RAMDISK
+     * (see #9510). Therefore, we use GetModuleFileNameW() and (if
+     * necessary) resolve file-level symlink ourselves, which is enough
+     * for the purpose of locating PKG archive and the contents directory
+     * (in onedir case). The security parent-process validation codepath
+     * in pyi_security.c, on the other hand, needs to use
+     * QueryFullProcessImageNameW() to look up the executable of both the
+     * current and the parent process and ensure consistent comparison. */
+    if (!GetModuleFileNameW(NULL, modulename_w, PYI_PATH_MAX)) {
+        PYI_WINERROR_W(L"GetModuleFileNameW", L"Failed to obtain executable path.\n");
         return -1;
     }
 
-    CloseHandle(process_handle);
+    /* If path is a symbolic link, resolve it */
+    if (pyi_win32_is_symlink(modulename_w)) {
+        wchar_t executable_filename_w[PYI_PATH_MAX];
+        int offset = 0;
 
-    /* Convert to UTF-8 */
-    if (!pyi_win32_wcs_to_utf8(executable_filename_w, executable_filename, PYI_PATH_MAX)) {
-        PYI_ERROR_W(L"Failed to convert executable path to UTF-8.\n");
-        return -1;
+        PYI_DEBUG_W(L"LOADER: executable file %ls is a symbolic link - resolving...\n", modulename_w);
+
+        /* Resolve */
+        if (pyi_win32_realpath(modulename_w, executable_filename_w) < 0) {
+            PYI_ERROR_W(L"Failed to resolve full path to executable %ls.\n", modulename_w);
+            return -1;
+        }
+
+        /* Remove the extended path indicator, to avoid potential issues due
+         * to its appearance in `sys.executable`, `sys._MEIPASS`, etc. */
+        if (wcsncmp(L"\\\\?\\", executable_filename_w, 4) == 0) {
+            offset = 4;
+        }
+
+        /* Convert to UTF-8 */
+        if (!pyi_win32_wcs_to_utf8(executable_filename_w + offset, executable_filename, PYI_PATH_MAX)) {
+            PYI_ERROR_W(L"Failed to convert executable path to UTF-8.\n");
+            return -1;
+        }
+    } else {
+        /* Convert to UTF-8 */
+        if (!pyi_win32_wcs_to_utf8(modulename_w, executable_filename, PYI_PATH_MAX)) {
+            PYI_ERROR_W(L"Failed to convert executable path to UTF-8.\n");
+            return -1;
+        }
     }
 
     return 0;

--- a/bootloader/src/pyi_security.c
+++ b/bootloader/src/pyi_security.c
@@ -59,8 +59,8 @@ _pyi_security_verify_parent_proces_win32(const struct PYI_CONTEXT *pyi_ctx)
 
     HANDLE process_handle;
     wchar_t parent_executable_w[PYI_PATH_MAX];
-    char parent_executable[PYI_PATH_MAX];
-    DWORD parent_executable_length;
+    wchar_t current_executable_w[PYI_PATH_MAX];
+    DWORD buffer_length;
 
     /* Current process ID, for look-up in the process snapshot */
     pid = GetCurrentProcessId();
@@ -103,13 +103,13 @@ _pyi_security_verify_parent_proces_win32(const struct PYI_CONTEXT *pyi_ctx)
      * via symbolic link. */
     process_handle = OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, FALSE, ppid);
     if (process_handle == INVALID_HANDLE_VALUE) {
-        PYI_ERROR_W(L"Security validation failure: failed to obtain information about parent proces!\n");
+        PYI_ERROR_W(L"Security validation failure: failed to obtain information about parent process!\n");
         return -1;
     }
 
-    parent_executable_length = PYI_PATH_MAX;
-    if (!QueryFullProcessImageNameW(process_handle, 0, parent_executable_w, &parent_executable_length)) {
-        PYI_ERROR_W(L"Security validation failure: failed to obtain executable path for parent proces!\n");
+    buffer_length = PYI_PATH_MAX;
+    if (!QueryFullProcessImageNameW(process_handle, PROCESS_NAME_NATIVE, parent_executable_w, &buffer_length)) {
+        PYI_ERROR_W(L"Security validation failure: failed to obtain executable path for parent process!\n");
         CloseHandle(process_handle);
         return -1;
     }
@@ -118,14 +118,26 @@ _pyi_security_verify_parent_proces_win32(const struct PYI_CONTEXT *pyi_ctx)
 
     PYI_DEBUG_W(L"SECURITY: parent process executable: %ls\n", parent_executable_w);
 
-    /* Convert to UTF-8 for comparison */
-    if (!pyi_win32_wcs_to_utf8(parent_executable_w, parent_executable, PYI_PATH_MAX)) {
-        PYI_ERROR_W(L"Security validation failure: failed to convert parent process executable path to UTF-8!\n");
+    /* Look up the current-process executable. We cannot use pyi_ctx->executable_filename,
+     * which is resolved using GetModuleFileNameW() for compatibility reasons (see #9510),
+     * whereas we need to resolve the executable using QueryFullProcessImageNameW() here
+     * to ensure same behavior (i.e., full resolution of file symbolic links, directory
+     * symbolic links, and junctions) as above with parent-process executable (see #9508). */
+    process_handle = GetCurrentProcess();
+
+    buffer_length = PYI_PATH_MAX;
+    if (!QueryFullProcessImageNameW(process_handle, PROCESS_NAME_NATIVE, current_executable_w, &buffer_length)) {
+        PYI_ERROR_W(L"Security validation failure: failed to obtain executable path for current process!\n");
+        CloseHandle(process_handle);
         return -1;
     }
 
+    CloseHandle(process_handle);
+
+    PYI_DEBUG_W(L"SECURITY: current process executable: %ls\n", current_executable_w);
+
     /* Ensure that same executable is used */
-    if (strcmp(parent_executable, pyi_ctx->executable_filename) != 0) {
+    if (wcscmp(parent_executable_w, current_executable_w) != 0) {
         PYI_ERROR_W(L"Security validation failure: parent process has different executable!\n");
         return -1;
     }

--- a/news/9510.bugfix.rst
+++ b/news/9510.bugfix.rst
@@ -1,0 +1,2 @@
+(Windows) Revise earlier fix for :issue:`9508` to avoid breaking
+executables located on ImDisk RAMDISK volumes.

--- a/tests/functional/test_security.py
+++ b/tests/functional/test_security.py
@@ -272,7 +272,8 @@ def test_application_home_directory_hijack(pyi_builder, tmp_path, parent_level):
             # directory name to fail (since executable in this test does not have setuid bit set, which would fail
             # due to strict parent process validation requirement).
             assert p.returncode not in {0, 42}
-            assert (MSG_PARENT_EXECUTABLE in p.stderr) or (MSG_HOME_DIRECTORY in p.stderr)
+            assert (MSG_PARENT_EXECUTABLE in p.stderr) or \
+                ((not compat.is_win and not compat.is_darwin) and MSG_HOME_DIRECTORY in p.stderr)
 
 
 # Test that parent-process security validation works correctly in case of symlinked executables (i.e., the executable


### PR DESCRIPTION
Revert https://github.com/pyinstaller/pyinstaller/commit/72bbdb4bbe82f6b63bc5a21b4444c65c1e1a3220 and avoid using `QueryFullProcessImageNameW()` to obtain `pyi->executable_filename`. It turns out that in certain corner cases, such as ImDisk RAMDISK volumes, this function returns NT-style path even if Win32 path format is requested (i.e., as if we were passing `dwFlags=PROCESS_NAME_NATIVE` instead of `dwFlags=0`). This causes subsequent failure when such path is used in the attempt to open PKG archive. See https://github.com/pyinstaller/pyinstaller/issues/9510.

Instead, we go back to using tried and true combination of `GetModuleFileNameW()` and manual resolution of file symlink (if necessary) for `pyi->executable_filename`, while having the `_pyi_security_verify_parent_proces_win32()` separately resolve the executable path for the current process using `QueryFullProcessImageNameW()` to ensure consistent comparison against the executable path for the parent process (which is obtained using the same function).

Because the paths obtained via `QueryFullProcessImageNameW()` are now used only for comparison, we explicitly request them to be returned in the native (NT-style) format.

Fixes #9510.