### PR TITLE
bootloader: revise onefile parent-process verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -631,6 +631,7 @@ jobs:
               python py312-pip py312-sqlite3 py312-tkinter \
               py312-psutil py312-pytest py312-pytest-xdist \
               py312-numpy py312-pillow
+            mount -t procfs proc /proc
 
       - name: Setup VM (OpenBSD)
         if: matrix.platform == 'openbsd'

--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -419,7 +419,7 @@ pyi_main(struct PYI_CONTEXT *pyi_ctx)
          * process, instead of trying to set up a child process that is
          * doomed to fail... */
         if (pyi_ctx->has_setuid) {
-            if (pyi_security_check_onefile_setuid_allowed() < 0) {
+            if (pyi_security_onefile_parent_verification_available() != true) {
                 return -1;
             }
         }
@@ -509,7 +509,7 @@ pyi_main(struct PYI_CONTEXT *pyi_ctx)
             /* Verify the name of the inherited top-level application
              * directory, and extract the process ID of the onefile parent
              * process from it. */
-            if (pyi_security_verify_application_home_dir_name(pyi_ctx, &onefile_parent_pid) < 0) {
+            if (pyi_security_verify_application_home_dir_name(pyi_ctx, &onefile_parent_pid) != true) {
                 return -1;
             }
             PYI_DEBUG("SECURITY: process ID of the originating onefile parent process: %d\n", onefile_parent_pid);
@@ -517,7 +517,7 @@ pyi_main(struct PYI_CONTEXT *pyi_ctx)
             /* Check permissions on the inherited top-level application
              * directory (applicable only to setuid-enabled executables
              * on POSIX systems, otherwise no-op). */
-            if (pyi_security_verify_application_home_dir_permissions(pyi_ctx) < 0) {
+            if (pyi_security_verify_application_home_dir_permissions(pyi_ctx) != true) {
                 return -1;
             }
 
@@ -548,12 +548,12 @@ pyi_main(struct PYI_CONTEXT *pyi_ctx)
                  * parent (if this is main application process), or grandparent
                  * or further ancestor (if this is spawned worker sub-proces)... */
                 const bool search_process_tree = pyi_ctx->process_level != PYI_PROCESS_LEVEL_MAIN; /* = PYI_PROCESS_LEVEL_SUBPROCESS */
-                if (pyi_security_verify_onefile_parent_pid(pyi_ctx, onefile_parent_pid, search_process_tree)) {
+                if (pyi_security_verify_onefile_parent_pid(pyi_ctx, onefile_parent_pid, search_process_tree) != true) {
                     return -1;
                 }
                 /* ... and check that the originating onefile parent process
                  * is using the same executable as this process. */
-                if (pyi_security_verify_onefile_parent_executable(pyi_ctx, onefile_parent_pid) < 0) {
+                if (pyi_security_verify_onefile_parent_executable(pyi_ctx, onefile_parent_pid) != true) {
                     return -1;
                 }
             }
@@ -591,7 +591,7 @@ pyi_main(struct PYI_CONTEXT *pyi_ctx)
         /* On POSIX platforms, if setuid bit is set on the executable,
          * check owner/permissions on the top-level application's directory
          * to ensure its contents are accessible only to the effective user. */
-        if (pyi_security_verify_application_home_dir_permissions(pyi_ctx) < 0) {
+        if (pyi_security_verify_application_home_dir_permissions(pyi_ctx) != true) {
             return -1;
         }
     }

--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -515,7 +515,7 @@ pyi_main(struct PYI_CONTEXT *pyi_ctx)
                 /* This is supposed to be a onefile child process; therefore,
                  * its parent should be a valid onefile process, and should
                  * be using the same executable... */
-                if (pyi_security_verify_parent_proces(pyi_ctx) < 0) {
+                if (pyi_security_verify_parent_process(pyi_ctx) < 0) {
                     return -1;
                 }
                 /* Verify the name of the application's home directory.

--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -448,7 +448,7 @@ pyi_main(struct PYI_CONTEXT *pyi_ctx)
          * we exit with an early error in the parent onefile process,
          * instead of trying to set up a child process that is doomed
          * to fail... */
-        if (pyi_ctx->has_elevated_privileges) {
+        if (pyi_ctx->has_elevated_privileges || pyi_ctx->enable_onefile_parent_verification) {
             if (pyi_security_onefile_parent_verification_available() != true) {
                 return -1;
             }
@@ -558,7 +558,11 @@ pyi_main(struct PYI_CONTEXT *pyi_ctx)
                  * needs to set LD_LIBRARY_PATH and restart itself before
                  * running splash screen. So this process effectively
                  * inherited the application directory from itself, and
-                 * therefore, the PIDs should be identical. */
+                 * therefore, the PIDs should be identical.
+                 *
+                 * This check should be basic enough that we can enforce
+                 * it regardless of whether the executable is running in
+                 * privileged mode or not. */
 #if defined(_WIN32)
                 unsigned int current_pid = _getpid();
 #else
@@ -573,18 +577,33 @@ pyi_main(struct PYI_CONTEXT *pyi_ctx)
                  * there should be an originating onefile parent process
                  * that uses the same executable, and its PID is supposed
                  * to be embedded in the inherited application top-level
-                 * directory name. So first, ensure that we can find process
-                 * with this ID in our ancestor tree - either as direct
-                 * parent (if this is main application process), or grandparent
-                 * or further ancestor (if this is spawned worker sub-proces)... */
-                const bool search_process_tree = pyi_ctx->process_level != PYI_PROCESS_LEVEL_MAIN; /* = PYI_PROCESS_LEVEL_SUBPROCESS */
-                if (pyi_security_verify_onefile_parent_pid(pyi_ctx, onefile_parent_pid, search_process_tree) != true) {
-                    return -1;
-                }
-                /* ... and check that the originating onefile parent process
-                 * is using the same executable as this process. */
-                if (pyi_security_verify_onefile_parent_executable(pyi_ctx, onefile_parent_pid) != true) {
-                    return -1;
+                 * directory name.
+                 *
+                 * So first, ensure that we can find process with this ID
+                 * in our ancestor tree - either as direct parent (if this
+                 * is main application process), or grandparent or further
+                 * ancestor (if this is spawned worker sub-process)...
+                 *
+                 * ... and then check that the originating onefile parent
+                 * process is using the same executable as this process.
+                 *
+                 * In unprivileged mode, this check might fail due to
+                 * insufficient permissions (or lack of support on the
+                 * target platform). Therefore, we enforce it only when
+                 * the executable is running in privileged mode, or if
+                 * explicitly opted-in (which is mostly available to
+                 * allow testing with non-privileged executables). */
+                if (pyi_ctx->has_elevated_privileges || pyi_ctx->enable_onefile_parent_verification) {
+                    const bool search_process_tree = pyi_ctx->process_level != PYI_PROCESS_LEVEL_MAIN; /* = PYI_PROCESS_LEVEL_SUBPROCESS */
+                    PYI_DEBUG("SECURITY: verifying onefile parent process due to %s...\n", pyi_ctx->has_elevated_privileges ? "executable running in privileged mode" : "explicit opt-in");
+                    if (pyi_security_verify_onefile_parent_pid(pyi_ctx, onefile_parent_pid, search_process_tree) != true) {
+                        return -1;
+                    }
+                    if (pyi_security_verify_onefile_parent_executable(pyi_ctx, onefile_parent_pid) != true) {
+                        return -1;
+                    }
+                } else {
+                    PYI_DEBUG("SECURITY: onefile parent-process verification is disabled\n");
                 }
             }
         }
@@ -958,6 +977,14 @@ _pyi_main_read_runtime_options(struct PYI_CONTEXT *pyi_ctx)
             continue;
         }
 #endif
+
+        /* pyi-enable-onefile-parent-verification
+         *
+         * Explicitly enable (onefile parent-process validation */
+        if (strncmp(toc_entry->name, "pyi-enable-onefile-parent-verification", 38) == 0) {
+            pyi_ctx->enable_onefile_parent_verification = 1;
+            continue;
+        }
     }
 }
 

--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -126,22 +126,51 @@ pyi_main(struct PYI_CONTEXT *pyi_ctx)
     }
     PYI_DEBUG("LOADER: executable file: %s\n", pyi_ctx->executable_filename);
 
-    /* Check if executable set setuid bit set (POSIX platforms only). */
-#if !defined(_WIN32)
+    /* Check if executable is running with elevated privileges while
+     * inheriting environment variables set by unprivileged user. On
+     * POSIX platforms, this happens with executables that have setuid
+     * bit set. On Windows, it happens with UAC-elevated executables.
+     * In both cases, the OS sanitizes some of environment variables
+     * (e.g., PATH, or LD_LIBRARY_PATH or equivalent), but not the ones
+     * that are used by PyInstaller. Thus, we might need to perform
+     * additional security checks before inheriting the environment. */
     if (1) {
+#if defined(_WIN32)
+        HANDLE token;
+        TOKEN_ELEVATION_TYPE elevation_type;
+        DWORD ret_size;
+
+        if (OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &token) == 0) {
+            PYI_WINERROR_W(L"OpenProcessToken", L"Security validation failure: could not obtain token information for current process!\n");
+            return -1;
+        }
+
+        if (GetTokenInformation(token, TokenElevationType, &elevation_type, sizeof(elevation_type), &ret_size) == 0) {
+            PYI_WINERROR_W(L"GetTokenInformation", L"Security validation failure: could not obtain token information for current process!\n");
+            CloseHandle(token);
+            return -1;
+        }
+
+        CloseHandle(token);
+
+        if (elevation_type == TokenElevationTypeFull) {
+            PYI_DEBUG_W(L"SECURITY: executable is running with TokenElevationTypeFull.\n");
+            pyi_ctx->has_elevated_privileges = 1;
+        }
+#else
         struct stat executable_stat;
 
         if (stat(pyi_ctx->executable_filename, &executable_stat) < 0) {
             PYI_ERROR("Security validation failure: could not stat() the executable!\n");
             return -1;
         }
-        pyi_ctx->has_setuid = (executable_stat.st_mode & S_ISUID) == S_ISUID;
 
-        if (pyi_ctx->has_setuid) {
+        if (executable_stat.st_mode & S_ISUID) {
             PYI_DEBUG("SECURITY: executable has setuid bit set.\n");
+            pyi_ctx->has_elevated_privileges = 1;
         }
-    }
 #endif
+    }
 
     /* Resolve main PKG archive - embedded or side-loaded. */
     if (_pyi_main_resolve_pkg_archive(pyi_ctx) < 0) {
@@ -412,13 +441,14 @@ pyi_main(struct PYI_CONTEXT *pyi_ctx)
     if (pyi_ctx->is_onefile) {
         bool create_temp_dir;
 
-        /* If setuid bit is set on the executable, check that parent-process
-         * security validation is available on this platform/system. This
-         * ensures that on known unsupported platforms (such as AIX and
-         * OpenBSD), we exit with an early error in the parent onefile
-         * process, instead of trying to set up a child process that is
-         * doomed to fail... */
-        if (pyi_ctx->has_setuid) {
+        /* If process is running with elevated privileges (e.g., setuid
+         * bit on POSIX platforms), check that parent-process security
+         * validation is available on this platform/system. This ensures
+         * that on known unsupported platforms (such as AIX and OpenBSD),
+         * we exit with an early error in the parent onefile process,
+         * instead of trying to set up a child process that is doomed
+         * to fail... */
+        if (pyi_ctx->has_elevated_privileges) {
             if (pyi_security_onefile_parent_verification_available() != true) {
                 return -1;
             }

--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -413,6 +413,18 @@ pyi_main(struct PYI_CONTEXT *pyi_ctx)
         bool create_temp_dir;
         bool is_parent = true;
 
+        /* If setuid bit is set on the executable, check that parent-process
+         * security validation is available on this platform/system. This
+         * ensures that on known unsupported platforms (such as AIX and
+         * OpenBSD), we exit with an early error in the parent onefile
+         * process, instead of trying to set up a child process that is
+         * doomed to fail... */
+        if (pyi_ctx->has_setuid) {
+            if (pyi_security_check_onefile_setuid_allowed() < 0) {
+                return -1;
+            }
+        }
+
         if (pyi_ctx->process_level == PYI_PROCESS_LEVEL_PARENT_NEEDS_RESTART) {
             /* POSIX build with splash screen enabled; before restart. */
             PYI_DEBUG("LOADER: this is parent process of onefile application (before restart).\n");

--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -127,7 +127,7 @@ pyi_main(struct PYI_CONTEXT *pyi_ctx)
     PYI_DEBUG("LOADER: executable file: %s\n", pyi_ctx->executable_filename);
 
     /* Check if executable set setuid bit set (POSIX platforms only). */
-#if !defined(_WIN32) && !defined(__APPLE__)
+#if !defined(_WIN32)
     if (1) {
         struct stat executable_stat;
 

--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -521,7 +521,7 @@ pyi_main(struct PYI_CONTEXT *pyi_ctx)
                 return -1;
             }
 
-            /* Verify the parent process */
+            /* Verify the originating onefile parent process */
             if (pyi_ctx->process_level == PYI_PROCESS_LEVEL_PARENT && pyi_ctx->parent_process_level == PYI_PROCESS_LEVEL_PARENT_NEEDS_RESTART) {
                 /* This codepath should be reached only in onefile POSIX
                  * builds with splash screen, where the parent process
@@ -539,10 +539,21 @@ pyi_main(struct PYI_CONTEXT *pyi_ctx)
                     return -1;
                 }
             } else {
-                /* This is supposed to be a onefile child process; therefore,
-                 * its parent should be a valid onefile process, and should
-                 * be using the same executable... */
-                if (pyi_security_verify_parent_process(pyi_ctx) < 0) {
+                /* This is supposed to be a onefile child process, so
+                 * there should be an originating onefile parent process
+                 * that uses the same executable, and its PID is supposed
+                 * to be embedded in the inherited application top-level
+                 * directory name. So first, ensure that we can find process
+                 * with this ID in our ancestor tree - either as direct
+                 * parent (if this is main application process), or grandparent
+                 * or further ancestor (if this is spawned worker sub-proces)... */
+                const bool search_process_tree = pyi_ctx->process_level != PYI_PROCESS_LEVEL_MAIN; /* = PYI_PROCESS_LEVEL_SUBPROCESS */
+                if (pyi_security_verify_onefile_parent_pid(pyi_ctx, onefile_parent_pid, search_process_tree)) {
+                    return -1;
+                }
+                /* ... and check that the originating onefile parent process
+                 * is using the same executable as this process. */
+                if (pyi_security_verify_onefile_parent_executable(pyi_ctx, onefile_parent_pid) < 0) {
                     return -1;
                 }
             }

--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -411,7 +411,6 @@ pyi_main(struct PYI_CONTEXT *pyi_ctx)
      * and based on that, determine the application's top-level directory. */
     if (pyi_ctx->is_onefile) {
         bool create_temp_dir;
-        bool is_parent = true;
 
         /* If setuid bit is set on the executable, check that parent-process
          * security validation is available on this platform/system. This
@@ -444,7 +443,6 @@ pyi_main(struct PYI_CONTEXT *pyi_ctx)
                 "main application process" : "spawned subprocess"
             );
             create_temp_dir = false; /* inherit */
-            is_parent = false; /* child process */
         }
 
         if (create_temp_dir) {
@@ -483,6 +481,8 @@ pyi_main(struct PYI_CONTEXT *pyi_ctx)
                 return -1;
             }
         } else {
+            unsigned int onefile_parent_pid;
+
             /* The ephemeral application top-level directory should already
              * exist, and the path to it should be available in the
              * _PYI_APPLICATION_HOME_DIR environment variable. */
@@ -505,22 +505,37 @@ pyi_main(struct PYI_CONTEXT *pyi_ctx)
              * from tricking us into using an arbitrary _PYI_APPLICATION_HOME_DIR
              * via spoofed _PYI_ARCHIVE_FILE and _PYI_PARENT_PROCESS_LEVEL.
              * See: https://github.com/pyinstaller/pyinstaller/security/advisories/GHSA-9fxf-4qw3-ghmr */
-            if (is_parent) {
+
+            /* Verify the name of the inherited top-level application
+             * directory, and extract the process ID of the onefile parent
+             * process from it. */
+            if (pyi_security_verify_application_home_dir_name(pyi_ctx, &onefile_parent_pid) < 0) {
+                return -1;
+            }
+            PYI_DEBUG("SECURITY: process ID of the originating onefile parent process: %d\n", onefile_parent_pid);
+
+            /* Check permissions on the inherited top-level application
+             * directory (applicable only to setuid-enabled executables
+             * on POSIX systems, otherwise no-op). */
+            if (pyi_security_verify_application_home_dir_permissions(pyi_ctx) < 0) {
+                return -1;
+            }
+
+            /* Verify the parent process */
+            if (pyi_ctx->process_level == PYI_PROCESS_LEVEL_PARENT && pyi_ctx->parent_process_level == PYI_PROCESS_LEVEL_PARENT_NEEDS_RESTART) {
                 /* This codepath should be reached only in onefile POSIX
                  * builds with splash screen, where the parent process
                  * needs to set LD_LIBRARY_PATH and restart itself before
-                 * running splash screen. In this case, we cannot verify
-                 * the parent process, but we can verify the inherited
-                 * top-level application directory; specifically, its
-                 * name should start with _MEI and should include the
-                 * PID of *this* process. If setuid bit is set on the
-                 * executable, also check owner/permissions on the directory. */
+                 * running splash screen. So this process effectively
+                 * inherited the application directory from itself, and
+                 * therefore, the PIDs should be identical. */
 #if defined(_WIN32)
-                unsigned int prefix_pid = _getpid();
+                unsigned int current_pid = _getpid();
 #else
-                unsigned int prefix_pid = getpid();
+                unsigned int current_pid = getpid();
 #endif
-                if (pyi_security_verify_application_home_dir(pyi_ctx, prefix_pid) < 0) {
+                if (current_pid != onefile_parent_pid) {
+                    PYI_ERROR("Security validation failure: unexpected PID found in the name of application's home directory!\n");
                     return -1;
                 }
             } else {
@@ -528,17 +543,6 @@ pyi_main(struct PYI_CONTEXT *pyi_ctx)
                  * its parent should be a valid onefile process, and should
                  * be using the same executable... */
                 if (pyi_security_verify_parent_process(pyi_ctx) < 0) {
-                    return -1;
-                }
-                /* Verify the name of the application's home directory.
-                 * Its name should start with _MEI prefix; for now, skip
-                 * the PID part of the check (by passing 0), as that
-                 * would require us to find the parent onefile process
-                 * (which might be more than one level up the ancestry
-                 * tree for worker sub-processes). On POSIX, if setuid
-                 * bit is set on the executable, also check owner/permissions
-                 * on the directory. */
-                if (pyi_security_verify_application_home_dir(pyi_ctx, 0) < 0) {
                     return -1;
                 }
             }
@@ -576,7 +580,7 @@ pyi_main(struct PYI_CONTEXT *pyi_ctx)
         /* On POSIX platforms, if setuid bit is set on the executable,
          * check owner/permissions on the top-level application's directory
          * to ensure its contents are accessible only to the effective user. */
-        if (pyi_security_verify_application_home_dir(pyi_ctx, 0) < 0) {
+        if (pyi_security_verify_application_home_dir_permissions(pyi_ctx) < 0) {
             return -1;
         }
     }

--- a/bootloader/src/pyi_main.h
+++ b/bootloader/src/pyi_main.h
@@ -148,11 +148,12 @@ struct PYI_CONTEXT
      * environment variable. */
     unsigned char suppress_splash;
 
-    /* Flag indicating whether the executable has `setuid` bit set or
-     * not. Applicable only to POSIX platforms, where it is used to
-     * toggle additional security checks. On other platforms, the value
-     * is left at 0. */
-    unsigned char has_setuid;
+    /* Flag indicating that the executable is running with elevated
+     * privileges while inheriting environment variables set by
+     * unprivileged user. On POSIX platforms, this corresponds to
+     * executable having setuid bit set. On Windows, it corresponds
+     * to a process running with TokenElevationTypeFull. */
+    unsigned char has_elevated_privileges;
 
     /* Splash screen context structure. */
     struct SPLASH_CONTEXT *splash;

--- a/bootloader/src/pyi_main.h
+++ b/bootloader/src/pyi_main.h
@@ -155,6 +155,11 @@ struct PYI_CONTEXT
      * to a process running with TokenElevationTypeFull. */
     unsigned char has_elevated_privileges;
 
+    /* Flag indicating whether onefile parent-process verification
+     * is explicitly enabled, even for non-privileged executables.
+     * Mostly intended for testing purposes. */
+    unsigned char enable_onefile_parent_verification;
+
     /* Splash screen context structure. */
     struct SPLASH_CONTEXT *splash;
 

--- a/bootloader/src/pyi_security.c
+++ b/bootloader/src/pyi_security.c
@@ -21,6 +21,8 @@
 #else
     #include <sys/stat.h> /* struct stat */
     #include <unistd.h> /* getppid(), geteuid() */
+    #include <fcntl.h>
+    #include <errno.h>
 #endif
 
 #include <stdio.h>  /* snprintf() */
@@ -43,22 +45,21 @@
 \**********************************************************************/
 /* Check whether parent-process validation is available on this platform
  * (strictly required for setuid-enabled onefile executables), so we can
- * raise an early error on known unsupported platforms. */
+ * raise an early error on known unsupported platforms.
+ *
+ * For details about constraints see platform-specific implementations
+ * of validation helpers below. */
 int
 pyi_security_check_onefile_setuid_allowed()
 {
 #if defined(_WIN32)
-    /* See _pyi_security_verify_parent_process_win32() */
     return 0;
 #elif defined(__APPLE__)
-    /* See _pyi_security_verify_parent_process_macos() */
     return 0;
 #elif defined(__linux__) || defined(__CYGWIN__) || defined(__NetBSD__)
-    /* See _pyi_security_verify_parent_process_posix() */
     return 0;
 #elif defined(__FreeBSD__)
-    /* See _pyi_security_verify_parent_process_posix(); supported only if
-     * /proc is available. */
+    /* Supported only if /proc is available. */
     struct stat curproc_dir_stat;
     if (stat("/proc/curproc", &curproc_dir_stat) < 0) {
         PYI_ERROR("Security validation failure: setuid-enabled executables are not supported on this system (missing /proc)!\n");
@@ -66,11 +67,10 @@ pyi_security_check_onefile_setuid_allowed()
     }
     return 0;
 #elif defined(__sun)
-    /* See _pyi_security_verify_parent_process_posix() */
     return 0;
 #else
-    /* See _pyi_security_verify_parent_process_posix; other POSIX platforms
-     * are unsupported due to lack of required information in /proc */
+    /* Other POSIX platforms are unsupported due to lack of required
+     * information in /proc */
     PYI_ERROR("Security validation failure: setuid-enabled executables are not supported on this platform!\n");
     return -1;
 #endif
@@ -78,85 +78,487 @@ pyi_security_check_onefile_setuid_allowed()
 
 
 /**********************************************************************\
- *                   Verification of parent process                   *
+ *                 Verification of parent-process PID                 *
 \**********************************************************************/
-/* Verify that parent process uses same executable as current process.
- * This aims to ensure that the run-time environment was indeed inherited
- * from a parent process of a onefile application, rather than being
- * spoofed by malicious user. */
+/* Verify that the given process ID of originating onefile parent process
+ * (extracted from the _MEI directory name) matches the process ID of
+ * the parent process of this process, or one of its ancestor processes. */
 
+#define PYI_MAX_PROCESS_TREE_DEPTH 128
+
+struct PYI_PROCESS_LINEAGE_TRACKER
+{
+    /* Keep track of seen ancestor PIDs, in order to prevent endless
+     * loop caused by re-use of process IDs. */
+    size_t ancestor_count;
+    unsigned int ancestor_pids[PYI_MAX_PROCESS_TREE_DEPTH];
+
+    /* Lowest valid PID value (platform-specific) */
+    unsigned int lowest_valid_pid;
+
+    /* Process snapshot (Windows) */
+#if defined(_WIN32)
+    HANDLE process_snapshot;
+    PROCESSENTRY32W process_entry;
+#endif
+};
+
+/* Initialize the platform-specific parts of the auxiliary structure */
+static int
+pyi_process_lineage_tracker_init(struct PYI_PROCESS_LINEAGE_TRACKER *tracker)
+{
+#if defined(_WIN32)
+    /* Take the process snapshot */
+    tracker->process_snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+    if (tracker->process_snapshot == INVALID_HANDLE_VALUE) {
+        PYI_ERROR_W(L"Security validation failure: could not obtain process snapshot!\n");
+        return -1;
+    }
+
+    /* Initialize the process entry structure */
+    tracker->process_entry.dwSize = sizeof(PROCESSENTRY32W);
+#endif
+
+    /* Initialize ancestor counter (= current depth of process tree) */
+    tracker->ancestor_count = 0;
+
+    /* Platform-specific lowest valid PID.
+     * On Windows, lowest PID is 4 (System).
+     * On POSIX systems, lowest PID is 1 (init). */
+#if defined(_WIN32)
+    tracker->lowest_valid_pid = 4;
+#else
+    tracker->lowest_valid_pid = 1;
+#endif
+
+    return 0;
+}
+
+/* Clean-up the platform-specific parts of the auxiliary structure */
+static void
+pyi_process_lineage_tracker_cleanup(struct PYI_PROCESS_LINEAGE_TRACKER *tracker)
+{
+#if defined(_WIN32)
+    CloseHandle(tracker->process_snapshot);
+#else
+    (void)tracker;
+#endif
+}
+
+/* Add the given process ID to the list of seen ancestor process IDs,
+ * and ensure that maximum allowed process-tree depth has not yet been
+ * reached. */
+static int
+pyi_process_lineage_tracker_add_ancestor(struct PYI_PROCESS_LINEAGE_TRACKER *tracker, const unsigned int ancestor_pid)
+{
+    if (tracker->ancestor_count + 1 >= PYI_MAX_PROCESS_TREE_DEPTH) {
+        PYI_ERROR("Security validation failure: maximum process tree depth exceeded!\n");
+        return -1;
+    }
+    tracker->ancestor_pids[tracker->ancestor_count++] = ancestor_pid;
+    return 0;
+}
+
+/* Check whether the given ancestor PID has already been encountered
+ * before (was registered by pyi_process_lineage_tracker_add_ancestor()). */
+static bool
+pyi_process_lineage_tracker_check_ancestor_seen(struct PYI_PROCESS_LINEAGE_TRACKER *tracker, const unsigned int ancestor_pid)
+{
+    size_t i;
+    for (i = 0; i < tracker->ancestor_count; i++) {
+        if (tracker->ancestor_pids[i] == ancestor_pid) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/* Find parent-process ID for the process identified by the given process
+ * ID. Uses platform-specific mechanism for looking up information about
+ * the given process. */
 #if defined(_WIN32)
 
 static int
-_pyi_security_verify_parent_process_win32(const struct PYI_CONTEXT *pyi_ctx)
+pyi_process_lineage_tracker_get_parent_pid(struct PYI_PROCESS_LINEAGE_TRACKER *tracker, const unsigned int target_pid, unsigned int *parent_pid)
 {
-    DWORD pid;
-    DWORD ppid;
+    /* Walk the process snapshot to find the entry for target_pid */
+    if (!Process32FirstW(tracker->process_snapshot, &tracker->process_entry)) {
+        PYI_ERROR_W(L"Security validation failure: could not walk the process snapshot!\n");
+        return -1;
+    }
 
-    HANDLE process_snapshot;
-    PROCESSENTRY32W process_entry;
-    BOOL entry_found;
+    do {
+        if (tracker->process_entry.th32ProcessID == target_pid) {
+            *parent_pid = tracker->process_entry.th32ParentProcessID;
+            PYI_DEBUG_W(L"SECURITY: parent of %u is %u (%ls)\n", target_pid, *parent_pid, tracker->process_entry.szExeFile);
+            return 0;
+        }
+    } while (Process32NextW(tracker->process_snapshot, &tracker->process_entry));
 
+    /* Not found; let caller handle that */
+    *parent_pid = 0;
+    return 0;
+}
+
+#elif defined(__APPLE__)
+
+static int
+pyi_process_lineage_tracker_get_parent_pid(struct PYI_PROCESS_LINEAGE_TRACKER *tracker, const unsigned int target_pid, unsigned int *parent_pid)
+{
+    struct proc_bsdshortinfo info;
+
+    if (proc_pidinfo(target_pid, PROC_PIDT_SHORTBSDINFO, 0, &info, sizeof(info)) != sizeof(info)) {
+        PYI_ERROR("Security validation failure: could not look up ancestor process info!\n");
+        return -1;
+    }
+    *parent_pid = info.pbsi_ppid;
+
+    return 0;
+}
+
+#else /* All other POSIX platforms */
+
+#if defined(__linux__) || defined(__CYGWIN__) || defined(__NetBSD__) || defined(__FreeBSD__) || defined(__sun)
+
+/* Read contents of a /proc file into given buffer */
+static size_t
+_read_proc_file(const char *filename, unsigned char *buffer, size_t buflen)
+{
+    unsigned char *bufptr = buffer;
+    size_t to_read = buflen;
+    size_t ret;
+    int fd;
+
+    fd = open(filename, O_RDONLY | O_NOFOLLOW);
+    if (fd == -1) {
+        return -1;
+    }
+
+    while (to_read > 0) {
+        ret = read(fd, bufptr, to_read);
+        if (ret < 0) {
+            if (errno == EAGAIN || errno == EINTR) {
+                continue;
+            } else {
+                close(fd);
+                return -1;
+            }
+        } else if (ret == 0) {
+            break; /* end of file */
+        }
+
+        to_read -= ret;
+        bufptr += ret;
+    }
+
+    close(fd);
+
+    return (size_t)(bufptr - buffer);
+}
+
+#endif /* defined(__linux__) || defined(__CYGWIN__) || defined(__NetBSD__) || defined(__FreeBSD__) || defined(__sun) */
+
+#if defined(__linux__) || defined(__CYGWIN__) || defined(__NetBSD__)
+
+static int
+pyi_process_lineage_tracker_get_parent_pid(struct PYI_PROCESS_LINEAGE_TRACKER *tracker, const unsigned int target_pid, unsigned int *parent_pid)
+{
+    /* As per "man proc_pid_stat", the /proc/pid/stat file contains
+     * space-delimited fields:
+     * pid (%d), (comm) (%s), state (%c), ppid (%d), ...
+     *
+     * Unfortunately, the process name (comm) can contain a whitespace or
+     * even a newline, which precludes direct parsing with sscanf(). Instead,
+     * we read the beginning of the file, scan for the closing brace, and
+     * then parse the state and ppid part using sscanf().
+     *
+     * We read first 48 bytes; pid is a 32-bit integer (max 10 characters), comm
+     * is max 15 characters plus enclosing braces, state is a single-character
+     * flag, and ppid is 32-bit integer. */
+    char proc_path[PYI_PATH_MAX];
+    char buffer[48];
+    size_t ret;
+    size_t pos;
+
+    (void)tracker;
+
+    if (snprintf(proc_path, 4096, "/proc/%u/stat", target_pid) >= PYI_PATH_MAX) {
+        PYI_ERROR("Security validation failure: could not format /proc/pid/stat path!\n");
+        return -1;
+    }
+
+    ret = _read_proc_file(proc_path, (unsigned char *)buffer, sizeof(buffer));
+    if (ret != sizeof(buffer)) {
+        PYI_ERROR("Security validation failure: could not read from /proc/pid/stat!\n");
+        return -1;
+    }
+    buffer[ret - 1] = 0;
+
+    /* Search for closing brace */
+    for (pos = ret; pos >= 0; pos--) {
+        if (buffer[pos] == ')') {
+            break;
+        }
+    }
+    if (pos < 0) {
+        PYI_ERROR("Security validation failure: could not parse /proc/pid/stat!\n");
+        return -1;
+    }
+
+    /* Extract ppid */
+    if (sscanf(buffer + pos, ") %*c %u ", parent_pid) != 1) {
+        PYI_ERROR("Security validation failure: could not parse /proc/pid/stat!\n");
+        return -1;
+    }
+
+    return 0;
+}
+
+#elif defined(__FreeBSD__)
+
+static int
+pyi_process_lineage_tracker_get_parent_pid(struct PYI_PROCESS_LINEAGE_TRACKER *tracker, const unsigned int target_pid, unsigned int *parent_pid)
+{
+    /* /proc/pid/status seem to contain whitespace-delimited fields,
+     * with first three being: process name, pid, and ppid. Characters
+     * such as whitespace in process name are escaped using octal sequence
+     * (e.g., \040). It seems that up to 19 characters are included,
+     * but presumably all could be octal escape sequences; so the buffer
+     * needs to account for max. 76 characters in the process name alone. */
+    char proc_path[PYI_PATH_MAX];
+    char buffer[128];
+    size_t ret;
+
+    (void)tracker;
+
+    if (snprintf(proc_path, PYI_PATH_MAX, "/proc/%u/status", target_pid) >= PYI_PATH_MAX) {
+        PYI_ERROR("Security validation failure: could not format /proc/pid/status path!\n");
+        return -1;
+    }
+
+    /* Depending on process name, fewer than 128 bytes might be read, so
+     * do not enforce expected length. But expect at least one byte to
+     * have been read... */
+    ret = _read_proc_file(proc_path, (unsigned char *)buffer, sizeof(buffer));
+    if (ret <= 0) {
+        PYI_ERROR("Security validation failure: could not read from /proc/pid/status!\n");
+        return -1;
+    }
+    buffer[ret - 1] = 0;
+
+    /* Extract ppid */
+    if (sscanf(buffer, "%*s %*d %u ", parent_pid) != 1) {
+        PYI_ERROR("Security validation failure: could not parse /proc/pid/status!\n");
+        return -1;
+    }
+
+    return 0;
+}
+
+#elif defined(__sun)
+
+static int
+pyi_process_lineage_tracker_get_parent_pid(struct PYI_PROCESS_LINEAGE_TRACKER *tracker, const unsigned int target_pid, unsigned int *parent_pid)
+{
+    /* Read first four 32-bit integer fields from /proc/pid/psinfo:
+     * pr_flag, pr_nlwp, pr_pid, pr_ppid. We could also use struct
+     * psinfo_t from /usr/include/sys/procfs.h */
+    char proc_path[PYI_PATH_MAX];
+    unsigned char buffer[16];
+    size_t ret;
+
+    if (snprintf(proc_path, PYI_PATH_MAX, "/proc/%u/psinfo", target_pid) >= PYI_PATH_MAX) {
+        PYI_ERROR("Security validation failure: could not format /proc/pid/psinfo path!\n");
+        return -1;
+    }
+
+    ret = _read_proc_file(proc_path, buffer, sizeof(buffer));
+    if (ret != sizeof(buffer)) {
+        PYI_ERROR("Security validation failure: could not read from /proc/pid/psinfo!\n");
+        return -1;
+    }
+    *parent_pid = *(unsigned int *)(buffer + 12); /* Presumably native endianness is used */
+
+    return 0;
+}
+
+#else
+
+static int
+pyi_process_lineage_tracker_get_parent_pid(struct PYI_PROCESS_LINEAGE_TRACKER *tracker, const unsigned int target_pid, unsigned int *parent_pid)
+{
+    (void)tracker;
+    (void)target_pid;
+    (void)parent_pid;
+    PYI_ERROR("Security validation failure: parent-process ID validation is not implemented on this platform!\n");
+    return -1;
+}
+
+#endif /* defined(__linux__) || defined(__CYGWIN__) || defined(__NetBSD__) */
+
+#endif /* defined(_WIN32) */
+
+
+/* Get process ID for the immediate parent process of the current process.
+ * On POSIX platforms, this wraps the getppid() system call. On Windows,
+ * we need to walk the process snapshot, same as for arbitrary target
+ * process. */
+static int
+pyi_process_lineage_tracker_get_immediate_parent_pid(struct PYI_PROCESS_LINEAGE_TRACKER *tracker, unsigned int *parent_pid)
+{
+#if defined(_WIN32)
+    return pyi_process_lineage_tracker_get_parent_pid(tracker, GetCurrentProcessId(), parent_pid);
+#else
+    (void)tracker;
+    *parent_pid = getppid();
+    return 0;
+#endif
+}
+
+
+int
+pyi_security_verify_onefile_parent_pid(const struct PYI_CONTEXT *pyi_ctx, const unsigned int onefile_parent_pid, const bool search_process_tree)
+{
+    struct PYI_PROCESS_LINEAGE_TRACKER tracker;
+    unsigned int current_pid;
+    unsigned int parent_pid;
+    int ret = -1;
+
+    PYI_DEBUG("SECURITY: verifying process ID of originating onefile parent process (%u)...\n", onefile_parent_pid);
+
+    /* Initialize the auxiliary tracker structure. */
+    if (pyi_process_lineage_tracker_init(&tracker) < 0) {
+        goto end;
+    }
+
+    /* Get process ID of immediate parent process. */
+    if (pyi_process_lineage_tracker_get_immediate_parent_pid(&tracker, &parent_pid) < 0) {
+        goto end;
+    }
+    PYI_DEBUG("SECURITY: parent process ID of current process: %u\n", parent_pid);
+
+    if (!search_process_tree) {
+        /* We strictly require the parent process to be the originating process. */
+        if (parent_pid == onefile_parent_pid) {
+            ret = 0; /* OK */
+            goto end;
+        } else {
+            PYI_ERROR("Security validation failure: invalid originating onefile parent process (different PID)!\n");
+            goto end;
+        }
+    }
+
+    /* We strictly require grandparent or one of further ancestor processes
+     * to be the originating process. So a match on immediate parent is
+     * considered a failure here. */
+    if (parent_pid == onefile_parent_pid) {
+        PYI_ERROR("Security validation failure: invalid originating onefile parent process (different PID)!\n");
+        goto end;
+    }
+
+    /* Walk the process tree */
+    if (pyi_process_lineage_tracker_add_ancestor(&tracker, parent_pid) < 0) {
+        goto end;
+    }
+    current_pid = parent_pid;
+
+    while (1) {
+        PYI_DEBUG("SECURITY: looking up parent of %u...\n", current_pid);
+
+        /* Look up parent PID of the given current PID. */
+        if (pyi_process_lineage_tracker_get_parent_pid(&tracker, current_pid, &parent_pid) < 0) {
+            goto end;
+        }
+
+        /* 0 is used to denote that parent of current-level PID could not
+         * be found */
+        if (parent_pid == 0) {
+            PYI_DEBUG("SECURITY: parent process of %u not found!\n", current_pid);
+            break;
+        }
+
+        /* Windows implementation of pyi_process_lineage_tracker_get_parent_pid()
+         * emits its own message (that also includes process name) */
+#if !defined(_WIN32)
+        PYI_DEBUG("SECURITY: parent of %u is %u\n", current_pid, parent_pid);
+#endif
+
+        /* Check if we reached the end of the process tree. */
+        if (parent_pid <= tracker.lowest_valid_pid || parent_pid == current_pid) {
+            PYI_DEBUG("SECURITY: reached root of process tree!\n");
+            break;
+        }
+
+        /* Check if we have a match. */
+        if (parent_pid == onefile_parent_pid) {
+            PYI_DEBUG("SECURITY: process %u is a valid ancestor process!\n", onefile_parent_pid);
+            ret = 0; /* OK */
+            goto end;
+        }
+
+        /* Ensure we are not looping, by checking obtained the parent PID
+         * against the list of already-seen ancestor PIDs. This might happen
+         * if an ancestor process died and had its PID reused. In the context
+         * of security validation here, this means that we reached the end of
+         * searchable process tree without finding the onefile parent process ID. */
+        if (pyi_process_lineage_tracker_check_ancestor_seen(&tracker, parent_pid) != 0) {
+            PYI_DEBUG("SECURITY: detected parent-process ID loop!\n");
+            break;
+        }
+
+        /* Add to the list of seen ancestor processes, and ensure we
+         * have not hit the maximum allowed depth of process tree. */
+        if (pyi_process_lineage_tracker_add_ancestor(&tracker, parent_pid) < 0) {
+            goto end;
+        }
+
+        current_pid = parent_pid;
+    }
+
+    /* We could not find the target PID in the ancestor tree */
+    PYI_ERROR("Security validation failure: invalid originating onefile parent process (PID not found)!\n");
+
+end:
+    pyi_process_lineage_tracker_cleanup(&tracker);
+    return ret;
+}
+
+
+/**********************************************************************\
+ *              Verification of parent-process executable             *
+\**********************************************************************/
+/* Verify that the originating onefile parent process uses the same
+ * executable as the current process. */
+#if defined(_WIN32)
+
+static int
+_pyi_security_verify_onefile_parent_executable_win32(const struct PYI_CONTEXT *pyi_ctx, const DWORD process_id)
+{
     HANDLE process_handle;
     wchar_t parent_executable_w[PYI_PATH_MAX];
     wchar_t current_executable_w[PYI_PATH_MAX];
     DWORD buffer_length;
 
-    /* Current process ID, for look-up in the process snapshot */
-    pid = GetCurrentProcessId();
-
-    /* Take the process snapshot */
-    process_snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
-    if (process_snapshot == INVALID_HANDLE_VALUE) {
-        PYI_ERROR_W(L"Security validation failure: could not obtain process snapshot!\n");
-        return -1;
-    }
-
-    /* Walk the process snapshot to find entry for our process, and get
-     * parent process ID from it. */
-    process_entry.dwSize = sizeof(PROCESSENTRY32);
-    if (!Process32FirstW(process_snapshot, &process_entry)) {
-        PYI_ERROR_W(L"Security validation failure: could not walk the process snapshot!\n");
-        CloseHandle(process_snapshot);
-        return -1;
-    }
-
-    entry_found = FALSE;
-    do {
-        if (process_entry.th32ProcessID == pid) {
-            ppid = process_entry.th32ParentProcessID;
-            entry_found = TRUE;
-            break;
-        }
-    } while(Process32NextW(process_snapshot, &process_entry));
-
-    CloseHandle(process_snapshot);
-
-    if (!entry_found) {
-        PYI_ERROR_W(L"Security validation failure: could not determine parent process ID!\n");
-        return -1;
-    }
-
-    /* Now try to query process for its executable name.
+    /* Query the target process for its executable name.
      * QueryFullProcessImageNameW() seems to return a fully-resolved
      * path to the executable, even when the parent process is launched
      * via symbolic link. */
-    process_handle = OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, FALSE, ppid);
+    process_handle = OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, FALSE, process_id);
     if (process_handle == INVALID_HANDLE_VALUE) {
-        PYI_ERROR_W(L"Security validation failure: failed to obtain information about parent process!\n");
+        PYI_ERROR_W(L"Security validation failure: failed to obtain information about originating onefile parent process!\n");
         return -1;
     }
 
     buffer_length = PYI_PATH_MAX;
     if (!QueryFullProcessImageNameW(process_handle, PROCESS_NAME_NATIVE, parent_executable_w, &buffer_length)) {
-        PYI_ERROR_W(L"Security validation failure: failed to obtain executable path for parent process!\n");
+        PYI_ERROR_W(L"Security validation failure: failed to obtain executable path for originating onefile parent process!\n");
         CloseHandle(process_handle);
         return -1;
     }
 
     CloseHandle(process_handle);
 
-    PYI_DEBUG_W(L"SECURITY: parent process executable: %ls\n", parent_executable_w);
+    PYI_DEBUG_W(L"SECURITY: originating onefile parent process executable: %ls\n", parent_executable_w);
 
     /* Look up the current-process executable. We cannot use pyi_ctx->executable_filename,
      * which is resolved using GetModuleFileNameW() for compatibility reasons (see #9510),
@@ -178,7 +580,7 @@ _pyi_security_verify_parent_process_win32(const struct PYI_CONTEXT *pyi_ctx)
 
     /* Ensure that same executable is used */
     if (wcscmp(parent_executable_w, current_executable_w) != 0) {
-        PYI_ERROR_W(L"Security validation failure: parent process has different executable!\n");
+        PYI_ERROR_W(L"Security validation failure: invalid originating onefile parent process (different executable)!\n");
         return -1;
     }
 
@@ -188,24 +590,20 @@ _pyi_security_verify_parent_process_win32(const struct PYI_CONTEXT *pyi_ctx)
 #elif defined(__APPLE__)
 
 static int
-_pyi_security_verify_parent_process_macos(const struct PYI_CONTEXT *pyi_ctx)
+_pyi_security_verify_onefile_parent_executable_macos(const struct PYI_CONTEXT *pyi_ctx, const pid_t process_id)
 {
-    /* Try to look up the executable of the parent process - it should
-     * be the same as that of the current process. */
-    pid_t ppid;
     char parent_executable[PYI_PATH_MAX];
 
-    /* Get parent PID and corresponding executable name. proc_pidpath()
-     * seems to return a fully-resolved path to the executable, even
-     * when the parent process was launched via symbolic link. */
-    ppid = getppid();
-    proc_pidpath(ppid, parent_executable, sizeof(parent_executable));
+    /* proc_pidpath() seems to return a fully-resolved path to the
+     * executable, even when the parent process is launched via symbolic
+     * link. */
+    proc_pidpath(process_id, parent_executable, sizeof(parent_executable));
 
-    PYI_DEBUG("SECURITY: parent process executable: %s\n", parent_executable);
+    PYI_DEBUG("SECURITY: originating onefile parent process executable: %s\n", parent_executable);
 
     /* Ensure that same executable is used */
     if (strcmp(parent_executable, pyi_ctx->executable_filename) != 0) {
-        PYI_ERROR("Security validation failure: parent process has different executable!\n");
+        PYI_ERROR("Security validation failure: invalid originating onefile parent process (different executable)!\n");
         return -1;
     }
 
@@ -215,11 +613,8 @@ _pyi_security_verify_parent_process_macos(const struct PYI_CONTEXT *pyi_ctx)
 #else
 
 static int
-_pyi_security_verify_parent_process_posix(const struct PYI_CONTEXT *pyi_ctx)
+_pyi_security_verify_onefile_parent_executable_posix(const struct PYI_CONTEXT *pyi_ctx, const pid_t process_id)
 {
-    /* Try to look up the executable of the parent process - it should
-     * be the same as that of the current process. */
-    pid_t ppid;
     char proc_path[PYI_PATH_MAX];
     char parent_executable[PYI_PATH_MAX];
 
@@ -234,8 +629,8 @@ _pyi_security_verify_parent_process_posix(const struct PYI_CONTEXT *pyi_ctx)
 #endif
 
     /* Handle unsupported POSIX platforms, where we have no way to look up
-     * the parent executable. Disallow setuid-enabled executables, otherwise
-     * skip the check. */
+     * the executable for a given process. Disallow setuid-enabled executables,
+     * otherwise skip the check. */
     if (!proc_path_fmt) {
         if (pyi_ctx->has_setuid) {
             PYI_ERROR("Security validation failure: setuid-enabled executables are not supported on this platform!\n");
@@ -246,16 +641,13 @@ _pyi_security_verify_parent_process_posix(const struct PYI_CONTEXT *pyi_ctx)
         }
     }
 
-    /* Get parent PID */
-    ppid = getppid();
-
     /* Try to look up the /proc entry. On some platforms, the entry points
      * at "true" file location, i.e., canonical and with all symbolic links
      * resolved; on others (e.g., NetBSD), the entry is neither canonical
      * nor fully resolved. So to be safe, always pass the symlink to realpath()
      * for full resolution. This matches the behavior of _pyi_resolve_executable_posix()
      * in pyi_main.c */
-    if (snprintf(proc_path, PYI_PATH_MAX, proc_path_fmt, ppid) >= PYI_PATH_MAX) {
+    if (snprintf(proc_path, PYI_PATH_MAX, proc_path_fmt, process_id) >= PYI_PATH_MAX) {
         PYI_ERROR("Security validation failure: could not format /proc entry path!\n");
         return -1;
     }
@@ -264,10 +656,10 @@ _pyi_security_verify_parent_process_posix(const struct PYI_CONTEXT *pyi_ctx)
         /* The access to /proc entry might be blocked due to security policy,
          * or by proc filesystem not being mounted (as is the case on FreeBSD
          * by default). Allow this to be the case for a non-setuid executable
-         * (and skip the parent-process verification), but fail in the case of
-         * a setuid executable. */
+         * (and skip the verification), but fail in the case of a setuid-enabled
+         * executable. */
         if (pyi_ctx->has_setuid) {
-            PYI_ERROR("Security validation failure: could not determine the executable path for parent process!\n");
+            PYI_ERROR("Security validation failure: could not determine the executable path for originating onefile parent process!\n");
             return -1;
         } else {
             PYI_DEBUG("SECURITY: could not access %s - skipping check for non-setuid executable!\n", proc_path);
@@ -283,18 +675,18 @@ _pyi_security_verify_parent_process_posix(const struct PYI_CONTEXT *pyi_ctx)
         if (len >= 5) {
             char *suffix_ptr = parent_executable + len - 4;
             if (strcasecmp(suffix_ptr, ".exe") == 0) {
-                PYI_DEBUG("SECURITY: removing .exe suffix from parent executable name\n");
+                PYI_DEBUG("SECURITY: removing .exe suffix from originating onefile parent executable\n");
                 *suffix_ptr = 0;
             }
         }
     }
 #endif
 
-    PYI_DEBUG("SECURITY: parent process executable: %s\n", parent_executable);
+    PYI_DEBUG("SECURITY: originating onefile parent process executable: %s\n", parent_executable);
 
     /* Ensure that same executable is used */
     if (strcmp(parent_executable, pyi_ctx->executable_filename) != 0) {
-        PYI_ERROR("Security validation failure: parent process has different executable!\n");
+        PYI_ERROR("Security validation failure: invalid originating onefile parent process (different executable)!\n");
         return -1;
     }
 
@@ -304,17 +696,17 @@ _pyi_security_verify_parent_process_posix(const struct PYI_CONTEXT *pyi_ctx)
 #endif
 
 int
-pyi_security_verify_parent_process(const struct PYI_CONTEXT *pyi_ctx)
+pyi_security_verify_onefile_parent_executable(const struct PYI_CONTEXT *pyi_ctx, const unsigned int onefile_parent_pid)
 {
-    PYI_DEBUG("SECURITY: verifying parent process...\n");
+    PYI_DEBUG("SECURITY: verifying executable of originating onefile parent process (%d)...\n", onefile_parent_pid);
 
-    /* Use OS-specific implementation */
+    /* Use corresponding platform-specific implementation */
 #if defined(_WIN32)
-    return _pyi_security_verify_parent_process_win32(pyi_ctx);
+    return _pyi_security_verify_onefile_parent_executable_win32(pyi_ctx, onefile_parent_pid);
 #elif defined(__APPLE__)
-    return _pyi_security_verify_parent_process_macos(pyi_ctx);
+    return _pyi_security_verify_onefile_parent_executable_macos(pyi_ctx, onefile_parent_pid);
 #else
-    return _pyi_security_verify_parent_process_posix(pyi_ctx);
+    return _pyi_security_verify_onefile_parent_executable_posix(pyi_ctx, onefile_parent_pid);
 #endif
 }
 

--- a/bootloader/src/pyi_security.c
+++ b/bootloader/src/pyi_security.c
@@ -390,7 +390,7 @@ pyi_process_lineage_tracker_get_parent_pid(struct PYI_PROCESS_LINEAGE_TRACKER *t
     (void)tracker;
     (void)target_pid;
     (void)parent_pid;
-    PYI_ERROR("Security validation failure: parent-process ID validation is not implemented on this platform!\n");
+    PYI_ERROR("Security validation failure: parent-process ID validation is not supported on this platform!\n");
     return -1;
 }
 
@@ -628,17 +628,11 @@ _pyi_security_verify_onefile_parent_executable_posix(const struct PYI_CONTEXT *p
     const char *proc_path_fmt = NULL;
 #endif
 
-    /* Handle unsupported POSIX platforms, where we have no way to look up
-     * the executable for a given process. Disallow setuid-enabled executables,
-     * otherwise skip the check. */
+    /* Raise an error on unsupported POSIX platforms, where we have no
+     * way to look up the executable for a given process. */
     if (!proc_path_fmt) {
-        if (pyi_ctx->has_setuid) {
-            PYI_ERROR("Security validation failure: setuid-enabled executables are not supported on this platform!\n");
-            return -1;
-        } else {
-            PYI_DEBUG("SECURITY: unsupported platform - skipping check for non-setuid executable!\n");
-            return 0;
-        }
+        PYI_ERROR("Security validation failure: parent-process executable validation is not supported on this platform!\n");
+        return -1;
     }
 
     /* Try to look up the /proc entry. On some platforms, the entry points
@@ -655,16 +649,9 @@ _pyi_security_verify_onefile_parent_executable_posix(const struct PYI_CONTEXT *p
     if (realpath(proc_path, parent_executable) == NULL) {
         /* The access to /proc entry might be blocked due to security policy,
          * or by proc filesystem not being mounted (as is the case on FreeBSD
-         * by default). Allow this to be the case for a non-setuid executable
-         * (and skip the verification), but fail in the case of a setuid-enabled
-         * executable. */
-        if (pyi_ctx->has_setuid) {
-            PYI_ERROR("Security validation failure: could not determine the executable path for originating onefile parent process!\n");
-            return -1;
-        } else {
-            PYI_DEBUG("SECURITY: could not access %s - skipping check for non-setuid executable!\n", proc_path);
-            return 0;
-        }
+         * by default).  */
+        PYI_ERROR("Security validation failure: could not access /proc entry to determine the executable path for originating onefile parent process!\n");
+        return -1;
     }
 
     /* Exclude the .exe suffix from the resolved executable path, in order to

--- a/bootloader/src/pyi_security.c
+++ b/bootloader/src/pyi_security.c
@@ -302,7 +302,7 @@ pyi_security_verify_parent_proces(const struct PYI_CONTEXT *pyi_ctx)
  * it should ensure that setuid-enabled onedir executable has an
  * accompanying contents directory that cannot be modified by a
  * non-privileged user. */
-#if !defined(_WIN32) && !defined(__APPLE__)
+#if !defined(_WIN32)
 
 static int
 pyi_security_verify_application_home_dir_permissions(const struct PYI_CONTEXT *pyi_ctx)
@@ -420,7 +420,7 @@ pyi_security_verify_application_home_dir(const struct PYI_CONTEXT *pyi_ctx, unsi
 
     /* POSIX: additional owner/permissions validation when setuid bit is
      * set on the executable */
-#if !defined(_WIN32) && !defined(__APPLE__)
+#if !defined(_WIN32)
     if (pyi_security_verify_application_home_dir_permissions(pyi_ctx) < 0) {
         return -1;
     }

--- a/bootloader/src/pyi_security.c
+++ b/bootloader/src/pyi_security.c
@@ -37,6 +37,46 @@
 #include "pyi_utils.h"
 
 
+
+/**********************************************************************\
+ *      Early check for availability of parent-process validation     *
+\**********************************************************************/
+/* Check whether parent-process validation is available on this platform
+ * (strictly required for setuid-enabled onefile executables), so we can
+ * raise an early error on known unsupported platforms. */
+int
+pyi_security_check_onefile_setuid_allowed()
+{
+#if defined(_WIN32)
+    /* See _pyi_security_verify_parent_process_win32() */
+    return 0;
+#elif defined(__APPLE__)
+    /* See _pyi_security_verify_parent_process_macos() */
+    return 0;
+#elif defined(__linux__) || defined(__CYGWIN__) || defined(__NetBSD__)
+    /* See _pyi_security_verify_parent_process_posix() */
+    return 0;
+#elif defined(__FreeBSD__)
+    /* See _pyi_security_verify_parent_process_posix(); supported only if
+     * /proc is available. */
+    struct stat curproc_dir_stat;
+    if (stat("/proc/curproc", &curproc_dir_stat) < 0) {
+        PYI_ERROR("Security validation failure: setuid-enabled executables are not supported on this system (missing /proc)!\n");
+        return -1;
+    }
+    return 0;
+#elif defined(__sun)
+    /* See _pyi_security_verify_parent_process_posix() */
+    return 0;
+#else
+    /* See _pyi_security_verify_parent_process_posix; other POSIX platforms
+     * are unsupported due to lack of required information in /proc */
+    PYI_ERROR("Security validation failure: setuid-enabled executables are not supported on this platform!\n");
+    return -1;
+#endif
+}
+
+
 /**********************************************************************\
  *                   Verification of parent process                   *
 \**********************************************************************/
@@ -262,7 +302,6 @@ _pyi_security_verify_parent_process_posix(const struct PYI_CONTEXT *pyi_ctx)
 }
 
 #endif
-
 
 int
 pyi_security_verify_parent_process(const struct PYI_CONTEXT *pyi_ctx)

--- a/bootloader/src/pyi_security.c
+++ b/bootloader/src/pyi_security.c
@@ -48,7 +48,7 @@
 #if defined(_WIN32)
 
 static int
-_pyi_security_verify_parent_proces_win32(const struct PYI_CONTEXT *pyi_ctx)
+_pyi_security_verify_parent_process_win32(const struct PYI_CONTEXT *pyi_ctx)
 {
     DWORD pid;
     DWORD ppid;
@@ -148,7 +148,7 @@ _pyi_security_verify_parent_proces_win32(const struct PYI_CONTEXT *pyi_ctx)
 #elif defined(__APPLE__)
 
 static int
-_pyi_security_verify_parent_proces_macos(const struct PYI_CONTEXT *pyi_ctx)
+_pyi_security_verify_parent_process_macos(const struct PYI_CONTEXT *pyi_ctx)
 {
     /* Try to look up the executable of the parent process - it should
      * be the same as that of the current process. */
@@ -175,7 +175,7 @@ _pyi_security_verify_parent_proces_macos(const struct PYI_CONTEXT *pyi_ctx)
 #else
 
 static int
-_pyi_security_verify_parent_proces_posix(const struct PYI_CONTEXT *pyi_ctx)
+_pyi_security_verify_parent_process_posix(const struct PYI_CONTEXT *pyi_ctx)
 {
     /* Try to look up the executable of the parent process - it should
      * be the same as that of the current process. */
@@ -265,17 +265,17 @@ _pyi_security_verify_parent_proces_posix(const struct PYI_CONTEXT *pyi_ctx)
 
 
 int
-pyi_security_verify_parent_proces(const struct PYI_CONTEXT *pyi_ctx)
+pyi_security_verify_parent_process(const struct PYI_CONTEXT *pyi_ctx)
 {
     PYI_DEBUG("SECURITY: verifying parent process...\n");
 
     /* Use OS-specific implementation */
 #if defined(_WIN32)
-    return _pyi_security_verify_parent_proces_win32(pyi_ctx);
+    return _pyi_security_verify_parent_process_win32(pyi_ctx);
 #elif defined(__APPLE__)
-    return _pyi_security_verify_parent_proces_macos(pyi_ctx);
+    return _pyi_security_verify_parent_process_macos(pyi_ctx);
 #else
-    return _pyi_security_verify_parent_proces_posix(pyi_ctx);
+    return _pyi_security_verify_parent_process_posix(pyi_ctx);
 #endif
 }
 

--- a/bootloader/src/pyi_security.c
+++ b/bootloader/src/pyi_security.c
@@ -49,30 +49,30 @@
  *
  * For details about constraints see platform-specific implementations
  * of validation helpers below. */
-int
-pyi_security_check_onefile_setuid_allowed()
+bool
+pyi_security_onefile_parent_verification_available()
 {
 #if defined(_WIN32)
-    return 0;
+    return true;
 #elif defined(__APPLE__)
-    return 0;
+    return true;
 #elif defined(__linux__) || defined(__CYGWIN__) || defined(__NetBSD__)
-    return 0;
+    return true;
 #elif defined(__FreeBSD__)
     /* Supported only if /proc is available. */
     struct stat curproc_dir_stat;
     if (stat("/proc/curproc", &curproc_dir_stat) < 0) {
         PYI_ERROR("Security validation failure: setuid-enabled executables are not supported on this system (missing /proc)!\n");
-        return -1;
+        return false;
     }
-    return 0;
+    return true;
 #elif defined(__sun)
-    return 0;
+    return true;
 #else
     /* Other POSIX platforms are unsupported due to lack of required
      * information in /proc */
     PYI_ERROR("Security validation failure: setuid-enabled executables are not supported on this platform!\n");
-    return -1;
+    return false;
 #endif
 }
 
@@ -153,10 +153,10 @@ pyi_process_lineage_tracker_add_ancestor(struct PYI_PROCESS_LINEAGE_TRACKER *tra
 {
     if (tracker->ancestor_count + 1 >= PYI_MAX_PROCESS_TREE_DEPTH) {
         PYI_ERROR("Security validation failure: maximum process tree depth exceeded!\n");
-        return -1;
+        return false;
     }
     tracker->ancestor_pids[tracker->ancestor_count++] = ancestor_pid;
-    return 0;
+    return true;
 }
 
 /* Check whether the given ancestor PID has already been encountered
@@ -416,13 +416,13 @@ pyi_process_lineage_tracker_get_immediate_parent_pid(struct PYI_PROCESS_LINEAGE_
 }
 
 
-int
+bool
 pyi_security_verify_onefile_parent_pid(const struct PYI_CONTEXT *pyi_ctx, const unsigned int onefile_parent_pid, const bool search_process_tree)
 {
     struct PYI_PROCESS_LINEAGE_TRACKER tracker;
     unsigned int current_pid;
     unsigned int parent_pid;
-    int ret = -1;
+    bool succeeded = false;
 
     PYI_DEBUG("SECURITY: verifying process ID of originating onefile parent process (%u)...\n", onefile_parent_pid);
 
@@ -440,7 +440,7 @@ pyi_security_verify_onefile_parent_pid(const struct PYI_CONTEXT *pyi_ctx, const 
     if (!search_process_tree) {
         /* We strictly require the parent process to be the originating process. */
         if (parent_pid == onefile_parent_pid) {
-            ret = 0; /* OK */
+            succeeded = true; /* OK */
             goto end;
         } else {
             PYI_ERROR("Security validation failure: invalid originating onefile parent process (different PID)!\n");
@@ -492,7 +492,7 @@ pyi_security_verify_onefile_parent_pid(const struct PYI_CONTEXT *pyi_ctx, const 
         /* Check if we have a match. */
         if (parent_pid == onefile_parent_pid) {
             PYI_DEBUG("SECURITY: process %u is a valid ancestor process!\n", onefile_parent_pid);
-            ret = 0; /* OK */
+            succeeded = true; /* OK */
             goto end;
         }
 
@@ -501,7 +501,7 @@ pyi_security_verify_onefile_parent_pid(const struct PYI_CONTEXT *pyi_ctx, const 
          * if an ancestor process died and had its PID reused. In the context
          * of security validation here, this means that we reached the end of
          * searchable process tree without finding the onefile parent process ID. */
-        if (pyi_process_lineage_tracker_check_ancestor_seen(&tracker, parent_pid) != 0) {
+        if (pyi_process_lineage_tracker_check_ancestor_seen(&tracker, parent_pid) != false) {
             PYI_DEBUG("SECURITY: detected parent-process ID loop!\n");
             break;
         }
@@ -520,7 +520,7 @@ pyi_security_verify_onefile_parent_pid(const struct PYI_CONTEXT *pyi_ctx, const 
 
 end:
     pyi_process_lineage_tracker_cleanup(&tracker);
-    return ret;
+    return succeeded;
 }
 
 
@@ -531,7 +531,7 @@ end:
  * executable as the current process. */
 #if defined(_WIN32)
 
-static int
+static bool
 _pyi_security_verify_onefile_parent_executable_win32(const struct PYI_CONTEXT *pyi_ctx, const DWORD process_id)
 {
     HANDLE process_handle;
@@ -546,14 +546,14 @@ _pyi_security_verify_onefile_parent_executable_win32(const struct PYI_CONTEXT *p
     process_handle = OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, FALSE, process_id);
     if (process_handle == INVALID_HANDLE_VALUE) {
         PYI_ERROR_W(L"Security validation failure: failed to obtain information about originating onefile parent process!\n");
-        return -1;
+        return false;
     }
 
     buffer_length = PYI_PATH_MAX;
     if (!QueryFullProcessImageNameW(process_handle, PROCESS_NAME_NATIVE, parent_executable_w, &buffer_length)) {
         PYI_ERROR_W(L"Security validation failure: failed to obtain executable path for originating onefile parent process!\n");
         CloseHandle(process_handle);
-        return -1;
+        return false;
     }
 
     CloseHandle(process_handle);
@@ -571,7 +571,7 @@ _pyi_security_verify_onefile_parent_executable_win32(const struct PYI_CONTEXT *p
     if (!QueryFullProcessImageNameW(process_handle, PROCESS_NAME_NATIVE, current_executable_w, &buffer_length)) {
         PYI_ERROR_W(L"Security validation failure: failed to obtain executable path for current process!\n");
         CloseHandle(process_handle);
-        return -1;
+        return false;
     }
 
     CloseHandle(process_handle);
@@ -581,10 +581,10 @@ _pyi_security_verify_onefile_parent_executable_win32(const struct PYI_CONTEXT *p
     /* Ensure that same executable is used */
     if (wcscmp(parent_executable_w, current_executable_w) != 0) {
         PYI_ERROR_W(L"Security validation failure: invalid originating onefile parent process (different executable)!\n");
-        return -1;
+        return false;
     }
 
-    return 0;
+    return true;
 }
 
 #elif defined(__APPLE__)
@@ -604,10 +604,10 @@ _pyi_security_verify_onefile_parent_executable_macos(const struct PYI_CONTEXT *p
     /* Ensure that same executable is used */
     if (strcmp(parent_executable, pyi_ctx->executable_filename) != 0) {
         PYI_ERROR("Security validation failure: invalid originating onefile parent process (different executable)!\n");
-        return -1;
+        return false;
     }
 
-    return 0;
+    return true;
 }
 
 #else
@@ -632,7 +632,7 @@ _pyi_security_verify_onefile_parent_executable_posix(const struct PYI_CONTEXT *p
      * way to look up the executable for a given process. */
     if (!proc_path_fmt) {
         PYI_ERROR("Security validation failure: parent-process executable validation is not supported on this platform!\n");
-        return -1;
+        return false;
     }
 
     /* Try to look up the /proc entry. On some platforms, the entry points
@@ -643,7 +643,7 @@ _pyi_security_verify_onefile_parent_executable_posix(const struct PYI_CONTEXT *p
      * in pyi_main.c */
     if (snprintf(proc_path, PYI_PATH_MAX, proc_path_fmt, process_id) >= PYI_PATH_MAX) {
         PYI_ERROR("Security validation failure: could not format /proc entry path!\n");
-        return -1;
+        return false;
     }
 
     if (realpath(proc_path, parent_executable) == NULL) {
@@ -651,7 +651,7 @@ _pyi_security_verify_onefile_parent_executable_posix(const struct PYI_CONTEXT *p
          * or by proc filesystem not being mounted (as is the case on FreeBSD
          * by default).  */
         PYI_ERROR("Security validation failure: could not access /proc entry to determine the executable path for originating onefile parent process!\n");
-        return -1;
+        return false;
     }
 
     /* Exclude the .exe suffix from the resolved executable path, in order to
@@ -674,15 +674,15 @@ _pyi_security_verify_onefile_parent_executable_posix(const struct PYI_CONTEXT *p
     /* Ensure that same executable is used */
     if (strcmp(parent_executable, pyi_ctx->executable_filename) != 0) {
         PYI_ERROR("Security validation failure: invalid originating onefile parent process (different executable)!\n");
-        return -1;
+        return false;
     }
 
-    return 0;
+    return true;
 }
 
 #endif
 
-int
+bool
 pyi_security_verify_onefile_parent_executable(const struct PYI_CONTEXT *pyi_ctx, const unsigned int onefile_parent_pid)
 {
     PYI_DEBUG("SECURITY: verifying executable of originating onefile parent process (%d)...\n", onefile_parent_pid);
@@ -715,7 +715,7 @@ pyi_security_verify_onefile_parent_executable(const struct PYI_CONTEXT *pyi_ctx,
  * needs to be further verified (i.e., that is a parent or an ancestor
  * process of the current process, and that the said process uses same
  * executable as the current process). */
-int
+bool
 pyi_security_verify_application_home_dir_name(const struct PYI_CONTEXT *pyi_ctx, unsigned int *onefile_parent_pid)
 {
     char basename[PYI_PATH_MAX];
@@ -723,7 +723,7 @@ pyi_security_verify_application_home_dir_name(const struct PYI_CONTEXT *pyi_ctx,
 
     if (!pyi_path_basename(basename, pyi_ctx->application_home_dir)) {
         PYI_ERROR("Security validation failure: failed to obtain name of application's home directory!\n");
-        return -1;
+        return false;
     }
 
     PYI_DEBUG("SECURITY: verifying the name of application's home directory (%s)...\n", basename);
@@ -740,12 +740,12 @@ pyi_security_verify_application_home_dir_name(const struct PYI_CONTEXT *pyi_ctx,
 #ifdef _WIN32
     if (name_len < 12) {
         PYI_ERROR("Security validation failure: unexpected name of application's home directory!\n");
-        return -1;
+        return false;
     }
 #else
     if (name_len != 18) {
         PYI_ERROR("Security validation failure: unexpected name of application's home directory!\n");
-        return -1;
+        return false;
     }
 #endif
 
@@ -754,10 +754,10 @@ pyi_security_verify_application_home_dir_name(const struct PYI_CONTEXT *pyi_ctx,
      * in pyi_utils_posix.c and pyi_utis_win32.c */
     if (sscanf(basename, "_MEI%08x", onefile_parent_pid) != 1) {
         PYI_ERROR("Security validation failure: unexpected name of application's home directory!\n");
-        return -1;
+        return false;
     }
 
-    return 0;
+    return true;
 }
 
 
@@ -769,12 +769,12 @@ pyi_security_verify_application_home_dir_name(const struct PYI_CONTEXT *pyi_ctx,
  *    0700
  * Applicable to both onefile and onedir builds. No-op on Windows, and
  * no-op on other platforms when setuid bit is not set on the executable. */
-int
+bool
 pyi_security_verify_application_home_dir_permissions(const struct PYI_CONTEXT *pyi_ctx)
 {
 #if defined(_WIN32)
     (void)pyi_ctx;
-    return 0;
+    return true;
 #else
     uid_t euid;
     uid_t permissions;
@@ -783,14 +783,14 @@ pyi_security_verify_application_home_dir_permissions(const struct PYI_CONTEXT *p
     /* Applicable only to executables with setuid bit set. */
     if (!pyi_ctx->has_setuid) {
         PYI_DEBUG("SECURITY: setuid bit is not set - skipping verification of owner/permissions of application's home directory.\n");
-        return 0;
+        return true;
     }
 
     PYI_DEBUG("SECURITY: setuid bit is set - verifying owner/permissions of application's home directory...\n");
 
     if (stat(pyi_ctx->application_home_dir, &application_home_dir_stat) < 0) {
         PYI_ERROR("Security validation failure: could not stat() the application's home directory!\n");
-        return -1;
+        return false;
     }
 
     /* Ensure that owner ID of application's temporary directory matches
@@ -808,7 +808,7 @@ pyi_security_verify_application_home_dir_permissions(const struct PYI_CONTEXT *p
             "Security validation failure: owner ID of application's home directory (%d) does not match the effective user ID (%d)!\n",
             application_home_dir_stat.st_uid, euid
         );
-        return -1;
+        return false;
     }
 
     /* Ensure that the application's home directory has permissions used
@@ -819,9 +819,9 @@ pyi_security_verify_application_home_dir_permissions(const struct PYI_CONTEXT *p
     permissions = application_home_dir_stat.st_mode & (S_IRWXU | S_IRWXG | S_IRWXO);
     if (permissions != S_IRWXU) {
         PYI_ERROR("Security validation failure: application's home directory has invalid permissions (0%o)!\n", permissions);
-        return -1;
+        return false;
     }
 
-    return 0;
+    return true;
 #endif
 }

--- a/bootloader/src/pyi_security.c
+++ b/bootloader/src/pyi_security.c
@@ -322,30 +322,81 @@ pyi_security_verify_parent_process(const struct PYI_CONTEXT *pyi_ctx)
 /**********************************************************************\
  *            Verification of application's home directory            *
 \**********************************************************************/
-/* Verify the application's top-level / home directory.
+/* Verify the name of application's top-level / home directory in
+ * onefile mode. Check that the directory's name matches the format used
+ * by PyInstaller's bootloader, and extract the process ID (PID) of the
+ * originating onefile parent process (i.e., the process that set up the
+ * directory).
  *
- * In onefile mode, check that the directory's name matches the format
- * used by PyInstaller's bootloader.
- *
- * On POSIX platforms, perform additional check for executables with
- * setuid bit set; in that case, we require:
- *  - the owner ID of the top-level application directory to match the
- *    effective user ID
- *  - permissions on the top-level application directory to be set to
- *    0700
- *
- * This should be ensure that the onefile child processes are inheriting
- * temporary application directory that was set up by the onefile parent
- * process (instead of being passed an arbitrary directory as top-level
- * application directory via spoofed environment variables). Similarly,
- * it should ensure that setuid-enabled onedir executable has an
- * accompanying contents directory that cannot be modified by a
- * non-privileged user. */
-#if !defined(_WIN32)
+ * The name check should largely prevent spoofed environment variables
+ * from being used to pass an arbitrary directory as the top-level
+ * application to a onefile child process. However, this could still
+ * happen with directories that do conform to PyInstaller's naming scheme;
+ * to prevent this, the extracted PID of the originating onefile process
+ * needs to be further verified (i.e., that is a parent or an ancestor
+ * process of the current process, and that the said process uses same
+ * executable as the current process). */
+int
+pyi_security_verify_application_home_dir_name(const struct PYI_CONTEXT *pyi_ctx, unsigned int *onefile_parent_pid)
+{
+    char basename[PYI_PATH_MAX];
+    size_t name_len;
 
-static int
+    if (!pyi_path_basename(basename, pyi_ctx->application_home_dir)) {
+        PYI_ERROR("Security validation failure: failed to obtain name of application's home directory!\n");
+        return -1;
+    }
+
+    PYI_DEBUG("SECURITY: verifying the name of application's home directory (%s)...\n", basename);
+
+    /* Verify the length of the name:
+     *  - Windows: _MEI + process ID number (%08x format) + suffix
+     *    added by _wtempnam(); so we check that the name is at least
+     *    12 characters long...
+     *  - other platforms: _MEI + process ID number (%08x format) +
+     *    six random characters added by mkdtemp(); so we check that
+     *    the name is exactly 18 characters long... */
+    name_len = strlen(basename);
+
+#ifdef _WIN32
+    if (name_len < 12) {
+        PYI_ERROR("Security validation failure: unexpected name of application's home directory!\n");
+        return -1;
+    }
+#else
+    if (name_len != 18) {
+        PYI_ERROR("Security validation failure: unexpected name of application's home directory!\n");
+        return -1;
+    }
+#endif
+
+    /* Verify the prefix and extract PID part at the same time. Keep in
+     * sync with pyi_create_temporary_application_directory() implementations
+     * in pyi_utils_posix.c and pyi_utis_win32.c */
+    if (sscanf(basename, "_MEI%08x", onefile_parent_pid) != 1) {
+        PYI_ERROR("Security validation failure: unexpected name of application's home directory!\n");
+        return -1;
+    }
+
+    return 0;
+}
+
+
+/* Verification of owner ID and permissions on top-level application
+ * directory for POSIX executables with setuid bit set:
+ *  - the owner ID of the top-level application directory must match the
+ *    effective user ID
+ *  - permissions on the top-level application directory must be set to
+ *    0700
+ * Applicable to both onefile and onedir builds. No-op on Windows, and
+ * no-op on other platforms when setuid bit is not set on the executable. */
+int
 pyi_security_verify_application_home_dir_permissions(const struct PYI_CONTEXT *pyi_ctx)
 {
+#if defined(_WIN32)
+    (void)pyi_ctx;
+    return 0;
+#else
     uid_t euid;
     uid_t permissions;
     struct stat application_home_dir_stat;
@@ -393,77 +444,5 @@ pyi_security_verify_application_home_dir_permissions(const struct PYI_CONTEXT *p
     }
 
     return 0;
-}
-
 #endif
-
-
-int
-pyi_security_verify_application_home_dir(const struct PYI_CONTEXT *pyi_ctx, unsigned int prefix_pid)
-{
-    /* In onefile mode, the application home directory name should have
-     * distrinct, PyInstaller-specific format: _MEIXXXXXX */
-    if (pyi_ctx->is_onefile) {
-        char basename[PYI_PATH_MAX];
-        size_t name_len;
-
-        char expected_prefix[32];
-        int expected_prefix_len;
-
-        if (!pyi_path_basename(basename, pyi_ctx->application_home_dir)) {
-            PYI_ERROR("Security validation failure: failed to obtain name of application's home directory!\n");
-            return -1;
-        }
-
-        PYI_DEBUG("SECURITY: verifying the name of application's home directory (%s)...\n", basename);
-
-        /* Verify the length of the name:
-         *  - Windows: _MEI + process ID number (%08x format) + suffix
-         *    added by _wtempnam(); so we check that the name is at least
-         *    12 characters long...
-         *  - other platforms: _MEI + process ID number (%08x format) +
-         *    six random characters added by mkdtemp(); so we check that
-         *    the name is exactly 18 characters long... */
-        name_len = strlen(basename);
-
-#ifdef _WIN32
-        if (name_len < 12) {
-            PYI_ERROR("Security validation failure: unexpected name of application's home directory!\n");
-            return -1;
-        }
-#else
-        if (name_len != 18) {
-            PYI_ERROR("Security validation failure: unexpected name of application's home directory!\n");
-            return -1;
-        }
-#endif
-
-        /* Verify the prefix */
-        if (prefix_pid > 0) {
-            expected_prefix_len = snprintf(expected_prefix, 32, "_MEI%08x", prefix_pid);
-        } else {
-            expected_prefix_len = snprintf(expected_prefix, 32, "_MEI");
-        }
-        if (expected_prefix_len < 0 || expected_prefix_len >= 32) {
-            PYI_ERROR("Security validation failure: failed to format expected name prefix!\n");
-            return -1;
-        }
-
-        PYI_DEBUG("SECURITY: expected prefix: %s\n", expected_prefix);
-
-        if (strncmp(basename, expected_prefix, expected_prefix_len) != 0) {
-            PYI_ERROR("Security validation failure: unexpected name of application's home directory!\n");
-            return -1;
-        }
-    }
-
-    /* POSIX: additional owner/permissions validation when setuid bit is
-     * set on the executable */
-#if !defined(_WIN32)
-    if (pyi_security_verify_application_home_dir_permissions(pyi_ctx) < 0) {
-        return -1;
-    }
-#endif
-
-    return 0;
 }

--- a/bootloader/src/pyi_security.c
+++ b/bootloader/src/pyi_security.c
@@ -781,7 +781,7 @@ pyi_security_verify_application_home_dir_permissions(const struct PYI_CONTEXT *p
     struct stat application_home_dir_stat;
 
     /* Applicable only to executables with setuid bit set. */
-    if (!pyi_ctx->has_setuid) {
+    if (!pyi_ctx->has_elevated_privileges) {
         PYI_DEBUG("SECURITY: setuid bit is not set - skipping verification of owner/permissions of application's home directory.\n");
         return true;
     }

--- a/bootloader/src/pyi_security.h
+++ b/bootloader/src/pyi_security.h
@@ -21,12 +21,12 @@
 
 struct PYI_CONTEXT;
 
-int pyi_security_check_onefile_setuid_allowed();
+bool pyi_security_onefile_parent_verification_available();
 
-int pyi_security_verify_application_home_dir_name(const struct PYI_CONTEXT *pyi_ctx, unsigned int *onefile_parent_pid);
-int pyi_security_verify_application_home_dir_permissions(const struct PYI_CONTEXT *pyi_ctx);
+bool pyi_security_verify_application_home_dir_name(const struct PYI_CONTEXT *pyi_ctx, unsigned int *onefile_parent_pid);
+bool pyi_security_verify_application_home_dir_permissions(const struct PYI_CONTEXT *pyi_ctx);
 
-int pyi_security_verify_onefile_parent_pid(const struct PYI_CONTEXT *pyi_ctx, const unsigned int onefile_parent_pid, const bool search_process_tree);
-int pyi_security_verify_onefile_parent_executable(const struct PYI_CONTEXT *pyi_ctx, const unsigned int onefile_parent_pid);
+bool pyi_security_verify_onefile_parent_pid(const struct PYI_CONTEXT *pyi_ctx, const unsigned int onefile_parent_pid, const bool search_process_tree);
+bool pyi_security_verify_onefile_parent_executable(const struct PYI_CONTEXT *pyi_ctx, const unsigned int onefile_parent_pid);
 
 #endif /* PYI_SECURITY_H */

--- a/bootloader/src/pyi_security.h
+++ b/bootloader/src/pyi_security.h
@@ -22,7 +22,10 @@
 struct PYI_CONTEXT;
 
 int pyi_security_check_onefile_setuid_allowed();
+
+int pyi_security_verify_application_home_dir_name(const struct PYI_CONTEXT *pyi_ctx, unsigned int *onefile_parent_pid);
+int pyi_security_verify_application_home_dir_permissions(const struct PYI_CONTEXT *pyi_ctx);
+
 int pyi_security_verify_parent_process(const struct PYI_CONTEXT *pyi_ctx);
-int pyi_security_verify_application_home_dir(const struct PYI_CONTEXT *pyi_ctx, unsigned int prefix_pid);
 
 #endif /* PYI_SECURITY_H */

--- a/bootloader/src/pyi_security.h
+++ b/bootloader/src/pyi_security.h
@@ -21,7 +21,7 @@
 
 struct PYI_CONTEXT;
 
-int pyi_security_verify_parent_proces(const struct PYI_CONTEXT *pyi_ctx);
+int pyi_security_verify_parent_process(const struct PYI_CONTEXT *pyi_ctx);
 int pyi_security_verify_application_home_dir(const struct PYI_CONTEXT *pyi_ctx, unsigned int prefix_pid);
 
 #endif /* PYI_SECURITY_H */

--- a/bootloader/src/pyi_security.h
+++ b/bootloader/src/pyi_security.h
@@ -21,6 +21,7 @@
 
 struct PYI_CONTEXT;
 
+int pyi_security_check_onefile_setuid_allowed();
 int pyi_security_verify_parent_process(const struct PYI_CONTEXT *pyi_ctx);
 int pyi_security_verify_application_home_dir(const struct PYI_CONTEXT *pyi_ctx, unsigned int prefix_pid);
 

--- a/bootloader/src/pyi_security.h
+++ b/bootloader/src/pyi_security.h
@@ -26,6 +26,7 @@ int pyi_security_check_onefile_setuid_allowed();
 int pyi_security_verify_application_home_dir_name(const struct PYI_CONTEXT *pyi_ctx, unsigned int *onefile_parent_pid);
 int pyi_security_verify_application_home_dir_permissions(const struct PYI_CONTEXT *pyi_ctx);
 
-int pyi_security_verify_parent_process(const struct PYI_CONTEXT *pyi_ctx);
+int pyi_security_verify_onefile_parent_pid(const struct PYI_CONTEXT *pyi_ctx, const unsigned int onefile_parent_pid, const bool search_process_tree);
+int pyi_security_verify_onefile_parent_executable(const struct PYI_CONTEXT *pyi_ctx, const unsigned int onefile_parent_pid);
 
 #endif /* PYI_SECURITY_H */

--- a/doc/advanced-topics.rst
+++ b/doc/advanced-topics.rst
@@ -348,10 +348,13 @@ Starting with PyInstaller v6.22.1, additional security validation has been
 implemented in the child process codepath of a frozen application built
 in ``onefile`` mode - i.e., the main application process and worker
 sub-processes spawned by the main application process via ``sys.executable``.
-The process attempts to look up the path to the executable of its parent
-process, and verifies that it matches its own executable, in order to
-ensure that the run-time environment it is supposed to inherit was indeed
-set up by a parent process of a ``onefile`` application.
+The process attempts to look up the originating onefile parent process
+based on the process ID encoded in the name of inherited top-level
+application directory. If this process is determined to be a valid
+ancestor process (i.e., can be found by traversing the ancestor process
+tree of the current process), the next step involves look-up of its
+executable, and ensuring that it matches the executable of the current
+process.
 
 This validation aims to prevent the ``onefile`` executable from being
 tricked, via a crafted set of :ref:`environment variables <bootloader environment variables>`,
@@ -360,27 +363,37 @@ Depending on the content of the spoofed top-level application directory,
 this may result in execution with altered behavior, or even local privilege
 escalation (e.g., POSIX executable with ``setuid`` bit set).
 
+Starting with PyInstaller v6.22.3, the onefile parent-process validation
+has been limited only to processes that are running with elevated privileges
+while inheriting environment variables set by unprivileged user. On
+POSIX systems, this corresponds to executables with ``setuid`` bit set,
+while on Windows, it corresponds to UAC-elevated processes (running with
+``TokenElevationTypeFull`` token).
+
 Windows
 -------
 
-On Windows, the parent process ID is obtained by walking the current
-process snapshot (``CreateToolhelp32Snapshot``, ``Process32First``,
-``Process32Next``), and the path to corresponding executable is retrieved
-using ``QueryFullProcessImageName``.
+On Windows, the parent process look-up is performed by walking the current
+process snapshot (``CreateToolhelp32Snapshot``, ``Process32FirstW``,
+``Process32NextW``) and looking for entry with specified process ID. The
+path to corresponding executable is retrieved using ``QueryFullProcessImageNameW``.
 
 macOS
 -----
 
 On macOS, the parent process ID is obtained via standard POSIX
-``getppid()`` system call, and the path to corresponding executable is
-retrieved using ``proc_pidpath()``.
+``getppid()`` system call, while further ancestor process look-up is
+performed using ``proc_pidinfo`` with ``PROC_PIDT_SHORTBSDINFO``
+argument. The path to corresponding executable is retrieved using
+``proc_pidpath()``.
 
 
 POSIX platforms
 ---------------
 
 On other POSIX platforms, the parent process ID is obtained via
-standard POSIX ``getppid()`` system call, followed by the look-up of
+standard POSIX ``getppid()`` system call. Retrieval of further ancestor
+processes and look-up of their executable requires look-up of
 the platform-specific entry on the ``procfs`` filesystem
 (i.e., inside the ``/proc/<ppid>`` directory).
 
@@ -394,26 +407,7 @@ Some of otherwise supported POSIX platforms do not implement ``procfs``
 at all (for example, OpenBSD), or do not provide the information about the
 executable path (for example, AIX). On such platforms, setting ``setuid``
 bit on ``onefile`` executables is not supported anymore - the implemented
-security validation will automatically fail. Running regular ``onefile``
-executables is still supported, but due to lack of validation, it may be
-subject to environment manipulation.
-
-On POSIX platforms where look-up via ``procfs`` is nominally supported
-(i.e., Linux, Cygwin, FreeBSD, NetBSD, and SunOS), the behavior depends
-on whether the executable has ``setuid`` bit set and whether the
-corresponding entry under ``/proc/<ppid>`` is accessible or not.
-
-For executables with ``setuid`` bit set, the parent-process validation
-is mandatory. If the corresponding entry under ``/proc/<ppid>`` is
-inaccessible for whatever reason (for example, due to ``procfs`` not
-being mounted, as is the case on FreeBSD by default, or due to access
-being blocked by local security policy), security validation will
-automatically fail and the process will exit with security validation
-error message.
-
-For regular executables (without ``setuid`` bit set), the parent-process
-check is enforced when the relevant ``procfs`` entry is accessible, and
-skipped when it happens to be inaccessible.
+security validation will automatically fail.
 
 
 .. _bootloader security validation onedir:

--- a/news/9513.bugfix.rst
+++ b/news/9513.bugfix.rst
@@ -1,0 +1,2 @@
+Fix ``onefile`` parent-process validation to allow intermixed nested
+sub-processes.

--- a/news/9520.bootloader.rst
+++ b/news/9520.bootloader.rst
@@ -1,0 +1,5 @@
+Limit ``onefile`` parent-process validation only to executables that are
+running with elevated privileges while inheriting environment variables
+set by unprivileged user. On POSIX systems, this corresponds to executables
+with ``setuid`` bit set, while on Windows, it corresponds to UAC-elevated
+processes (running with ``TokenElevationTypeFull`` token).

--- a/tests/functional/test_security.py
+++ b/tests/functional/test_security.py
@@ -419,42 +419,48 @@ def test_application_home_directory_hijack(
             assert p.returncode not in {0, 42}
             assert MSG_HOME_DIRECTORY_NAME in p.stderr
         elif scenario == SCENARIO_MEI_DIR_MISMATCHED_PID:
-            if mitigation_unavailable:
-                assert p.returncode == 42
-            else:
-                # The PID part of _MEI directory in this scenario is set to 0.
-                #
-                # When running as main application process level (i.e., the spoofed parent process level is
-                # PYI_PROCESS_LEVEL_PARENT), the declared PID=0 differs from that of immediate parent, and fails
-                # the validation.
-                #
-                # When running as spawned worker sub-process (i.e., the spoofed parent process level is
-                # PYI_PROCESS_LEVEL_MAIN), the declared PID=0 cannot be found among ancestor processes, and fails
-                # the validation.
+            # The PID part of _MEI directory in this scenario is set to 0.
+            #
+            # When running as main application process level (i.e., the spoofed parent process level is
+            # PYI_PROCESS_LEVEL_PARENT), the declared PID=0 differs from that of immediate parent, and fails
+            # the validation. This is true even on POSIX platforms where /proc filesystem is unavailable.
+            #
+            # When running as spawned worker sub-process (i.e., the spoofed parent process level is
+            # PYI_PROCESS_LEVEL_MAIN), the declared PID=0 cannot be found among ancestor processes, and fails
+            # the validation. On POSIX platforms the process tree traversal requires /proc filesystem, so this
+            # scenario is expected to slip through if `mitigation_unavailable` is set.
+            if parent_level == PYI_PROCESS_LEVEL_PARENT:
                 assert p.returncode not in {0, 42}
-                if parent_level == PYI_PROCESS_LEVEL_PARENT:
-                    assert MSG_PARENT_DIFFERENT_PID in p.stderr
+                assert MSG_PARENT_DIFFERENT_PID in p.stderr
+            else:
+                if mitigation_unavailable:
+                    assert p.returncode == 42
                 else:
+                    assert p.returncode not in {0, 42}
                     assert MSG_PARENT_PID_NOT_FOUND in p.stderr
         elif scenario == SCENARIO_MEI_DIR_MATCHED_PID:
-            if mitigation_unavailable:
-                assert p.returncode == 42
-            else:
-                # The PID part of _MEI directory in this scenario is set to the PID of current (= pytest) process.
-                #
-                # When running as main application process level (i.e., the spoofed parent process level is
-                # PYI_PROCESS_LEVEL_PARENT), the declared PID matches that of immediate parent, and passes
-                # validation; therefore, it fails in subsequent executable validation.
-                #
-                # When running as spawned worker sub-process (i.e., the spoofed parent process level is
-                # PYI_PROCESS_LEVEL_MAIN), the declared PID matches that of immediate parent; this fails the
-                # validation, because in this case we expect the originating onefile parent process to be at least
-                # a grand-parent or a further ancestor.
-                assert p.returncode not in {0, 42}
-                if parent_level == PYI_PROCESS_LEVEL_PARENT:
-                    assert MSG_PARENT_DIFFERENT_EXECUTABLE in p.stderr
+            # The PID part of _MEI directory in this scenario is set to the PID of current (= pytest) process.
+            #
+            # When running as main application process level (i.e., the spoofed parent process level is
+            # PYI_PROCESS_LEVEL_PARENT), the declared PID matches that of immediate parent, and passes
+            # validation; therefore, it fails in subsequent executable validation. On POSIX platforms the
+            # executable validation requires /proc filesystem, so this scenario is expected to split through
+            # if `mitigation_unavailable` is set.
+            #
+            # When running as spawned worker sub-process (i.e., the spoofed parent process level is
+            # PYI_PROCESS_LEVEL_MAIN), the declared PID matches that of immediate parent; this fails the
+            # validation, because in this case we expect the originating onefile parent process to be at least
+            # a grand-parent or a further ancestor. This is true even on POSIX platforms where /proc filesystem
+            # is unavailable.
+            if parent_level == PYI_PROCESS_LEVEL_PARENT:
+                if mitigation_unavailable:
+                    assert p.returncode == 42
                 else:
-                    assert MSG_PARENT_DIFFERENT_PID in p.stderr
+                    assert p.returncode not in {0, 42}
+                    assert MSG_PARENT_DIFFERENT_EXECUTABLE in p.stderr
+            else:
+                assert p.returncode not in {0, 42}
+                assert MSG_PARENT_DIFFERENT_PID in p.stderr
         elif scenario == SCENARIO_SETUID_EXECUTABLE:
             assert p.returncode not in {0, 42}
             # Platforms without mitigation are explicitly handled earlier; so here, we expect security validation

--- a/tests/functional/test_security.py
+++ b/tests/functional/test_security.py
@@ -361,6 +361,7 @@ def test_application_home_directory_hijack(
 
     # Onefile mode
     MSG_HOME_DIRECTORY = "Security validation failure: unexpected name of application's home directory!"
+    MSG_PID = "Security validation failure: unexpected PID found in the name of application's home directory!"
     MSG_PARENT_EXECUTABLE = "Security validation failure: parent process has different executable!"
 
     # If we are running setuid-executable scenario and no mitigation is available, the executable should exit with an
@@ -391,23 +392,25 @@ def test_application_home_directory_hijack(
         # This level is valid only in POSIX onefile builds with splash screen enabled. Since the process retains
         # its process ID across restart, it can always detect mismatch in the home directory name.
         assert p.returncode not in {0, 42}
-        assert MSG_HOME_DIRECTORY in p.stderr
+        if scenario == SCENARIO_ARBITRARY_DIR:
+            assert MSG_HOME_DIRECTORY in p.stderr
+        else:
+            assert MSG_PID in p.stderr
     else:  # PYI_PROCESS_LEVEL_PARENT, PYI_PROCESS_LEVEL_MAIN
         # The process is supposed to be either main application process, or worker sub-process spawned via
-        # `sys.executable`. These should fail the parent process verification in the bootloader.
+        # `sys.executable`. The arbitrarily-named application directory should fail the name check. The
+        # _MEI-formatted application directory should pass the name check, but should fail the parent-process
+        # validation.
         #
         # On platforms where procfs-based look-up of parent executable is not supported (AIX, OpenBSD) or the
         # relevant entry under /proc/<ppid> is inaccessible (e.g., FreeBSD without /proc mounted, or any other
         # supported POSIX platform where local security policy blocks access to /proc/<ppid> directory for other
         # processes), we cannot validate the parent process. In these cases, we expect the validation of
         # arbitrary home directory name to fail, the faked home directory with _MEI prefix to slip through,
-        # and executable with setuid bit set to block the execution.
+        # and executable with setuid bit set to block the execution (already handled by preceding if-block).
         if scenario == SCENARIO_ARBITRARY_DIR:
             assert p.returncode not in {0, 42}
-            if mitigation_unavailable:
-                assert MSG_HOME_DIRECTORY in p.stderr
-            else:
-                assert MSG_PARENT_EXECUTABLE in p.stderr
+            assert MSG_HOME_DIRECTORY in p.stderr
         elif scenario == SCENARIO_MEI_DIR_MISMATCHED_PID:
             if mitigation_unavailable:
                 assert p.returncode == 42

--- a/tests/functional/test_security.py
+++ b/tests/functional/test_security.py
@@ -344,7 +344,7 @@ def test_application_home_directory_hijack(
             assert "Security validation failure: unexpected process level!" in p.stderr
             return
 
-    # Onedir mode
+    # *** Onedir mode ***
     if build_mode == 'onedir':
         # In a onedir build, the _PYI_APPLICATION_HOME_DIR environment variable should not be used at all - so the test
         # application should run normally, even if it is tricked into believing to be a sub-process of a onedir main
@@ -359,10 +359,17 @@ def test_application_home_directory_hijack(
             assert p.returncode == 0
         return
 
-    # Onefile mode
-    MSG_HOME_DIRECTORY = "Security validation failure: unexpected name of application's home directory!"
-    MSG_PID = "Security validation failure: unexpected PID found in the name of application's home directory!"
-    MSG_PARENT_EXECUTABLE = "Security validation failure: parent process has different executable!"
+    # *** Onefile mode ***
+    MSG_HOME_DIRECTORY_NAME = \
+        "Security validation failure: unexpected name of application's home directory!"
+    MSG_HOME_DIRECTORY_PID = \
+        "Security validation failure: unexpected PID found in the name of application's home directory!"
+    MSG_PARENT_DIFFERENT_EXECUTABLE = \
+        "Security validation failure: invalid originating onefile parent process (different executable)!"
+    MSG_PARENT_DIFFERENT_PID = \
+        "Security validation failure: invalid originating onefile parent process (different PID)!"
+    MSG_PARENT_PID_NOT_FOUND = \
+        "Security validation failure: invalid originating onefile parent process (PID not found)!"
 
     # If we are running setuid-executable scenario and no mitigation is available, the executable should exit with an
     # early error.
@@ -393,9 +400,9 @@ def test_application_home_directory_hijack(
         # its process ID across restart, it can always detect mismatch in the home directory name.
         assert p.returncode not in {0, 42}
         if scenario == SCENARIO_ARBITRARY_DIR:
-            assert MSG_HOME_DIRECTORY in p.stderr
+            assert MSG_HOME_DIRECTORY_NAME in p.stderr
         else:
-            assert MSG_PID in p.stderr
+            assert MSG_HOME_DIRECTORY_PID in p.stderr
     else:  # PYI_PROCESS_LEVEL_PARENT, PYI_PROCESS_LEVEL_MAIN
         # The process is supposed to be either main application process, or worker sub-process spawned via
         # `sys.executable`. The arbitrarily-named application directory should fail the name check. The
@@ -410,24 +417,54 @@ def test_application_home_directory_hijack(
         # and executable with setuid bit set to block the execution (already handled by preceding if-block).
         if scenario == SCENARIO_ARBITRARY_DIR:
             assert p.returncode not in {0, 42}
-            assert MSG_HOME_DIRECTORY in p.stderr
+            assert MSG_HOME_DIRECTORY_NAME in p.stderr
         elif scenario == SCENARIO_MEI_DIR_MISMATCHED_PID:
             if mitigation_unavailable:
                 assert p.returncode == 42
             else:
+                # The PID part of _MEI directory in this scenario is set to 0.
+                #
+                # When running as main application process level (i.e., the spoofed parent process level is
+                # PYI_PROCESS_LEVEL_PARENT), the declared PID=0 differs from that of immediate parent, and fails
+                # the validation.
+                #
+                # When running as spawned worker sub-process (i.e., the spoofed parent process level is
+                # PYI_PROCESS_LEVEL_MAIN), the declared PID=0 cannot be found among ancestor processes, and fails
+                # the validation.
                 assert p.returncode not in {0, 42}
-                assert MSG_PARENT_EXECUTABLE in p.stderr
+                if parent_level == PYI_PROCESS_LEVEL_PARENT:
+                    assert MSG_PARENT_DIFFERENT_PID in p.stderr
+                else:
+                    assert MSG_PARENT_PID_NOT_FOUND in p.stderr
         elif scenario == SCENARIO_MEI_DIR_MATCHED_PID:
             if mitigation_unavailable:
                 assert p.returncode == 42
             else:
+                # The PID part of _MEI directory in this scenario is set to the PID of current (= pytest) process.
+                #
+                # When running as main application process level (i.e., the spoofed parent process level is
+                # PYI_PROCESS_LEVEL_PARENT), the declared PID matches that of immediate parent, and passes
+                # validation; therefore, it fails in subsequent executable validation.
+                #
+                # When running as spawned worker sub-process (i.e., the spoofed parent process level is
+                # PYI_PROCESS_LEVEL_MAIN), the declared PID matches that of immediate parent; this fails the
+                # validation, because in this case we expect the originating onefile parent process to be at least
+                # a grand-parent or a further ancestor.
                 assert p.returncode not in {0, 42}
-                assert MSG_PARENT_EXECUTABLE in p.stderr
+                if parent_level == PYI_PROCESS_LEVEL_PARENT:
+                    assert MSG_PARENT_DIFFERENT_EXECUTABLE in p.stderr
+                else:
+                    assert MSG_PARENT_DIFFERENT_PID in p.stderr
         elif scenario == SCENARIO_SETUID_EXECUTABLE:
             assert p.returncode not in {0, 42}
             # Platforms without mitigation are explicitly handled earlier; so here, we expect security validation
-            # failure.
-            assert MSG_PARENT_EXECUTABLE in p.stderr
+            # failure. Since the spoofed setup is the same as in SCENARIO_MEI_DIR_MATCHED_PID, the expected result
+            # is also the same.
+            assert p.returncode not in {0, 42}
+            if parent_level == PYI_PROCESS_LEVEL_PARENT:
+                assert MSG_PARENT_DIFFERENT_EXECUTABLE in p.stderr
+            else:
+                assert MSG_PARENT_DIFFERENT_PID in p.stderr
         else:
             raise ValueError(f"Unsupported scenario: {scenario!r}")
 
@@ -484,10 +521,6 @@ def test_security_validation_with_symlinked_executable(pyi_builder, tmp_path):
 # Test that parent-process security validation works correctly in case of intermixed processes, i.e., the application
 # process spawning another program, which then spawns another instance of application (subprocess). See #9512 and #9513.
 def test_security_validation_with_intermixed_subprocesses(pyi_builder, tmp_path):
-    # TODO
-    if pyi_builder._mode == 'onefile':
-        pytest.xfail("security validation needs to be reworked to allow for intermixed processes")
-
     # Wrapper script
     wrapper_script = '\n'.join([
         "import sys",

--- a/tests/functional/test_security.py
+++ b/tests/functional/test_security.py
@@ -293,7 +293,6 @@ def test_security_validation_with_symlinked_executable(pyi_builder, tmp_path):
         os.symlink(test_dir, test_dir_symlink, target_is_directory=True)
     except OSError:
         if compat.is_win:
-            raise
             pytest.skip("OS does not support creation of symbolic links.")
         else:
             raise

--- a/tests/functional/test_security.py
+++ b/tests/functional/test_security.py
@@ -364,20 +364,21 @@ def test_application_home_directory_hijack(
     MSG_PARENT_EXECUTABLE = "Security validation failure: parent process has different executable!"
 
     # If we are running setuid-executable scenario and no mitigation is available, the executable should exit with an
-    # error.
+    # early error.
     if scenario == SCENARIO_SETUID_EXECUTABLE and mitigation_unavailable:
         assert p.returncode not in {0, 42}
-        # AIX, OpenBSD
-        MSG_ALWAYS_UNSUPPORTED = \
-            "Security validation failure: setuid-enabled executables are not supported on this platform!"
-        # FreeBSD without /proc mounted
-        MSG_CONDITIONALLY_UNSUPPORTED = \
-            "Security validation failure: could not determine the executable path for parent process!"
-        if parent_level == PYI_PROCESS_LEVEL_PARENT_NEEDS_RESTART:
-            # TODO: we should raise early setuid-executable-not-supported error...
-            assert MSG_HOME_DIRECTORY in p.stderr
+        if compat.is_freebsd:
+            # FreeBSD without /proc mounted
+            MSG_UNSUPPORTED_SYSTEM = (
+                "Security validation failure: setuid-enabled executables are not supported on this system "
+                "(missing /proc)!"
+            )
+            assert MSG_UNSUPPORTED_SYSTEM in p.stderr
         else:
-            assert (MSG_ALWAYS_UNSUPPORTED in p.stderr) or (MSG_CONDITIONALLY_UNSUPPORTED in p.stderr)
+            # AIX, OpenBSD
+            MSG_UNSUPPORTED_PLATFORM = \
+                "Security validation failure: setuid-enabled executables are not supported on this platform!"
+            assert MSG_UNSUPPORTED_PLATFORM in p.stderr
         return
 
     if parent_level == PYI_PROCESS_LEVEL_UNKNOWN:

--- a/tests/functional/test_security.py
+++ b/tests/functional/test_security.py
@@ -12,6 +12,8 @@
 import copy
 import os
 import pathlib
+import shutil
+import stat
 import subprocess
 import sys
 
@@ -25,6 +27,17 @@ PYI_PROCESS_LEVEL_PARENT_NEEDS_RESTART = -1
 PYI_PROCESS_LEVEL_PARENT = 0
 PYI_PROCESS_LEVEL_MAIN = 1
 PYI_PROCESS_LEVEL_SUBPROCESS = 2
+
+# ** Scenarios **
+# Arbitrary directory passed as the application's top-level directory (i.e., does not have a _MEI prefix).
+SCENARIO_ARBITRARY_DIR = 0
+# Directory with _MEI prefix passed, but with PID part not corresponding to any process in the process ancestor tree.
+SCENARIO_MEI_DIR_MISMATCHED_PID = 1
+# Directory with _MEI prefix passed, and with PID part set to the PID of the current (pytest) process.
+SCENARIO_MEI_DIR_MATCHED_PID = 2
+# Additional test for non-Windows: same as above, but with setuid bit set on the executable (the owner still being the
+# user, as setting up setuid-root is difficult for the test...)
+SCENARIO_SETUID_EXECUTABLE = 3
 
 
 def _ensure_long_path(path):
@@ -114,8 +127,61 @@ def _ensure_long_path(path):
         'SUBPROCESS',
     ],
 )
-def test_application_home_directory_hijack(pyi_builder, tmp_path, parent_level):
-    mode = pyi_builder._mode  # Original mode
+@pytest.mark.parametrize(
+    'scenario', [
+        SCENARIO_ARBITRARY_DIR,
+        SCENARIO_MEI_DIR_MISMATCHED_PID,
+        SCENARIO_MEI_DIR_MATCHED_PID,
+        *([] if compat.is_win else [SCENARIO_SETUID_EXECUTABLE]),
+    ],
+    ids=[
+        'ArbitraryDir',
+        'MeiDirMismatchedPid',
+        'MeiDirMatchedPid',
+        *([] if compat.is_win else ['SetuidExecutable']),
+    ]
+)
+@pytest.mark.parametrize('splash_enabled', [False, True], ids=['nosplash', 'splash'])
+def test_application_home_directory_hijack(
+    pyi_builder,
+    tmp_path,
+    script_dir,
+    monkeypatch,
+    splash_enabled,
+    parent_level,
+    scenario,
+):
+    build_mode = pyi_builder._mode  # The original build mode (i.e., of the real test application)
+
+    # Splash-screen enabled variant requires tkinter to build; but since we do not require splash screen to actually
+    # work, we do not need to check if tkinter is fully-functional, only available.
+    splash_args = []
+    if splash_enabled:
+        if compat.is_darwin:
+            pytest.skip('splash screen is not supported on macOS')
+        else:
+            from PyInstaller.utils.hooks.tcl_tk import tcltk_info
+            if not tcltk_info.available:
+                pytest.skip('tkinter is not available')
+
+        splash_image = script_dir.parent / 'data' / 'splash' / 'image.png'
+        splash_args = ['--splash', str(splash_image)]
+
+        # For this test, we need splash screen enabled in the build, but we are not interested in having it shown at
+        # run-time. Therefore, explicitly suppress - primarily to avoid spurious errors on our Cygwin CI, where splash
+        # screen tends to be flaky, but also to avoid unnecessarily running it on other platforms.
+        monkeypatch.setenv("PYINSTALLER_SUPPRESS_SPLASH_SCREEN", "1")
+
+    # Flag indicating that mitigation is unavailable; hijack is possible for unprivileged onefile executables, while
+    # setuid-enabled onefile executables should raise an error.
+    mitigation_unavailable = (
+        # OpenBSD does not have /proc filesystem available at all.
+        compat.is_openbsd or
+        # AIX has /proc filesystem available, but does not provide executable information.
+        compat.is_aix or
+        # On FreeBSD, /proc filesystem is not mounted by default
+        (compat.is_freebsd and not os.path.isdir('/proc/curproc'))
+    )
 
     # Create files with secrets
     SECRET_REAL = "REAL"
@@ -155,7 +221,7 @@ def test_application_home_directory_hijack(pyi_builder, tmp_path, parent_level):
     # Build the test application
     pyi_builder.test_source(
         test_script,
-        pyi_args=['--add-data', f'{str(real_secret_file)}:.'],
+        pyi_args=['--add-data', f'{str(real_secret_file)}:.', *splash_args],
         app_name='app_real',
         app_args=[SECRET_REAL],
     )
@@ -165,28 +231,64 @@ def test_application_home_directory_hijack(pyi_builder, tmp_path, parent_level):
 
     pyi_builder.test_source(
         test_script,
-        pyi_args=['--add-data', f'{str(fake_secret_file)}:.'],
+        pyi_args=['--add-data', f'{str(fake_secret_file)}:.', *splash_args],
         app_name='app_fake',
         app_args=[SECRET_FAKE],
     )
 
     # The actual test - try to pass the fake application's contents
     # directory as top-level directory for the real test application.
-    print("\nFinished build and sanity-check tests - preparing the actual test...", file=sys.stdout)
     print("\nFinished build and sanity-check tests - preparing the actual test...", file=sys.stderr)
 
     executables = pyi_builder._find_executables('app_real')
     assert len(executables) == 1
     executable = executables[0]
-    print(f"Test application's executable: {executable}", file=sys.stdout)
-    print(f"Test application's executable: {executable}", file=sys.stderr)
 
     executables = pyi_builder._find_executables('app_fake')
     assert len(executables) == 1
     fake_app_dir = pathlib.Path(executables[0]).parent / '_internal'
-    print(f"Fake application's directory: {str(fake_app_dir)!r}", file=sys.stdout)
-    print(f"Fake application's directory: {str(fake_app_dir)!r}", file=sys.stderr)
     assert fake_app_dir.is_dir()
+
+    # Scenario-specific adjustments to executable and/or application directory
+    if scenario == SCENARIO_ARBITRARY_DIR:
+        pass  # Pass the fake_app_dir and executable as-is
+    elif scenario == SCENARIO_MEI_DIR_MISMATCHED_PID:
+        # Copy the fake_app_dir into _MEI-formatted directory with PID part set to 0. The "random" part is also
+        # set to 0, to pass the length check.
+        mei_dir = tmp_path / f'_MEI{0:08x}000000'
+        shutil.copytree(fake_app_dir, mei_dir, symlinks=True)
+        fake_app_dir = mei_dir
+    elif scenario == SCENARIO_MEI_DIR_MATCHED_PID:
+        # Same as above, but with the process ID of the current (pytest) process. While technically a valid ancestor
+        # process, it should still fail the executable check.
+        mei_dir = tmp_path / f'_MEI{os.getpid():08x}000000'
+        shutil.copytree(fake_app_dir, mei_dir, symlinks=True)
+        fake_app_dir = mei_dir
+    elif scenario == SCENARIO_SETUID_EXECUTABLE:
+        assert not compat.is_win, 'Test scenario not supported on Windows'
+
+        # Make a copy of executable with setuid bit set. The copy is kept in the same place as the original
+        # executable, to ensure it has adjacent contents directory in onedir mode.
+        setuid_executable = pathlib.Path(executable).with_name('setuid_executable')
+        shutil.copy2(executable, setuid_executable)
+
+        st_mode = os.lstat(setuid_executable).st_mode
+        os.chmod(setuid_executable, st_mode | stat.S_ISUID)
+
+        executable = setuid_executable
+
+        # Also format the _MEI directory with process ID of the current (pytest) process, and ensure 0700 permissions
+        # on the directory. This combination simulates an attempt at accessing a temporary directory of another onefile
+        # PyInstaller-frozen application.
+        mei_dir = tmp_path / f'_MEI{os.getpid():08x}000000'
+        shutil.copytree(fake_app_dir, mei_dir, symlinks=True)
+        os.chmod(mei_dir, stat.S_IRWXU)
+        fake_app_dir = mei_dir
+    else:
+        raise ValueError(f"Unsupported scenario: {scenario!r}")
+
+    print(f"Test application's executable: {executable}", file=sys.stderr)
+    print(f"Fake application's directory: {str(fake_app_dir)!r}", file=sys.stderr)
 
     # The cloak & dagger part...
     fake_env = copy.deepcopy(os.environ)
@@ -201,7 +303,6 @@ def test_application_home_directory_hijack(pyi_builder, tmp_path, parent_level):
     archive_path = _ensure_long_path(archive_path)
     if compat.is_cygwin and archive_path.lower().endswith('.exe'):
         archive_path = archive_path[:-4]  # Under Cygwin, bootloader resolves executable/archive without .exe suffix
-    print(f"Setting _PYI_ARCHIVE_FILE to: {archive_path!r}", file=sys.stdout)
     print(f"Setting _PYI_ARCHIVE_FILE to: {archive_path!r}", file=sys.stderr)
     fake_env['_PYI_ARCHIVE_FILE'] = archive_path
     # Try to trick process into running a specific codepath by manipulating its parent level.
@@ -209,11 +310,9 @@ def test_application_home_directory_hijack(pyi_builder, tmp_path, parent_level):
     # Try to hijack the top-level application directory
     fake_env['_PYI_APPLICATION_HOME_DIR'] = str(fake_app_dir)
 
-    print(f"Running executable: {executable}", file=sys.stdout)
     print(f"Running executable: {executable}", file=sys.stderr)
     p = subprocess.run([executable, SECRET_REAL], env=fake_env, capture_output=True, encoding='utf-8')
 
-    print(f"Return code: {p.returncode}", file=sys.stdout)
     print(f"Return code: {p.returncode}", file=sys.stderr)
 
     if p.stdout:
@@ -232,48 +331,101 @@ def test_application_home_directory_hijack(pyi_builder, tmp_path, parent_level):
         assert f"Invalid parent process level: {parent_level}" in p.stderr
         return
 
-    # PYI_PROCESS_LEVEL_PARENT_NEEDS_RESTART should be invalid on Windows, macOS, and Cygwin, regardless of mode.
-    non_posix = compat.is_win or compat.is_darwin or compat.is_cygwin
-    if non_posix and parent_level == PYI_PROCESS_LEVEL_PARENT_NEEDS_RESTART:
-        assert p.returncode not in {0, 42}
-        assert f"Invalid parent process level: {parent_level}" in p.stderr
-        return
+    # PYI_PROCESS_LEVEL_PARENT_NEEDS_RESTART should be invalid on Windows, macOS, and Cygwin, regardless of build mode
+    # and regardless of whether splash screen is enabled in the build or not. On other platforms, it is valid for onedir
+    # mode, and for onefile mode with splash screen enabled.
+    if parent_level == PYI_PROCESS_LEVEL_PARENT_NEEDS_RESTART:
+        if compat.is_win or compat.is_darwin or compat.is_cygwin:
+            assert p.returncode not in {0, 42}
+            assert f"Invalid parent process level: {parent_level}" in p.stderr
+            return
+        elif build_mode == 'onefile' and not splash_enabled:
+            assert p.returncode not in {0, 42}
+            assert "Security validation failure: unexpected process level!" in p.stderr
+            return
 
-    if mode == 'onedir':
-        # In onedir build, the _PYI_APPLICATION_HOME_DIR environment variable should not be used at all - so the test
+    # Onedir mode
+    if build_mode == 'onedir':
+        # In a onedir build, the _PYI_APPLICATION_HOME_DIR environment variable should not be used at all - so the test
         # application should run normally, even if it is tricked into believing to be a sub-process of a onedir main
         # application process...
-        assert p.returncode == 0
-    else:
-        # Onefile mode
-        MSG_PROCESS_LEVEL = "Security validation failure: unexpected process level!"
-        MSG_HOME_DIRECTORY = "Security validation failure: unexpected name of application's home directory!"
-        MSG_PARENT_EXECUTABLE = "Security validation failure: parent process has different executable!"
-
-        if parent_level == PYI_PROCESS_LEVEL_UNKNOWN:
-            # This is same as _PYI_PARENT_PROCESS_LEVEL not being set at all; the process should run as parent process
-            # of onefile application and set up new environment. Thus, the test application should run normally.
+        #
+        # In the setuid-executable scenario, we expect the executable to fail validation, because the _internal
+        # directory has default permissions (typically 755), which are not as strict as required (0700).
+        if scenario == SCENARIO_SETUID_EXECUTABLE:
+            assert p.returncode not in {0, 42}
+            assert "Security validation failure: application's home directory has invalid permissions " in p.stderr
+        else:
             assert p.returncode == 0
-        elif parent_level == PYI_PROCESS_LEVEL_PARENT_NEEDS_RESTART:
-            # This level is valid only in POSIX onefile builds with splash screen enabled. On non-POSIX systems, it
-            # should exit with message about unrecognized level (handled by an earlier check). On POSIX systems, it
-            # should similarly exit with message about unexpected level, since splash screen is not enabled on the
-            # build; if it were enabled, the validation of directory name would fail instead.
+        return
+
+    # Onefile mode
+    MSG_HOME_DIRECTORY = "Security validation failure: unexpected name of application's home directory!"
+    MSG_PARENT_EXECUTABLE = "Security validation failure: parent process has different executable!"
+
+    # If we are running setuid-executable scenario and no mitigation is available, the executable should exit with an
+    # error.
+    if scenario == SCENARIO_SETUID_EXECUTABLE and mitigation_unavailable:
+        assert p.returncode not in {0, 42}
+        # AIX, OpenBSD
+        MSG_ALWAYS_UNSUPPORTED = \
+            "Security validation failure: setuid-enabled executables are not supported on this platform!"
+        # FreeBSD without /proc mounted
+        MSG_CONDITIONALLY_UNSUPPORTED = \
+            "Security validation failure: could not determine the executable path for parent process!"
+        if parent_level == PYI_PROCESS_LEVEL_PARENT_NEEDS_RESTART:
+            # TODO: we should raise early setuid-executable-not-supported error...
+            assert MSG_HOME_DIRECTORY in p.stderr
+        else:
+            assert (MSG_ALWAYS_UNSUPPORTED in p.stderr) or (MSG_CONDITIONALLY_UNSUPPORTED in p.stderr)
+        return
+
+    if parent_level == PYI_PROCESS_LEVEL_UNKNOWN:
+        # This is same as _PYI_PARENT_PROCESS_LEVEL not being set at all; the process should run as parent process
+        # of onefile application and set up new environment. Thus, the test application should run normally.
+        # (Except in the setuid-executable scenario with mitigation being unavailable, which should already be
+        # handled by earlier check.)
+        assert p.returncode == 0
+    elif parent_level == PYI_PROCESS_LEVEL_PARENT_NEEDS_RESTART:
+        # This level is valid only in POSIX onefile builds with splash screen enabled. Since the process retains
+        # its process ID across restart, it can always detect mismatch in the home directory name.
+        assert p.returncode not in {0, 42}
+        assert MSG_HOME_DIRECTORY in p.stderr
+    else:  # PYI_PROCESS_LEVEL_PARENT, PYI_PROCESS_LEVEL_MAIN
+        # The process is supposed to be either main application process, or worker sub-process spawned via
+        # `sys.executable`. These should fail the parent process verification in the bootloader.
+        #
+        # On platforms where procfs-based look-up of parent executable is not supported (AIX, OpenBSD) or the
+        # relevant entry under /proc/<ppid> is inaccessible (e.g., FreeBSD without /proc mounted, or any other
+        # supported POSIX platform where local security policy blocks access to /proc/<ppid> directory for other
+        # processes), we cannot validate the parent process. In these cases, we expect the validation of
+        # arbitrary home directory name to fail, the faked home directory with _MEI prefix to slip through,
+        # and executable with setuid bit set to block the execution.
+        if scenario == SCENARIO_ARBITRARY_DIR:
             assert p.returncode not in {0, 42}
-            assert (MSG_PROCESS_LEVEL in p.stderr) or (MSG_HOME_DIRECTORY in p.stderr)
-        else:  # PYI_PROCESS_LEVEL_PARENT, PYI_PROCESS_LEVEL_MAIN
-            # The process is supposed to be either main application process, or worker sub-process spawned via
-            # `sys.executable`. These should fail the parent process verification in the bootloader.
-            #
-            # On platforms where procfs-based look-up of parent executable is not supported (AIX, OpenBSD) or the
-            # relevant entry under /proc/<ppid> is inaccessible (e.g., FreeBSD without /proc mounted, or any other
-            # supported POSIX platform where local security policy blocks access to /proc/<ppid> directory for other
-            # processes), we cannot validate the parent process. In these cases, we expect the validation of home
-            # directory name to fail (since executable in this test does not have setuid bit set, which would fail
-            # due to strict parent process validation requirement).
+            if mitigation_unavailable:
+                assert MSG_HOME_DIRECTORY in p.stderr
+            else:
+                assert MSG_PARENT_EXECUTABLE in p.stderr
+        elif scenario == SCENARIO_MEI_DIR_MISMATCHED_PID:
+            if mitigation_unavailable:
+                assert p.returncode == 42
+            else:
+                assert p.returncode not in {0, 42}
+                assert MSG_PARENT_EXECUTABLE in p.stderr
+        elif scenario == SCENARIO_MEI_DIR_MATCHED_PID:
+            if mitigation_unavailable:
+                assert p.returncode == 42
+            else:
+                assert p.returncode not in {0, 42}
+                assert MSG_PARENT_EXECUTABLE in p.stderr
+        elif scenario == SCENARIO_SETUID_EXECUTABLE:
             assert p.returncode not in {0, 42}
-            assert (MSG_PARENT_EXECUTABLE in p.stderr) or \
-                ((not compat.is_win and not compat.is_darwin) and MSG_HOME_DIRECTORY in p.stderr)
+            # Platforms without mitigation are explicitly handled earlier; so here, we expect security validation
+            # failure.
+            assert MSG_PARENT_EXECUTABLE in p.stderr
+        else:
+            raise ValueError(f"Unsupported scenario: {scenario!r}")
 
 
 # Test that parent-process security validation works correctly in case of symlinked executables (i.e., the executable
@@ -302,20 +454,17 @@ def test_security_validation_with_symlinked_executable(pyi_builder, tmp_path):
         print("Hello world")
     """)
 
-    print("\nFinished build and sanity-check tests - preparing the actual test...", file=sys.stdout)
     print("\nFinished build and sanity-check tests - preparing the actual test...", file=sys.stderr)
 
     executables = pyi_builder._find_executables('test_source')
     assert len(executables) == 1
     executable = executables[0]
-    print(f"Test application's executable: {executable}", file=sys.stdout)
     print(f"Test application's executable: {executable}", file=sys.stderr)
 
     # Symlinked executable
     symlinked_exe = tmp_path / ('symlinked_executable.exe' if compat.is_win else 'symlinked_executable')
     os.symlink(executable, symlinked_exe)
 
-    print(f"Running symlinked executable: {symlinked_exe}", file=sys.stdout)
     print(f"Running symlinked executable: {symlinked_exe}", file=sys.stderr)
     subprocess.run([symlinked_exe], check=True)
 
@@ -324,7 +473,6 @@ def test_security_validation_with_symlinked_executable(pyi_builder, tmp_path):
     os.symlink(tmp_path / 'dist', symlinked_dist)
     symlinked_dist_exe = symlinked_dist / pathlib.Path(executable).relative_to(tmp_path / 'dist')
 
-    print(f"Running executable in symlinked dist directory: {symlinked_dist_exe}", file=sys.stdout)
     print(f"Running executable in symlinked dist directory: {symlinked_dist_exe}", file=sys.stderr)
     subprocess.run([symlinked_dist_exe], check=True)
 

--- a/tests/functional/test_security.py
+++ b/tests/functional/test_security.py
@@ -116,6 +116,19 @@ def _enable_onefile_parent_verification(monkeypatch):
     monkeypatch.setattr('PyInstaller.building.build_main.EXE', MyEXE)
 
 
+# Flag indicating that onefile parent-process verification is unavailable on the platform/system. With verification
+# turned on (either due to privileged mode, or due to explicit opt-in), the program should raise an early error, which
+# limits the scope of testing we can do.
+verification_unavailable = (
+    # OpenBSD does not have /proc filesystem available at all.
+    compat.is_openbsd or
+    # AIX has /proc filesystem available, but does not provide executable information.
+    compat.is_aix or
+    # On FreeBSD, /proc filesystem is not mounted by default
+    (compat.is_freebsd and not os.path.isdir('/proc/curproc'))
+)
+
+
 # Check whether application's top level directory can be hijacked via manipulation of _PYI_ environment variables.
 # See: https://github.com/pyinstaller/pyinstaller/security/advisories/GHSA-9fxf-4qw3-ghmr
 @pytest.mark.parametrize(
@@ -181,17 +194,6 @@ def test_application_home_directory_hijack(
         # screen tends to be flaky, but also to avoid unnecessarily running it on other platforms.
         monkeypatch.setenv("PYINSTALLER_SUPPRESS_SPLASH_SCREEN", "1")
 
-    # Flag indicating that mitigation is unavailable; with verification (automatically or explicitly) turned on, the
-    # program should raise an early error.
-    mitigation_unavailable = (
-        # OpenBSD does not have /proc filesystem available at all.
-        compat.is_openbsd or
-        # AIX has /proc filesystem available, but does not provide executable information.
-        compat.is_aix or
-        # On FreeBSD, /proc filesystem is not mounted by default
-        (compat.is_freebsd and not os.path.isdir('/proc/curproc'))
-    )
-
     # Create files with secrets
     SECRET_REAL = "REAL"
     SECRET_FAKE = "FAKE"
@@ -228,11 +230,15 @@ def test_application_home_directory_hijack(
     """
 
     # Build the test application
+    # If onefile parent-process verification is unavailable, we expect the program to fail here. The return code on
+    # POSIX platforms (where verification might be unavailable) should be 255 (= (unsigned char)-1).
+    expected_retcode = 255 if (build_mode == 'onefile' and verification_unavailable) else 0
     pyi_builder.test_source(
         test_script,
         pyi_args=['--add-data', f'{str(real_secret_file)}:.', *splash_args],
         app_name='app_real',
         app_args=[SECRET_REAL],
+        retcode=expected_retcode,
     )
 
     # Build the fake application - in onedir mode
@@ -354,7 +360,7 @@ def test_application_home_directory_hijack(
         "Security validation failure: invalid originating onefile parent process (PID not found)!"
 
     # On unsupported platforms, the program should raise an early error.
-    if mitigation_unavailable:
+    if verification_unavailable:
         assert p.returncode not in {0, 42}
         if compat.is_freebsd:
             # FreeBSD without /proc mounted
@@ -472,32 +478,44 @@ def test_security_validation_with_setuid_executable(pyi_builder, tmp_path, monke
     else:
         print("Captured stderr: N/A", file=sys.stderr)
 
-    # Check the output
+    # Ensure that setuid bit was detected
+    assert "SECURITY: executable has setuid bit set" in p.stderr
+
+    MSG_VERIFICATION = "SECURITY: setuid bit is set - verifying owner/permissions of application's home directory..."
+
     if pyi_builder._mode == 'onefile':
-        # Onefile mode: check that program succeeded
-        assert p.returncode == 0
+        # Onefile mode
+        if verification_unavailable:
+            # If onefile parent-process verification is unavailable, the setuid-enabled executable should raise an early
+            # error.
+            assert p.returncode != 0
 
-        # Ensure that setuid bit was detected
-        assert "SECURITY: executable has setuid bit set" in p.stderr
+            if compat.is_freebsd:
+                ERR_MSG = (
+                    "Security validation failure: setuid-enabled executables are not supported on this system "
+                    "(missing /proc)!"
+                )
+            else:
+                ERR_MSG = "Security validation failure: setuid-enabled executables are not supported on this platform!"
+            assert ERR_MSG in p.stderr
+        else:
+            assert p.returncode == 0
 
-        # Ensure that owner/permissions on application's home directory were validated
-        assert \
-            "SECURITY: setuid bit is set - verifying owner/permissions of application's home directory..." in p.stderr
+            # Ensure that owner/permissions on application's home directory were validated
+            assert MSG_VERIFICATION in p.stderr
 
-        # Ensure that onefile-parent process validation was auto-enabled, and performed.
-        assert "SECURITY: verifying onefile parent process due to executable running in privileged mode..." in p.stderr
-        assert "SECURITY: verifying process ID of originating onefile parent process" in p.stderr
-        assert "SECURITY: verifying executable of originating onefile parent process" in p.stderr
+            # Ensure that onefile-parent process validation was auto-enabled, and performed.
+            assert "SECURITY: verifying onefile parent process due to executable running in privileged mode..." \
+                in p.stderr
+            assert "SECURITY: verifying process ID of originating onefile parent process" in p.stderr
+            assert "SECURITY: verifying executable of originating onefile parent process" in p.stderr
     else:
         # Onedir mode: check that program failed due to incorrect permissions on application's contents directory. The
         # actual permissions may vary between platforms (for example, 0755 on linux, 0775 on Cygwin), so skip that part
         # of the message.
         assert p.returncode != 0
 
-        assert "SECURITY: executable has setuid bit set" in p.stderr
-
-        assert \
-            "SECURITY: setuid bit is set - verifying owner/permissions of application's home directory..." in p.stderr
+        assert MSG_VERIFICATION in p.stderr
         assert "Security validation failure: application's home directory has invalid permissions (" in p.stderr
 
         # Adjust permissions on contents directory, and try again.
@@ -522,13 +540,16 @@ def test_security_validation_with_setuid_executable(pyi_builder, tmp_path, monke
         # The program should succeed now
         assert p.returncode == 0
         assert "SECURITY: executable has setuid bit set" in p.stderr
-        assert \
-            "SECURITY: setuid bit is set - verifying owner/permissions of application's home directory..." in p.stderr
+        assert MSG_VERIFICATION in p.stderr
 
 
 # Test that parent-process security validation works correctly in case of symlinked executables (i.e., the executable
 # itself being symlinked, or one of its parent directories being symlinked). See #9508.
 def test_security_validation_with_symlinked_executable(pyi_builder, tmp_path, monkeypatch):
+    # Skip if onefile parent-process verification is unavailable
+    if pyi_builder._mode == 'onefile' and verification_unavailable:
+        pytest.skip(reason='onefile parent-process verification is unavailable on this platform/system.')
+
     # Enable onefile parent-process verification on the build
     _enable_onefile_parent_verification(monkeypatch)
 
@@ -617,6 +638,10 @@ def test_security_validation_with_symlinked_executable(pyi_builder, tmp_path, mo
 
 # Test that parent-process security validation works correctly with nested subprocsses.
 def test_security_validation_with_subprocesses(pyi_builder, tmp_path, monkeypatch, capfd):
+    # Skip if onefile parent-process verification is unavailable
+    if pyi_builder._mode == 'onefile' and verification_unavailable:
+        pytest.skip(reason='onefile parent-process verification is unavailable on this platform/system.')
+
     # Enable onefile parent-process verification on the build
     _enable_onefile_parent_verification(monkeypatch)
 
@@ -654,6 +679,10 @@ def test_security_validation_with_subprocesses(pyi_builder, tmp_path, monkeypatc
 # Test that parent-process security validation works correctly in case of intermixed processes, i.e., the application
 # process spawning another program, which then spawns another instance of application (subprocess). See #9512 and #9513.
 def test_security_validation_with_intermixed_subprocesses(pyi_builder, tmp_path, capfd, monkeypatch):
+    # Skip if onefile parent-process verification is unavailable
+    if pyi_builder._mode == 'onefile' and verification_unavailable:
+        pytest.skip(reason='onefile parent-process verification is unavailable on this platform/system.')
+
     # Enable onefile parent-process verification on the build
     _enable_onefile_parent_verification(monkeypatch)
 

--- a/tests/functional/test_security.py
+++ b/tests/functional/test_security.py
@@ -327,3 +327,64 @@ def test_security_validation_with_symlinked_executable(pyi_builder, tmp_path):
     print(f"Running executable in symlinked dist directory: {symlinked_dist_exe}", file=sys.stdout)
     print(f"Running executable in symlinked dist directory: {symlinked_dist_exe}", file=sys.stderr)
     subprocess.run([symlinked_dist_exe], check=True)
+
+
+# Test that parent-process security validation works correctly in case of intermixed processes, i.e., the application
+# process spawning another program, which then spawns another instance of application (subprocess). See #9512 and #9513.
+def test_security_validation_with_intermixed_subprocesses(pyi_builder, tmp_path):
+    # TODO
+    if pyi_builder._mode == 'onefile':
+        pytest.xfail("security validation needs to be reworked to allow for intermixed processes")
+
+    # Wrapper script
+    wrapper_script = '\n'.join([
+        "import sys",
+        "import subprocess",
+        "print('Wrapper script: launching executable...', file=sys.stderr)",
+        "subprocess.run(sys.argv[1:3], check=True)",
+        "print('Wrapper script: done!', file=sys.stderr)",
+    ])
+    script_file = tmp_path / "wrapper_script.py"
+    script_file.write_text(wrapper_script, encoding='utf-8')
+
+    # Test program
+    pyi_builder.test_source(
+        """
+        import sys
+        import os
+        import subprocess
+
+        if len(sys.argv) == 3:
+            output_dir = sys.argv[1]
+            python_executable = sys.argv[2]
+            mode = 'main'
+        elif len(sys.argv) == 2:
+            output_dir = sys.argv[1]
+            mode = 'nested'
+        else:
+            raise ValueError("Invalid number of arguments")
+
+        # Write path to top-level application directory to a file
+        print(f"Application top-level directory: {sys._MEIPASS!r}", file=sys.stderr)
+        output_file = os.path.join(output_dir, mode + '.txt')
+        with open(output_file, 'w', encoding='utf-8') as fp:
+            print(sys._MEIPASS, file=fp)
+
+        # In main mode, spawn python process to run the wrapper script (which will run the executable again)
+        if mode == 'main':
+            print("Running wrapper script...", file=sys.stderr)
+            script_file = os.path.join(output_dir, 'wrapper_script.py')
+            subprocess.run([python_executable, script_file, sys.executable, output_dir], check=True)
+        """,
+        app_args=[str(tmp_path), str(compat.python_executable)]
+    )
+
+    output_file_main = tmp_path / 'main.txt'
+    application_dir_main = output_file_main.read_text(encoding='utf-8').strip()
+    print(f"Top-level application directory (main): {application_dir_main!r}", file=sys.stderr)
+
+    output_file_nested = tmp_path / 'nested.txt'
+    application_dir_nested = output_file_nested.read_text(encoding='utf-8').strip()
+    print(f"Top-level application directory (nested): {application_dir_nested!r}", file=sys.stderr)
+
+    assert application_dir_main == application_dir_nested

--- a/tests/functional/test_security.py
+++ b/tests/functional/test_security.py
@@ -35,9 +35,6 @@ SCENARIO_ARBITRARY_DIR = 0
 SCENARIO_MEI_DIR_MISMATCHED_PID = 1
 # Directory with _MEI prefix passed, and with PID part set to the PID of the current (pytest) process.
 SCENARIO_MEI_DIR_MATCHED_PID = 2
-# Additional test for non-Windows: same as above, but with setuid bit set on the executable (the owner still being the
-# user, as setting up setuid-root is difficult for the test...)
-SCENARIO_SETUID_EXECUTABLE = 3
 
 
 def _ensure_long_path(path):
@@ -108,6 +105,17 @@ def _ensure_long_path(path):
     return long_path
 
 
+def _enable_onefile_parent_verification(monkeypatch):
+    import PyInstaller.building.build_main
+    EXE = PyInstaller.building.build_main.EXE
+
+    def MyEXE(*args, **kwargs):
+        extra_options = [('pyi-enable-onefile-parent-verification', None, 'OPTION')]
+        return EXE(*args, extra_options, **kwargs)
+
+    monkeypatch.setattr('PyInstaller.building.build_main.EXE', MyEXE)
+
+
 # Check whether application's top level directory can be hijacked via manipulation of _PYI_ environment variables.
 # See: https://github.com/pyinstaller/pyinstaller/security/advisories/GHSA-9fxf-4qw3-ghmr
 @pytest.mark.parametrize(
@@ -132,13 +140,11 @@ def _ensure_long_path(path):
         SCENARIO_ARBITRARY_DIR,
         SCENARIO_MEI_DIR_MISMATCHED_PID,
         SCENARIO_MEI_DIR_MATCHED_PID,
-        *([] if compat.is_win else [SCENARIO_SETUID_EXECUTABLE]),
     ],
     ids=[
         'ArbitraryDir',
         'MeiDirMismatchedPid',
         'MeiDirMatchedPid',
-        *([] if compat.is_win else ['SetuidExecutable']),
     ]
 )
 @pytest.mark.parametrize('splash_enabled', [False, True], ids=['nosplash', 'splash'])
@@ -151,6 +157,9 @@ def test_application_home_directory_hijack(
     parent_level,
     scenario,
 ):
+    # Enable onefile parent-process verification on the build
+    _enable_onefile_parent_verification(monkeypatch)
+
     build_mode = pyi_builder._mode  # The original build mode (i.e., of the real test application)
 
     # Splash-screen enabled variant requires tkinter to build; but since we do not require splash screen to actually
@@ -172,8 +181,8 @@ def test_application_home_directory_hijack(
         # screen tends to be flaky, but also to avoid unnecessarily running it on other platforms.
         monkeypatch.setenv("PYINSTALLER_SUPPRESS_SPLASH_SCREEN", "1")
 
-    # Flag indicating that mitigation is unavailable; hijack is possible for unprivileged onefile executables, while
-    # setuid-enabled onefile executables should raise an error.
+    # Flag indicating that mitigation is unavailable; with verification (automatically or explicitly) turned on, the
+    # program should raise an early error.
     mitigation_unavailable = (
         # OpenBSD does not have /proc filesystem available at all.
         compat.is_openbsd or
@@ -264,26 +273,6 @@ def test_application_home_directory_hijack(
         mei_dir = tmp_path / f'_MEI{os.getpid():08x}000000'
         shutil.copytree(fake_app_dir, mei_dir, symlinks=True)
         fake_app_dir = mei_dir
-    elif scenario == SCENARIO_SETUID_EXECUTABLE:
-        assert not compat.is_win, 'Test scenario not supported on Windows'
-
-        # Make a copy of executable with setuid bit set. The copy is kept in the same place as the original
-        # executable, to ensure it has adjacent contents directory in onedir mode.
-        setuid_executable = pathlib.Path(executable).with_name('setuid_executable')
-        shutil.copy2(executable, setuid_executable)
-
-        st_mode = os.lstat(setuid_executable).st_mode
-        os.chmod(setuid_executable, st_mode | stat.S_ISUID)
-
-        executable = setuid_executable
-
-        # Also format the _MEI directory with process ID of the current (pytest) process, and ensure 0700 permissions
-        # on the directory. This combination simulates an attempt at accessing a temporary directory of another onefile
-        # PyInstaller-frozen application.
-        mei_dir = tmp_path / f'_MEI{os.getpid():08x}000000'
-        shutil.copytree(fake_app_dir, mei_dir, symlinks=True)
-        os.chmod(mei_dir, stat.S_IRWXU)
-        fake_app_dir = mei_dir
     else:
         raise ValueError(f"Unsupported scenario: {scenario!r}")
 
@@ -349,44 +338,36 @@ def test_application_home_directory_hijack(
         # In a onedir build, the _PYI_APPLICATION_HOME_DIR environment variable should not be used at all - so the test
         # application should run normally, even if it is tricked into believing to be a sub-process of a onedir main
         # application process...
-        #
-        # In the setuid-executable scenario, we expect the executable to fail validation, because the _internal
-        # directory has default permissions (typically 755), which are not as strict as required (0700).
-        if scenario == SCENARIO_SETUID_EXECUTABLE:
-            assert p.returncode not in {0, 42}
-            assert "Security validation failure: application's home directory has invalid permissions " in p.stderr
-        else:
-            assert p.returncode == 0
+        assert p.returncode == 0
         return
 
     # *** Onefile mode ***
-    MSG_HOME_DIRECTORY_NAME = \
+    ERR_HOME_DIRECTORY_NAME = \
         "Security validation failure: unexpected name of application's home directory!"
-    MSG_HOME_DIRECTORY_PID = \
+    ERR_HOME_DIRECTORY_PID = \
         "Security validation failure: unexpected PID found in the name of application's home directory!"
-    MSG_PARENT_DIFFERENT_EXECUTABLE = \
+    ERR_PARENT_DIFFERENT_EXECUTABLE = \
         "Security validation failure: invalid originating onefile parent process (different executable)!"
-    MSG_PARENT_DIFFERENT_PID = \
+    ERR_PARENT_DIFFERENT_PID = \
         "Security validation failure: invalid originating onefile parent process (different PID)!"
-    MSG_PARENT_PID_NOT_FOUND = \
+    ERR_PARENT_PID_NOT_FOUND = \
         "Security validation failure: invalid originating onefile parent process (PID not found)!"
 
-    # If we are running setuid-executable scenario and no mitigation is available, the executable should exit with an
-    # early error.
-    if scenario == SCENARIO_SETUID_EXECUTABLE and mitigation_unavailable:
+    # On unsupported platforms, the program should raise an early error.
+    if mitigation_unavailable:
         assert p.returncode not in {0, 42}
         if compat.is_freebsd:
             # FreeBSD without /proc mounted
-            MSG_UNSUPPORTED_SYSTEM = (
+            ERR_UNSUPPORTED_SYSTEM = (
                 "Security validation failure: setuid-enabled executables are not supported on this system "
                 "(missing /proc)!"
             )
-            assert MSG_UNSUPPORTED_SYSTEM in p.stderr
+            assert ERR_UNSUPPORTED_SYSTEM in p.stderr
         else:
             # AIX, OpenBSD
-            MSG_UNSUPPORTED_PLATFORM = \
+            ERR_UNSUPPORTED_PLATFORM = \
                 "Security validation failure: setuid-enabled executables are not supported on this platform!"
-            assert MSG_UNSUPPORTED_PLATFORM in p.stderr
+            assert ERR_UNSUPPORTED_PLATFORM in p.stderr
         return
 
     if parent_level == PYI_PROCESS_LEVEL_UNKNOWN:
@@ -400,9 +381,9 @@ def test_application_home_directory_hijack(
         # its process ID across restart, it can always detect mismatch in the home directory name.
         assert p.returncode not in {0, 42}
         if scenario == SCENARIO_ARBITRARY_DIR:
-            assert MSG_HOME_DIRECTORY_NAME in p.stderr
+            assert ERR_HOME_DIRECTORY_NAME in p.stderr
         else:
-            assert MSG_HOME_DIRECTORY_PID in p.stderr
+            assert ERR_HOME_DIRECTORY_PID in p.stderr
     else:  # PYI_PROCESS_LEVEL_PARENT, PYI_PROCESS_LEVEL_MAIN
         # The process is supposed to be either main application process, or worker sub-process spawned via
         # `sys.executable`. The arbitrarily-named application directory should fail the name check. The
@@ -417,67 +398,140 @@ def test_application_home_directory_hijack(
         # and executable with setuid bit set to block the execution (already handled by preceding if-block).
         if scenario == SCENARIO_ARBITRARY_DIR:
             assert p.returncode not in {0, 42}
-            assert MSG_HOME_DIRECTORY_NAME in p.stderr
+            assert ERR_HOME_DIRECTORY_NAME in p.stderr
         elif scenario == SCENARIO_MEI_DIR_MISMATCHED_PID:
             # The PID part of _MEI directory in this scenario is set to 0.
             #
             # When running as main application process level (i.e., the spoofed parent process level is
             # PYI_PROCESS_LEVEL_PARENT), the declared PID=0 differs from that of immediate parent, and fails
-            # the validation. This is true even on POSIX platforms where /proc filesystem is unavailable.
+            # the validation.
             #
             # When running as spawned worker sub-process (i.e., the spoofed parent process level is
             # PYI_PROCESS_LEVEL_MAIN), the declared PID=0 cannot be found among ancestor processes, and fails
-            # the validation. On POSIX platforms the process tree traversal requires /proc filesystem, so this
-            # scenario is expected to slip through if `mitigation_unavailable` is set.
+            # the validation.
+            assert p.returncode not in {0, 42}
             if parent_level == PYI_PROCESS_LEVEL_PARENT:
-                assert p.returncode not in {0, 42}
-                assert MSG_PARENT_DIFFERENT_PID in p.stderr
+                assert ERR_PARENT_DIFFERENT_PID in p.stderr
             else:
-                if mitigation_unavailable:
-                    assert p.returncode == 42
-                else:
-                    assert p.returncode not in {0, 42}
-                    assert MSG_PARENT_PID_NOT_FOUND in p.stderr
+                assert ERR_PARENT_PID_NOT_FOUND in p.stderr
         elif scenario == SCENARIO_MEI_DIR_MATCHED_PID:
             # The PID part of _MEI directory in this scenario is set to the PID of current (= pytest) process.
             #
             # When running as main application process level (i.e., the spoofed parent process level is
             # PYI_PROCESS_LEVEL_PARENT), the declared PID matches that of immediate parent, and passes
-            # validation; therefore, it fails in subsequent executable validation. On POSIX platforms the
-            # executable validation requires /proc filesystem, so this scenario is expected to split through
-            # if `mitigation_unavailable` is set.
+            # validation; therefore, it fails in subsequent executable validation.
             #
             # When running as spawned worker sub-process (i.e., the spoofed parent process level is
             # PYI_PROCESS_LEVEL_MAIN), the declared PID matches that of immediate parent; this fails the
             # validation, because in this case we expect the originating onefile parent process to be at least
-            # a grand-parent or a further ancestor. This is true even on POSIX platforms where /proc filesystem
-            # is unavailable.
-            if parent_level == PYI_PROCESS_LEVEL_PARENT:
-                if mitigation_unavailable:
-                    assert p.returncode == 42
-                else:
-                    assert p.returncode not in {0, 42}
-                    assert MSG_PARENT_DIFFERENT_EXECUTABLE in p.stderr
-            else:
-                assert p.returncode not in {0, 42}
-                assert MSG_PARENT_DIFFERENT_PID in p.stderr
-        elif scenario == SCENARIO_SETUID_EXECUTABLE:
-            assert p.returncode not in {0, 42}
-            # Platforms without mitigation are explicitly handled earlier; so here, we expect security validation
-            # failure. Since the spoofed setup is the same as in SCENARIO_MEI_DIR_MATCHED_PID, the expected result
-            # is also the same.
+            # a grand-parent or a further ancestor.
             assert p.returncode not in {0, 42}
             if parent_level == PYI_PROCESS_LEVEL_PARENT:
-                assert MSG_PARENT_DIFFERENT_EXECUTABLE in p.stderr
+                assert ERR_PARENT_DIFFERENT_EXECUTABLE in p.stderr
             else:
-                assert MSG_PARENT_DIFFERENT_PID in p.stderr
+                assert ERR_PARENT_DIFFERENT_PID in p.stderr
         else:
             raise ValueError(f"Unsupported scenario: {scenario!r}")
 
 
+# Test that in onefile mode, parent-process security validation is automatically enabled for executable that has setuid
+# bit set. Test that in onedir mode, the permissions on application's contents directory are verified.
+@pytest.mark.skipif(compat.is_win, reason="applicable only to POSIX platforms.")
+def test_security_validation_with_setuid_executable(pyi_builder, tmp_path, monkeypatch):
+    # Do NOT enable onefile parent-process verification on the build!
+
+    # Basic test application
+    pyi_builder.test_source("""
+        import sys
+        print("Hello world", file=sys.stderr)
+    """)
+
+    print("\nFinished build and sanity-check tests - preparing the actual test...", file=sys.stderr)
+
+    executables = pyi_builder._find_executables('test_source')
+    assert len(executables) == 1
+    executable = executables[0]
+
+    # Set setuid bit on the executable. The file is owned by current user, so this is not a "real" setuid-root scenario.
+    # But since the bootloader checks the setuid bit, it should suffice for the purposes of the test.
+    st_mode = os.lstat(executable).st_mode
+    os.chmod(executable, st_mode | stat.S_ISUID)
+
+    print(f"Running executable with setuid bit set: {executable}", file=sys.stderr)
+    p = subprocess.run([executable], capture_output=True, encoding='utf-8')
+
+    print(f"Return code: {p.returncode}", file=sys.stderr)
+
+    if p.stdout:
+        print(f"Captured stdout:\n----------------\n{p.stdout}\n----------------", file=sys.stderr)
+    else:
+        print("Captured stdout: N/A", file=sys.stderr)
+
+    if p.stderr:
+        print(f"Captured stderr:\n----------------\n{p.stderr}\n----------------", file=sys.stderr)
+    else:
+        print("Captured stderr: N/A", file=sys.stderr)
+
+    # Check the output
+    if pyi_builder._mode == 'onefile':
+        # Onefile mode: check that program succeeded
+        assert p.returncode == 0
+
+        # Ensure that setuid bit was detected
+        assert "SECURITY: executable has setuid bit set" in p.stderr
+
+        # Ensure that owner/permissions on application's home directory were validated
+        assert \
+            "SECURITY: setuid bit is set - verifying owner/permissions of application's home directory..." in p.stderr
+
+        # Ensure that onefile-parent process validation was auto-enabled, and performed.
+        assert "SECURITY: verifying onefile parent process due to executable running in privileged mode..." in p.stderr
+        assert "SECURITY: verifying process ID of originating onefile parent process" in p.stderr
+        assert "SECURITY: verifying executable of originating onefile parent process" in p.stderr
+    else:
+        # Onedir mode: check that program failed due to incorrect permissions on application's contents directory. The
+        # actual permissions may vary between platforms (for example, 0755 on linux, 0775 on Cygwin), so skip that part
+        # of the message.
+        assert p.returncode != 0
+
+        assert "SECURITY: executable has setuid bit set" in p.stderr
+
+        assert \
+            "SECURITY: setuid bit is set - verifying owner/permissions of application's home directory..." in p.stderr
+        assert "Security validation failure: application's home directory has invalid permissions (" in p.stderr
+
+        # Adjust permissions on contents directory, and try again.
+        contents_dir = pathlib.Path(executable).with_name('_internal')
+        os.chmod(contents_dir, stat.S_IRWXU)  # 0700
+
+        print("Running executable after adjusting permissions on contents directory", file=sys.stderr)
+        p = subprocess.run([executable], capture_output=True, encoding='utf-8')
+
+        print(f"Return code: {p.returncode}", file=sys.stderr)
+
+        if p.stdout:
+            print(f"Captured stdout:\n----------------\n{p.stdout}\n----------------", file=sys.stderr)
+        else:
+            print("Captured stdout: N/A", file=sys.stderr)
+
+        if p.stderr:
+            print(f"Captured stderr:\n----------------\n{p.stderr}\n----------------", file=sys.stderr)
+        else:
+            print("Captured stderr: N/A", file=sys.stderr)
+
+        # The program should succeed now
+        assert p.returncode == 0
+        assert "SECURITY: executable has setuid bit set" in p.stderr
+        assert \
+            "SECURITY: setuid bit is set - verifying owner/permissions of application's home directory..." in p.stderr
+
+
 # Test that parent-process security validation works correctly in case of symlinked executables (i.e., the executable
 # itself being symlinked, or one of its parent directories being symlinked). See #9508.
-def test_security_validation_with_symlinked_executable(pyi_builder, tmp_path):
+def test_security_validation_with_symlinked_executable(pyi_builder, tmp_path, monkeypatch):
+    # Enable onefile parent-process verification on the build
+    _enable_onefile_parent_verification(monkeypatch)
+
     # Ensure that symbolic links can be created
     try:
         test_dir = tmp_path / 'sanity-check' / 'test-dir'
@@ -498,7 +552,8 @@ def test_security_validation_with_symlinked_executable(pyi_builder, tmp_path):
 
     # Basic test application
     pyi_builder.test_source("""
-        print("Hello world")
+        import sys
+        print("Hello world", file=sys.stderr)
     """)
 
     print("\nFinished build and sanity-check tests - preparing the actual test...", file=sys.stderr)
@@ -513,7 +568,25 @@ def test_security_validation_with_symlinked_executable(pyi_builder, tmp_path):
     os.symlink(executable, symlinked_exe)
 
     print(f"Running symlinked executable: {symlinked_exe}", file=sys.stderr)
-    subprocess.run([symlinked_exe], check=True)
+    p = subprocess.run([symlinked_exe], check=True, capture_output=True, encoding='utf-8')
+
+    print(f"Return code: {p.returncode}", file=sys.stderr)
+
+    if p.stdout:
+        print(f"Captured stdout:\n----------------\n{p.stdout}\n----------------", file=sys.stderr)
+    else:
+        print("Captured stdout: N/A", file=sys.stderr)
+
+    if p.stderr:
+        print(f"Captured stderr:\n----------------\n{p.stderr}\n----------------", file=sys.stderr)
+    else:
+        print("Captured stderr: N/A", file=sys.stderr)
+
+    # Ensure that onefile-parent process validation was enabled, and performed.
+    if pyi_builder._mode == 'onefile':
+        assert "SECURITY: verifying onefile parent process due to explicit opt-in..." in p.stderr
+        assert "SECURITY: verifying process ID of originating onefile parent process" in p.stderr
+        assert "SECURITY: verifying executable of originating onefile parent process" in p.stderr
 
     # Symlinked dist directory
     symlinked_dist = tmp_path / 'symlinked-dist'
@@ -521,12 +594,69 @@ def test_security_validation_with_symlinked_executable(pyi_builder, tmp_path):
     symlinked_dist_exe = symlinked_dist / pathlib.Path(executable).relative_to(tmp_path / 'dist')
 
     print(f"Running executable in symlinked dist directory: {symlinked_dist_exe}", file=sys.stderr)
-    subprocess.run([symlinked_dist_exe], check=True)
+    p = subprocess.run([symlinked_dist_exe], check=True, capture_output=True, encoding='utf-8')
+
+    print(f"Return code: {p.returncode}", file=sys.stderr)
+
+    if p.stdout:
+        print(f"Captured stdout:\n----------------\n{p.stdout}\n----------------", file=sys.stderr)
+    else:
+        print("Captured stdout: N/A", file=sys.stderr)
+
+    if p.stderr:
+        print(f"Captured stderr:\n----------------\n{p.stderr}\n----------------", file=sys.stderr)
+    else:
+        print("Captured stderr: N/A", file=sys.stderr)
+
+    # Ensure that onefile-parent process validation was enabled, and performed.
+    if pyi_builder._mode == 'onefile':
+        assert "SECURITY: verifying onefile parent process due to explicit opt-in..." in p.stderr
+        assert "SECURITY: verifying process ID of originating onefile parent process" in p.stderr
+        assert "SECURITY: verifying executable of originating onefile parent process" in p.stderr
+
+
+# Test that parent-process security validation works correctly with nested subprocsses.
+def test_security_validation_with_subprocesses(pyi_builder, tmp_path, monkeypatch, capfd):
+    # Enable onefile parent-process verification on the build
+    _enable_onefile_parent_verification(monkeypatch)
+
+    # Test program
+    pyi_builder.test_source(
+        """
+        import sys
+        import os
+        import subprocess
+
+        if len(sys.argv) == 2:
+            print("Running as main process...", file=sys.stderr)
+            print("Starting subprocess...", file=sys.stderr)
+            subprocess.run([sys.executable], check=True)
+        else:
+            print("Running as subprocess", file=sys.stderr)
+
+        print("Done!")
+        """,
+        app_args=['main']
+    )
+
+    # Ensure that onefile-parent process validation was enabled, and performed.
+    #
+    # NOTE: we need to use capfd instead of capsys to capture output from the test program subprocess(es).
+    # Unfortunately this means that in the case of a test program failure, we do not get any captured output from it...
+    if pyi_builder._mode == 'onefile':
+        _, err = capfd.readouterr()
+
+        assert "SECURITY: verifying onefile parent process due to explicit opt-in..." in err
+        assert "SECURITY: verifying process ID of originating onefile parent process" in err
+        assert "SECURITY: verifying executable of originating onefile parent process" in err
 
 
 # Test that parent-process security validation works correctly in case of intermixed processes, i.e., the application
 # process spawning another program, which then spawns another instance of application (subprocess). See #9512 and #9513.
-def test_security_validation_with_intermixed_subprocesses(pyi_builder, tmp_path):
+def test_security_validation_with_intermixed_subprocesses(pyi_builder, tmp_path, capfd, monkeypatch):
+    # Enable onefile parent-process verification on the build
+    _enable_onefile_parent_verification(monkeypatch)
+
     # Wrapper script
     wrapper_script = '\n'.join([
         "import sys",
@@ -570,6 +700,15 @@ def test_security_validation_with_intermixed_subprocesses(pyi_builder, tmp_path)
         app_args=[str(tmp_path), str(compat.python_executable)]
     )
 
+    # Ensure that onefile-parent process validation was enabled, and performed.
+    if pyi_builder._mode == 'onefile':
+        _, err = capfd.readouterr()
+
+        assert "SECURITY: verifying onefile parent process due to explicit opt-in..." in err
+        assert "SECURITY: verifying process ID of originating onefile parent process" in err
+        assert "SECURITY: verifying executable of originating onefile parent process" in err
+
+    # Check that both processes used the same top-level application directory
     output_file_main = tmp_path / 'main.txt'
     application_dir_main = output_file_main.read_text(encoding='utf-8').strip()
     print(f"Top-level application directory (main): {application_dir_main!r}", file=sys.stderr)


### PR DESCRIPTION
Revise the `onefile` parent-process verification to account for intermixed nested subprocesses. Fixes #9512 and #9513.

Limit the `onefile` parent-process verification only to executables that are running with elevated privileges while inheriting environment variables set by unprivileged user. On POSIX systems, this corresponds to executables with `setuid` bit set, while on Windows, it corresponds to UAC-elevated processes (running with `TokenElevationTypeFull` token).

---

Under the hood, the order of verification steps has been changed. First, we now validate the temporary directory name; we ensure that it starts with `_MEI` prefix, has enough characters to contain both the PID part and the random string part, and that we can extract the PID from it. 

We then use the extracted PID to ensure that this process is either:
- a direct parent of our process if we are supposed to be main application process; or
- an ancestor (grandparent or greater; but not direct parent) of our process if we are supposed to be a spawned worker sub-process. This part requires traversal of ancestor process tree, which is platform-specific. Overall, it does not impose any additional restrictions compared to existing limitations due to executable path lookup (i.e., OpenBSD and AIX are unsupported, FreeBSD is supported when /proc is mounted).

Lastly, we look up the executable for extracted PID, and ensure that it matches the executable of the current process.

---

As mentioned at the top, the `onefile` parent-process verification is now limited only to elevated processes. This introduces a bit of disconnect with our tests; the current compromise here is that we have tests explicitly re-enable the verification even though they run in unprivileged mode, and test various verification codepaths. In addition, we have a POSIX-only test with `setuid`-enabled executable (with owner beign the regular user instead of root, so effectively still unprivileged) that checks that verification is automatically enabled. On Windows, there is currently no equivalent, so that part needs to be tested manually.