### PR TITLE
bootloader: enable security check for executables with setgid and file capabilities

### DIFF
--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -129,7 +129,8 @@ pyi_main(struct PYI_CONTEXT *pyi_ctx)
     /* Check if executable is running with elevated privileges while
      * inheriting environment variables set by unprivileged user. On
      * POSIX platforms, this happens with executables that have setuid
-     * bit set. On Windows, it happens with UAC-elevated executables.
+     * or setgid bit set.
+     * On Windows, it happens with UAC-elevated executables.
      * In both cases, the OS sanitizes some of environment variables
      * (e.g., PATH, or LD_LIBRARY_PATH or equivalent), but not the ones
      * that are used by PyInstaller. Thus, we might need to perform
@@ -155,7 +156,7 @@ pyi_main(struct PYI_CONTEXT *pyi_ctx)
 
         if (elevation_type == TokenElevationTypeFull) {
             PYI_DEBUG_W(L"SECURITY: executable is running with TokenElevationTypeFull.\n");
-            pyi_ctx->has_elevated_privileges = 1;
+            pyi_ctx->has_elevated_privileges |= PYI_ELEVATED_PRIVILEGES_UAC;
         }
 #else
         struct stat executable_stat;
@@ -167,7 +168,12 @@ pyi_main(struct PYI_CONTEXT *pyi_ctx)
 
         if (executable_stat.st_mode & S_ISUID) {
             PYI_DEBUG("SECURITY: executable has setuid bit set.\n");
-            pyi_ctx->has_elevated_privileges = 1;
+            pyi_ctx->has_elevated_privileges |= PYI_ELEVATED_PRIVILEGES_SETUID;
+        }
+
+        if (executable_stat.st_mode & S_ISGID) {
+            PYI_DEBUG("SECURITY: executable has setgid bit set.\n");
+            pyi_ctx->has_elevated_privileges |= PYI_ELEVATED_PRIVILEGES_SETGID;
         }
 #endif
     }

--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -562,15 +562,14 @@ pyi_main(struct PYI_CONTEXT *pyi_ctx)
             /* Verify the name of the inherited top-level application
              * directory, and extract the process ID of the onefile parent
              * process from it. */
-            if (pyi_security_verify_application_home_dir_name(pyi_ctx, &onefile_parent_pid) != true) {
+            if (pyi_security_verify_onefile_application_home_dir_name(pyi_ctx, &onefile_parent_pid) != true) {
                 return -1;
             }
             PYI_DEBUG("SECURITY: process ID of the originating onefile parent process: %d\n", onefile_parent_pid);
 
-            /* Check permissions on the inherited top-level application
-             * directory (applicable only to setuid-enabled executables
-             * on POSIX systems, otherwise no-op). */
-            if (pyi_security_verify_application_home_dir_permissions(pyi_ctx) != true) {
+            /* Check owner and permissions on the inherited top-level application
+             * directory, if necessary (otherwise this call is no-op). */
+            if (pyi_security_verify_onefile_application_home_dir_permissions(pyi_ctx) != true) {
                 return -1;
             }
 
@@ -660,10 +659,10 @@ pyi_main(struct PYI_CONTEXT *pyi_ctx)
             }
         }
 
-        /* On POSIX platforms, if setuid bit is set on the executable,
-         * check owner/permissions on the top-level application's directory
-         * to ensure its contents are accessible only to the effective user. */
-        if (pyi_security_verify_application_home_dir_permissions(pyi_ctx) != true) {
+        /* Check owner and permissions on the application's top-level
+         * (contents) directory, if necessary (otherwise this call
+         * is no-op). */
+        if (pyi_security_verify_onedir_application_home_dir_permissions(pyi_ctx) != true) {
             return -1;
         }
     }

--- a/bootloader/src/pyi_main.c
+++ b/bootloader/src/pyi_main.c
@@ -36,6 +36,7 @@
 
 #if defined(__linux__)
     #include <sys/prctl.h> /* prctl() */
+    #include <sys/xattr.h> /* getxattr() */
 #endif
 
 #if defined(__APPLE__) && defined(WINDOWED)
@@ -161,6 +162,7 @@ pyi_main(struct PYI_CONTEXT *pyi_ctx)
 #else
         struct stat executable_stat;
 
+        /* Check for setuid/setgid bit */
         if (stat(pyi_ctx->executable_filename, &executable_stat) < 0) {
             PYI_ERROR("Security validation failure: could not stat() the executable!\n");
             return -1;
@@ -175,7 +177,22 @@ pyi_main(struct PYI_CONTEXT *pyi_ctx)
             PYI_DEBUG("SECURITY: executable has setgid bit set.\n");
             pyi_ctx->has_elevated_privileges |= PYI_ELEVATED_PRIVILEGES_SETGID;
         }
-#endif
+
+        /* Check for file capabilities (linux only) */
+#if defined(__linux__)
+        if (1) {
+            ssize_t ret = getxattr(pyi_ctx->executable_filename, "security.capability", NULL, 0);
+            if (ret > 0) {
+                PYI_DEBUG("SECURITY: executable has file capabilities set (security.capability xattr found).\n");
+                pyi_ctx->has_elevated_privileges |= PYI_ELEVATED_PRIVILEGES_FILE_CAPABILITIES;
+            } else if (ret < 0 && !(errno == E2BIG || errno == ENODATA || errno == ENOTSUP)) {
+                PYI_PERROR("getxattr", "Security validation failure: could not query extended attributes on the executable file!\n");
+                return -1;
+            }
+        }
+#endif /* defined(linux) */
+
+#endif /* defined(WIN32 */
     }
 
     /* Resolve main PKG archive - embedded or side-loaded. */

--- a/bootloader/src/pyi_main.h
+++ b/bootloader/src/pyi_main.h
@@ -81,6 +81,19 @@ enum PYI_PROCESS_LEVEL
     PYI_PROCESS_LEVEL_SUBPROCESS = 2
 };
 
