### PR TITLE
Compare icon suffix case-insensitively

### DIFF
--- a/PyInstaller/building/icon.py
+++ b/PyInstaller/building/icon.py
@@ -35,6 +35,7 @@ def normalize_icon_type(icon_path: str, allowed_types: Tuple[str], convert_type:
 
     _, extension = os.path.splitext(icon_path)
     extension = extension[1:]  # get rid of the "." in ".whatever"
+    extension = extension.lower()  # allowed_types and hex_signatures are keyed on lowercase
 
     # if the file is already in the right format, pass it back unchanged
     if extension in allowed_types:

--- a/news/9521.bugfix.rst
+++ b/news/9521.bugfix.rst
@@ -1,0 +1,3 @@
+Compare the icon file suffix case-insensitively, so an icon named with an
+upper-case suffix such as ``MyApp.ICO`` is recognised as already being in the
+right format instead of being rejected or silently re-encoded.

--- a/tests/unit/test_normalize_icon_type.py
+++ b/tests/unit/test_normalize_icon_type.py
@@ -36,6 +36,14 @@ def test_normalize_icon(monkeypatch, tmp_path):
     if ret != icon:
         pytest.fail("icon validation changed path even though the format was correct already", False)
 
+    # Native image with an upper-case suffix - also passed through unchanged.
+    # Suffixes are compared against the lower-case allowed_types, so without
+    # normalising the case a valid .ICO is treated as the wrong format.
+
+    icon = str(Path(__file__, "../../functional/data/set_icon/pyi_icon.ico").resolve())
+    upper = shutil.copy(icon, str(tmp_path / "upper_case_suffix.ICO"))
+    assert normalize_icon_type(upper, ("ico",), "ico", workpath) == upper
+
     # Alternative image - after calling monkeypatch.setitem(sys.modules, "PIL", None): Raise the install pillow error
 
     monkeypatch.setitem(sys.modules, "PIL", None)


### PR DESCRIPTION
`normalize_icon_type` compares the icon's suffix against `allowed_types`, which is always lower case (`("ico",)`, or `("exe", "ico")` from `CopyIcons`), but it never lower-cases the suffix it read:

```python
_, extension = os.path.splitext(icon_path)
extension = extension[1:]  # get rid of the "." in ".whatever"

if extension in allowed_types:
```

So `MyApp.ICO` is treated as the wrong format. What happens next depends on whether Pillow is installed:

- Without Pillow, it raises `ValueError` saying the file "is not in the correct format" for an icon that is perfectly valid.
- With Pillow, it silently re-encodes the icon through PIL instead of passing it through. Measured on `tests/functional/data/set_icon/pyi_icon.ico`: the original carries sizes 16, 32, 48 and 256 in 56,493 bytes, and the round-tripped copy comes out as 16, 24, 32, 48, 64, 128 and 256 in 75,558 bytes. The frames are regenerated by resampling rather than being the ones the author put in the file, so an icon with hand-tuned small sizes does not survive the trip intact.

`CopyIcons` in `PyInstaller/utils/win32/icon.py` already compares the same suffix with `.lower()` five lines after calling this function, so the lower-case comparison is the intended behaviour, just missing here.

The existing test iterates `["ico", "ICO"]`, but only over a mislabelled `.png`, which needs conversion in both cases. So the upper-case path passes today for the wrong reason. The new assertion uses the real `pyi_icon.ico` fixture and fails without the change.

`flake8` and `yapf --diff` are both clean.