+/* Elevated privileges mode */
+enum PYI_ELEVATED_PRIVILEGES
+{
+    /* Regular mode without elevated privileges */
+    PYI_ELEVATED_PRIVILEGES_NONE = 0,
+    /* Elevation via UAC on Windows (i.e., running with TokenElevationTypeFull) */
+    PYI_ELEVATED_PRIVILEGES_UAC = 1,
+    /* Elevation via setuid (POSIX platforms) */
+    PYI_ELEVATED_PRIVILEGES_SETUID = 2,
+    /* Elevation via setgid (POSIX platforms) */
+    PYI_ELEVATED_PRIVILEGES_SETGID = 4,
+};
+
 
 struct PYI_CONTEXT
 {

--- a/bootloader/src/pyi_main.h
+++ b/bootloader/src/pyi_main.h
@@ -92,6 +92,8 @@ enum PYI_ELEVATED_PRIVILEGES
     PYI_ELEVATED_PRIVILEGES_SETUID = 2,
     /* Elevation via setgid (POSIX platforms) */
     PYI_ELEVATED_PRIVILEGES_SETGID = 4,
+    /* Elevation via file capabilities (linux) */
+    PYI_ELEVATED_PRIVILEGES_FILE_CAPABILITIES = 8,
 };
 
 

--- a/bootloader/src/pyi_security.c
+++ b/bootloader/src/pyi_security.c
@@ -722,7 +722,7 @@ pyi_security_verify_onefile_parent_executable(const struct PYI_CONTEXT *pyi_ctx,
  * process of the current process, and that the said process uses same
  * executable as the current process). */
 bool
-pyi_security_verify_application_home_dir_name(const struct PYI_CONTEXT *pyi_ctx, unsigned int *onefile_parent_pid)
+pyi_security_verify_onefile_application_home_dir_name(const struct PYI_CONTEXT *pyi_ctx, unsigned int *onefile_parent_pid)
 {
     char basename[PYI_PATH_MAX];
     size_t name_len;
@@ -767,46 +767,30 @@ pyi_security_verify_application_home_dir_name(const struct PYI_CONTEXT *pyi_ctx,
 }
 
 
-/* Verification of owner ID and permissions on top-level application
- * directory for POSIX executables with setuid/setgid bit set. No-op on
- * Windows, and no-op on other platforms when setuid/setgid bit is not
- * set on the executable.
- *
- * With setuid bit set, the following must be true:
+/* Verification of owner ID and permissions on the inherited (temporary)
+ * top-level application directory in onefile mode. Applicable only to
+ * POSIX executables running in privileged mode, no-op in other cases:
  *  - the owner ID of the top-level application directory must match the
  *    effective user ID
  *  - permissions on the top-level application directory must be set to
  *    0700
- * In onefile mode, this matches the owner/permissions with which the
- * bootloader creates the temproary directory. In onedir mode, this
- * should prevent unprivileged users from modifying contents of application
- * that runs in privileged mode.
- *
- * With setgid bit set, the requirements depend on onefile/onedir mode.
- * In onefile mode, the same conditions as with setuid mode must be
- * true (i.e., owner must be effective user ID, permissions must be 0700;
- * as created by bootloader). In onedir mode, the only requirement is that
- * "other" bit must be 0; i.e., other users must not have access to the
- * contents directory.
- *
- * If both setuid and setgid bit are set, setuid bit and its requirements
- * take precedence. */
+ * This matches the this matches the owner/permissions with which the
+ * bootloader creates the temproary directory. */
 bool
-pyi_security_verify_application_home_dir_permissions(const struct PYI_CONTEXT *pyi_ctx)
+pyi_security_verify_onefile_application_home_dir_permissions(const struct PYI_CONTEXT *pyi_ctx)
 {
 #if defined(_WIN32)
     (void)pyi_ctx;
-    return true;
 #else
-    uid_t euid;
-    uid_t permissions;
-    struct stat application_home_dir_stat;
+    if (pyi_ctx->has_elevated_privileges) {
+        uid_t euid;
+        uid_t permissions;
+        struct stat application_home_dir_stat;
 
-    if (pyi_ctx->has_elevated_privileges & PYI_ELEVATED_PRIVILEGES_SETUID) {
-        PYI_DEBUG("SECURITY: setuid bit is set - verifying owner/permissions of application's home directory...\n");
+        PYI_DEBUG("SECURITY: running in privileged mode - verifying owner/permissions of application's home directory...\n");
 
         if (stat(pyi_ctx->application_home_dir, &application_home_dir_stat) < 0) {
-            PYI_ERROR("Security validation failure: could not stat() the application's home directory!\n");
+            PYI_PERROR("stat", "Security validation failure: could not stat() the application's home directory!\n");
             return false;
         }
 
@@ -830,63 +814,103 @@ pyi_security_verify_application_home_dir_permissions(const struct PYI_CONTEXT *p
 
         /* Ensure that the application's home directory has permissions used
          * by bootloader when creating ephemeral application directory
-         * (i.e., S_IRWXU = 0700). In case of onedir application, it ensures
-         * that the contents directory cannot be modified by unprivileged
-         * user. */
+         * (i.e., S_IRWXU = 0700). */
         permissions = application_home_dir_stat.st_mode & (S_IRWXU | S_IRWXG | S_IRWXO);
         if (permissions != S_IRWXU) {
             PYI_ERROR("Security validation failure: application's home directory has invalid permissions (0%o)!\n", permissions);
             return false;
         }
+    }
+#endif
 
-        return true;
-    } else if (pyi_ctx->has_elevated_privileges & PYI_ELEVATED_PRIVILEGES_SETGID) {
-        uid_t euid;
+    return true;
+}
+
+/* Verification of owner ID and permissions on the onedir application's
+ * top-level (contents) directory. Applicable only to POSIX executables
+ * with setuid or setgid bit set, no-op in other cases.
+ *
+ * When setuid bit set, the following must be true:
+ *  - the owner ID of the top-level application directory must match the
+ *    owner ID of the executable
+ *  - only owner is allowed to have write permissions on the directory.
+ *
+ * With setgid bit set, the following must be true:
+ *  - the group ID of the top-level application directory must match the
+ *    group ID of the executable
+ *  - only owner and group are allowed to have write permissions on the
+ *    directory.
+ *
+ * NOTE: we match owner/group ID of the top-level application directory
+ * against the corresponding ID of the executable instead of the effective
+ * owner/group ID of the process; this attempts to accommodate the cases
+ * when user code drops the privileges and then spawns a worker sub-process
+ * (which has read access to contents).
+ *
+ * NOTE: for complete security validation, we would need to recursively
+ * enforce these checks on all contents in the top-level application
+ * directory. But for the time being, only top-level directory is checked
+ * in an attempt to catch gross errors in deployment of setuid/setgid-enabled
+ * onedir applications. */
+bool
+pyi_security_verify_onedir_application_home_dir_permissions(const struct PYI_CONTEXT *pyi_ctx)
+{
+#if defined(_WIN32)
+    (void)pyi_ctx;
+#else
+    if (pyi_ctx->has_elevated_privileges & (PYI_ELEVATED_PRIVILEGES_SETUID | PYI_ELEVATED_PRIVILEGES_SETGID)) {
+        const bool is_setuid = pyi_ctx->has_elevated_privileges & PYI_ELEVATED_PRIVILEGES_SETUID;
         uid_t permissions;
+        struct stat executable_stat;
         struct stat application_home_dir_stat;
 
-        PYI_DEBUG("SECURITY: setgid bit is set - verifying owner/permissions of application's home directory...\n");
+        PYI_DEBUG("SECURITY: %s bit is set - verifying owner/permissions of application's home directory...\n", is_setuid ? "setuid" : "setgid");
 
         if (stat(pyi_ctx->application_home_dir, &application_home_dir_stat) < 0) {
-            PYI_ERROR("Security validation failure: could not stat() the application's home directory!\n");
+            PYI_PERROR("stat", "Security validation failure: could not stat() the application's home directory!\n");
             return false;
         }
 
-        if (pyi_ctx->is_onefile) {
-            /* In onefile mode, check that owner and permissions match what
-             * the bootloader uses (see the setuid mode above). */
-            euid = geteuid();
-            if (application_home_dir_stat.st_uid != euid) {
+        if (stat(pyi_ctx->executable_filename, &executable_stat) < 0) {
+            PYI_PERROR("stat", "Security validation failure: could not stat() the executable file\n");
+            return false;
+        }
+
+        permissions = application_home_dir_stat.st_mode & (S_IRWXU | S_IRWXG | S_IRWXO);
+
+        if (is_setuid) {
+            /* Check that owner ID matches */
+            if (application_home_dir_stat.st_uid != executable_stat.st_uid) {
                 PYI_ERROR(
-                    "Security validation failure: owner ID of application's home directory (%d) does not match the effective user ID (%d)!\n",
-                    application_home_dir_stat.st_uid, euid
+                    "Security validation failure: owner ID of application's home directory (%d) does not match owner ID of the executable (%d)!\n",
+                    application_home_dir_stat.st_uid, executable_stat.st_uid
                 );
                 return false;
             }
 
-            permissions = application_home_dir_stat.st_mode & (S_IRWXU | S_IRWXG | S_IRWXO);
-            if (permissions != S_IRWXU) {
+            /* Only owner may have write permissions */
+            if ((permissions & (S_IWGRP | S_IWOTH)) != 0) {
                 PYI_ERROR("Security validation failure: application's home directory has invalid permissions (0%o)!\n", permissions);
                 return false;
             }
         } else {
-            /* In onedir mode, check that other users do not have access
-             * to contents directory. */
-            permissions = application_home_dir_stat.st_mode & (S_IRWXU | S_IRWXG | S_IRWXO);
-            if ((permissions & S_IRWXO) != 0) {
+            /* Check that group ID matches */
+            if (application_home_dir_stat.st_gid != executable_stat.st_gid) {
+                PYI_ERROR(
+                    "Security validation failure: group ID of application's home directory (%d) does not match group ID of the executable (%d)!\n",
+                    application_home_dir_stat.st_gid, executable_stat.st_gid
+                );
+                return false;
+            }
+
+            /* Only owner and group may have write permissions */
+            if ((permissions & S_IWOTH) != 0) {
                 PYI_ERROR("Security validation failure: application's home directory has invalid permissions (0%o)!\n", permissions);
                 return false;
             }
         }
-
-        return true;
-    } else {
-        PYI_DEBUG("SECURITY: setuid/setgid bit is not set - skipping verification of owner/permissions of application's home directory.\n");
-        return true;
     }
-
-    /* Should not be reached */
-    PYI_ERROR("Security validation failure: uhandled codepath!\n");
-    return false;
 #endif
+
+    return true;
 }

--- a/bootloader/src/pyi_security.c
+++ b/bootloader/src/pyi_security.c
@@ -62,7 +62,10 @@ pyi_security_onefile_parent_verification_available()
     /* Supported only if /proc is available. */
     struct stat curproc_dir_stat;
     if (stat("/proc/curproc", &curproc_dir_stat) < 0) {
-        PYI_ERROR("Security validation failure: setuid-enabled executables are not supported on this system (missing /proc)!\n");
+        PYI_ERROR(
+            "Security validation failure: onefile parent-process validation, which is required for onefile "
+            "executables running with elevated privileges, is not supported on this system (missing /proc)!\n"
+        );
         return false;
     }
     return true;
@@ -71,7 +74,10 @@ pyi_security_onefile_parent_verification_available()
 #else
     /* Other POSIX platforms are unsupported due to lack of required
      * information in /proc */
-    PYI_ERROR("Security validation failure: setuid-enabled executables are not supported on this platform!\n");
+    PYI_ERROR(
+        "Security validation failure: onefile parent-process validation, which is required for onefile "
+        "executables running with elevated privileges, is not supported on this platform!\n"
+    );
     return false;
 #endif
 }

--- a/bootloader/src/pyi_security.c
+++ b/bootloader/src/pyi_security.c
@@ -768,13 +768,29 @@ pyi_security_verify_application_home_dir_name(const struct PYI_CONTEXT *pyi_ctx,
 
 
 /* Verification of owner ID and permissions on top-level application
- * directory for POSIX executables with setuid bit set:
+ * directory for POSIX executables with setuid/setgid bit set. No-op on
+ * Windows, and no-op on other platforms when setuid/setgid bit is not
+ * set on the executable.
+ *
+ * With setuid bit set, the following must be true:
  *  - the owner ID of the top-level application directory must match the
  *    effective user ID
  *  - permissions on the top-level application directory must be set to
  *    0700
- * Applicable to both onefile and onedir builds. No-op on Windows, and
- * no-op on other platforms when setuid bit is not set on the executable. */
+ * In onefile mode, this matches the owner/permissions with which the
+ * bootloader creates the temproary directory. In onedir mode, this
+ * should prevent unprivileged users from modifying contents of application
+ * that runs in privileged mode.
+ *
+ * With setgid bit set, the requirements depend on onefile/onedir mode.
+ * In onefile mode, the same conditions as with setuid mode must be
+ * true (i.e., owner must be effective user ID, permissions must be 0700;
+ * as created by bootloader). In onedir mode, the only requirement is that
+ * "other" bit must be 0; i.e., other users must not have access to the
+ * contents directory.
+ *
+ * If both setuid and setgid bit are set, setuid bit and its requirements
+ * take precedence. */
 bool
 pyi_security_verify_application_home_dir_permissions(const struct PYI_CONTEXT *pyi_ctx)
 {
@@ -786,48 +802,91 @@ pyi_security_verify_application_home_dir_permissions(const struct PYI_CONTEXT *p
     uid_t permissions;
     struct stat application_home_dir_stat;
 
-    /* Applicable only to executables with setuid bit set. */
-    if (!pyi_ctx->has_elevated_privileges) {
-        PYI_DEBUG("SECURITY: setuid bit is not set - skipping verification of owner/permissions of application's home directory.\n");
+    if (pyi_ctx->has_elevated_privileges & PYI_ELEVATED_PRIVILEGES_SETUID) {
+        PYI_DEBUG("SECURITY: setuid bit is set - verifying owner/permissions of application's home directory...\n");
+
+        if (stat(pyi_ctx->application_home_dir, &application_home_dir_stat) < 0) {
+            PYI_ERROR("Security validation failure: could not stat() the application's home directory!\n");
+            return false;
+        }
+
+        /* Ensure that owner ID of application's temporary directory matches
+         * the effective user ID. By comparing effective user ID instead of
+         * executable's owner ID, we attempt to accommodate scenario where a
+         * setuid-enabled application drops its privileges and attempts to
+         * spawn a worker subprocess. Note that this requires that the
+         * application transfers the ownership of its temporary directory
+         * prior to privilege drop; but this is the case anyway, otherwise
+         * it would end up locking both itself and its worker subprocesses
+         * out of the temporary directory... */
+        euid = geteuid();
+        if (application_home_dir_stat.st_uid != euid) {
+            PYI_ERROR(
+                "Security validation failure: owner ID of application's home directory (%d) does not match the effective user ID (%d)!\n",
+                application_home_dir_stat.st_uid, euid
+            );
+            return false;
+        }
+
+        /* Ensure that the application's home directory has permissions used
+         * by bootloader when creating ephemeral application directory
+         * (i.e., S_IRWXU = 0700). In case of onedir application, it ensures
+         * that the contents directory cannot be modified by unprivileged
+         * user. */
+        permissions = application_home_dir_stat.st_mode & (S_IRWXU | S_IRWXG | S_IRWXO);
+        if (permissions != S_IRWXU) {
+            PYI_ERROR("Security validation failure: application's home directory has invalid permissions (0%o)!\n", permissions);
+            return false;
+        }
+
+        return true;
+    } else if (pyi_ctx->has_elevated_privileges & PYI_ELEVATED_PRIVILEGES_SETGID) {
+        uid_t euid;
+        uid_t permissions;
+        struct stat application_home_dir_stat;
+
+        PYI_DEBUG("SECURITY: setgid bit is set - verifying owner/permissions of application's home directory...\n");
+
+        if (stat(pyi_ctx->application_home_dir, &application_home_dir_stat) < 0) {
+            PYI_ERROR("Security validation failure: could not stat() the application's home directory!\n");
+            return false;
+        }
+
+        if (pyi_ctx->is_onefile) {
+            /* In onefile mode, check that owner and permissions match what
+             * the bootloader uses (see the setuid mode above). */
+            euid = geteuid();
+            if (application_home_dir_stat.st_uid != euid) {
+                PYI_ERROR(
+                    "Security validation failure: owner ID of application's home directory (%d) does not match the effective user ID (%d)!\n",
+                    application_home_dir_stat.st_uid, euid
+                );
+                return false;
+            }
+
+            permissions = application_home_dir_stat.st_mode & (S_IRWXU | S_IRWXG | S_IRWXO);
+            if (permissions != S_IRWXU) {
+                PYI_ERROR("Security validation failure: application's home directory has invalid permissions (0%o)!\n", permissions);
+                return false;
+            }
+        } else {
+            /* In onedir mode, check that other users do not have access
+             * to contents directory. */
+            permissions = application_home_dir_stat.st_mode & (S_IRWXU | S_IRWXG | S_IRWXO);
+            if ((permissions & S_IRWXO) != 0) {
+                PYI_ERROR("Security validation failure: application's home directory has invalid permissions (0%o)!\n", permissions);
+                return false;
+            }
+        }
+
+        return true;
+    } else {
+        PYI_DEBUG("SECURITY: setuid/setgid bit is not set - skipping verification of owner/permissions of application's home directory.\n");
         return true;
     }
 
-    PYI_DEBUG("SECURITY: setuid bit is set - verifying owner/permissions of application's home directory...\n");
-
-    if (stat(pyi_ctx->application_home_dir, &application_home_dir_stat) < 0) {
-        PYI_ERROR("Security validation failure: could not stat() the application's home directory!\n");
-        return false;
-    }
-
-    /* Ensure that owner ID of application's temporary directory matches
-     * the effective user ID. By comparing effective user ID instead of
-     * executable's owner ID, we attempt to accommodate scenario where a
-     * setuid-enabled application drops its privileges and attempts to
-     * spawn a worker subprocess. Note that this requires that the
-     * application transfers the ownership of its temporary directory
-     * prior to privilege drop; but this is the case anyway, otherwise
-     * it would end up locking both itself and its worker subprocesses
-     * out of the temporary directory... */
-    euid = geteuid();
-    if (application_home_dir_stat.st_uid != euid) {
-        PYI_ERROR(
-            "Security validation failure: owner ID of application's home directory (%d) does not match the effective user ID (%d)!\n",
-            application_home_dir_stat.st_uid, euid
-        );
-        return false;
-    }
-
-    /* Ensure that the application's home directory has permissions used
-     * by bootloader when creating ephemeral application directory
-     * (i.e., S_IRWXU = 0700). In case of onedir application, it ensures
-     * that the contents directory cannot be modified by unprivileged
-     * user. */
-    permissions = application_home_dir_stat.st_mode & (S_IRWXU | S_IRWXG | S_IRWXO);
-    if (permissions != S_IRWXU) {
-        PYI_ERROR("Security validation failure: application's home directory has invalid permissions (0%o)!\n", permissions);
-        return false;
-    }
-
-    return true;
+    /* Should not be reached */
+    PYI_ERROR("Security validation failure: uhandled codepath!\n");
+    return false;
 #endif
 }

--- a/bootloader/src/pyi_security.h
+++ b/bootloader/src/pyi_security.h
@@ -23,8 +23,10 @@ struct PYI_CONTEXT;
 
 bool pyi_security_onefile_parent_verification_available();
 
-bool pyi_security_verify_application_home_dir_name(const struct PYI_CONTEXT *pyi_ctx, unsigned int *onefile_parent_pid);
-bool pyi_security_verify_application_home_dir_permissions(const struct PYI_CONTEXT *pyi_ctx);
+bool pyi_security_verify_onefile_application_home_dir_name(const struct PYI_CONTEXT *pyi_ctx, unsigned int *onefile_parent_pid);
+bool pyi_security_verify_onefile_application_home_dir_permissions(const struct PYI_CONTEXT *pyi_ctx);
+
+bool pyi_security_verify_onedir_application_home_dir_permissions(const struct PYI_CONTEXT *pyi_ctx);
 
 bool pyi_security_verify_onefile_parent_pid(const struct PYI_CONTEXT *pyi_ctx, const unsigned int onefile_parent_pid, const bool search_process_tree);
 bool pyi_security_verify_onefile_parent_executable(const struct PYI_CONTEXT *pyi_ctx, const unsigned int onefile_parent_pid);

--- a/doc/advanced-topics.rst
+++ b/doc/advanced-topics.rst
@@ -365,10 +365,12 @@ escalation (e.g., POSIX executable with ``setuid`` bit set).
 
 Starting with PyInstaller v6.22.3, the onefile parent-process validation
 has been limited only to processes that are running with elevated privileges
-while inheriting environment variables set by unprivileged user. On
-POSIX systems, this corresponds to executables with ``setuid`` bit set,
-while on Windows, it corresponds to UAC-elevated processes (running with
-``TokenElevationTypeFull`` token).
+while inheriting environment variables set by unprivileged user. On Windows,
+this corresponds to UAC-elevated processes (running with
+``TokenElevationTypeFull`` token), while on POSIX systems, it corresponds
+to executables with either ``setuid`` or ``setgid`` bit set. On Linux,
+the validation is also enabled for executables that have applied file
+capabilities (i.e., have the ``security.capability`` extended attribute).
 
 Windows
 -------
@@ -397,17 +399,40 @@ processes and look-up of their executable requires look-up of
 the platform-specific entry on the ``procfs`` filesystem
 (i.e., inside the ``/proc/<ppid>`` directory).
 
-If the executable has ``setuid`` bit set, additional validation is
-performed on the inherited (temporary) top-level application directory.
-The owner ID of the said directory must match the owner ID of the
-executable, and its permissions must be ``0700`` (i.e., permissions
-that the bootloader uses when creating a temporary application directory).
+Additionally, the onefile child processes performs validation of owner
+ID and permissions on the inherited (temporary) top-level application
+directory. The owner ID of the said directory is required to match the
+effective user ID of the current process, and the permissions on the
+directory need to be  ``0700`` (i.e., must match permissions that the
+bootloader uses when creating a temporary application directory).
 
 Some of otherwise supported POSIX platforms do not implement ``procfs``
 at all (for example, OpenBSD), or do not provide the information about the
 executable path (for example, AIX). On such platforms, setting ``setuid``
-bit on ``onefile`` executables is not supported anymore - the implemented
-security validation will automatically fail.
+or ``setgid`` bit on ``onefile`` executables is not supported anymore -
+the implemented security validation will automatically fail with an
+early error. On FreeBSD, the ``/proc`` filesystem is not mounted by
+default; it needs to be explicitly mounted to enable support for running
+``onefile`` executables with ``setuid`` or ``setgid`` bit set.
+
+.. Note::
+    On contemporary Linux distributions, onefile executables with ``setgid``
+    bit set may end up being unable to look up the executable of the
+    originating onefile parent process due to restricted access to
+    ``/proc/<ppid>/exe``. In order for onefile parent-process validation
+    to pass, the executable also needs to be granted ``CAP_SYS_PTRACE``
+    capability, for example by setting corresponding file capability::
+
+        sudo setcap cap_sys_ptrace=+ep /path/to/executable
+
+.. Note::
+    In general, PyInstaller offers only limited support for POSIX
+    executables that are running with elevated privileges; be it either
+    via ``setuid`` or ``setgid`` bit, or file capabilities (on Linux).
+    In all these cases the underlying operating system facilities tend
+    to reset the ``LD_LIBRARY_PATH`` environment variable (or equivalent),
+    which is used by PyInstaller's bootloader to set the library search
+    path for bundled shared libraries.
 
 
 .. _bootloader security validation onedir:
@@ -417,17 +442,24 @@ Security Validation in ``onedir`` Mode
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Starting with PyInstaller v6.22.1, an additional security requirement has
-been imposed on POSIX onedir executables that have ``setuid`` bit set.
-Such executables now validate the owner and permissions on their contents
-directory (typically the ``_internal`` directory); the owner ID must match
-the effective user ID under which the process is running, and the
-permissions on the directory need to be ``0700``.
+been imposed on POSIX onedir executables that have ``setuid`` or ``setgid``
+bit set. Such executables now validate the owner and permissions on their
+contents directory (typically the ``_internal`` directory).
 
-The above restriction aims to prevent unprivileged users from modifying
-contents of an application that runs in privileged mode. However, it
-also prevents an application from starting in privileged mode and later
-dropping the privileges (for example, via the ``os.setuid()`` call), as
-this would prevent further access to the content directory.
+In the case of executable with ``setuid`` bit, the owner ID of the contents
+directory must match the owner ID of the executable itself, and only the
+owner is allowed to have write permissions on the directory (i.e., neither
+``S_IWGRP`` nor ``S_IWOTH`` bit is allowed to be set).
+
+In the case executable with ``setgid`` bit, the group ID of the contents
+directory must match the group ID of the executable itself, and only
+the owner and the group are allowed to have write permissions on the
+directory (i.e., ``S_IWOTH`` bit is not allowed to be set).
+
+Note that this is not an in-depth check, as permissions on individual
+files and sud-directories inside the contents directory are not verified.
+It is up to administrator to properly secure access to the contents of
+a ``onedir`` application that is intended to be ran with elevated privileges.
 
 
 .. _pyi_splash Module:

--- a/news/9524.bootloader.1.rst
+++ b/news/9524.bootloader.1.rst
@@ -1,0 +1,8 @@
+(POSIX) Revise the validation of owner and permissions of ``onedir``
+application's contents directory when the executable has either ``setuid``
+or ``setgid`` bit set. If ``setuid`` bit is set, the owner ID of the
+application's contents directory must match the owner ID of the executable
+itself, and only owner is allowed to have write permissions on the directory.
+If ``setgid`` bit is set, the group ID of the application's contents
+directory must match the group ID of the executable itself, and only
+owner and the group are allowed to have write permissions on the directory.

--- a/news/9524.bootloader.rst
+++ b/news/9524.bootloader.rst
@@ -1,0 +1,4 @@
+(POSIX) Enable ``onefile`` parent-process validation for POSIX executables
+that have ``setgid`` bit set, and for Linux executables that have file
+capabilities set (i.e., have a ``security.capability`` extended file
+attribute).

--- a/tests/functional/test_security.py
+++ b/tests/functional/test_security.py
@@ -462,6 +462,12 @@ def test_security_validation_with_setxid_executable(pyi_builder, tmp_path, monke
     else:
         os.chmod(executable, st_mode | stat.S_ISGID)
 
+    # If running in onedir mode, ensure that permissions on contents directory are 0755. This should already be the
+    # case on most POSIX platforms, but on Cygwin, they seem to be 0775 by default...
+    if pyi_builder._mode == 'onedir':
+        contents_dir = pathlib.Path(executable).with_name('_internal')
+        os.chmod(contents_dir, 0o755)
+
     print(f"Running executable with {bit_type} bit set: {executable}", file=sys.stderr)
     p = subprocess.run([executable], capture_output=True, encoding='utf-8')
 
@@ -513,6 +519,8 @@ def test_security_validation_with_setxid_executable(pyi_builder, tmp_path, monke
             assert p.returncode == 0
 
             # Ensure that owner/permissions on application's home directory were validated
+            MSG_VERIFICATION = \
+                "SECURITY: running in privileged mode - verifying owner/permissions of application's home directory..."
             assert MSG_VERIFICATION in p.stderr
 
             # Ensure that onefile-parent process validation was auto-enabled, and performed.
@@ -521,23 +529,18 @@ def test_security_validation_with_setxid_executable(pyi_builder, tmp_path, monke
             assert "SECURITY: verifying process ID of originating onefile parent process" in p.stderr
             assert "SECURITY: verifying executable of originating onefile parent process" in p.stderr
     else:
-        # Onedir mode: check that program failed due to incorrect permissions on application's contents directory. The
-        # actual permissions may vary between platforms (for example, 0755 on linux, 0775 on Cygwin), so skip that part
-        # of the message.
-        assert p.returncode != 0
+        # Onedir mode: we earlier ensure that permissions on contents directory are 0755, so this run should succeed
+        # regardless of whether setuid or setgid bit is set.
+        assert p.returncode == 0
 
         assert MSG_VERIFICATION in p.stderr
-        assert "Security validation failure: application's home directory has invalid permissions (" in p.stderr
 
-        # Adjust permissions on contents directory, and try again.
-        # With setuid, we strictly require 0700. With setgid, we require that other bit is 0, so 0770 should work.
+        # Both setuid and setgid modes should fail when other users (non-owner, non-group) have write permissions.
         contents_dir = pathlib.Path(executable).with_name('_internal')
-        if bit_type == 'setuid':
-            os.chmod(contents_dir, stat.S_IRWXU)  # 0700
-        else:
-            os.chmod(contents_dir, stat.S_IRWXU | stat.S_IRWXG)  # 0770
+        permissions = 0o757
+        os.chmod(contents_dir, permissions)
 
-        print("Running executable after adjusting permissions on contents directory", file=sys.stderr)
+        print(f"Running executable with permissions on contents directory set to {permissions:o}", file=sys.stderr)
         p = subprocess.run([executable], capture_output=True, encoding='utf-8')
 
         print(f"Return code: {p.returncode}", file=sys.stderr)
@@ -552,10 +555,40 @@ def test_security_validation_with_setxid_executable(pyi_builder, tmp_path, monke
         else:
             print("Captured stderr: N/A", file=sys.stderr)
 
-        # The program should succeed now
-        assert p.returncode == 0
+        ERR_MSG = "Security validation failure: application's home directory has invalid permissions ("
+
+        assert p.returncode != 0
         assert MSG_BIT_DETECTED in p.stderr
         assert MSG_VERIFICATION in p.stderr
+        assert ERR_MSG in p.stderr
+
+        # Setuid mode should also fail when group users have write permissions. Setgid mode should pass.
+        contents_dir = pathlib.Path(executable).with_name('_internal')
+        permissions = 0o770
+        os.chmod(contents_dir, permissions)
+
+        print(f"Running executable with permissions on contents directory set to {permissions:o}", file=sys.stderr)
+        p = subprocess.run([executable], capture_output=True, encoding='utf-8')
+
+        if p.stdout:
+            print(f"Captured stdout:\n----------------\n{p.stdout}\n----------------", file=sys.stderr)
+        else:
+            print("Captured stdout: N/A", file=sys.stderr)
+
+        if p.stderr:
+            print(f"Captured stderr:\n----------------\n{p.stderr}\n----------------", file=sys.stderr)
+        else:
+            print("Captured stderr: N/A", file=sys.stderr)
+
+        if bit_type == 'setuid':
+            assert p.returncode != 0
+            assert MSG_BIT_DETECTED in p.stderr
+            assert MSG_VERIFICATION in p.stderr
+            assert ERR_MSG in p.stderr
+        else:
+            assert p.returncode == 0
+            assert MSG_BIT_DETECTED in p.stderr
+            assert MSG_VERIFICATION in p.stderr
 
 
 # Test that parent-process security validation works correctly in case of symlinked executables (i.e., the executable

--- a/tests/functional/test_security.py
+++ b/tests/functional/test_security.py
@@ -435,9 +435,10 @@ def test_application_home_directory_hijack(
 
 
 # Test that in onefile mode, parent-process security validation is automatically enabled for executable that has setuid
-# bit set. Test that in onedir mode, the permissions on application's contents directory are verified.
+# or setgid bit set. Test that in onedir mode, the permissions on application's contents directory are verified.
 @pytest.mark.skipif(compat.is_win, reason="applicable only to POSIX platforms.")
-def test_security_validation_with_setuid_executable(pyi_builder, tmp_path, monkeypatch):
+@pytest.mark.parametrize('bit_type', ['setuid', 'setgid'])
+def test_security_validation_with_setxid_executable(pyi_builder, tmp_path, monkeypatch, bit_type):
     # Do NOT enable onefile parent-process verification on the build!
 
     # Basic test application
@@ -452,12 +453,16 @@ def test_security_validation_with_setuid_executable(pyi_builder, tmp_path, monke
     assert len(executables) == 1
     executable = executables[0]
 
-    # Set setuid bit on the executable. The file is owned by current user, so this is not a "real" setuid-root scenario.
-    # But since the bootloader checks the setuid bit, it should suffice for the purposes of the test.
+    # Set setuid/setgid bit on the executable. The file is owned by current user (and their group), so this is not a
+    # "real" setuid/setgid-root scenario. But since the bootloader checks the presence of setuid/setgid bit, it should
+    # suffice for the purposes of the test.
     st_mode = os.lstat(executable).st_mode
-    os.chmod(executable, st_mode | stat.S_ISUID)
+    if bit_type == 'setuid':
+        os.chmod(executable, st_mode | stat.S_ISUID)
+    else:
+        os.chmod(executable, st_mode | stat.S_ISGID)
 
-    print(f"Running executable with setuid bit set: {executable}", file=sys.stderr)
+    print(f"Running executable with {bit_type} bit set: {executable}", file=sys.stderr)
     p = subprocess.run([executable], capture_output=True, encoding='utf-8')
 
     print(f"Return code: {p.returncode}", file=sys.stderr)
@@ -472,16 +477,23 @@ def test_security_validation_with_setuid_executable(pyi_builder, tmp_path, monke
     else:
         print("Captured stderr: N/A", file=sys.stderr)
 
-    # Ensure that setuid bit was detected
-    assert "SECURITY: executable has setuid bit set" in p.stderr
+    # Ensure that setuid/setgid bit was detected
+    if bit_type == 'setuid':
+        MSG_BIT_DETECTED = "SECURITY: executable has setuid bit set"
+        MSG_VERIFICATION = \
+            "SECURITY: setuid bit is set - verifying owner/permissions of application's home directory..."
+    else:
+        MSG_BIT_DETECTED = "SECURITY: executable has setgid bit set"
+        MSG_VERIFICATION = \
+            "SECURITY: setgid bit is set - verifying owner/permissions of application's home directory..."
 
-    MSG_VERIFICATION = "SECURITY: setuid bit is set - verifying owner/permissions of application's home directory..."
+    assert MSG_BIT_DETECTED in p.stderr
 
     if pyi_builder._mode == 'onefile':
         # Onefile mode
         if verification_unavailable:
-            # If onefile parent-process verification is unavailable, the setuid-enabled executable should raise an early
-            # error.
+            # If onefile parent-process verification is unavailable, the setuid/setgid-enabled executable should raise
+            # an early error.
             assert p.returncode != 0
 
             if compat.is_freebsd:
@@ -518,8 +530,12 @@ def test_security_validation_with_setuid_executable(pyi_builder, tmp_path, monke
         assert "Security validation failure: application's home directory has invalid permissions (" in p.stderr
 
         # Adjust permissions on contents directory, and try again.
+        # With setuid, we strictly require 0700. With setgid, we require that other bit is 0, so 0770 should work.
         contents_dir = pathlib.Path(executable).with_name('_internal')
-        os.chmod(contents_dir, stat.S_IRWXU)  # 0700
+        if bit_type == 'setuid':
+            os.chmod(contents_dir, stat.S_IRWXU)  # 0700
+        else:
+            os.chmod(contents_dir, stat.S_IRWXU | stat.S_IRWXG)  # 0770
 
         print("Running executable after adjusting permissions on contents directory", file=sys.stderr)
         p = subprocess.run([executable], capture_output=True, encoding='utf-8')
@@ -538,7 +554,7 @@ def test_security_validation_with_setuid_executable(pyi_builder, tmp_path, monke
 
         # The program should succeed now
         assert p.returncode == 0
-        assert "SECURITY: executable has setuid bit set" in p.stderr
+        assert MSG_BIT_DETECTED in p.stderr
         assert MSG_VERIFICATION in p.stderr
 
 

--- a/tests/functional/test_security.py
+++ b/tests/functional/test_security.py
@@ -365,22 +365,23 @@ def test_application_home_directory_hijack(
         if compat.is_freebsd:
             # FreeBSD without /proc mounted
             ERR_UNSUPPORTED_SYSTEM = (
-                "Security validation failure: setuid-enabled executables are not supported on this system "
-                "(missing /proc)!"
+                "Security validation failure: onefile parent-process validation, which is required for onefile "
+                "executables running with elevated privileges, is not supported on this system (missing /proc)!"
             )
             assert ERR_UNSUPPORTED_SYSTEM in p.stderr
         else:
             # AIX, OpenBSD
-            ERR_UNSUPPORTED_PLATFORM = \
-                "Security validation failure: setuid-enabled executables are not supported on this platform!"
+            ERR_UNSUPPORTED_PLATFORM = (
+                "Security validation failure: onefile parent-process validation, which is required for onefile "
+                "executables running with elevated privileges, is not supported on this platform!"
+            )
             assert ERR_UNSUPPORTED_PLATFORM in p.stderr
         return
 
     if parent_level == PYI_PROCESS_LEVEL_UNKNOWN:
         # This is same as _PYI_PARENT_PROCESS_LEVEL not being set at all; the process should run as parent process
         # of onefile application and set up new environment. Thus, the test application should run normally.
-        # (Except in the setuid-executable scenario with mitigation being unavailable, which should already be
-        # handled by earlier check.)
+        # (Except when early error is raised due to lack of onefile parent-process support, which is handled above).
         assert p.returncode == 0
     elif parent_level == PYI_PROCESS_LEVEL_PARENT_NEEDS_RESTART:
         # This level is valid only in POSIX onefile builds with splash screen enabled. Since the process retains
@@ -395,13 +396,6 @@ def test_application_home_directory_hijack(
         # `sys.executable`. The arbitrarily-named application directory should fail the name check. The
         # _MEI-formatted application directory should pass the name check, but should fail the parent-process
         # validation.
-        #
-        # On platforms where procfs-based look-up of parent executable is not supported (AIX, OpenBSD) or the
-        # relevant entry under /proc/<ppid> is inaccessible (e.g., FreeBSD without /proc mounted, or any other
-        # supported POSIX platform where local security policy blocks access to /proc/<ppid> directory for other
-        # processes), we cannot validate the parent process. In these cases, we expect the validation of
-        # arbitrary home directory name to fail, the faked home directory with _MEI prefix to slip through,
-        # and executable with setuid bit set to block the execution (already handled by preceding if-block).
         if scenario == SCENARIO_ARBITRARY_DIR:
             assert p.returncode not in {0, 42}
             assert ERR_HOME_DIRECTORY_NAME in p.stderr
@@ -491,12 +485,17 @@ def test_security_validation_with_setuid_executable(pyi_builder, tmp_path, monke
             assert p.returncode != 0
 
             if compat.is_freebsd:
+                # FreeBSD without /proc mounted
                 ERR_MSG = (
-                    "Security validation failure: setuid-enabled executables are not supported on this system "
-                    "(missing /proc)!"
+                    "Security validation failure: onefile parent-process validation, which is required for onefile "
+                    "executables running with elevated privileges, is not supported on this system (missing /proc)!"
                 )
             else:
-                ERR_MSG = "Security validation failure: setuid-enabled executables are not supported on this platform!"
+                # AIX, OpenBSD
+                ERR_MSG = (
+                    "Security validation failure: onefile parent-process validation, which is required for onefile "
+                    "executables running with elevated privileges, is not supported on this platform!"
+                )
             assert ERR_MSG in p.stderr
         else:
             assert p.returncode == 0


### PR DESCRIPTION
A follow-up to revisions made in #9520.

As per https://github.com/pyinstaller/pyinstaller/pull/9520#issuecomment-5559767897, we now also enable `onefile` parent-process validation for executables that have `setgid` bit set. On Linux, we also detect presence of file attributes on the executable (i.e., the presence of `security.capabilities`), and likewise enable `onefile` parent-process validation.

For `onedir` applications, we now perform extra check on owner and permissions of contents directory for both `setuid`-enabled and `setgid`-executables (formerly only `setuid` was covered). The requirements have been relaxed as well - for `setuid`, the owner ID of the contents directory needs to match the owner ID of the executable itself (previously, we required it to match the effective user ID of the current process). As far as permissions go, only owner is now allowed to have write permissions on the directory (previous iteration mandated `0700` permissions, even though `0500` would be reasonable as well). Similarly for `setgid`, we require that the group ID of the contents directory matches the group ID of the executable, and the contents directory may be writable only by owner and the group.

This should give some leeway to `onedir` applications that start in privileged mode and then drop back to unprivileged user (as such user can now have a read/execute access to the contents directory). On the other hand, the currently-implemented permissions check does not guarantee that none of the files or subdirectories are writable by unprivileged users; that would require us to go recursively through the contents directory on each run, which I think is an overkill...